### PR TITLE
Network animator optimizations

### DIFF
--- a/Mirror/Runtime/NetworkAnimator.cs
+++ b/Mirror/Runtime/NetworkAnimator.cs
@@ -231,6 +231,8 @@ namespace Mirror
 
         void WriteParameters(NetworkWriter writer, bool autoSend)
         {
+            // store the animator parameters in a variable - the "Animator.parameters" getter allocates
+            // a new parameter array every time it is accessed so we should avoid doing it in a loop
             AnimatorControllerParameter[] parameters = m_Animator.parameters;
 
             for (int i = 0; i < parameters.Length; i++)
@@ -261,6 +263,8 @@ namespace Mirror
 
         void ReadParameters(NetworkReader reader, bool autoSend)
         {
+            // store the animator parameters in a variable - the "Animator.parameters" getter allocates
+            // a new parameter array every time it is accessed so we should avoid doing it in a loop
             AnimatorControllerParameter[] parameters = m_Animator.parameters;
 
             for (int i = 0; i < parameters.Length; i++)

--- a/Mirror/Runtime/NetworkAnimator.cs
+++ b/Mirror/Runtime/NetworkAnimator.cs
@@ -241,24 +241,24 @@ namespace Mirror
                     continue;
 
                 AnimatorControllerParameter par = parameters[i];
-                switch (par.type)
+                if (par.type == AnimatorControllerParameterType.Int)
                 {
-                    case AnimatorControllerParameterType.Int:
-                        writer.WritePackedUInt32((uint)m_Animator.GetInteger(par.nameHash));
-                        SetSendTrackingParam(par.name + ":" + m_Animator.GetInteger(par.nameHash), i);
-                        break;
-
-                    case AnimatorControllerParameterType.Float:
-                        writer.Write(m_Animator.GetFloat(par.nameHash));
-                        SetSendTrackingParam(par.name + ":" + m_Animator.GetFloat(par.nameHash), i);
-                        break;
-
-                    case AnimatorControllerParameterType.Bool:
-                        writer.Write(m_Animator.GetBool(par.nameHash));
-                        SetSendTrackingParam(par.name + ":" + m_Animator.GetBool(par.nameHash), i);
-                        break;
+                    writer.WritePackedUInt32((uint)m_Animator.GetInteger(par.nameHash));
+                    
+                    SetSendTrackingParam(par.name + ":" + m_Animator.GetInteger(par.nameHash), i);
                 }
-            }
+                else if (par.type == AnimatorControllerParameterType.Float)
+                {
+                    writer.Write(m_Animator.GetFloat(par.nameHash));
+
+                    SetSendTrackingParam(par.name + ":" + m_Animator.GetFloat(par.nameHash), i);
+                }
+                else if (par.type == AnimatorControllerParameterType.Bool)
+                {
+                    writer.Write(m_Animator.GetBool(par.nameHash));
+
+                    SetSendTrackingParam(par.name + ":" + m_Animator.GetBool(par.nameHash), i);
+                }
         }
 
         void ReadParameters(NetworkReader reader, bool autoSend)
@@ -273,25 +273,26 @@ namespace Mirror
                     continue;
 
                 AnimatorControllerParameter par = parameters[i];
-                switch (par.type)
+                if (par.type == AnimatorControllerParameterType.Int)
                 {
-                    case AnimatorControllerParameterType.Int:
-                        int newValue = (int)reader.ReadPackedUInt32();
-                        m_Animator.SetInteger(par.nameHash, newValue);
-                        SetRecvTrackingParam(par.name + ":" + newValue, i);
-                        break;
+                    int newValue = (int)reader.ReadPackedUInt32();
+                    m_Animator.SetInteger(par.nameHash, newValue);
 
-                    case AnimatorControllerParameterType.Float:
-                        float newFloatValue = reader.ReadSingle();
-                        m_Animator.SetFloat(par.nameHash, newFloatValue);
-                        SetRecvTrackingParam(par.name + ":" + newFloatValue, i);
-                        break;
+                    SetRecvTrackingParam(par.name + ":" + newValue, i);
+                }
+                else if (par.type == AnimatorControllerParameterType.Float)
+                {
+                    float newFloatValue = reader.ReadSingle();
+                    m_Animator.SetFloat(par.nameHash, newFloatValue);
 
-                    case AnimatorControllerParameterType.Bool:
-                        bool newBoolValue = reader.ReadBoolean();
-                        m_Animator.SetBool(par.nameHash, newBoolValue);
-                        SetRecvTrackingParam(par.name + ":" + newBoolValue, i);
-                        break;
+                    SetRecvTrackingParam(par.name + ":" + newFloatValue, i);
+                }
+                else if (par.type == AnimatorControllerParameterType.Bool)
+                {
+                    bool newBoolValue = reader.ReadBoolean();
+                    m_Animator.SetBool(par.nameHash, newBoolValue);
+
+                    SetRecvTrackingParam(par.name + ":" + newBoolValue, i);
                 }
             }
         }

