### PR TITLE
Print a more informative error than NPE

### DIFF
--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -342,6 +342,12 @@ namespace Mirror
 
         internal void OnStartAuthority()
         {
+            if (m_NetworkBehaviours == null && LogFilter.logError)
+            {
+                Debug.LogError("Network object " + name + " not initialized properly. Do you have more than one NetworkIdentity in the same object?", this);
+                return;
+            }
+
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];

--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -344,7 +344,7 @@ namespace Mirror
         {
             if (m_NetworkBehaviours == null && LogFilter.logError)
             {
-                Debug.LogError("Network object " + name + " not initialized properly. Do you have more than one NetworkIdentity in the same object?", this);
+                Debug.LogError("Network object " + name + " not initialized properly. Do you have more than one NetworkIdentity in the same object? Did you forget to spawn this object with NetworkServer?", this);
                 return;
             }
 


### PR DESCRIPTION
OnStartAuthority throws NPE when there is more than one NetworkIdentity in a gameobject.  

This PR improves the error message and gives the developer a hint about what to do.