### PR TITLE
Synchronize network time and calculate rtt

### DIFF
--- a/Mirror/Runtime/ClientScene.cs
+++ b/Mirror/Runtime/ClientScene.cs
@@ -218,6 +218,7 @@ namespace Mirror
                 client.RegisterHandler(MsgType.Animation, NetworkAnimator.OnAnimationClientMessage);
                 client.RegisterHandler(MsgType.AnimationParameters, NetworkAnimator.OnAnimationParametersClientMessage);
                 client.RegisterHandler(MsgType.LocalClientAuthority, OnClientAuthority);
+                client.RegisterHandler((short)MsgType.Pong, NetworkTime.OnClientPong);
             }
 
             client.RegisterHandler(MsgType.Rpc, OnRPCMessage);

--- a/Mirror/Runtime/ClientScene.cs
+++ b/Mirror/Runtime/ClientScene.cs
@@ -218,7 +218,7 @@ namespace Mirror
                 client.RegisterHandler(MsgType.Animation, NetworkAnimator.OnAnimationClientMessage);
                 client.RegisterHandler(MsgType.AnimationParameters, NetworkAnimator.OnAnimationParametersClientMessage);
                 client.RegisterHandler(MsgType.LocalClientAuthority, OnClientAuthority);
-                client.RegisterHandler((short)MsgType.Pong, NetworkTime.OnClientPong);
+                client.RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
             }
 
             client.RegisterHandler(MsgType.Rpc, OnRPCMessage);

--- a/Mirror/Runtime/ExponentialMovingAverage.cs
+++ b/Mirror/Runtime/ExponentialMovingAverage.cs
@@ -5,11 +5,11 @@ namespace Mirror
     // it calculates an exponential moving average roughy equivalent to the last n observations
     public class ExponentialMovingAverage
     {
-        private float alpha;
-        private bool initialized = false;
+        float alpha;
+        bool initialized = false;
 
-        private double _value = 0;
-        private double _var = 0;
+        double _value = 0;
+        double _var = 0;
 
         public ExponentialMovingAverage(int n)
         {
@@ -34,14 +34,18 @@ namespace Mirror
             }
         }
 
