### PR TITLE
Removed [ServerCallback] / [ClientCallback], use [Server]/[Client] instead

### DIFF
--- a/Mirror/Runtime/CustomAttributes.cs
+++ b/Mirror/Runtime/CustomAttributes.cs
@@ -41,17 +41,7 @@ namespace Mirror
     }
 
     [AttributeUsage(AttributeTargets.Method)]
-    public class ServerCallbackAttribute : Attribute
-    {
-    }
-
-    [AttributeUsage(AttributeTargets.Method)]
     public class ClientAttribute : Attribute
-    {
-    }
-
-    [AttributeUsage(AttributeTargets.Method)]
-    public class ClientCallbackAttribute : Attribute
     {
     }
 }

--- a/Mirror/Weaver/MonoBehaviourProcessor.cs
+++ b/Mirror/Weaver/MonoBehaviourProcessor.cs
@@ -73,19 +73,9 @@ namespace Mirror.Weaver
                         Log.Error("Script " + m_td.FullName + " uses the attribute [Server] on the method " + md.Name + " but is not a NetworkBehaviour.");
                         Weaver.fail = true;
                     }
-                    else if (attrName == "Mirror.ServerCallbackAttribute")
-                    {
-                        Log.Error("Script " + m_td.FullName + " uses the attribute [ServerCallback] on the method " + md.Name + " but is not a NetworkBehaviour.");
-                        Weaver.fail = true;
-                    }
                     else if (attrName == "Mirror.ClientAttribute")
                     {
                         Log.Error("Script " + m_td.FullName + " uses the attribute [Client] on the method " + md.Name + " but is not a NetworkBehaviour.");
-                        Weaver.fail = true;
-                    }
-                    else if (attrName == "Mirror.ClientCallbackAttribute")
-                    {
-                        Log.Error("Script " + m_td.FullName + " uses the attribute [ClientCallback] on the method " + md.Name + " but is not a NetworkBehaviour.");
                         Weaver.fail = true;
                     }
                 }


### PR DESCRIPTION
ServerCallback was meant only for MonoBehaviour functions like Update:
https://docs.unity3d.com/ScriptReference/Networking.ServerCallbackAttribute.html

The big question is, what is [Server] supposed to do?
a) This function is server-only and show warning if tried to call on client
b) This function will silently return if tried to call on Client

a) is good for development/debugging
b) is good for MonoBehaviour functions like Update

This pull request is a mix between a) and b), where it shows warnings UNLESS for Update etc.

Alternatives:

1. [Server(warning=false)]
2. [Server] always warns and just don't use it for MonoBehaviour functions like Update
3. No tags, always use 'if (!isServer) return;' and do exactly what you want to do there.
4. Keep [ServerCallback] for those 'callback' functions
5. Better name for [ServerCallback]?
