### PR TITLE
Add a NetworkTime component 

### DIFF
--- a/Mirror/Runtime/ExponentialMovingAverage.cs
+++ b/Mirror/Runtime/ExponentialMovingAverage.cs
@@ -1,0 +1,49 @@
+﻿using System;
+namespace Mirror
+{
+    // implementation of N-day EMA
+    // it calculates an exponential moving average roughy equivalent to the last n observations
+    public class ExponentialMovingAverage
+    {
+        private float alpha;
+        private bool initialized = false;
+
+        private double _value = 0;
+        private double _var = 0;
+
+        public ExponentialMovingAverage(int n)
+        {
+            // standard N-day EMA alpha calculation
+            alpha = 2.0f / (n + 1);
+        }
+
+        public void Add(double newValue)
+        {
+            // simple algorithm for EMA described here:
+            // https://en.wikipedia.org/wiki/Moving_average#Exponentially_weighted_moving_variance_and_standard_deviation
+            if (initialized)
+            {
+                double delta = newValue - _value;
+                _value = _value + alpha * delta;
+                _var = (1 - alpha) * (_var + alpha * delta * delta);
+            }
+            else
+            {
+                _value = newValue;
+                initialized = true;
+            }
+        }
+
+        public double Value {
+            get {
+                return _value;
+            }
+        }
+
+        public double Var {
+            get {
+                return _var;
+            }
+        }
+    }
+}

--- a/Mirror/Runtime/Messages.cs
+++ b/Mirror/Runtime/Messages.cs
@@ -428,6 +428,43 @@ namespace Mirror
         }
     }
 
