### PR TITLE
Avoid array allocations in NetworkWriter.ToArray()

### DIFF
--- a/Mirror/Runtime/NetworkWriter.cs
+++ b/Mirror/Runtime/NetworkWriter.cs
@@ -25,7 +25,10 @@ namespace Mirror
         {
             writer.Flush();
             byte[] slice = new byte[Position];
-            Array.Copy(((MemoryStream)writer.BaseStream).ToArray(), slice, Position);
+
+            // We can use MemoryStream.GetBuffer() to obtain the stream's underlaying array without copying it.
+            // This is safe because we're manually returning a copy of the array anyway.
+            Array.Copy(((MemoryStream)writer.BaseStream).GetBuffer(), slice, Position);
             return slice;
         }
 


### PR DESCRIPTION
We can use MemoryStream.GetBuffer() to obtain the underlaying array.
This is safe because we're returning a copy of the array anyway.

See: https://referencesource.microsoft.com/#mscorlib/system/io/memorystream.cs,5df5fc757781f05e,references