### PR TITLE
Sync To Owner

### DIFF
--- a/Unity-Technologies-networking/Runtime/CustomAttributes.cs
+++ b/Unity-Technologies-networking/Runtime/CustomAttributes.cs
@@ -11,10 +11,14 @@ namespace UnityEngine.Networking
         public float sendInterval = 0.1f;
     }
 
+    // SyncTarget enum is cleaner than 'bool onlyToOwner and allows for more options if needed
+    public enum SyncTarget {Observers, Owner};
+
     [AttributeUsage(AttributeTargets.Field)]
     public class SyncVarAttribute : Attribute
     {
         public string hook;
+        public SyncTarget target = SyncTarget.Observers; // for 'only sync to owner' support
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
@@ -25,7 +25,8 @@ namespace UnityEngine.Networking
         public NetworkConnection connectionToServer { get { return myView.connectionToServer; } }
         public NetworkConnection connectionToClient { get { return myView.connectionToClient; } }
         public short playerControllerId { get { return myView.playerControllerId; } }
-        protected ulong syncVarDirtyBits { get { return m_SyncVarDirtyBits; } }
+        public ulong syncVarDirtyBits { get { return m_SyncVarDirtyBits; } set { m_SyncVarDirtyBits = value; } }
+        public float lastSendTime { get { return m_LastSendTime; } set { m_LastSendTime = value; } }
         protected bool syncVarHookGuard { get { return m_SyncVarGuard; } set { m_SyncVarGuard = value; }}
         // determine which variables are SyncToOwner
         // to get dirty owners, we do syncVarDirtyBits & syncVarOwnerMask
@@ -546,6 +547,11 @@ namespace UnityEngine.Networking
         {
             m_LastSendTime = Time.time;
             m_SyncVarDirtyBits = 0L;
+        }
+
+        public void ClearOwnerDirtyBits()
+        {
+            m_SyncVarDirtyBits = m_SyncVarDirtyBits & (~syncVarOwnerMask);
         }
 
         public void SetAllDirtyBits()

--- a/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
@@ -27,6 +27,10 @@ namespace UnityEngine.Networking
         public short playerControllerId { get { return myView.playerControllerId; } }
         protected ulong syncVarDirtyBits { get { return m_SyncVarDirtyBits; } }
         protected bool syncVarHookGuard { get { return m_SyncVarGuard; } set { m_SyncVarGuard = value; }}
+        // determine which variables are SyncToOwner
+        // to get dirty owners, we do syncVarDirtyBits & syncVarOwnerMask
+        // by default it is 0 because none of the variables are synctowoner
+        protected virtual ulong syncVarOwnerMask { get { return 0; } }
 
         internal NetworkIdentity netIdentity { get { return myView; } }
 

--- a/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
@@ -548,6 +548,12 @@ namespace UnityEngine.Networking
             m_SyncVarDirtyBits = 0L;
         }
 
+        public void SetAllDirtyBits()
+        {
+            m_LastSendTime = float.MinValue;
+            m_SyncVarDirtyBits = ~0uL;
+        }
+
         internal bool IsDirty()
         {
             return

--- a/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
@@ -467,6 +467,10 @@ namespace UnityEngine.Networking
                     // set bit #i to 1 in dirty mask
                     dirtyComponentsMask |= (ulong)(1L << i);
 
+                    if (initialState)
+                    {
+                        comp.SetAllDirtyBits();
+                    }
                     // serialize the data
                     if (LogFilter.logDebug) { Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState + " channelId=" + channelId); }
                     OnSerializeSafely(comp, payload, initialState);

--- a/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
@@ -443,9 +443,23 @@ namespace UnityEngine.Networking
             return result;
         }
 
+        internal void ClearDirtyBits()
+        {
+            foreach (NetworkBehaviour comp in m_NetworkBehaviours)
+            {
+                // we only want to clear the ones we just sent
+                // otherwise we would be resetting the components waiting for their timer
+                // waiting for their turn.
+                if (comp.IsDirty())
+                {
+                    comp.ClearAllDirtyBits();
+                }
+            }
+        }
+
         // serialize all components (or only dirty ones for channelId if not initial state)
         // -> returns TRUE if any date other than dirtyMask was written!
