### PR TITLE
Flush when starting or finishing a message.

### DIFF
--- a/Unity-Technologies-networking/Runtime/NetworkWriter.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkWriter.cs
@@ -23,6 +23,7 @@ namespace UnityEngine.Networking
         //     => .ToArray() would return 10 bytes because of the first write, which is exactly what we don't want.
         public byte[] ToArray()
         {
+            writer.Flush();
             byte[] slice = new byte[Position];
             Array.Copy(((MemoryStream)writer.BaseStream).ToArray(), slice, Position);
             return slice;
@@ -382,6 +383,7 @@ namespace UnityEngine.Networking
 
         public void SeekZero()
         {
+            writer.Flush();
             writer.BaseStream.Position = 0;
         }
 
@@ -398,6 +400,7 @@ namespace UnityEngine.Networking
 
         public void FinishMessage()
         {
+            writer.Flush();
             // size has to fit into ushort
             if (Position > UInt16.MaxValue)
             {


### PR DESCRIPTION
This is a no-op with BinaryWriter/MemoryStream,  but this is necesary if we do
any sort of transformation,  such as BitWriter, compression or encryption