--- a/Mirror/Runtime/NetworkAnimator.cs
+++ b/Mirror/Runtime/NetworkAnimator.cs
@@ -247,13 +247,15 @@ namespace Mirror
 
                     SetSendTrackingParam(par.name + ":" + m_Animator.GetInteger(par.nameHash), i);
                 }
-                else if (par.type == AnimatorControllerParameterType.Float)
+
+                if (par.type == AnimatorControllerParameterType.Float)
                 {
                     writer.Write(m_Animator.GetFloat(par.nameHash));
 
                     SetSendTrackingParam(par.name + ":" + m_Animator.GetFloat(par.nameHash), i);
                 }
-                else if (par.type == AnimatorControllerParameterType.Bool)
+
+                if (par.type == AnimatorControllerParameterType.Bool)
                 {
                     writer.Write(m_Animator.GetBool(par.nameHash));
 
@@ -281,14 +283,16 @@ namespace Mirror
 
                     SetRecvTrackingParam(par.name + ":" + newValue, i);
                 }
-                else if (par.type == AnimatorControllerParameterType.Float)
+
+                if (par.type == AnimatorControllerParameterType.Float)
                 {
                     float newFloatValue = reader.ReadSingle();
                     m_Animator.SetFloat(par.nameHash, newFloatValue);
 
                     SetRecvTrackingParam(par.name + ":" + newFloatValue, i);
                 }
-                else if (par.type == AnimatorControllerParameterType.Bool)
+
+                if (par.type == AnimatorControllerParameterType.Bool)
                 {
                     bool newBoolValue = reader.ReadBoolean();
                     m_Animator.SetBool(par.nameHash, newBoolValue);

--- a/Mirror/Runtime/NetworkAnimator.cs
+++ b/Mirror/Runtime/NetworkAnimator.cs
@@ -239,25 +239,22 @@ namespace Mirror
                     continue;
 
                 AnimatorControllerParameter par = parameters[i];
-                if (par.type == AnimatorControllerParameterType.Int)
+                switch (par.type)
                 {
-                    writer.WritePackedUInt32((uint)m_Animator.GetInteger(par.nameHash));
+                    case AnimatorControllerParameterType.Int:
+                        writer.WritePackedUInt32((uint)m_Animator.GetInteger(par.nameHash));
+                        SetSendTrackingParam(par.name + ":" + m_Animator.GetInteger(par.nameHash), i);
+                        break;
 
-                    SetSendTrackingParam(par.name + ":" + m_Animator.GetInteger(par.nameHash), i);
-                }
+                    case AnimatorControllerParameterType.Float:
+                        writer.Write(m_Animator.GetFloat(par.nameHash));
+                        SetSendTrackingParam(par.name + ":" + m_Animator.GetFloat(par.nameHash), i);
+                        break;
 
-                if (par.type == AnimatorControllerParameterType.Float)
-                {
-                    writer.Write(m_Animator.GetFloat(par.nameHash));
-
-                    SetSendTrackingParam(par.name + ":" + m_Animator.GetFloat(par.nameHash), i);
-                }
-
-                if (par.type == AnimatorControllerParameterType.Bool)
-                {
-                    writer.Write(m_Animator.GetBool(par.nameHash));
-
-                    SetSendTrackingParam(par.name + ":" + m_Animator.GetBool(par.nameHash), i);
+                    case AnimatorControllerParameterType.Bool:
+                        writer.Write(m_Animator.GetBool(par.nameHash));
+                        SetSendTrackingParam(par.name + ":" + m_Animator.GetBool(par.nameHash), i);
+                        break;
                 }
             }
         }
@@ -272,28 +269,25 @@ namespace Mirror
                     continue;
 
                 AnimatorControllerParameter par = parameters[i];
