### PR TITLE
Fix #75, determine the RPC target

### DIFF
--- a/Mirror/Runtime/ClientScene.cs
+++ b/Mirror/Runtime/ClientScene.cs
@@ -558,7 +558,7 @@ namespace Mirror
             NetworkIdentity uv;
             if (s_NetworkScene.GetNetworkIdentity(message.netId, out uv))
             {
-                uv.HandleRPC(message.rpcHash, new NetworkReader(message.payload));
+                uv.HandleRPC(message.componentIndex, message.rpcHash, new NetworkReader(message.payload));
             }
             else
             {
@@ -579,7 +579,7 @@ namespace Mirror
             NetworkIdentity uv;
             if (s_NetworkScene.GetNetworkIdentity(message.netId, out uv))
             {
-                uv.HandleSyncEvent(message.eventHash, new NetworkReader(message.payload));
+                uv.HandleSyncEvent(message.componentIndex, message.eventHash, new NetworkReader(message.payload));
             }
             else
             {

--- a/Mirror/Runtime/Messages.cs
+++ b/Mirror/Runtime/Messages.cs
@@ -149,12 +149,14 @@ namespace Mirror
     class CommandMessage : MessageBase
     {
         public uint netId;
+        public byte componentIndex;
         public int cmdHash;
         public byte[] payload; // the parameters for the Cmd function
 
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
+            componentIndex = reader.ReadByte();
             cmdHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
             payload = reader.ReadBytesAndSize();
         }
@@ -162,6 +164,7 @@ namespace Mirror
         public override void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
+            writer.Write(componentIndex);
             writer.Write(cmdHash);
             writer.WriteBytesAndSize(payload);
         }

--- a/Mirror/Runtime/Messages.cs
+++ b/Mirror/Runtime/Messages.cs
@@ -149,14 +149,14 @@ namespace Mirror
     class CommandMessage : MessageBase
     {
         public uint netId;
+        public int componentIndex;
         public int cmdHash;
-        public byte componentIndex;
         public byte[] payload; // the parameters for the Cmd function
 
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
-            componentIndex = reader.ReadByte();
+            componentIndex = (int)reader.ReadPackedUInt32();
             cmdHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
             payload = reader.ReadBytesAndSize();
         }
@@ -164,7 +164,7 @@ namespace Mirror
         public override void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
-            writer.Write(componentIndex);
+            writer.WritePackedUInt32((uint)componentIndex);
             writer.Write(cmdHash);
             writer.WriteBytesAndSize(payload);
         }
@@ -173,14 +173,14 @@ namespace Mirror
     class RpcMessage : MessageBase
     {
         public uint netId;
+        public int componentIndex;
         public int rpcHash;
-        public byte componentIndex;
         public byte[] payload; // the parameters for the Rpc function
 
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
-            componentIndex = reader.ReadByte();
+            componentIndex = (int)reader.ReadPackedUInt32();
             rpcHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
             payload = reader.ReadBytesAndSize();
         }
@@ -188,7 +188,7 @@ namespace Mirror
         public override void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
-            writer.Write(componentIndex);
+            writer.WritePackedUInt32((uint)componentIndex);
             writer.Write(rpcHash);
             writer.WriteBytesAndSize(payload);
         }
@@ -197,14 +197,14 @@ namespace Mirror
     class SyncEventMessage : MessageBase
     {
         public uint netId;
+        public int componentIndex;
         public int eventHash;
-        public byte componentIndex;
         public byte[] payload; // the parameters for the Rpc function
 
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
-            componentIndex = reader.ReadByte();
+            componentIndex = (int)reader.ReadPackedUInt32();
             eventHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
             payload = reader.ReadBytesAndSize();
         }
@@ -212,7 +212,7 @@ namespace Mirror
         public override void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
-            writer.Write(componentIndex);
+            writer.WritePackedUInt32((uint)componentIndex);
             writer.Write(eventHash);
             writer.WriteBytesAndSize(payload);
         }

--- a/Mirror/Runtime/Messages.cs
+++ b/Mirror/Runtime/Messages.cs
@@ -149,8 +149,8 @@ namespace Mirror
     class CommandMessage : MessageBase
     {
         public uint netId;
-        public byte componentIndex;
         public int cmdHash;
+        public byte componentIndex;
         public byte[] payload; // the parameters for the Cmd function
 
         public override void Deserialize(NetworkReader reader)
@@ -174,11 +174,13 @@ namespace Mirror
     {
         public uint netId;
         public int rpcHash;
+        public byte componentIndex;
         public byte[] payload; // the parameters for the Rpc function
 
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
+            componentIndex = reader.ReadByte();
             rpcHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
             payload = reader.ReadBytesAndSize();
         }
@@ -186,6 +188,7 @@ namespace Mirror
         public override void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
+            writer.Write(componentIndex);
             writer.Write(rpcHash);
             writer.WriteBytesAndSize(payload);
         }
