### PR TITLE
Fix issue #75, determining the command target

### DIFF
--- a/Mirror/Runtime/Messages.cs
+++ b/Mirror/Runtime/Messages.cs
@@ -149,12 +149,14 @@ namespace Mirror
     class CommandMessage : MessageBase
     {
         public uint netId;
+        public byte componentIndex;
         public int cmdHash;
         public byte[] payload; // the parameters for the Cmd function
 
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
+            componentIndex = reader.ReadByte();
             cmdHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
             payload = reader.ReadBytesAndSize();
         }
@@ -162,6 +164,7 @@ namespace Mirror
         public override void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
+            writer.Write(componentIndex);
             writer.Write(cmdHash);
             writer.WriteBytesAndSize(payload);
         }

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -48,6 +48,22 @@ namespace Mirror
             }
         }
 
+        public byte ComponentIndex { 
+            get 
+            {
+                NetworkBehaviour[] components = GetComponents<NetworkBehaviour>();
+
+                for (int i = 0; i < components.Length; i++)
+                {
+                    if (components[i] == this)
+                        return (byte)i;
+                }
+                // this should never happen
+                Debug.LogError("Could not find component in gameobject", this);
+                return 0;
+            } 
+        }
+
         // this gets called in the constructor by the weaver
         // for every SyncObject in the component (e.g. SyncLists).
         // We collect all of them and we synchronize them with OnSerialize/OnDeserialize
@@ -77,6 +93,7 @@ namespace Mirror
             // construct the message
             CommandMessage message = new CommandMessage();
             message.netId = netId;
+            message.componentIndex = ComponentIndex;
             message.cmdHash = cmdHash;
             message.payload = writer.ToArray();
 

--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -607,7 +607,7 @@ namespace Mirror
         }
 
         // happens on server
-        internal void HandleCommand(int cmdHash, NetworkReader reader)
+        internal void HandleCommand(byte componentIndex, int cmdHash, NetworkReader reader)
         {
             // this doesn't use NetworkBehaviour.InvokeCommand function (anymore). this method of calling is faster.
             // The hash is only looked up once, insted of twice(!) per NetworkBehaviour on the object.
@@ -632,14 +632,14 @@ namespace Mirror
             }
 
             // find the right component to invoke the function on
-            NetworkBehaviour invokeComponent;
-            if (!GetInvokeComponent(cmdHash, invokeClass, out invokeComponent))
+            if (componentIndex >= m_NetworkBehaviours.Length)
             {
                 string errorCmdName = NetworkBehaviour.GetCmdHashHandlerName(cmdHash);
                 if (LogFilter.logWarn) { Debug.LogWarning("Command [" + errorCmdName + "] handler not found [netId=" + netId + "]"); }
                 return;
             }
-
+            NetworkBehaviour invokeComponent = m_NetworkBehaviours[componentIndex];
+           
             invokeFunction(invokeComponent, reader);
         }
 

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -904,7 +904,7 @@ namespace Mirror
             }
 
             if (LogFilter.logDev) { Debug.Log("OnCommandMessage for netId=" + message.netId + " conn=" + netMsg.conn); }
-            uv.HandleCommand(message.cmdHash, new NetworkReader(message.payload));
+            uv.HandleCommand(message.componentIndex, message.cmdHash, new NetworkReader(message.payload));
         }
 
         internal static void SpawnObject(GameObject obj)


### PR DESCRIPTION
If you add the same networkbehavior twice to a gameobject,  only the commands in the first one work.

This can also happen if you have a base class,  you inherit it,  and you add more than one of the inherited classes to the same gameobject.

It should fix issue #75 for commands,  I still need to fix ClientRpc, TargetRPC and NetworkEvents,  but lets see if this works first