-        public double Value {
-            get {
+        public double Value 
+        {
+            get 
+            {
                 return _value;
             }
         }
 
-        public double Var {
-            get {
+        public double Var 
+        {
+            get 
+            {
                 return _var;
             }
         }

--- a/Mirror/Runtime/ExponentialMovingAverage.cs
+++ b/Mirror/Runtime/ExponentialMovingAverage.cs
@@ -1,0 +1,49 @@
+﻿using System;
+namespace Mirror
+{
+    // implementation of N-day EMA
+    // it calculates an exponential moving average roughy equivalent to the last n observations
+    public class ExponentialMovingAverage
+    {
+        private float alpha;
+        private bool initialized = false;
+
+        private double _value = 0;
+        private double _var = 0;
+
+        public ExponentialMovingAverage(int n)
+        {
+            // standard N-day EMA alpha calculation
+            alpha = 2.0f / (n + 1);
+        }
+
+        public void Add(double newValue)
+        {
+            // simple algorithm for EMA described here:
+            // https://en.wikipedia.org/wiki/Moving_average#Exponentially_weighted_moving_variance_and_standard_deviation
+            if (initialized)
+            {
+                double delta = newValue - _value;
+                _value = _value + alpha * delta;
+                _var = (1 - alpha) * (_var + alpha * delta * delta);
+            }
+            else
+            {
+                _value = newValue;
+                initialized = true;
+            }
+        }
+
+        public double Value {
+            get {
+                return _value;
+            }
+        }
+
+        public double Var {
+            get {
+                return _var;
+            }
+        }
+    }
+}

--- a/Mirror/Runtime/ExponentialMovingAverage.cs
+++ b/Mirror/Runtime/ExponentialMovingAverage.cs
@@ -3,6 +3,7 @@ namespace Mirror
 {
     // implementation of N-day EMA
     // it calculates an exponential moving average roughy equivalent to the last n observations
+    // https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
     public class ExponentialMovingAverage
     {
         float alpha;

--- a/Mirror/Runtime/Messages.cs
+++ b/Mirror/Runtime/Messages.cs
@@ -65,6 +65,30 @@ namespace Mirror
         }
     }
 
+    public class DoubleMessage : MessageBase
+    {
+        public double value;
+
+        public DoubleMessage()
+        {
+        }
+
+        public DoubleMessage(double v)
+        {
+            value = v;
+        }
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            value = reader.ReadDouble();
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            writer.Write(value);
+        }
+    }
+
     public class EmptyMessage : MessageBase
     {
         public override void Deserialize(NetworkReader reader)
@@ -413,18 +437,14 @@ namespace Mirror
 
     // A client sends this message to the server 
     // to calculate RTT and synchronize time
-    class NetworkPingMessage : MessageBase
+    class NetworkPingMessage : DoubleMessage
     {
-        public double clientTime;
-
-        public override void Deserialize(NetworkReader reader)
+        public NetworkPingMessage()
         {
-            clientTime = reader.ReadDouble();
         }
 
-        public override void Serialize(NetworkWriter writer)
+        public NetworkPingMessage(double value) : base(value)
         {
-            writer.Write(clientTime);
         }
     }
 

--- a/Mirror/Runtime/Messages.cs
+++ b/Mirror/Runtime/Messages.cs
@@ -411,6 +411,43 @@ namespace Mirror
         }
     }
 
+    // A client sends this message to the server 
+    // to calculate RTT and synchronize time
+    class NetworkPingMessage : MessageBase
+    {
+        public double clientTime;
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            clientTime = reader.ReadDouble();
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            writer.Write(clientTime);
+        }
+    }
+
+    // The server responds with this message
+    // The client can use this to calculate RTT and sync time
+    class NetworkPongMessage : MessageBase
+    {
+        public double clientTime;
+        public double serverTime;
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            clientTime = reader.ReadDouble();
+            serverTime = reader.ReadDouble();
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            writer.Write(clientTime);
+            writer.Write(serverTime);
+        }
+    }
+
     class LocalChildTransformMessage : MessageBase
     {
         public NetworkInstanceId netId;

--- a/Mirror/Runtime/Mirror.Runtime.csproj
+++ b/Mirror/Runtime/Mirror.Runtime.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -95,6 +95,8 @@
     <Compile Include="NetworkServer.cs" />
     <Compile Include="SyncList.cs" />
     <Compile Include="NetworkWriter.cs" />
+    <Compile Include="NetworkTime.cs" />
+    <Compile Include="ExponentialMovingAverage.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Mirror/Runtime/NetworkClient.cs
+++ b/Mirror/Runtime/NetworkClient.cs
@@ -293,6 +293,7 @@ namespace Mirror
             }
         }
 
+        [Obsolete("Use NetworkTime.rtt instead")]
         public float GetRTT()
         {
             return (float)NetworkTime.rtt;

--- a/Mirror/Runtime/NetworkClient.cs
+++ b/Mirror/Runtime/NetworkClient.cs
@@ -194,7 +194,7 @@ namespace Mirror
                 return;
             }
 
-            if (connectState == ConnectState.Connected && Time.time - lastPing > pingFrequency)
+            if (connectState == ConnectState.Connected && Time.time - lastPing >= pingFrequency)
             {
                 NetworkPingMessage pingMessage = NetworkTime.GetPing();
                 Send((short)MsgType.Ping, pingMessage);

--- a/Mirror/Runtime/NetworkClient.cs
+++ b/Mirror/Runtime/NetworkClient.cs
@@ -24,7 +24,7 @@ namespace Mirror
         // average out the last few results from Ping
         public int pingWindowSize = 10;
 
-        double lastPing = 0;
+        double lastPingTime = 0;
 
         int m_HostPort;
 
@@ -194,11 +194,11 @@ namespace Mirror
                 return;
             }
 
-            if (connectState == ConnectState.Connected && Time.time - lastPing >= pingFrequency)
+            if (connectState == ConnectState.Connected && Time.time - lastPingTime >= pingFrequency)
             {
                 NetworkPingMessage pingMessage = NetworkTime.GetPing();
                 Send((short)MsgType.Ping, pingMessage);
-                lastPing = Time.time;
+                lastPingTime = Time.time;
             }
 
             // any new message?

--- a/Mirror/Runtime/NetworkClient.cs
+++ b/Mirror/Runtime/NetworkClient.cs
@@ -24,7 +24,7 @@ namespace Mirror
         // average out the last few results from Ping
         public int pingWindowSize = 10;
 
-        private double lastPing = 0;
+        double lastPing = 0;
 
         int m_HostPort;
 

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -96,7 +96,7 @@ namespace Mirror
             RegisterHandler(MsgType.Animation, NetworkAnimator.OnAnimationServerMessage);
             RegisterHandler(MsgType.AnimationParameters, NetworkAnimator.OnAnimationParametersServerMessage);
             RegisterHandler(MsgType.AnimationTrigger, NetworkAnimator.OnAnimationTriggerServerMessage);
