### PR TITLE
Fix unit tests

### DIFF
--- a/Mirror/Runtime/Transport/Transport.cs
+++ b/Mirror/Runtime/Transport/Transport.cs
@@ -9,8 +9,21 @@ namespace Mirror
         // hlapi needs to know max packet size to show warnings
         public static int MaxPacketSize = ushort.MaxValue;
 
+        public static TransportLayer _layer;
+
         // selected transport layer: Telepathy by default
-        public static TransportLayer layer = new TelepathyWebsocketsMultiplexTransport();
+        public static TransportLayer layer 
+        {
+            get {
+                if (_layer == null) {
+                    _layer = new TelepathyWebsocketsMultiplexTransport();
+                }
+                return _layer;
+            }
+            set {
+                _layer = value;
+            }
+        }
     }
 
     // abstract transport layer class //////////////////////////////////////////

--- a/Mirror/Tests/NetworkWriterTest.cs
+++ b/Mirror/Tests/NetworkWriterTest.cs
@@ -31,6 +31,8 @@ namespace Mirror.Tests
         [Test]
         public void TestWritingHugeArray()
         {
+            // allow for large packets
+            Transport.MaxPacketSize = 1000000;
             // try serializing array > 64KB and see what happens
             NetworkWriter writer = new NetworkWriter();
             writer.WriteBytesAndSize(new byte[100000]);
@@ -40,7 +42,6 @@ namespace Mirror.Tests
             byte[] deserialized = reader.ReadBytesAndSize();
             Assert.That(deserialized.Length, Is.EqualTo(100000));
         }
-
 
         [Test]
         public void TestToArray()


### PR DESCRIPTION
lazy load the transport layer so it is not initialized if it is not needed