### PR TITLE
Fix #91 editor crash

### DIFF
--- a/Mirror/Weaver/Weaver.cs
+++ b/Mirror/Weaver/Weaver.cs
@@ -627,6 +627,13 @@ namespace Mirror.Weaver
 
         static MethodDefinition GenerateReadFunction(TypeReference variable)
         {
+            if (s_RecursionCount++ > MaxRecursionCount)
+            {
+                Log.Error("GetReadFunc recursion depth exceeded for " + variable.Name + ". Check for self-referencing member variables.");
+                fail = true;
+                return null;
+            }
+
             if (!IsValidTypeToGenerate(variable.Resolve()))
             {
                 return null;


### PR DESCRIPTION
When we try to generate a reader for a class that references itself,  we have infinite recursion and editor crash

This PR stops the infinite recursion and displays an error instead just like with writers