+    // A client sends this message to the server 
+    // to calculate RTT and synchronize time
+    class NetworkPingMessage : MessageBase
+    {
+        public double clientTime;
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            clientTime = reader.ReadDouble();
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            writer.Write(clientTime);
+        }
+    }
+
+    // The server responds with this message
+    // The client can use this to calculate RTT and sync time
+    class NetworkPongMessage : MessageBase
+    {
+        public double clientTime;
+        public double serverTime;
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            clientTime = reader.ReadDouble();
+            serverTime = reader.ReadDouble();
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            writer.Write(clientTime);
+            writer.Write(serverTime);
+        }
+    }
+
     class LocalChildTransformMessage : MessageBase
     {
         public NetworkInstanceId netId;

--- a/Mirror/Runtime/Mirror.Runtime.csproj
+++ b/Mirror/Runtime/Mirror.Runtime.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -96,6 +96,8 @@
     <Compile Include="NetworkServer.cs" />
     <Compile Include="SyncList.cs" />
     <Compile Include="NetworkWriter.cs" />
+    <Compile Include="NetworkTime.cs" />
+    <Compile Include="ExponentialMovingAverage.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using UnityEngine;
+
+namespace Mirror
+{
+    // calculates synchronized time and rtt
+    public class NetworkTime : NetworkBehaviour
+    {
+        // some arbitrary point in time where time started
+        private static readonly DateTime epoch = new DateTime(2018, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        private static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(10);
+        private static ExponentialMovingAverage _offset = new ExponentialMovingAverage(10);
+
+        // returns the clock time _in this system_
+        private static double LocalTime()
+        {
+            var now = DateTime.Now;
+            TimeSpan span = DateTime.Now.Subtract(epoch);
+            return span.TotalSeconds;
+        }
+
+        // how often are we synchronizing the clock
+        public float syncInterval = 2.0f;
+        // average out the last 10 values for RTT
+        public int windowSize = 10;
+
+        public override void OnStartClient()
+        {
+
+            if (!isServer)
+            {
+                NetworkManager.singleton.client.RegisterHandler((short)MsgType.Pong, OnNetworkPongClientMessage);
+                _rtt = new ExponentialMovingAverage(windowSize);
+                _offset = new ExponentialMovingAverage(windowSize);
+                CancelInvoke("SendPing");
+                InvokeRepeating("SendPing", 0, syncInterval);
+            }
+        }
+
+        public override void OnStartServer()
+        {
+            base.OnStartServer();
+           
+            NetworkServer.RegisterHandler((short)MsgType.Ping, OnNetworkPingServerMessage);
+
+        }
+
+        private void SendPing()
+        {
+            var pingMsg = new NetworkPingMessage
+            {
+                clientTime = LocalTime()
+            };
+
+            if (NetworkManager.singleton.client != null)
+            {
+                NetworkManager.singleton.client.Send((short)MsgType.Ping, pingMsg);
+            }
+        }
+
+        // The server receives a time from the client
+        // it replies with the same time plus the server time
+        public void OnNetworkPingServerMessage(NetworkMessage netMsg)
+        {
+            var pingMsg = new NetworkPingMessage();
+            netMsg.ReadMessage(pingMsg);
+
+            if (LogFilter.logDev) { Debug.Log("OnPingServerMessage  conn=" + netMsg.conn); }
+
+            var pongMsg = new NetworkPongMessage
+            {
+                clientTime = pingMsg.clientTime,
+                serverTime = LocalTime()
+            };
+
+            netMsg.conn.Send((short)MsgType.Pong, pongMsg);
+        }
+
+        // we received the response to our ping message
+        // Update round trip time and time offset
+        public void OnNetworkPongClientMessage(NetworkMessage netMsg)
+        {
+            var pongMsg = new NetworkPongMessage();
+            netMsg.ReadMessage(pongMsg);
+
+            // how long did this message take to come back
+            double rtt = LocalTime() - pongMsg.clientTime;
+            // the difference in time between the client and the server
+            // but subtract half of the rtt to compensate for latency
+            // half of rtt is the best approximation we have
+            double offset = LocalTime() - rtt * 0.5f - pongMsg.serverTime;
+
+            _rtt.Add(rtt);
+            _offset.Add(offset);
+
+        }
+
+        // returns the same time in both client and server
+        public static double time
+        {
+            get {
+                // Notice _offset is 0 at the server
+                return LocalTime() - _offset.Value;
+            }
+        }
+
+        // measure volatility of time.  
+        // the higher the number,  the less accurate the time is
+        public static double timeVar
+        {
+            get {
+                return _offset.Var;
+            }
+        }
+
+        // standard deviation of time
+        public static double timeSd
+        {
+            get {
+                return Math.Sqrt(timeVar);
+            }
+        }
+
+        public static double offset
+        {
+            get {
+                return _offset.Value;
+            }
+        }
+
+        // how long does it take for a message to go 
+        // to the server and come back
+        public static double rtt
+        {
+            get {
+                return _rtt.Value;
+            }
+        }
+
+        // measure volatility of rtt
+        // the higher the number,  the less accurate rtt is
+        public static double rttVar
+        {
+            get {
+                return _rtt.Var;
+            }
+        }
+
+        // standard deviation of rtt
+        public static double rttSd
+        {
+            get
+            {
+                return Math.Sqrt(rttVar);
+            }
+        }
+    }
+}

--- a/Mirror/Runtime/UNetwork.cs
+++ b/Mirror/Runtime/UNetwork.cs
@@ -52,7 +52,13 @@ namespace Mirror
         AnimationParameters = 41,
         AnimationTrigger = 42,
 
+        // time synchronization
+        Ping = 43,
+        Pong = 44,
+
         Highest = 47
+
+
     }
 
     public class NetworkMessage

--- a/Mirror/Tests/ExponentialMovingAverageTest.cs
+++ b/Mirror/Tests/ExponentialMovingAverageTest.cs
@@ -1,0 +1,46 @@
+﻿using NUnit.Framework;
+using System;
+namespace Mirror
+{
+    [TestFixture]
+    public class ExponentialMovingAverageTest
+    {
+        [Test]
+        public void TestInitial()
+        {
+            var ema = new ExponentialMovingAverage(10);
+
+            ema.Add(3);
+
+            Assert.That(ema.Value, Is.EqualTo(3));
+            Assert.That(ema.Var, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestMovingAverage()
+        {
+            var ema = new ExponentialMovingAverage(10);
+
+            ema.Add(5);
+            ema.Add(6);
+
+            Assert.That(ema.Value, Is.EqualTo(5.1818).Within(0.0001f));
+            Assert.That(ema.Var, Is.EqualTo(0.1487).Within(0.0001f));
+
+        }
+
+        [Test]
+        public void TestVar()
+        {
+            var ema = new ExponentialMovingAverage(10);
+
+            ema.Add(5);
+            ema.Add(6);
+            ema.Add(7);
+
+            Assert.That(ema.Var, Is.EqualTo(0.6134).Within(0.0001f));
+
+        }
+
+    }
+}

--- a/Mirror/Tests/Mirror.Tests.csproj
+++ b/Mirror/Tests/Mirror.Tests.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="NetworkWriterTest.cs" />
     <Compile Include="NetworkHash128Test.cs" />
+    <Compile Include="ExponentialMovingAverageTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This new component can synchronize time between client and server.

To use it,  add a networked gameojbect to the scene and add `NetworkTime` to it.
Then you can get the time:
```NetworkTime.time```

The time is calculated as the amount of seconds since 2018/01/01 

It can also provide other useful statistics such as:
rtt   ->  Round Trip Time
Var  -> Variance of Time (determines how accurate the time is)
offset -> What is the difference in time between the server and the client
  