### PR TITLE
Type safe register/unregister handlers

### DIFF
--- a/Mirror/Runtime/NetworkClient.cs
+++ b/Mirror/Runtime/NetworkClient.cs
@@ -303,9 +303,19 @@ namespace Mirror
             m_MessageHandlers[msgType] = handler;
         }
 
+        public void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
+        {
+            RegisterHandler((short)msgType, handler);
+        }
+
         public void UnregisterHandler(short msgType)
         {
             m_MessageHandlers.Remove(msgType);
+        }
+
+        public void UnregisterHandler(MsgType msgType)
+        {
+            UnregisterHandler((short)msgType);
         }
 
         internal static void AddClient(NetworkClient client)

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -535,6 +535,11 @@ namespace Mirror
             s_MessageHandlers.Remove(msgType);
         }
 
+        public static void UnregisterHandler(MsgType msgType)
+        {
+            UnregisterHandler((short)msgType);
+        }
+
         public static void ClearHandlers()
         {
             s_MessageHandlers.Clear();


### PR DESCRIPTION
Register and Unregister handlers can receive the enumeration without casting.

This avoid compilation errors for people migrating from HLAPI,  and enforces type safety when using MsgType