### PR TITLE
Flush when sending message

### DIFF
--- a/Mirror/Runtime/NetworkWriter.cs
+++ b/Mirror/Runtime/NetworkWriter.cs
@@ -23,6 +23,7 @@ namespace Mirror
         //     => .ToArray() would return 10 bytes because of the first write, which is exactly what we don't want.
         public byte[] ToArray()
         {
+            writer.Flush();
             byte[] slice = new byte[Position];
             Array.Copy(((MemoryStream)writer.BaseStream).ToArray(), slice, Position);
             return slice;


### PR DESCRIPTION
_Ported to Mirror from original @paulpach PR._

This is a no-op with BinaryWriter/MemoryStream, but this is necesary if we do
any sort of transformation, such as BitWriter, compression or encryption.