@@ -195,11 +198,13 @@ namespace Mirror
     {
         public uint netId;
         public int eventHash;
+        public byte componentIndex;
         public byte[] payload; // the parameters for the Rpc function
 
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
+            componentIndex = reader.ReadByte();
             eventHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
             payload = reader.ReadBytesAndSize();
         }
@@ -207,6 +212,7 @@ namespace Mirror
         public override void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
+            writer.Write(componentIndex);
             writer.Write(eventHash);
             writer.WriteBytesAndSize(payload);
         }

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -54,14 +54,14 @@ namespace Mirror
             {
                 NetworkBehaviour[] components = m_MyView.NetworkBehaviours;
 
-                for (int i = 0; i < components.Length; i++)
+                int index = Array.FindIndex(components, component => component == this);
+                if (index < 0)
                 {
-                    if (components[i] == this)
-                        return (byte)i;
+                    // this should never happen
+                    Debug.LogError("Could not find component in gameobject. You shoud not add/remove components in networked objects dinamically", this);
                 }
-                // this should never happen
-                Debug.LogError("Could not find component in gameobject", this);
-                return 0;
+
+                return (byte)index;
             } 
         }
 

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -48,7 +48,8 @@ namespace Mirror
             }
         }
 
-        public byte ComponentIndex { 
+        public byte ComponentIndex 
+        { 
             get 
             {
                 NetworkBehaviour[] components = GetComponents<NetworkBehaviour>();

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -52,7 +52,7 @@ namespace Mirror
         { 
             get 
             {
-                NetworkBehaviour[] components = GetComponents<NetworkBehaviour>();
+                NetworkBehaviour[] components = m_MyView.NetworkBehaviours;
 
                 for (int i = 0; i < components.Length; i++)
                 {

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -121,6 +121,7 @@ namespace Mirror
             // construct the message
             RpcMessage message = new RpcMessage();
             message.netId = netId;
+            message.componentIndex = ComponentIndex;
             message.rpcHash = rpcHash;
             message.payload = writer.ToArray();
 
@@ -140,6 +141,7 @@ namespace Mirror
             // construct the message
             RpcMessage message = new RpcMessage();
             message.netId = netId;
+            message.componentIndex = ComponentIndex;
             message.rpcHash = rpcHash;
             message.payload = writer.ToArray();
 
@@ -166,6 +168,7 @@ namespace Mirror
             // construct the message
             SyncEventMessage message = new SyncEventMessage();
             message.netId = netId;
+            message.componentIndex = ComponentIndex;
             message.eventHash = eventHash;
             message.payload = writer.ToArray();
 
@@ -261,28 +264,27 @@ namespace Mirror
         }
 
         // wrapper fucntions for each type of network operation
-        internal static bool GetInvokerForHashCommand(int cmdHash, out Type invokeClass, out CmdDelegate invokeFunction)
+        internal static bool GetInvokerForHashCommand(int cmdHash, out CmdDelegate invokeFunction)
         {
-            return GetInvokerForHash(cmdHash, UNetInvokeType.Command, out invokeClass, out invokeFunction);
+            return GetInvokerForHash(cmdHash, UNetInvokeType.Command, out invokeFunction);
         }
 
-        internal static bool GetInvokerForHashClientRpc(int cmdHash, out Type invokeClass, out CmdDelegate invokeFunction)
+        internal static bool GetInvokerForHashClientRpc(int cmdHash, out CmdDelegate invokeFunction)
         {
-            return GetInvokerForHash(cmdHash, UNetInvokeType.ClientRpc, out invokeClass, out invokeFunction);
+            return GetInvokerForHash(cmdHash, UNetInvokeType.ClientRpc, out invokeFunction);
         }
 
-        internal static bool GetInvokerForHashSyncEvent(int cmdHash, out Type invokeClass, out CmdDelegate invokeFunction)
+        internal static bool GetInvokerForHashSyncEvent(int cmdHash, out CmdDelegate invokeFunction)
         {
-            return GetInvokerForHash(cmdHash, UNetInvokeType.SyncEvent, out invokeClass, out invokeFunction);
+            return GetInvokerForHash(cmdHash, UNetInvokeType.SyncEvent, out invokeFunction);
         }
 
-        static bool GetInvokerForHash(int cmdHash, UNetInvokeType invokeType, out Type invokeClass, out CmdDelegate invokeFunction)
+        static bool GetInvokerForHash(int cmdHash, UNetInvokeType invokeType, out CmdDelegate invokeFunction)
         {
             Invoker invoker = null;
             if (!s_CmdHandlerDelegates.TryGetValue(cmdHash, out invoker))
             {
                 if (LogFilter.logDev) { Debug.Log("GetInvokerForHash hash:" + cmdHash + " not found"); }
-                invokeClass = null;
                 invokeFunction = null;
                 return false;
             }
@@ -290,7 +292,6 @@ namespace Mirror
             if (invoker == null)
             {
                 if (LogFilter.logDev) { Debug.Log("GetInvokerForHash hash:" + cmdHash + " invoker null"); }
-                invokeClass = null;
                 invokeFunction = null;
                 return false;
             }
@@ -298,12 +299,10 @@ namespace Mirror
             if (invoker.invokeType != invokeType)
             {
                 if (LogFilter.logError) { Debug.LogError("GetInvokerForHash hash:" + cmdHash + " mismatched invokeType"); }
-                invokeClass = null;
                 invokeFunction = null;
                 return false;
             }
 
-            invokeClass = invoker.invokeClass;
             invokeFunction = invoker.invokeFunction;
             return true;
         }

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -48,6 +48,22 @@ namespace Mirror
             }
         }
 
+        public byte ComponentIndex { 
+            get 
+            {
+                NetworkBehaviour[] components = GetComponents<NetworkBehaviour>();
+
+                for (int i = 0; i < components.Length; i++)
+                {
+                    if (components[i] == this)
+                        return (byte)i;
+                }
+                // this should never happen
+                Debug.LogError("Could not find component in gameobject", this);
+                return 0;
+            } 
+        }
+
         // this gets called in the constructor by the weaver
         // for every SyncObject in the component (e.g. SyncLists).
         // We collect all of them and we synchronize them with OnSerialize/OnDeserialize
@@ -77,6 +93,7 @@ namespace Mirror
             // construct the message
             CommandMessage message = new CommandMessage();
             message.netId = netId;
+            message.componentIndex = ComponentIndex;
             message.cmdHash = cmdHash;
             message.payload = writer.ToArray();
 

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -220,7 +220,7 @@ namespace Mirror
             inv.invokeClass = invokeClass;
             inv.invokeFunction = func;
             s_CmdHandlerDelegates[cmdHash] = inv;
-            if (LogFilter.logDebug) { Debug.Log("RegisterCommandDelegate hash:" + cmdHash + " " + func.GetMethodName()); }
+            if (LogFilter.Debug) { Debug.Log("RegisterCommandDelegate hash:" + cmdHash + " " + func.GetMethodName()); }
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -235,7 +235,7 @@ namespace Mirror
             inv.invokeClass = invokeClass;
             inv.invokeFunction = func;
             s_CmdHandlerDelegates[cmdHash] = inv;
-            if (LogFilter.logDebug) { Debug.Log("RegisterRpcDelegate hash:" + cmdHash + " " + func.GetMethodName()); }
+            if (LogFilter.Debug) { Debug.Log("RegisterRpcDelegate hash:" + cmdHash + " " + func.GetMethodName()); }
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -250,7 +250,7 @@ namespace Mirror
             inv.invokeClass = invokeClass;
             inv.invokeFunction = func;
             s_CmdHandlerDelegates[cmdHash] = inv;
-            if (LogFilter.logDebug) { Debug.Log("RegisterEventDelegate hash:" + cmdHash + " " + func.GetMethodName()); }
+            if (LogFilter.Debug) { Debug.Log("RegisterEventDelegate hash:" + cmdHash + " " + func.GetMethodName()); }
         }
 
         internal static string GetInvoker(int cmdHash)
@@ -285,14 +285,14 @@ namespace Mirror
             Invoker invoker = null;
             if (!s_CmdHandlerDelegates.TryGetValue(cmdHash, out invoker))
             {
-                if (LogFilter.logDebug) { Debug.Log("GetInvokerForHash hash:" + cmdHash + " not found"); }
+                if (LogFilter.Debug) { Debug.Log("GetInvokerForHash hash:" + cmdHash + " not found"); }
                 invokeFunction = null;
                 return false;
             }
 
             if (invoker == null)
             {
-                if (LogFilter.logDebug) { Debug.Log("GetInvokerForHash hash:" + cmdHash + " invoker null"); }
+                if (LogFilter.Debug) { Debug.Log("GetInvokerForHash hash:" + cmdHash + " invoker null"); }
                 invokeFunction = null;
                 return false;
             }
@@ -446,7 +446,7 @@ namespace Mirror
 
             if (newGameObjectNetId != oldGameObjectNetId)
             {
-                if (LogFilter.logDebug) { Debug.Log("SetSyncVar GameObject " + GetType().Name + " bit [" + dirtyBit + "] netfieldId:" + oldGameObjectNetId + "->" + newGameObjectNetId); }
+                if (LogFilter.Debug) { Debug.Log("SetSyncVar GameObject " + GetType().Name + " bit [" + dirtyBit + "] netfieldId:" + oldGameObjectNetId + "->" + newGameObjectNetId); }
                 SetDirtyBit(dirtyBit);
                 gameObjectField = newGameObject;
                 netIdField = newGameObjectNetId;
@@ -460,7 +460,7 @@ namespace Mirror
             if ((value == null && fieldValue != null) ||
                 (value != null && !value.Equals(fieldValue)))
             {
-                if (LogFilter.logDebug) { Debug.Log("SetSyncVar " + GetType().Name + " bit [" + dirtyBit + "] " + fieldValue + "->" + value); }
+                if (LogFilter.Debug) { Debug.Log("SetSyncVar " + GetType().Name + " bit [" + dirtyBit + "] " + fieldValue + "->" + value); }
                 SetDirtyBit(dirtyBit);
                 fieldValue = value;
             }

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -52,9 +52,7 @@ namespace Mirror
         { 
             get 
             {
-                NetworkBehaviour[] components = m_MyView.NetworkBehaviours;
-
-                int index = Array.FindIndex(components, component => component == this);
+                int index = Array.FindIndex(m_MyView.NetworkBehaviours, component => component == this);
                 if (index < 0)
                 {
                     // this should never happen

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -48,7 +48,7 @@ namespace Mirror
             }
         }
 
-        public byte ComponentIndex 
+        public int ComponentIndex 
         { 
             get 
             {
@@ -59,7 +59,7 @@ namespace Mirror
                     Debug.LogError("Could not find component in gameobject. You shoud not add/remove components in networked objects dinamically", this);
                 }
 
-                return (byte)index;
+                return index;
             } 
         }
 

--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -634,8 +634,7 @@ namespace Mirror
             // find the right component to invoke the function on
             if (componentIndex >= m_NetworkBehaviours.Length)
             {
-                string errorCmdName = NetworkBehaviour.GetCmdHashHandlerName(cmdHash);
-                if (LogFilter.logWarn) { Debug.LogWarning("Command [" + errorCmdName + "] handler not found [netId=" + netId + "]"); }
+                if (LogFilter.logWarn) { Debug.LogWarning("Component [" + componentIndex + "] not found for [netId=" + netId + "]"); }
                 return;
             }
             NetworkBehaviour invokeComponent = m_NetworkBehaviours[componentIndex];

--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -607,7 +607,7 @@ namespace Mirror
         }
 
         // happens on server
-        internal void HandleCommand(int cmdHash, NetworkReader reader)
+        internal void HandleCommand(byte componentIndex, int cmdHash, NetworkReader reader)
         {
             // this doesn't use NetworkBehaviour.InvokeCommand function (anymore). this method of calling is faster.
             // The hash is only looked up once, insted of twice(!) per NetworkBehaviour on the object.
@@ -632,14 +632,14 @@ namespace Mirror
             }
 
             // find the right component to invoke the function on
-            NetworkBehaviour invokeComponent;
-            if (!GetInvokeComponent(cmdHash, invokeClass, out invokeComponent))
+            if (componentIndex >= m_NetworkBehaviours.Length)
             {
                 string errorCmdName = NetworkBehaviour.GetCmdHashHandlerName(cmdHash);
                 if (LogFilter.logWarn) { Debug.LogWarning("Command [" + errorCmdName + "] handler not found [netId=" + netId + "]"); }
                 return;
             }
-
+            NetworkBehaviour invokeComponent = m_NetworkBehaviours[componentIndex];
+           
             invokeFunction(invokeComponent, reader);
         }
 

--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -284,7 +284,7 @@ namespace Mirror
                 }
             }
 
