### PR TITLE
Use Bit-based Reader/Writer to avoid using whole bytes for nothing

### DIFF
--- a/Mirror/Runtime/BitReader.cs
+++ b/Mirror/Runtime/BitReader.cs
@@ -1,0 +1,129 @@
+﻿using System.IO;
+
+namespace Mirror
+{
+    // reads packed bits in the same byte
+    public class BitReader : BinaryReader
+    {
+        private byte currentByte;
+        private byte currentBitIndex = 8;
+
+        public BitReader(Stream s) : base(s) { }
+
+        public override byte ReadByte()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadByte();
+        }
+
+        public override byte[] ReadBytes(int count)
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadBytes(count);
+        }
+
+        public override sbyte ReadSByte()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadSByte();
+        }
+
+        public override int Read(byte[] buffer, int index, int count)
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.Read(buffer, index, count);
+        }
+
+        public override bool ReadBoolean()
+        {
+            if (currentBitIndex == 8)
+            {
+                // when actual byte is full, we load a new one 
+                currentByte = ReadByte();
+                currentBitIndex = 0;
+            }
+
+            bool b = (currentByte & (1 << currentBitIndex)) != 0;
+            currentBitIndex++;
+            return b;
+        }
+
+        public override string ReadString()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadString();
+        }
+
+        public override short ReadInt16()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadInt16();
+        }
+
+        public override ushort ReadUInt16()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadUInt16();
+        }
+
+        public override int ReadInt32()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadInt32();
+        }
+
+        public override uint ReadUInt32()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadUInt32();
+        }
+
+        public override long ReadInt64()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadInt64();
+        }
+
+        public override ulong ReadUInt64()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadUInt64();
+        }
+
+        public override float ReadSingle()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadSingle();
+        }
+
+        public override decimal ReadDecimal()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadDecimal();
+        }
+
+        public override double ReadDouble()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadDouble();
+        }
+
+        public override char ReadChar()
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadChar(); 
+        }
+
+        public override char[] ReadChars(int count)
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.ReadChars(count);
+        }
+
+        public override int Read(char[] buffer, int index, int count)
+        {
+            currentBitIndex = 8; // to be sure to read a whole new byte
+            return base.Read(buffer, index, count);
+        }
+    }
+}

