### PR TITLE
Make position private

### DIFF
--- a/Unity-Technologies-networking/Runtime/NetworkWriter.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkWriter.cs
@@ -12,7 +12,10 @@ namespace UnityEngine.Networking
 
         // 'int' is the best type for .Position. 'short' is too small if we send >32kb which would result in negative .Position
         // -> converting long to int is fine until 2GB of data (MAX_INT), so we don't have to worry about overflows here
-        public int Position { get { return (int)writer.BaseStream.Position; } set { writer.BaseStream.Position = value; } }
+
+        // There is no way to use Position safely if NetworkWriter does any sort of data transformation 
+        // such as compression, encryption or bitpacking.  Thus Position should not be accessible outside this class
+        private int Position { get { return (int)writer.BaseStream.Position; } set { writer.BaseStream.Position = value; } }
 
         // MemoryStream.ToArray() ignores .Position, but HLAPI's .ToArray() expects only the valid data until .Position.
         // .ToArray() is often used for payloads or sends, we don't unnecessary old data in there (bandwidth etc.)

--- a/Unity-Technologies-networking/UnityEngine.Networking.Tests/NetworkWriterTest.cs
+++ b/Unity-Technologies-networking/UnityEngine.Networking.Tests/NetworkWriterTest.cs
@@ -15,7 +15,9 @@ namespace UnityEngine.Networking.Tests
             NetworkWriter writer = new NetworkWriter();
             for (int i = 0; i < 30000 / 4; ++i)
                 writer.Write(i);
-            Assert.That(writer.Position, Is.EqualTo(30000));
+            byte[] bytes = writer.ToArray();
+
+            Assert.That(bytes.Length, Is.EqualTo(30000));
         }
 
         [Test]
@@ -25,7 +27,9 @@ namespace UnityEngine.Networking.Tests
             NetworkWriter writer = new NetworkWriter();
             for (int i = 0; i < 40000 / 4; ++i)
                 writer.Write(i);
-            Assert.That(writer.Position, Is.EqualTo(40000));
+            byte[] bytes = writer.ToArray();
+
+            Assert.That(bytes.Length, Is.EqualTo(40000));
         }
 
         [Test]
@@ -38,13 +42,6 @@ namespace UnityEngine.Networking.Tests
 
             // .ToArray() length is 2?
             Assert.That(writer.ToArray().Length, Is.EqualTo(2));
-
-            // set position back by one
-            writer.Position = 1;
-
-            // .ToArray() length is 1, even though the internal array contains 2 bytes?
-            // (see .ToArray() function comments)
-            Assert.That(writer.ToArray().Length, Is.EqualTo(1));
         }
 
         [Test]


### PR DESCRIPTION
Position should be private,

This way NetworkWriter could have any stream implementation inside,  and code outside of it doesn't assume it is backed by plain MemoryStream