### PR TITLE
Allow for serializing large arrays.  Fix #42

### DIFF
--- a/Mirror/Runtime/NetworkReader.cs
+++ b/Mirror/Runtime/NetworkReader.cs
@@ -48,8 +48,8 @@ namespace Mirror
             bool notNull = reader.ReadBoolean();
             if (notNull)
             {
-                ushort size = ReadUInt16();
-                return reader.ReadBytes(size);
+                uint size = ReadPackedUInt32();
+                return reader.ReadBytes((int)size);
             }
             return null;
         }

--- a/Mirror/Runtime/NetworkWriter.cs
+++ b/Mirror/Runtime/NetworkWriter.cs
@@ -77,8 +77,15 @@ namespace Mirror
                 if (LogFilter.logError) { Debug.LogError("NetworkWriter WriteBytesAndSize: size is too large (" + count + ") bytes. The maximum buffer size is " + Transport.MaxPacketSize + " bytes."); }
                 return;
             }
+            
+            if (count < 0)
+            {
+                if (LogFilter.logError) { Debug.LogError("NetworkWriter WriteBytesAndSize: size " + count + " cannot be negative"); }
+                return;
+            }
+
             writer.Write(true); // notNull?
-            writer.Write((UInt16)count);
+            WritePackedUInt32((uint)count);
             writer.Write(buffer, offset, count);
         }
 

--- a/Mirror/Tests/NetworkWriterTest.cs
+++ b/Mirror/Tests/NetworkWriterTest.cs
@@ -29,6 +29,20 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestWritingHugeArray()
+        {
+            // try serializing array > 64KB and see what happens
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteBytesAndSize(new byte[100000]);
+            byte[] data = writer.ToArray();
+
+            NetworkReader reader = new NetworkReader(data);
+            byte[] deserialized = reader.ReadBytesAndSize();
+            Assert.That(deserialized.Length, Is.EqualTo(100000));
+        }
+
+
+        [Test]
         public void TestToArray()
         {
             // write 2 bytes


### PR DESCRIPTION
byte array sizes are now varinted, so that we can serialize large arrays.