-        internal bool OnSerializeAllSafely(NetworkBehaviour[] components, NetworkWriter writer, bool initialState, int channelId)
+        internal bool OnSerializeAllSafely(NetworkBehaviour[] components, NetworkWriter writer, bool initialState, SyncTarget target, int channelId)
         {
             if (components.Length > 64)
             {
@@ -462,26 +476,37 @@ namespace UnityEngine.Networking
                 // -> always serialize if initialState so all components with all channels are included in spawn packet
                 // -> note: IsDirty() is false if the component isn't dirty or sendInterval isn't elapsed yet
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
-                if (initialState || (comp.IsDirty() && comp.GetNetworkChannel() == channelId))
+                ulong dirtyBits = comp.syncVarDirtyBits;
+                float lastSentTime = comp.lastSendTime;
+
+                if (initialState)
+                {
+                    // during initial state,  consider everything as dirty
+                    comp.SetAllDirtyBits();    
+                }
+
+                if (target == SyncTarget.Observers)
+                {
+                    // if we are synchronizing for observers, all owner variables are treated as clean
+                    comp.ClearOwnerDirtyBits();
+                }
+
+                // if it is initializing,  channel does not matter,  they all go to reliable channel
+                // otherwise,  only send the component if we are looking at the right channel.
+                // note that if we are spawning,  we expect all varibles to be dirty
+                // except for the owner bits if we are talking about observers
+                if (comp.IsDirty() && (comp.GetNetworkChannel() == channelId || initialState))
                 {
                     // set bit #i to 1 in dirty mask
                     dirtyComponentsMask |= (ulong)(1L << i);
 
-                    if (initialState)
-                    {
-                        comp.SetAllDirtyBits();
-                    }
-                    // serialize the data
                     if (LogFilter.logDebug) { Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState + " channelId=" + channelId); }
                     OnSerializeSafely(comp, payload, initialState);
-
-                    // Clear dirty bits only if we are synchronizing data and not sending a spawn message.
-                    // This preserves the behavior in HLAPI
-                    if (!initialState)
-                    {
-                        comp.ClearAllDirtyBits();
-                    }
                 }
+
+                // restory the dirty bits, serialization should not have side effec
+                comp.syncVarDirtyBits = dirtyBits;
+                comp.lastSendTime = lastSentTime;
             }
 
             // did we write anything? then write dirty, payload and return true
@@ -498,7 +523,7 @@ namespace UnityEngine.Networking
         }
 
         // extra version that uses m_NetworkBehaviours so we can call it from the outside
-        internal void OnSerializeAllSafely(NetworkWriter writer, bool initialState, int channelId) { OnSerializeAllSafely(m_NetworkBehaviours, writer, initialState, channelId); }
+        internal void OnSerializeAllSafely(NetworkWriter writer, bool initialState, SyncTarget target, int channelId) { OnSerializeAllSafely(m_NetworkBehaviours, writer, initialState, target, channelId); }
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -752,23 +777,67 @@ namespace UnityEngine.Networking
             // go through each channel
             for (int channelId = 0; channelId < NetworkServer.numChannels; channelId++)
             {
-                // serialize all the dirty components and send (if any were dirty)
-                NetworkWriter writer = new NetworkWriter();
-                if (OnSerializeAllSafely(m_NetworkBehaviours, writer, false, channelId))
+                SendUpdateVarsMessage(channelId, SyncTarget.Owner);
+                SendUpdateVarsMessage(channelId, SyncTarget.Observers);
+            }
+
+            // reset dirty bits for everything that was sent
+            ClearDirtyBits();
+        }
+
+        // sends a message to all observers except the owner
+        public void SendToObservers(short msgType, MessageBase msg, int channelId)
+        {
+            for (int i = 0; i < observers.Count; ++i)
+            {
+                NetworkConnection conn = observers[i];
+                if (conn.isReady && conn != m_ClientAuthorityOwner)
                 {
+                    conn.SendByChannel(msgType, msg, channelId);
+                }
+            }
+        }
+
+        public void SendToOwner(short msgType, MessageBase msg, int channelId)
+        {
+            m_ClientAuthorityOwner.SendByChannel(msgType, msg, channelId);
+        }
+
+        private bool SendUpdateVarsMessage(int channelId, SyncTarget target)
+        {
+            if (m_ClientAuthorityOwner == null && target == SyncTarget.Owner)
+            {
+                // there is no owner
+                return false;
+            }
+
+            // serialize all the dirty components and send (if any were dirty)
+            NetworkWriter writer = new NetworkWriter();
+            if (OnSerializeAllSafely(m_NetworkBehaviours, writer, false, target, channelId))
+            {
 #if UNITY_EDITOR
                             UnityEditor.NetworkDetailStats.IncrementStat(
                                 UnityEditor.NetworkDetailStats.NetworkDirection.Outgoing,
                                 (short)MsgType.UpdateVars, name, 1);
 #endif
-                    // construct message and send
-                    UpdateVarsMessage message = new UpdateVarsMessage();
-                    message.netId = netId;
-                    message.payload = writer.ToArray();
+                // construct message and send
+                UpdateVarsMessage message = new UpdateVarsMessage();
+                message.netId = netId;
+                message.payload = writer.ToArray();
 
-                    NetworkServer.SendByChannelToReady(gameObject, (short)MsgType.UpdateVars, message, channelId);
+                if (target == SyncTarget.Owner)
+                {
+                    SendToOwner((short)MsgType.UpdateVars, message, channelId);
                 }
+                else
+                {
+                    SendToObservers((short)MsgType.UpdateVars, message, channelId);
+                }
+
+                if (LogFilter.logDev) { Debug.Log("Synchronized data for " + target + ", data size = " + message.payload.Length); } 
+                return true;
             }
+            return false;
         }
 
         internal void OnUpdateVars(NetworkReader reader, bool initialState)

