### PR TITLE
Add source compatibility with HLAPI,  people should not need to cast

### DIFF
--- a/Unity-Technologies-networking/Runtime/NetworkServer.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkServer.cs
@@ -622,6 +622,11 @@ namespace UnityEngine.Networking
             s_MessageHandlers[msgType] = handler;
         }
 
+        static public void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
+        {
+            RegisterHandler((short)msgType, handler);    
+        }
+
         static public void UnregisterHandler(short msgType)
         {
             s_MessageHandlers.Remove(msgType);


### PR DESCRIPTION
People should not need to cast to short when calling RegisterHandler.   Everyone using RegisterHandler in HLAPI gets compilation errors when switching to HLAPI CE. 

This pull request fixes those compilation errors.