-                if (par.type == AnimatorControllerParameterType.Int)
+                switch (par.type)
                 {
-                    int newValue = (int)reader.ReadPackedUInt32();
-                    m_Animator.SetInteger(par.nameHash, newValue);
+                    case AnimatorControllerParameterType.Int:
+                        int newValue = (int)reader.ReadPackedUInt32();
+                        m_Animator.SetInteger(par.nameHash, newValue);
+                        SetRecvTrackingParam(par.name + ":" + newValue, i);
+                        break;
 
-                    SetRecvTrackingParam(par.name + ":" + newValue, i);
-                }
+                    case AnimatorControllerParameterType.Float:
+                        float newFloatValue = reader.ReadSingle();
+                        m_Animator.SetFloat(par.nameHash, newFloatValue);
+                        SetRecvTrackingParam(par.name + ":" + newFloatValue, i);
+                        break;
 
-                if (par.type == AnimatorControllerParameterType.Float)
-                {
-                    float newFloatValue = reader.ReadSingle();
-                    m_Animator.SetFloat(par.nameHash, newFloatValue);
-
-                    SetRecvTrackingParam(par.name + ":" + newFloatValue, i);
-                }
-
-                if (par.type == AnimatorControllerParameterType.Bool)
-                {
-                    bool newBoolValue = reader.ReadBoolean();
-                    m_Animator.SetBool(par.nameHash, newBoolValue);
-
-                    SetRecvTrackingParam(par.name + ":" + newBoolValue, i);
+                    case AnimatorControllerParameterType.Bool:
+                        bool newBoolValue = reader.ReadBoolean();
+                        m_Animator.SetBool(par.nameHash, newBoolValue);
+                        SetRecvTrackingParam(par.name + ":" + newBoolValue, i);
+                        break;
                 }
             }
         }

--- a/Mirror/Runtime/NetworkAnimator.cs
+++ b/Mirror/Runtime/NetworkAnimator.cs
@@ -231,12 +231,14 @@ namespace Mirror
 
         void WriteParameters(NetworkWriter writer, bool autoSend)
         {
-            for (int i = 0; i < m_Animator.parameters.Length; i++)
+            AnimatorControllerParameter[] parameters = m_Animator.parameters;
+
+            for (int i = 0; i < parameters.Length; i++)
             {
                 if (autoSend && !GetParameterAutoSend(i))
                     continue;
 
-                AnimatorControllerParameter par = m_Animator.parameters[i];
+                AnimatorControllerParameter par = parameters[i];
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
                     writer.WritePackedUInt32((uint)m_Animator.GetInteger(par.nameHash));
@@ -262,12 +264,14 @@ namespace Mirror
 
         void ReadParameters(NetworkReader reader, bool autoSend)
         {
-            for (int i = 0; i < m_Animator.parameters.Length; i++)
+            AnimatorControllerParameter[] parameters = m_Animator.parameters;
+
+            for (int i = 0; i < parameters.Length; i++)
             {
                 if (autoSend && !GetParameterAutoSend(i))
                     continue;
 
-                AnimatorControllerParameter par = m_Animator.parameters[i];
+                AnimatorControllerParameter par = parameters[i];
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
                     int newValue = (int)reader.ReadPackedUInt32();

--- a/Mirror/Runtime/NetworkAnimator.cs
+++ b/Mirror/Runtime/NetworkAnimator.cs
@@ -244,7 +244,7 @@ namespace Mirror
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
                     writer.WritePackedUInt32((uint)m_Animator.GetInteger(par.nameHash));
-                    
+
                     SetSendTrackingParam(par.name + ":" + m_Animator.GetInteger(par.nameHash), i);
                 }
                 else if (par.type == AnimatorControllerParameterType.Float)
@@ -259,6 +259,7 @@ namespace Mirror
 
                     SetSendTrackingParam(par.name + ":" + m_Animator.GetBool(par.nameHash), i);
                 }
+            }
         }
 
         void ReadParameters(NetworkReader reader, bool autoSend)


### PR DESCRIPTION
This is an old pull request that I made in the UNET repo that never got merged:

https://bitbucket.org/Unity-Technologies/networking/pull-requests/21/cache-animator-parameters-to-avoid/diff

> This is a simple optimization to minimize the amount of calls to the `Animator.parameters` getter which turns out to be an extremely costly operation.
> *  Profiler before: https://i.imgur.com/2hDW2Lf.png
> *  Profiler after: https://i.imgur.com/tjeb0Fi.png

Keep in mind that we could go with this even *further* and cache the parameters in the NetworkAnimator object to avoid allocations completely. However, I'm not sure how that would behave in practice, especially in development. The developer could tweak the parameters at runtime - maybe we could handle that separately as a specific `#if UNITY_EDITOR` case, and only optimize in builds (where we're guaranteed (?) that things don't change at runtime).