-            if (LogFilter.logDebug) { Debug.Log("OnStartServer " + gameObject + " GUID:" + netId); }
+            if (LogFilter.Debug) { Debug.Log("OnStartServer " + gameObject + " GUID:" + netId); }
             NetworkServer.SetLocalObjectOnServer(netId, gameObject);
 
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
@@ -318,7 +318,7 @@ namespace Mirror
             m_IsClient = true;
             CacheBehaviours();
 
-            if (LogFilter.logDebug) { Debug.Log("OnStartClient " + gameObject + " GUID:" + netId + " localPlayerAuthority:" + localPlayerAuthority); }
+            if (LogFilter.Debug) { Debug.Log("OnStartClient " + gameObject + " GUID:" + netId + " localPlayerAuthority:" + localPlayerAuthority); }
             for (int i = 0; i < m_NetworkBehaviours.Length; i++)
             {
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
@@ -428,7 +428,7 @@ namespace Mirror
                 Debug.LogError("OnSerialize failed for: object=" + name + " component=" + comp.GetType() + " sceneId=" + m_SceneId + "\n\n" + e.ToString());
             }
             byte[] bytes = temp.ToArray();
-            if (LogFilter.logDebug) { Debug.Log("OnSerializeSafely written for object=" + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId + " length=" + bytes.Length); }
+            if (LogFilter.Debug) { Debug.Log("OnSerializeSafely written for object=" + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId + " length=" + bytes.Length); }
 
             // original HLAPI had a warning in UNetUpdate() in case of large state updates. let's move it here, might
             // be useful for debugging.