-            RegisterHandler((short)MsgType.Ping, NetworkTime.OnServerPing);
+            RegisterHandler(MsgType.Ping, NetworkTime.OnServerPing);
         }
 
         public static bool Listen(int serverPort, int maxConnections)

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -96,6 +96,7 @@ namespace Mirror
             RegisterHandler(MsgType.Animation, NetworkAnimator.OnAnimationServerMessage);
             RegisterHandler(MsgType.AnimationParameters, NetworkAnimator.OnAnimationParametersServerMessage);
             RegisterHandler(MsgType.AnimationTrigger, NetworkAnimator.OnAnimationTriggerServerMessage);
+            RegisterHandler((short)MsgType.Ping, NetworkTime.OnServerPing);
         }
 
         public static bool Listen(int serverPort, int maxConnections)

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -33,10 +33,7 @@ namespace Mirror
 
         internal static NetworkPingMessage GetPing()
         {
-            return new NetworkPingMessage
-            {
-                clientTime = LocalTime()
-            };
+            return new NetworkPingMessage(LocalTime()); 
         }
 
         // executed at the server when we receive a ping message
@@ -51,7 +48,7 @@ namespace Mirror
 
             var pongMsg = new NetworkPongMessage
             {
-                clientTime = pingMsg.clientTime,
+                clientTime = pingMsg.value,
                 serverTime = LocalTime()
             };
 

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -7,13 +7,13 @@ namespace Mirror
     public class NetworkTime 
     {
         // some arbitrary point in time where time started
-        private static readonly DateTime epoch = new DateTime(2018, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        static readonly DateTime epoch = new DateTime(2018, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
-        private static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(10);
-        private static ExponentialMovingAverage _offset = new ExponentialMovingAverage(10);
+        static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(10);
+        static ExponentialMovingAverage _offset = new ExponentialMovingAverage(10);
 
         // returns the clock time _in this system_
-        private static double LocalTime()
+        static double LocalTime()
         {
             var now = DateTime.Now;
             TimeSpan span = DateTime.Now.Subtract(epoch);
@@ -81,7 +81,8 @@ namespace Mirror
         // returns the same time in both client and server
         public static double time
         {
-            get {
+            get 
+            {
                 // Notice _offset is 0 at the server
                 return LocalTime() - _offset.Value;
             }
@@ -91,7 +92,8 @@ namespace Mirror
         // the higher the number,  the less accurate the time is
         public static double timeVar
         {
-            get {
+            get 
+            {
                 return _offset.Var;
             }
         }
@@ -99,14 +101,16 @@ namespace Mirror
         // standard deviation of time
         public static double timeSd
         {
-            get {
+            get 
+            {
                 return Math.Sqrt(timeVar);
             }
         }
 
         public static double offset
         {
-            get {
+            get
+            {
                 return _offset.Value;
             }
         }
@@ -115,7 +119,8 @@ namespace Mirror
         // to the server and come back
         public static double rtt
         {
-            get {
+            get 
+            {
                 return _rtt.Value;
             }
         }
@@ -124,7 +129,8 @@ namespace Mirror
         // the higher the number,  the less accurate rtt is
         public static double rttVar
         {
-            get {
+            get 
+            {
                 return _rtt.Var;
             }
         }

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace Mirror
 {
     // calculates synchronized time and rtt
-    public class NetworkTime 
+    public static class NetworkTime 
     {
         // Date and time when the application started
         static readonly DateTime epoch = DateTime.Now;
@@ -19,11 +19,6 @@ namespace Mirror
             TimeSpan span = DateTime.Now.Subtract(epoch);
             return span.TotalSeconds;
         }
-
-        // how often are we synchronizing the clock
-        public float syncInterval = 2.0f;
-        // average out the last 10 values for RTT
-        public int windowSize = 10;
 
         public static void Reset(int windowSize)
         {

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -6,7 +6,8 @@ namespace Mirror
     // calculates synchronized time and rtt
     public class NetworkTime 
     {
-        // some arbitrary point in time where time started
+        // a fixed point in time.  Both client and server should have the same epoch
+        // so that the clock offset will be small and safe to convert to float
         static readonly DateTime epoch = new DateTime(2018, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
         static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(10);

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -72,7 +72,6 @@ namespace Mirror
 
             _rtt.Add(rtt);
             _offset.Add(offset);
-
         }
 
         // returns the same time in both client and server

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using UnityEngine;
+
+namespace Mirror
+{
+    // calculates synchronized time and rtt
+    public class NetworkTime 
+    {
+        // some arbitrary point in time where time started
+        private static readonly DateTime epoch = new DateTime(2018, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        private static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(10);
+        private static ExponentialMovingAverage _offset = new ExponentialMovingAverage(10);
+
+        // returns the clock time _in this system_
+        private static double LocalTime()
+        {
+            var now = DateTime.Now;
+            TimeSpan span = DateTime.Now.Subtract(epoch);
+            return span.TotalSeconds;
+        }
+
+        // how often are we synchronizing the clock
+        public float syncInterval = 2.0f;
+        // average out the last 10 values for RTT
+        public int windowSize = 10;
+
+        public static void Reset(int windowSize)
+        {
+            _rtt = new ExponentialMovingAverage(windowSize);
+            _offset = new ExponentialMovingAverage(windowSize);
+        }
+
+        internal static NetworkPingMessage GetPing()
+        {
+            return new NetworkPingMessage
+            {
+                clientTime = LocalTime()
+            };
+        }
+
+        // executed at the server when we receive a ping message
+        // reply with a pong containing the time from the client
+        // and time from the server
+        internal static void OnServerPing(NetworkMessage netMsg)
+        {
+            var pingMsg = new NetworkPingMessage();
+            netMsg.ReadMessage(pingMsg);
+
+            if (LogFilter.logDev) { Debug.Log("OnPingServerMessage  conn=" + netMsg.conn); }
+
+            var pongMsg = new NetworkPongMessage
+            {
+                clientTime = pingMsg.clientTime,
+                serverTime = LocalTime()
+            };
+
+            netMsg.conn.Send((short)MsgType.Pong, pongMsg);
+        }
+
+        // Executed at the client when we receive a Pong message
+        // find out how long it took since we sent the Ping
+        // and update time offset
+        internal static void OnClientPong(NetworkMessage netMsg)
+        {
+            NetworkPongMessage pongMsg = new NetworkPongMessage();
+            netMsg.ReadMessage(pongMsg);
+
+            // how long did this message take to come back
+            double rtt = LocalTime() - pongMsg.clientTime;
+            // the difference in time between the client and the server
+            // but subtract half of the rtt to compensate for latency
+            // half of rtt is the best approximation we have
+            double offset = LocalTime() - rtt * 0.5f - pongMsg.serverTime;
+
+            _rtt.Add(rtt);
+            _offset.Add(offset);
+
+        }
+
+        // returns the same time in both client and server
+        public static double time
+        {
+            get {
+                // Notice _offset is 0 at the server
+                return LocalTime() - _offset.Value;
+            }
+        }
+
+        // measure volatility of time.  
+        // the higher the number,  the less accurate the time is
+        public static double timeVar
+        {
+            get {
+                return _offset.Var;
+            }
+        }
+
+        // standard deviation of time
+        public static double timeSd
+        {
+            get {
+                return Math.Sqrt(timeVar);
+            }
+        }
+
+        public static double offset
+        {
+            get {
+                return _offset.Value;
+            }
+        }
+
+        // how long does it take for a message to go 
+        // to the server and come back
+        public static double rtt
+        {
+            get {
+                return _rtt.Value;
+            }
+        }
+
+        // measure volatility of rtt
+        // the higher the number,  the less accurate rtt is
+        public static double rttVar
+        {
+            get {
+                return _rtt.Var;
+            }
+        }
+
+        // standard deviation of rtt
+        public static double rttSd
+        {
+            get
+            {
+                return Math.Sqrt(rttVar);
+            }
+        }
+    }
+}

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -6,9 +6,8 @@ namespace Mirror
     // calculates synchronized time and rtt
     public class NetworkTime 
     {
-        // a fixed point in time.  Both client and server should have the same epoch
-        // so that the clock offset will be small and safe to convert to float
-        static readonly DateTime epoch = new DateTime(2018, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        // Date and time when the application started
+        static readonly DateTime epoch = DateTime.Now;
 
         static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(10);
         static ExponentialMovingAverage _offset = new ExponentialMovingAverage(10);

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -75,6 +75,16 @@ namespace Mirror
         }
 
         // returns the same time in both client and server
+        // time should be a double because after a while
+        // float loses too much accuracy if the server is up for more than 
+        // a few days.  I measured the accuracy of float and I got this:
+        // for the same day,  accuracy is better than 1 ms(edited)
+        // after 1 day,  accuracy goes down to 7 ms(edited)
+        // after 10 days, accuracy is 61 ms(edited)
+        // after 30 days , accuracy is 238 ms(edited)
+        // after 60 days, accuracy is 454 ms(edited)
+        // in other words,  if the server is running for 2 months, 
+        // and you cast down to float,  then the time will jump in 0.4s intervals.
         public static double time
         {
             get 

--- a/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -144,11 +144,6 @@ namespace Mirror
             return true;
         }
 
-        public float ClientGetRTT()
-        {
-            return NetworkTransport.GetCurrentRTT(clientId, clientConnectionId, out error);
-        }
-
         public void ClientDisconnect()
         {
             if (clientId != -1)

--- a/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -50,7 +50,6 @@ namespace Mirror
             data = null;
             return false;
         }
-        public float ClientGetRTT() { return 0; } // TODO
         public void ClientDisconnect() { client.Disconnect(); }
 
         // server

--- a/Mirror/Runtime/Transport/TelepathyWebsocketsMultiplexTransport.cs
+++ b/Mirror/Runtime/Transport/TelepathyWebsocketsMultiplexTransport.cs
@@ -44,10 +44,6 @@ namespace Mirror
         {
             return client.ClientGetNextMessage(out transportEvent, out data);
         }
-        public float ClientGetRTT()
-        {
-            return client.ClientGetRTT();
-        }
         public void ClientDisconnect()
         {
             client.ClientDisconnect();

--- a/Mirror/Runtime/Transport/Transport.cs
+++ b/Mirror/Runtime/Transport/Transport.cs
@@ -25,7 +25,6 @@ namespace Mirror
         void ClientConnect(string address, int port);
         bool ClientSend(byte[] data);
         bool ClientGetNextMessage(out TransportEvent transportEvent, out byte[] data);
-        float ClientGetRTT();
         void ClientDisconnect();
 
         // server

--- a/Mirror/Runtime/UNetwork.cs
+++ b/Mirror/Runtime/UNetwork.cs
@@ -57,8 +57,6 @@ namespace Mirror
         Pong = 44,
 
         Highest = 47
-
-
     }
 
     public class NetworkMessage

--- a/Mirror/Runtime/UNetwork.cs
+++ b/Mirror/Runtime/UNetwork.cs
@@ -52,7 +52,13 @@ namespace Mirror
         AnimationParameters = 41,
         AnimationTrigger = 42,
 
+        // time synchronization
+        Ping = 43,
+        Pong = 44,
+
         Highest = 47
+
+
     }
 
     public class NetworkMessage

--- a/Mirror/Tests/ExponentialMovingAverageTest.cs
+++ b/Mirror/Tests/ExponentialMovingAverageTest.cs
@@ -1,0 +1,46 @@
+﻿using NUnit.Framework;
+using System;
+namespace Mirror
+{
+    [TestFixture]
+    public class ExponentialMovingAverageTest
+    {
+        [Test]
+        public void TestInitial()
+        {
+            var ema = new ExponentialMovingAverage(10);
+
+            ema.Add(3);
+
+            Assert.That(ema.Value, Is.EqualTo(3));
+            Assert.That(ema.Var, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestMovingAverage()
+        {
+            var ema = new ExponentialMovingAverage(10);
+
+            ema.Add(5);
+            ema.Add(6);
+
+            Assert.That(ema.Value, Is.EqualTo(5.1818).Within(0.0001f));
+            Assert.That(ema.Var, Is.EqualTo(0.1487).Within(0.0001f));
+
+        }
+
+        [Test]
+        public void TestVar()
+        {
+            var ema = new ExponentialMovingAverage(10);
+
+            ema.Add(5);
+            ema.Add(6);
+            ema.Add(7);
+
+            Assert.That(ema.Var, Is.EqualTo(0.6134).Within(0.0001f));
+
+        }
+
+    }
+}

--- a/Mirror/Tests/Mirror.Tests.csproj
+++ b/Mirror/Tests/Mirror.Tests.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="NetworkWriterTest.cs" />
     <Compile Include="NetworkHash128Test.cs" />
+    <Compile Include="ExponentialMovingAverageTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
NetworkClient and NetworkServer  now send a ping/pong message back and forth with times.

The times are used to synchronize clocks as well as calculate rtt.

The statistics are updated using EMA to smooth out erratic network behavior.