### PR TITLE
Initialize transport in network manager

### DIFF
--- a/Mirror/Runtime/NetworkManager.cs
+++ b/Mirror/Runtime/NetworkManager.cs
@@ -96,6 +96,7 @@ namespace Mirror
         {
             Debug.Log("Thank you for using Mirror! https://forum.unity.com/threads/unet-hlapi-community-edition.425437/");
             InitializeSingleton();
+            InitializeTransport();
         }
 
         void InitializeSingleton()
@@ -138,6 +139,13 @@ namespace Mirror
             {
                 m_NetworkAddress = s_Address;
             }
+        }
+
+        // Initializes the transport,  by default it is Telepathy
+        // override method if you want to use a different transport
+        public virtual void InitializeTransport()
+        {
+            Transport.layer = new TelepathyWebsocketsMultiplexTransport();
         }
 
         // NetworkIdentity.UNetStaticUpdate is called from UnityEngine while LLAPI network is active.

--- a/Mirror/Runtime/Transport/Transport.cs
+++ b/Mirror/Runtime/Transport/Transport.cs
@@ -9,8 +9,10 @@ namespace Mirror
         // hlapi needs to know max packet size to show warnings
         public static int MaxPacketSize = ushort.MaxValue;
 
-        // selected transport layer: Telepathy by default
-        public static TransportLayer layer = new TelepathyWebsocketsMultiplexTransport();
+        // selected transport layer
+        // the transport is normally initialized in NetworkManager InitializeTransport
+        // initialize it yourself if you are not using NetworkManager
+        public static TransportLayer layer;
     }
 
     // abstract transport layer class //////////////////////////////////////////

--- a/Mirror/Tests/NetworkWriterTest.cs
+++ b/Mirror/Tests/NetworkWriterTest.cs
@@ -31,6 +31,7 @@ namespace Mirror.Tests
         [Test]
         public void TestWritingHugeArray()
         {
+            Transport.MaxPacketSize = 1000000;
             // try serializing array > 64KB and see what happens
             NetworkWriter writer = new NetworkWriter();
             writer.WriteBytesAndSize(new byte[100000]);


### PR DESCRIPTION
This fixes the unit tests,  by avoiding initializing the transport prematurely.