--- a/Mirror/Runtime/BitWriter.cs
+++ b/Mirror/Runtime/BitWriter.cs
@@ -1,0 +1,146 @@
+﻿using System.IO;
+
+namespace Mirror
+{
+    // writes a single bit to the stream. Consecutive bits are packed together
+    // in the same byte to reduce message size. Especially useful for bools which
+    // don't need to use an entire byte for each.
+    public class BitWriter : BinaryWriter
+    {
+        private byte currentByte;
+        private byte currentBitIndex = 0;
+
+        public BitWriter(Stream s) : base(s) { }
+
+        public override void Flush()
+        {
+            FlushBuffer();
+            base.Flush();
+        }
+
+        public override void Write(byte[] buffer, int index, int count)
+        {
+            FlushBuffer();
+            base.Write(buffer, index, count);
+        }
+
+        public override void Write(byte value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(bool value)
+        {
+            byte bit = value ? (byte)1 : (byte)0;
+            currentByte |= (byte)(bit << currentBitIndex);
+            currentBitIndex++;
+
+            // if actual byte is full, we start a new one
+            if (currentBitIndex == 8)
+            {
+                FlushBuffer();
+            }
+        }
+
+        public override void Write(string value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(byte[] value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(sbyte value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(short value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(ushort value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(int value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(uint value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(long value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(ulong value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(float value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(decimal value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(double value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(char value)
+        {
+            FlushBuffer();
+            base.Write(value);
+        }
+
+        public override void Write(char[] chars)
+        {
+            FlushBuffer();
+            base.Write(chars);
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            FlushBuffer();
+            base.Write(buffer, index, count);
+        }
+
+        void FlushBuffer()
+        {
+            if (currentBitIndex == 0) // nothing to flush
+                return;
+
+            base.Write(currentByte);
+            currentByte = 0;
+            currentBitIndex = 0;
+        }
+    }
+}

--- a/Mirror/Runtime/Mirror.Runtime.csproj
+++ b/Mirror/Runtime/Mirror.Runtime.csproj
@@ -61,6 +61,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BitReader.cs" />
+    <Compile Include="BitWriter.cs" />
     <Compile Include="ClientScene.cs" />
     <Compile Include="CustomAttributes.cs" />
     <Compile Include="DotNetCompatibility.cs" />

--- a/Mirror/Runtime/NetworkReader.cs
+++ b/Mirror/Runtime/NetworkReader.cs
@@ -6,11 +6,11 @@ namespace Mirror
 {
     public class NetworkReader
     {
-        BinaryReader reader;
+        BitReader reader;
 
         public NetworkReader(byte[] buffer)
         {
-            reader = new BinaryReader(new MemoryStream(buffer));
+            reader = new BitReader(new MemoryStream(buffer));
         }
 
         // 'int' is the best type for .Position. 'short' is too small if we send >32kb which would result in negative .Position
@@ -37,9 +37,23 @@ namespace Mirror
             return reader.ReadBoolean() ? reader.ReadString() : null; // null support, see NetworkWriter
         }
 
+        public char[] ReadChars(int count)
+        {
+            return reader.ReadChars(count);
+        }
+        public int Read(char[] buffer, int index, int count)
+        {
+            return reader.Read(buffer, index, count);
+        }
+
         public byte[] ReadBytes(int count)
         {
             return reader.ReadBytes(count);
+        }
+
+        public int Read(byte[] buffer, int index, int count)
+        {
+            return reader.Read(buffer, index, count);
         }
 
         public byte[] ReadBytesAndSize()

--- a/Mirror/Runtime/NetworkWriter.cs
+++ b/Mirror/Runtime/NetworkWriter.cs
@@ -8,7 +8,7 @@ namespace Mirror
     public class NetworkWriter
     {
         // create writer immediately with it's own buffer so no one can mess with it and so that we can resize it.
-        public BinaryWriter writer = new BinaryWriter(new MemoryStream());
+        public BitWriter writer = new BitWriter(new MemoryStream());
 
         // 'int' is the best type for .Position. 'short' is too small if we send >32kb which would result in negative .Position
         // -> converting long to int is fine until 2GB of data (MAX_INT), so we don't have to worry about overflows here
@@ -31,6 +31,7 @@ namespace Mirror
         public void Write(byte value)  { writer.Write(value); }
         public void Write(sbyte value) { writer.Write(value); }
         public void Write(char value) { writer.Write(value); }
+        public void Write(char[] value) { writer.Write(value); }
         public void Write(bool value) { writer.Write(value); }
         public void Write(short value) { writer.Write(value); }
         public void Write(ushort value) { writer.Write(value); }
@@ -49,6 +50,12 @@ namespace Mirror
             //        should also be null on the client)
             writer.Write(value != null);
             if (value != null) writer.Write(value);
+        }
+
+        // for char arrays with consistent size
+        public void Write(char[] buffer, int offset, int count)
+        {
+            writer.Write(buffer, offset, count);
         }
 
         // for byte arrays with consistent size, where the reader knows how many to read

--- a/Mirror/Tests/NetworkWriterTest.cs
+++ b/Mirror/Tests/NetworkWriterTest.cs
@@ -159,5 +159,71 @@ namespace Mirror.Tests
 
             Assert.That(reader.ReadBytesAndSize(), Is.EqualTo(new byte[] { 22, 23 }));
         }
+
+        [Test]
+        public void TestWritingAndReadingCoupleBooleans()
+        {
+            // write three booleans
+            NetworkWriter writer = new NetworkWriter();
+            writer.Write(true);
+            writer.Write(false);
+            writer.Write(true);
+            writer.Write((byte)2);
+
+            // read it back
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Assert.That(reader.ReadBoolean(), Is.True);
+            Assert.That(reader.ReadBoolean(), Is.False);
+            Assert.That(reader.ReadBoolean(), Is.True);
+            Assert.That(reader.ReadByte(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestWritingAndReadingBytesBooleans()
+        {
+            // write three booleans
+            NetworkWriter writer = new NetworkWriter();
+            writer.Write((byte)1);
+            writer.Write(false);
+            writer.Write((byte)2);
+            writer.Write(true);
+            writer.Write((byte)3);
+
+            // read it back
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Assert.That(reader.ReadByte(), Is.EqualTo(1));
+            Assert.That(reader.ReadBoolean(), Is.False);
+            Assert.That(reader.ReadByte(), Is.EqualTo(2));
+            Assert.That(reader.ReadBoolean(), Is.True);
+            Assert.That(reader.ReadByte(), Is.EqualTo(3));
+        }
+
+        [Test]
+        public void TestWritingAndReadingLotBooleans()
+        {
+            // write three booleans
+            NetworkWriter writer = new NetworkWriter();
+            writer.Write(false);
+            writer.Write(true);
+            writer.Write(false);
+            writer.Write(false);
+            writer.Write(true);
+            writer.Write(false);
+            writer.Write(true);
+            writer.Write(true);
+            writer.Write(false);
+
+            // read it back
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Assert.That(reader.ReadBoolean(), Is.False);
+            Assert.That(reader.ReadBoolean(), Is.True);
+            Assert.That(reader.ReadBoolean(), Is.False);
+            Assert.That(reader.ReadBoolean(), Is.False);
+            Assert.That(reader.ReadBoolean(), Is.True);
+            Assert.That(reader.ReadBoolean(), Is.False);
+            Assert.That(reader.ReadBoolean(), Is.True);
+            Assert.That(reader.ReadBoolean(), Is.True);
+            Assert.That(reader.ReadBoolean(), Is.False);
+        }
     }
 }

--- a/Mirror/Weaver/UNetBehaviourProcessor.cs
+++ b/Mirror/Weaver/UNetBehaviourProcessor.cs
@@ -1987,8 +1987,13 @@ namespace Mirror.Weaver
             m_SyncVarNetIds.Clear();
             List<FieldDefinition> listFields = new List<FieldDefinition>();
 
+            // sort fields by type
+            // this way we serialize all boolean togethers to take
+            // advantage of the BitWriter
+            IEnumerable<FieldDefinition> sortedFields = m_td.Fields.OrderBy(fd => fd.FieldType.FullName);
+
             // find syncvars
-            foreach (FieldDefinition fd in m_td.Fields)
+            foreach (FieldDefinition fd in sortedFields)
             {
                 foreach (var ca in fd.CustomAttributes)
                 {


### PR DESCRIPTION
- Bit-based Reader/Writer
- **Weaver**: Sort fields by type in order to serialize all bools together (Thanks @paulpach )
- New Write/Read methods
- Added new tests