@@ -467,7 +467,7 @@ namespace Mirror
                     dirtyComponentsMask |= (ulong)(1L << i);
 
                     // serialize the data
-                    if (LogFilter.logDebug) { Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState); }
+                    if (LogFilter.Debug) { Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState); }
                     OnSerializeSafely(comp, payload, initialState);
 
                     // Clear dirty bits only if we are synchronizing data and not sending a spawn message.
@@ -502,7 +502,7 @@ namespace Mirror
             // extract data length and data safely, untouched by user code
             // -> returns empty array if length is 0, so .Length is always the proper length
             byte[] bytes = reader.ReadBytesAndSize();
-            if (LogFilter.logDebug) { Debug.Log("OnDeserializeSafely extracted: " + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId + " length=" + bytes.Length); }
+            if (LogFilter.Debug) { Debug.Log("OnDeserializeSafely extracted: " + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId + " length=" + bytes.Length); }
 
             // call OnDeserialize with a temporary reader, so that the
             // original one can't be messed with. we also wrap it in a
@@ -756,7 +756,7 @@ namespace Mirror
                 return;
             }
 
-            if (LogFilter.logDebug) { Debug.Log("Added observer " + conn.address + " added for " + gameObject); }
+            if (LogFilter.Debug) { Debug.Log("Added observer " + conn.address + " added for " + gameObject); }
 
             m_Observers[conn.connectionId] = conn;
             conn.AddToVisList(this);
