### PR TITLE
Remove redundant null checks.

### DIFF
--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -826,7 +826,7 @@ namespace Mirror
                     foreach (KeyValuePair<int, NetworkConnection> kvp in NetworkServer.connections)
                     {
                         NetworkConnection conn = kvp.Value;
-                        if (conn != null && conn.isReady)
+                        if (conn.isReady)
                             AddObserver(conn);
                     }
 


### PR DESCRIPTION
Enforce that connections are added in AddConnection and removed with RemoveConnection.
Since connection cannot be null anymore,  remove redundant null checks.