### PR TITLE
Patch NetworkIdentity to report possible duplicates of itself on game…

### DIFF
--- a/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
@@ -294,6 +294,11 @@ namespace UnityEngine.Networking
             if (LogFilter.logDev) { Debug.Log("OnStartServer " + gameObject + " GUID:" + netId); }
             NetworkServer.SetLocalObjectOnServer(netId, gameObject);
 
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
+
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -326,6 +331,12 @@ namespace UnityEngine.Networking
             CacheBehaviours();
 
             if (LogFilter.logDev) { Debug.Log("OnStartClient " + gameObject + " GUID:" + netId + " localPlayerAuthority:" + localPlayerAuthority); }
+
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
+
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -343,6 +354,11 @@ namespace UnityEngine.Networking
 
         internal void OnStartAuthority()
         {
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
+
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -359,6 +375,11 @@ namespace UnityEngine.Networking
 
         internal void OnStopAuthority()
         {
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
+
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -375,6 +396,11 @@ namespace UnityEngine.Networking
 
         internal void OnSetLocalVisibility(bool vis)
         {
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
+
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -391,6 +417,11 @@ namespace UnityEngine.Networking
 
         internal bool OnCheckObserver(NetworkConnection conn)
         {
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
+
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -791,6 +822,11 @@ namespace UnityEngine.Networking
                 m_HasAuthority = true;
             }
 
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
+
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -816,6 +852,11 @@ namespace UnityEngine.Networking
 
         internal void OnNetworkDestroy()
         {
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
+
             for (int i = 0; m_NetworkBehaviours != null && i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -880,6 +921,11 @@ namespace UnityEngine.Networking
             bool result = false;
             HashSet<NetworkConnection> newObservers = new HashSet<NetworkConnection>();
             HashSet<NetworkConnection> oldObservers = new HashSet<NetworkConnection>(m_Observers);
+
+            if (m_NetworkBehaviours == null)
+            {
+                Debug.LogError("NetworkIdentity m_NetworkBehaviours is NULL. Could something have added this NetworkIdentity script on " + gameObject.name + " twice? The original error will be emitted as normal, this is just to help find the culprit.");
+            }
 
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {


### PR DESCRIPTION
…objects if things are null.

It is possible for a prefab to add more than one NetworkIdentity to a gameobject that is already in the scene. This means that you have two NetworkIdentities on the same gameobject, and they bash each other up and give no real descriptive error message ... until now.

How to replicate the original bug:

1. Put a cube into the scene.
1. Create a prefab of the cube.
3. Put the network identity script on the scene instance cube which should now be blue in the hierarchy.
4. Then go to the prefab in the browser pane and add a network transform to the actual prefab, which should auto-add a network identity since it's required.
5. Then look at the scene instance of that prefab. If you successfully replicated the bug, you will find that scene instance object will have two network identity scripts! Not good.

This pull request simply makes the script throw an warning to help isolate the faulty gameobject that is prone to blow up in your face. It does nothing more than just say "Hey, I think you need to check this out" on the gameobject in question. Basically shining light instead of throwing a random NullReferenceError that has hardly any stack trace.