@@ -824,7 +824,7 @@ namespace Mirror
                 {
                     // new observer
                     conn.AddToVisList(this);
-                    if (LogFilter.logDebug) { Debug.Log("New Observer for " + gameObject + " " + conn); }
+                    if (LogFilter.Debug) { Debug.Log("New Observer for " + gameObject + " " + conn); }
                     changed = true;
                 }
             }
@@ -835,7 +835,7 @@ namespace Mirror
                 {
                     // removed observer
                     conn.RemoveFromVisList(this, false);
-                    if (LogFilter.logDebug) { Debug.Log("Removed Observer for " + gameObject + " " + conn); }
+                    if (LogFilter.Debug) { Debug.Log("Removed Observer for " + gameObject + " " + conn); }
                     changed = true;
                 }
             }

--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -553,7 +553,7 @@ namespace Mirror
         }
 
         // happens on client
-        internal void HandleSyncEvent(byte componentIndex, int cmdHash, NetworkReader reader)
+        internal void HandleSyncEvent(int componentIndex, int cmdHash, NetworkReader reader)
         {
             // this doesn't use NetworkBehaviour.InvokeSyncEvent function (anymore). this method of calling is faster.
             // The hash is only looked up once, insted of twice(!) per NetworkBehaviour on the object.
@@ -588,7 +588,7 @@ namespace Mirror
         }
 
         // happens on server
-        internal void HandleCommand(byte componentIndex, int cmdHash, NetworkReader reader)
+        internal void HandleCommand(int componentIndex, int cmdHash, NetworkReader reader)
         {
             // this doesn't use NetworkBehaviour.InvokeCommand function (anymore). this method of calling is faster.
             // The hash is only looked up once, insted of twice(!) per NetworkBehaviour on the object.
@@ -623,7 +623,7 @@ namespace Mirror
         }
 
         // happens on client
-        internal void HandleRPC(byte componentIndex, int cmdHash, NetworkReader reader)
+        internal void HandleRPC(int componentIndex, int cmdHash, NetworkReader reader)
         {
             // this doesn't use NetworkBehaviour.InvokeClientRpc function (anymore). this method of calling is faster.
             // The hash is only looked up once, insted of twice(!) per NetworkBehaviour on the object.

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -904,7 +904,7 @@ namespace Mirror
             }
 
             if (LogFilter.logDev) { Debug.Log("OnCommandMessage for netId=" + message.netId + " conn=" + netMsg.conn); }
-            uv.HandleCommand(message.cmdHash, new NetworkReader(message.payload));
+            uv.HandleCommand(message.componentIndex, message.cmdHash, new NetworkReader(message.payload));
         }
 
         internal static void SpawnObject(GameObject obj)

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -83,7 +83,7 @@ namespace Mirror
                 return;
 
             s_Initialized = true;
-            if (LogFilter.logDebug) { Debug.Log("NetworkServer Created version " + Version.Current); }
+            if (LogFilter.Debug) { Debug.Log("NetworkServer Created version " + Version.Current); }
         }
 
         internal static void RegisterMessageHandlers()
@@ -134,7 +134,7 @@ namespace Mirror
                     return false;
                 }
 
-                if (LogFilter.logDebug) { Debug.Log("Server listen: " + ipAddress + ":" + s_ServerPort); }
+                if (LogFilter.Debug) { Debug.Log("Server listen: " + ipAddress + ":" + s_ServerPort); }
             }
 
             s_Active = true;
@@ -192,7 +192,7 @@ namespace Mirror
 
         internal static void SetLocalObjectOnServer(uint netId, GameObject obj)
         {
-            if (LogFilter.logDebug) { Debug.Log("SetLocalObjectOnServer " + netId + " " + obj); }
+            if (LogFilter.Debug) { Debug.Log("SetLocalObjectOnServer " + netId + " " + obj); }
 
             s_NetworkScene.SetLocalObject(netId, obj, false, true);
         }