--- a/Unity-Technologies-networking/Weaver/UNetBehaviourProcessor.cs
+++ b/Unity-Technologies-networking/Weaver/UNetBehaviourProcessor.cs
@@ -36,6 +36,8 @@ namespace Unity.UNetWeaver
         const string k_RpcPrefix = "InvokeRpc";
         const string k_TargetRpcPrefix = "InvokeTargetRpc";
 
+        public enum SyncTarget { Observers, Owner };
+
         public NetworkBehaviourProcessor(TypeDefinition td)
         {
             Weaver.DLog(td, "NetworkBehaviourProcessor");
@@ -512,7 +514,6 @@ namespace Unity.UNetWeaver
             serialize.Body.Variables.Add(dirtyLocal);
 
             // call base class
-            bool baseClassSerialize = false;
             if (m_td.BaseType.FullName != Weaver.NetworkBehaviourType.FullName)
             {
                 MethodReference baseSerialize = Weaver.ResolveMethod(m_td.BaseType, "OnSerialize");
@@ -523,7 +524,6 @@ namespace Unity.UNetWeaver
                     serWorker.Append(serWorker.Create(OpCodes.Ldarg_2)); // forceAll
                     serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
                     serWorker.Append(serWorker.Create(OpCodes.Stloc_0)); // set dirtyLocal to result of base.OnSerialize()
-                    baseClassSerialize = true;
                 }
             }
 
@@ -1902,6 +1902,26 @@ namespace Unity.UNetWeaver
             return get;
         }
 
+        SyncTarget GetSyncVarSyncTarget(FieldDefinition fd)
+        {
+            foreach (CustomAttribute attr in fd.CustomAttributes)
+            {
+                if (attr.AttributeType.FullName == Weaver.SyncVarType.FullName)
+                {
+                    foreach (var field in attr.Fields)
+                    {
+                        if (field.Name == "target") // SyncVar.target == SyncTarget.XYZ
+                        {
+                            // SyncTarget enum: 0 == Observers, 1 == Owner
+                            return (SyncTarget)field.Argument.Value;
+                        }
+                    }
+                }
+            }
+
+            return SyncTarget.Observers;
+        }
+
         MethodDefinition ProcessSyncVarSet(FieldDefinition fd, string originalName, long dirtyBit, FieldDefinition netFieldId)
         {
             //Create the set method
@@ -2010,7 +2030,6 @@ namespace Unity.UNetWeaver
             {
                 GetMethod = get, SetMethod = set
             };
-
             //add the methods and property to the type.
             m_td.Methods.Add(get);
             m_td.Methods.Add(set);
@@ -2075,6 +2094,64 @@ namespace Unity.UNetWeaver
                 Weaver.int32Type);
         }
 
