### PR TITLE
Make method public

### DIFF
--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -1066,7 +1066,7 @@ namespace Mirror
 #endif
 
         // this is invoked by the UnityEngine
-        internal static void UNetStaticUpdate()
+        public static void UNetStaticUpdate()
         {
             NetworkServer.Update();
             NetworkClient.UpdateClients();


### PR DESCRIPTION
Not all users have a NetworkManager,  and they should not have to.

This method needs to be public so that users can call it if they don't have a NetworkManager