@@ -208,7 +208,7 @@ namespace Mirror
             {
                 if (!uv.isClient)
                 {
-                    if (LogFilter.logDebug) { Debug.Log("ActivateClientScene " + uv.netId + " " + uv.gameObject); }
+                    if (LogFilter.Debug) { Debug.Log("ActivateClientScene " + uv.netId + " " + uv.gameObject); }
 
                     ClientScene.SetLocalObject(uv.netId, uv.gameObject);
                     uv.OnStartClient();
@@ -220,7 +220,7 @@ namespace Mirror
         // this is used for ObjectDestroy messages.
         static bool SendToObservers(GameObject contextObj, short msgType, MessageBase msg)
         {
-            if (LogFilter.logDebug) { Debug.Log("Server.SendToObservers id:" + msgType); }
+            if (LogFilter.Debug) { Debug.Log("Server.SendToObservers id:" + msgType); }
 
             NetworkIdentity uv = contextObj.GetComponent<NetworkIdentity>();
             if (uv != null && uv.observers != null)
@@ -237,7 +237,7 @@ namespace Mirror
 
         public static bool SendToAll(short msgType, MessageBase msg)
         {
-            if (LogFilter.logDebug) { Debug.Log("Server.SendToAll id:" + msgType); }
+            if (LogFilter.Debug) { Debug.Log("Server.SendToAll id:" + msgType); }
 
             bool result = true;
             foreach (KeyValuePair<int, NetworkConnection> kvp in connections)
@@ -250,7 +250,7 @@ namespace Mirror
 
         public static bool SendToReady(GameObject contextObj, short msgType, MessageBase msg)
         {
-            if (LogFilter.logDebug) { Debug.Log("Server.SendToReady msgType:" + msgType); }
+            if (LogFilter.Debug) { Debug.Log("Server.SendToReady msgType:" + msgType); }
 
             if (contextObj == null)
             {
@@ -374,7 +374,7 @@ namespace Mirror
 
         static void HandleConnect(int connectionId, byte error)
         {
-            if (LogFilter.logDebug) { Debug.Log("Server accepted client:" + connectionId); }
+            if (LogFilter.Debug) { Debug.Log("Server accepted client:" + connectionId); }
 
             if (error != 0)
             {
@@ -395,20 +395,20 @@ namespace Mirror
 
         static void OnConnected(NetworkConnection conn)
         {
-            if (LogFilter.logDebug) { Debug.Log("Server accepted client:" + conn.connectionId); }
+            if (LogFilter.Debug) { Debug.Log("Server accepted client:" + conn.connectionId); }
             conn.InvokeHandlerNoData((short)MsgType.Connect);
         }
 
         static void HandleDisconnect(int connectionId, byte error)
         {
-            if (LogFilter.logDebug) { Debug.Log("Server disconnect client:" + connectionId); }
+            if (LogFilter.Debug) { Debug.Log("Server disconnect client:" + connectionId); }
 
             NetworkConnection conn;
             if (s_Connections.TryGetValue(connectionId, out conn))
             {
                 conn.Disconnect();
                 RemoveConnection(connectionId);
-                if (LogFilter.logDebug) { Debug.Log("Server lost client:" + connectionId); }
+                if (LogFilter.Debug) { Debug.Log("Server lost client:" + connectionId); }
 
                 OnDisconnected(conn);
             }
@@ -424,7 +424,7 @@ namespace Mirror
                 Debug.LogWarning("Player not destroyed when connection disconnected.");
             }
 
-            if (LogFilter.logDebug) { Debug.Log("Server lost client:" + conn.connectionId); }
+            if (LogFilter.Debug) { Debug.Log("Server lost client:" + conn.connectionId); }
             conn.RemoveObservers();
             conn.Dispose();
         }
@@ -490,7 +490,7 @@ namespace Mirror
         {
             if (s_MessageHandlers.ContainsKey(msgType))
             {
-                if (LogFilter.logDebug) { Debug.Log("NetworkServer.RegisterHandler replacing " + msgType); }
+                if (LogFilter.Debug) { Debug.Log("NetworkServer.RegisterHandler replacing " + msgType); }
             }
             s_MessageHandlers[msgType] = handler;
         }
@@ -607,7 +607,7 @@ namespace Mirror
                 return true;
             }
 
-            if (LogFilter.logDebug) { Debug.Log("Adding new playerGameObject object netId: " + playerGameObject.GetComponent<NetworkIdentity>().netId + " asset ID " + playerGameObject.GetComponent<NetworkIdentity>().assetId); }
+            if (LogFilter.Debug) { Debug.Log("Adding new playerGameObject object netId: " + playerGameObject.GetComponent<NetworkIdentity>().netId + " asset ID " + playerGameObject.GetComponent<NetworkIdentity>().assetId); }
 
             FinishPlayerForConnection(conn, playerNetworkIdentity, playerGameObject);
             if (playerNetworkIdentity.localPlayerAuthority)
@@ -619,12 +619,12 @@ namespace Mirror
 
         static bool SetupLocalPlayerForConnection(NetworkConnection conn, NetworkIdentity uv)
         {
-            if (LogFilter.logDebug) { Debug.Log("NetworkServer SetupLocalPlayerForConnection netID:" + uv.netId); }
+            if (LogFilter.Debug) { Debug.Log("NetworkServer SetupLocalPlayerForConnection netID:" + uv.netId); }
 
             var localConnection = conn as ULocalConnectionToClient;
             if (localConnection != null)
             {
-                if (LogFilter.logDebug) { Debug.Log("NetworkServer AddPlayer handling ULocalConnectionToClient"); }
+                if (LogFilter.Debug) { Debug.Log("NetworkServer AddPlayer handling ULocalConnectionToClient"); }
 
                 // Spawn this player for other players, instead of SpawnObject:
                 if (uv.netId == 0)
@@ -674,7 +674,7 @@ namespace Mirror
             }
 
             //NOTE: there can be an existing player
-            if (LogFilter.logDebug) { Debug.Log("NetworkServer ReplacePlayer"); }
+            if (LogFilter.Debug) { Debug.Log("NetworkServer ReplacePlayer"); }
 
             // is there already an owner that is a different object??
             if (conn.playerController != null)
@@ -690,14 +690,14 @@ namespace Mirror
 
             //NOTE: DONT set connection ready.
 
-            if (LogFilter.logDebug) { Debug.Log("NetworkServer ReplacePlayer setup local"); }
+            if (LogFilter.Debug) { Debug.Log("NetworkServer ReplacePlayer setup local"); }
 
             if (SetupLocalPlayerForConnection(conn, playerNetworkIdentity))
             {
                 return true;
             }
 
-            if (LogFilter.logDebug) { Debug.Log("Replacing playerGameObject object netId: " + playerGameObject.GetComponent<NetworkIdentity>().netId + " asset ID " + playerGameObject.GetComponent<NetworkIdentity>().assetId); }
+            if (LogFilter.Debug) { Debug.Log("Replacing playerGameObject object netId: " + playerGameObject.GetComponent<NetworkIdentity>().netId + " asset ID " + playerGameObject.GetComponent<NetworkIdentity>().assetId); }
 
             FinishPlayerForConnection(conn, playerNetworkIdentity, playerGameObject);
             if (playerNetworkIdentity.localPlayerAuthority)
@@ -725,18 +725,18 @@ namespace Mirror
 
         internal static void SetClientReadyInternal(NetworkConnection conn)
         {
-            if (LogFilter.logDebug) { Debug.Log("SetClientReadyInternal for conn:" + conn.connectionId); }
+            if (LogFilter.Debug) { Debug.Log("SetClientReadyInternal for conn:" + conn.connectionId); }
 
             if (conn.isReady)
             {
-                if (LogFilter.logDebug) { Debug.Log("SetClientReady conn " + conn.connectionId + " already ready"); }
+                if (LogFilter.Debug) { Debug.Log("SetClientReady conn " + conn.connectionId + " already ready"); }
                 return;
             }
 
             if (conn.playerController == null)
             {
                 // this is now allowed
-                if (LogFilter.logDebug) { Debug.LogWarning("Ready with no player object"); }
+                if (LogFilter.Debug) { Debug.LogWarning("Ready with no player object"); }
             }
 
             conn.isReady = true;
@@ -744,7 +744,7 @@ namespace Mirror
             var localConnection = conn as ULocalConnectionToClient;
             if (localConnection != null)
             {
-                if (LogFilter.logDebug) { Debug.Log("NetworkServer Ready handling ULocalConnectionToClient"); }
+                if (LogFilter.Debug) { Debug.Log("NetworkServer Ready handling ULocalConnectionToClient"); }
 
                 // Setup spawned objects for local player
                 // Only handle the local objects for the first player (no need to redo it when doing more local players)
@@ -762,7 +762,7 @@ namespace Mirror
                         }
                         if (!uv.isClient)
                         {
-                            if (LogFilter.logDebug) { Debug.Log("LocalClient.SetSpawnObject calling OnStartClient"); }
+                            if (LogFilter.Debug) { Debug.Log("LocalClient.SetSpawnObject calling OnStartClient"); }
                             uv.OnStartClient();
                         }
                     }
@@ -771,7 +771,7 @@ namespace Mirror
             }
 
             // Spawn/update all current server objects
-            if (LogFilter.logDebug) { Debug.Log("Spawning " + objects.Count + " objects for conn " + conn.connectionId); }
+            if (LogFilter.Debug) { Debug.Log("Spawning " + objects.Count + " objects for conn " + conn.connectionId); }
 
             ObjectSpawnFinishedMessage msg = new ObjectSpawnFinishedMessage();
             msg.state = 0;
@@ -789,7 +789,7 @@ namespace Mirror
                     continue;
                 }
 
-                if (LogFilter.logDebug) { Debug.Log("Sending spawn message for current server objects name='" + uv.gameObject.name + "' netId=" + uv.netId); }
+                if (LogFilter.Debug) { Debug.Log("Sending spawn message for current server objects name='" + uv.gameObject.name + "' netId=" + uv.netId); }
 
                 var vis = uv.OnCheckObserver(conn);
                 if (vis)
@@ -837,7 +837,7 @@ namespace Mirror
         {
             if (conn.isReady)
             {
-                if (LogFilter.logDebug) { Debug.Log("PlayerNotReady " + conn); }
+                if (LogFilter.Debug) { Debug.Log("PlayerNotReady " + conn); }
                 conn.isReady = false;
                 conn.RemoveObservers();
 
@@ -849,7 +849,7 @@ namespace Mirror
         // default ready handler.
         static void OnClientReadyMessage(NetworkMessage netMsg)
         {
-            if (LogFilter.logDebug) { Debug.Log("Default handler for ready message from " + netMsg.conn); }
+            if (LogFilter.Debug) { Debug.Log("Default handler for ready message from " + netMsg.conn); }
             SetClientReady(netMsg.conn);
         }
 
@@ -901,7 +901,7 @@ namespace Mirror
                 }
             }
 
-            if (LogFilter.logDebug) { Debug.Log("OnCommandMessage for netId=" + message.netId + " conn=" + netMsg.conn); }
+            if (LogFilter.Debug) { Debug.Log("OnCommandMessage for netId=" + message.netId + " conn=" + netMsg.conn); }
             uv.HandleCommand(message.componentIndex, message.cmdHash, new NetworkReader(message.payload));
         }
 
@@ -923,7 +923,7 @@ namespace Mirror
 
             objNetworkIdentity.OnStartServer(false);
 
-            if (LogFilter.logDebug) { Debug.Log("SpawnObject instance ID " + objNetworkIdentity.netId + " asset ID " + objNetworkIdentity.assetId); }
+            if (LogFilter.Debug) { Debug.Log("SpawnObject instance ID " + objNetworkIdentity.netId + " asset ID " + objNetworkIdentity.assetId); }
 
             objNetworkIdentity.RebuildObservers(true);
             //SendSpawnMessage(objNetworkIdentity, null);
@@ -934,7 +934,7 @@ namespace Mirror
             if (uv.serverOnly)
                 return;
 
-            if (LogFilter.logDebug) { Debug.Log("Server SendSpawnMessage: name=" + uv.name + " sceneId=" + uv.sceneId + " netid=" + uv.netId); } // for easier debugging
+            if (LogFilter.Debug) { Debug.Log("Server SendSpawnMessage: name=" + uv.name + " sceneId=" + uv.sceneId + " netid=" + uv.netId); } // for easier debugging
 
             // 'uv' is a prefab that should be spawned
             if (uv.sceneId == 0)
@@ -1020,7 +1020,7 @@ namespace Mirror
         {
             if (obj == null)
             {
-                if (LogFilter.logDebug) { Debug.Log("NetworkServer UnspawnObject is null"); }
+                if (LogFilter.Debug) { Debug.Log("NetworkServer UnspawnObject is null"); }
                 return;
             }
 
@@ -1039,7 +1039,7 @@ namespace Mirror
         {
             if (obj == null)
             {
-                if (LogFilter.logDebug) { Debug.Log("NetworkServer DestroyObject is null"); }
+                if (LogFilter.Debug) { Debug.Log("NetworkServer DestroyObject is null"); }
                 return;
             }
 
@@ -1051,7 +1051,7 @@ namespace Mirror
 
         static void DestroyObject(NetworkIdentity uv, bool destroyServerObject)
         {
-            if (LogFilter.logDebug) { Debug.Log("DestroyObject instance:" + uv.netId); }
+            if (LogFilter.Debug) { Debug.Log("DestroyObject instance:" + uv.netId); }
             if (objects.ContainsKey(uv.netId))
             {
                 objects.Remove(uv.netId);
@@ -1237,7 +1237,7 @@ namespace Mirror
                 if (!ValidateSceneObject(netId))
                     continue;
 
-                if (LogFilter.logDebug) { Debug.Log("SpawnObjects sceneId:" + netId.sceneId + " name:" + netId.gameObject.name); }
+                if (LogFilter.Debug) { Debug.Log("SpawnObjects sceneId:" + netId.sceneId + " name:" + netId.gameObject.name); }
                 netId.Reset();
                 netId.gameObject.SetActive(true);
             }


### PR DESCRIPTION
If you add the same NetworkBehaviour twice to a gameobject, only the commands in the first one work.

This can also happen if you have a base class, you inherit it, and you add more than one of the inherited classes to the same gameobject.

It should fix issue #75 for commands, ClientRpc, TargetRPC and SyncEvents.