+        // Generates a property in a file to get the owner mask
+        void GenerateOwnerMaskProperty(long ownerMask)
+        {
+            // no new variables are owners,  
+            // no need to override syncVarOwnerMask
+            if (ownerMask == 0L)
+                return;
+
+            // generates this:
+            //
+            // protected override ulong syncVarOwnerMask 
+            // {
+            //     get 
+            //     {
+            //         return 0x10 | base.syncVarOwnerMask;
+            //     }
+            // }
+
+
+            //Create the get method
+            MethodDefinition get = new MethodDefinition(
+                "get_syncVarOwnerMask", MethodAttributes.Family |
+                MethodAttributes.SpecialName |
+                MethodAttributes.HideBySig |
+                MethodAttributes.Virtual,
+                Weaver.uint64Type);
+
+            ILProcessor getWorker = get.Body.GetILProcessor();
+
+            // generate:  return (0xabc | base.syncVarOwnerMask);
+            getWorker.Append(getWorker.Create(OpCodes.Ldc_I8, ownerMask)); // 8 byte integer aka long
+
+            if (m_td.BaseType.FullName != Weaver.NetworkBehaviourType.FullName)
+            {
+                MethodReference baseSerialize = Weaver.ResolveMethod(m_td.BaseType, "get_syncVarOwnerMask");
+                if (baseSerialize != null)
+                {
+                    getWorker.Append(getWorker.Create(OpCodes.Ldarg_0)); // base
+                    getWorker.Append(getWorker.Create(OpCodes.Call, baseSerialize));
+                    getWorker.Append(getWorker.Create(OpCodes.Or)); 
+                }
+            }
+
+            getWorker.Append(getWorker.Create(OpCodes.Ret));
+
+            get.SemanticsAttributes = MethodSemanticsAttributes.Getter;
+
+
+            PropertyDefinition propertyDefinition = new PropertyDefinition("syncVarOwnerMask", PropertyAttributes.None, Weaver.uint64Type)
+            {
+                GetMethod = get
+            };
+            //add the methods and property to the type.
+            m_td.Methods.Add(get);
+            m_td.Properties.Add(propertyDefinition);
+
+        }
+
         void ProcessSyncVars()
         {
             int numSyncVars = 0;
@@ -2082,6 +2159,9 @@ namespace Unity.UNetWeaver
             // the mapping of dirtybits to sync-vars is implicit in the order of the fields here. this order is recorded in m_replacementProperties.
             // start assigning syncvars at the place the base class stopped, if any
             int dirtyBitCounter = Weaver.GetSyncVarStart(m_td.BaseType.FullName);
+
+            // mask that determines which of these bits are sync to owner
+            long ownerMask = 0;
 
             m_SyncVarNetIds.Clear();
             List<FieldDefinition> listFields = new List<FieldDefinition>();
@@ -2150,9 +2230,17 @@ namespace Unity.UNetWeaver
                             return;
                         }
 
+                        // at this point this is either a list or a syncvar and has
+                        // the [SyncVar] attribute.   Check if it is SyncToOwner
+                        // and adjust the mask
+                        if (GetSyncVarSyncTarget(fd) == SyncTarget.Owner)
+                        {
+                            ownerMask |= 1L << dirtyBitCounter;
+                        }
+
+
                         if (Helpers.InheritsFromSyncList(fd.FieldType))
                         {
-                            Log.Warning(string.Format("Script class [{0}] has [SyncVar] attribute on SyncList field {1}, SyncLists should not be marked with SyncVar.", m_td.FullName, fd.Name));
                             break;
                         }
 
@@ -2218,6 +2306,8 @@ namespace Unity.UNetWeaver
             {
                 m_td.Methods.Add(func);
             }
+
+            GenerateOwnerMaskProperty(ownerMask);
 
             Weaver.SetNumSyncVars(m_td.FullName, numSyncVars);
         }


### PR DESCRIPTION
Variables with the attribute:
```
[SyncVar(target = SyncTarget.Owner)]
```

will only be synchronized with the client with authority. This is useful for inventory and other data that doesn't need to be visible to other players.

Here is a full example:
```
public class SampleBehavior : NetworkBehaviour {

    [SyncVar]
    public int myVariable;

    [SyncVar(target = SyncTarget.Owner)]
    public string myData2;

    [SyncVar(target = SyncTarget.Owner)]
    public SyncListInt myOwnerList;
}
```

