### PR TITLE
Allow for sending message on unreliable channels

### DIFF
--- a/Mirror/Runtime/CustomAttributes.cs
+++ b/Mirror/Runtime/CustomAttributes.cs
@@ -18,21 +18,25 @@ namespace Mirror
     [AttributeUsage(AttributeTargets.Method)]
     public class CommandAttribute : Attribute
     {
+        public int channel = Channels.DefaultReliable; // this is zero
     }
 
     [AttributeUsage(AttributeTargets.Method)]
     public class ClientRpcAttribute : Attribute
     {
+        public int channel = Channels.DefaultReliable; // this is zero
     }
 
     [AttributeUsage(AttributeTargets.Method)]
     public class TargetRpcAttribute : Attribute
     {
+        public int channel = Channels.DefaultReliable; // this is zero
     }
 
     [AttributeUsage(AttributeTargets.Event)]
     public class SyncEventAttribute : Attribute
     {
+        public int channel = Channels.DefaultReliable; // this is zero
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/Mirror/Runtime/LocalConnections.cs
+++ b/Mirror/Runtime/LocalConnections.cs
@@ -17,7 +17,7 @@ namespace Mirror
             m_LocalClient = localClient;
         }
 
-        protected override bool SendBytes(int channelId, byte[] bytes)
+        protected override bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
         {
             m_LocalClient.InvokeBytesOnClient(bytes);
             return true;
@@ -33,7 +33,7 @@ namespace Mirror
             address = "localServer";
         }
 
-        protected override bool SendBytes(int channelId, byte[] bytes)
+        protected override bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
         {
             if (bytes.Length == 0)
             {

--- a/Mirror/Runtime/LocalConnections.cs
+++ b/Mirror/Runtime/LocalConnections.cs
@@ -17,7 +17,7 @@ namespace Mirror
             m_LocalClient = localClient;
         }
 
-        protected override bool SendBytes(byte[] bytes)
+        protected override bool SendBytes(int channelId, byte[] bytes)
         {
             m_LocalClient.InvokeBytesOnClient(bytes);
             return true;
@@ -33,7 +33,7 @@ namespace Mirror
             address = "localServer";
         }
 
-        protected override bool SendBytes(byte[] bytes)
+        protected override bool SendBytes(int channelId, byte[] bytes)
         {
             if (bytes.Length == 0)
             {

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -74,7 +74,7 @@ namespace Mirror
         // ----------------------------- Commands --------------------------------
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendCommandInternal(int cmdHash, NetworkWriter writer, string cmdName)
+        protected void SendCommandInternal(int cmdHash, NetworkWriter writer, int channelId, string cmdName)
         {
             // local players can always send commands, regardless of authority, other objects must have authority.
             if (!(isLocalPlayer || hasAuthority))
@@ -96,7 +96,7 @@ namespace Mirror
             message.cmdHash = cmdHash;
             message.payload = writer.ToArray();
 
-            ClientScene.readyConnection.Send((short)MsgType.Command, message);
+            ClientScene.readyConnection.Send((short)MsgType.Command, message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -108,7 +108,7 @@ namespace Mirror
         // ----------------------------- Client RPCs --------------------------------
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendRPCInternal(int rpcHash, NetworkWriter writer, string rpcName)
+        protected void SendRPCInternal(int rpcHash, NetworkWriter writer, int channelId, string rpcName)
         {
             // This cannot use NetworkServer.active, as that is not specific to this object.
             if (!isServer)
@@ -124,11 +124,11 @@ namespace Mirror
             message.rpcHash = rpcHash;
             message.payload = writer.ToArray();
 
-            NetworkServer.SendToReady(gameObject, (short)MsgType.Rpc, message);
+            NetworkServer.SendToReady(gameObject, (short)MsgType.Rpc, message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendTargetRPCInternal(NetworkConnection conn, int rpcHash, NetworkWriter writer, string rpcName)
+        protected void SendTargetRPCInternal(NetworkConnection conn, int rpcHash, NetworkWriter writer, int channelId, string rpcName)
         {
             // This cannot use NetworkServer.active, as that is not specific to this object.
             if (!isServer)
@@ -144,7 +144,7 @@ namespace Mirror
             message.rpcHash = rpcHash;
             message.payload = writer.ToArray();
 
-            conn.Send((short)MsgType.Rpc, message);
+            conn.Send((short)MsgType.Rpc, message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -156,7 +156,7 @@ namespace Mirror
         // ----------------------------- Sync Events --------------------------------
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendEventInternal(int eventHash, NetworkWriter writer, string eventName)
+        protected void SendEventInternal(int eventHash, NetworkWriter writer, int channelId, string eventName)
         {
             if (!NetworkServer.active)
             {
@@ -171,7 +171,7 @@ namespace Mirror
             message.eventHash = eventHash;
             message.payload = writer.ToArray();
 
-            NetworkServer.SendToReady(gameObject, (short)MsgType.SyncEvent, message);
+            NetworkServer.SendToReady(gameObject, (short)MsgType.SyncEvent, message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Mirror/Runtime/NetworkConnection.cs
+++ b/Mirror/Runtime/NetworkConnection.cs
@@ -158,19 +158,19 @@ namespace Mirror
             m_PlayerController = null;
         }
 
-        public virtual bool Send(short msgType, MessageBase msg)
+        public virtual bool Send(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             NetworkWriter writer = new NetworkWriter();
             msg.Serialize(writer);
 
             // pack message and send
             byte[] message = Protocol.PackMessage((ushort)msgType, writer.ToArray());
-            return SendBytes(message);
+            return SendBytes(channelId, message);
         }
 
         // protected because no one except NetworkConnection should ever send bytes directly to the client, as they
         // would be detected as some kind of message. send messages instead.
-        protected virtual bool SendBytes(byte[] bytes)
+        protected virtual bool SendBytes(int channelId, byte[] bytes)
         {
             if (logNetworkMessages) { Debug.Log("ConnectionSend con:" + connectionId + " bytes:" + BitConverter.ToString(bytes)); }
 
@@ -188,7 +188,7 @@ namespace Mirror
             }
 
             byte error;
-            return TransportSend(bytes, out error);
+            return TransportSend(channelId, bytes, out error);
         }
 
         // handle this message
@@ -269,17 +269,17 @@ namespace Mirror
             HandleBytes(bytes);
         }
 
-        public virtual bool TransportSend(byte[] bytes, out byte error)
+        public virtual bool TransportSend(int channelId, byte[] bytes, out byte error)
         {
             error = 0;
             if (Transport.layer.ClientConnected())
             {
-                Transport.layer.ClientSend(bytes);
+                Transport.layer.ClientSend(channelId, bytes);
                 return true;
             }
             else if (Transport.layer.ServerActive())
             {
-                Transport.layer.ServerSend(connectionId, bytes);
+                Transport.layer.ServerSend(connectionId, channelId, bytes);
                 return true;
             }
             return false;

--- a/Mirror/Runtime/NetworkConnection.cs
+++ b/Mirror/Runtime/NetworkConnection.cs
@@ -165,12 +165,12 @@ namespace Mirror
 
             // pack message and send
             byte[] message = Protocol.PackMessage((ushort)msgType, writer.ToArray());
-            return SendBytes(channelId, message);
+            return SendBytes(message, channelId);
         }
 
         // protected because no one except NetworkConnection should ever send bytes directly to the client, as they
         // would be detected as some kind of message. send messages instead.
-        protected virtual bool SendBytes(int channelId, byte[] bytes)
+        protected virtual bool SendBytes( byte[] bytes, int channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) { Debug.Log("ConnectionSend con:" + connectionId + " bytes:" + BitConverter.ToString(bytes)); }
 

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -235,7 +235,7 @@ namespace Mirror
             return false;
         }
 
-        public static bool SendToAll(short msgType, MessageBase msg)
+        public static bool SendToAll(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) { Debug.Log("Server.SendToAll id:" + msgType); }
 
@@ -243,12 +243,12 @@ namespace Mirror
             foreach (KeyValuePair<int, NetworkConnection> kvp in connections)
             {
                 NetworkConnection conn = kvp.Value;
-                result &= conn.Send(msgType, msg);
+                result &= conn.Send(msgType, msg, channelId);
             }
             return result;
         }
 
-        public static bool SendToReady(GameObject contextObj, short msgType, MessageBase msg)
+        public static bool SendToReady(GameObject contextObj, short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) { Debug.Log("Server.SendToReady msgType:" + msgType); }
 
@@ -260,7 +260,7 @@ namespace Mirror
                     NetworkConnection conn = kvp.Value;
                     if (conn.isReady)
                     {
-                        conn.Send(msgType, msg);
+                        conn.Send(msgType, msg, channelId);
                     }
                 }
                 return true;
@@ -274,7 +274,7 @@ namespace Mirror
                 {
                     if (kvp.Value.isReady)
                     {
-                        result &= kvp.Value.Send(msgType, msg);
+                        result &= kvp.Value.Send(msgType, msg, channelId);
                     }
                 }
                 return result;

--- a/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -25,7 +25,7 @@ namespace Mirror
         // client
         public bool ClientConnected() { return client.Connected; }
         public void ClientConnect(string address, int port) { client.Connect(address, port); }
-        public bool ClientSend(byte[] data) { return client.Send(data); }
+        public bool ClientSend(int channelId, byte[] data) { return client.Send(data); }
         public bool ClientGetNextMessage(out TransportEvent transportEvent, out byte[] data)
         {
             Telepathy.Message message;
@@ -59,7 +59,7 @@ namespace Mirror
         {
             Debug.LogWarning("TelepathyTransport.ServerStartWebsockets not implemented yet!");
         }
-        public bool ServerSend(int connectionId, byte[] data) { return server.Send(connectionId, data); }
+        public bool ServerSend(int connectionId, int channelId, byte[] data) { return server.Send(connectionId, data); }
         public bool ServerGetNextMessage(out int connectionId, out TransportEvent transportEvent, out byte[] data)
         {
             Telepathy.Message message;

--- a/Mirror/Runtime/Transport/TelepathyWebsocketsMultiplexTransport.cs
+++ b/Mirror/Runtime/Transport/TelepathyWebsocketsMultiplexTransport.cs
@@ -36,9 +36,9 @@ namespace Mirror
         {
             client.ClientConnect(address, port);
         }
-        public bool ClientSend(byte[] data)
+        public bool ClientSend(int channelId, byte[] data)
         {
-            return client.ClientSend(data);
+            return client.ClientSend(channelId, data);
         }
         public bool ClientGetNextMessage(out TransportEvent transportEvent, out byte[] data)
         {
@@ -81,9 +81,9 @@ namespace Mirror
             else Debug.LogWarning("ServerStartWebsockets can't be called in WebGL.");
         }
 
-        public bool ServerSend(int connectionId, byte[] data)
+        public bool ServerSend(int connectionId, int channelId, byte[] data)
         {
-            return server != null && server.ServerSend(connectionId, data);
+            return server != null && server.ServerSend(connectionId, channelId, data);
         }
 
         public bool ServerGetNextMessage(out int connectionId, out TransportEvent transportEvent, out byte[] data)

--- a/Mirror/Runtime/Transport/Transport.cs
+++ b/Mirror/Runtime/Transport/Transport.cs
@@ -23,7 +23,7 @@ namespace Mirror
         // client
         bool ClientConnected();
         void ClientConnect(string address, int port);
-        bool ClientSend(byte[] data);
+        bool ClientSend(int channelId, byte[] data);
         bool ClientGetNextMessage(out TransportEvent transportEvent, out byte[] data);
         void ClientDisconnect();
 
@@ -31,7 +31,7 @@ namespace Mirror
         bool ServerActive();
         void ServerStart(string address, int port, int maxConnections);
         void ServerStartWebsockets(string address, int port, int maxConnections);
-        bool ServerSend(int connectionId, byte[] data);
+        bool ServerSend(int connectionId, int channelId, byte[] data);
         bool ServerGetNextMessage(out int connectionId, out TransportEvent transportEvent, out byte[] data);
         bool ServerDisconnect(int connectionId);
         bool GetConnectionInfo(int connectionId, out string address);

--- a/Mirror/Runtime/UNetwork.cs
+++ b/Mirror/Runtime/UNetwork.cs
@@ -77,6 +77,12 @@ namespace Mirror
         Current = 1
     }
 
+    public class Channels
+    {
+        public const int DefaultReliable = 0;
+        public const int DefaultUnreliable = 1;
+    }
+
     // network protocol all in one place, instead of constructing headers in all kinds of different places
     //
     //   MsgType     (1-n bytes)

--- a/Mirror/Weaver/UNetBehaviourProcessor.cs
+++ b/Mirror/Weaver/UNetBehaviourProcessor.cs
@@ -606,7 +606,7 @@ namespace Mirror.Weaver
 
         void GeneratePreStartClient()
         {
-            int netIdFieldCounter = 0;
+            int netIdFieldCounter  = 0;
             MethodDefinition preStartMethod = null;
             ILProcessor serWorker = null;
 
@@ -663,7 +663,7 @@ namespace Mirror.Weaver
         void GenerateDeSerialization()
         {
             Weaver.DLog(m_td, "  GenerateDeSerialization");
-            int netIdFieldCounter = 0;
+            int netIdFieldCounter  = 0;
 
             foreach (var m in m_td.Methods)
             {
@@ -915,7 +915,7 @@ namespace Mirror.Weaver
         */
         MethodDefinition ProcessCommandCall(MethodDefinition md, CustomAttribute ca)
         {
-            MethodDefinition cmd = new MethodDefinition("Call" + md.Name, MethodAttributes.Public |
+            MethodDefinition cmd = new MethodDefinition("Call" +  md.Name, MethodAttributes.Public |
                     MethodAttributes.HideBySig,
                     Weaver.voidType);
 
@@ -1062,7 +1062,7 @@ namespace Mirror.Weaver
         */
         MethodDefinition ProcessTargetRpcCall(MethodDefinition md, CustomAttribute ca)
         {
-            MethodDefinition rpc = new MethodDefinition("Call" + md.Name, MethodAttributes.Public |
+            MethodDefinition rpc = new MethodDefinition("Call" +  md.Name, MethodAttributes.Public |
                     MethodAttributes.HideBySig,
                     Weaver.voidType);
 
@@ -1138,7 +1138,7 @@ namespace Mirror.Weaver
         */
         MethodDefinition ProcessRpcCall(MethodDefinition md, CustomAttribute ca)
         {
-            MethodDefinition rpc = new MethodDefinition("Call" + md.Name, MethodAttributes.Public |
+            MethodDefinition rpc = new MethodDefinition("Call" +  md.Name, MethodAttributes.Public |
                     MethodAttributes.HideBySig,
                     Weaver.voidType);
 
@@ -1556,7 +1556,7 @@ namespace Mirror.Weaver
         MethodDefinition ProcessEventCall(EventDefinition ed, CustomAttribute ca)
         {
             MethodReference invoke = Weaver.ResolveMethod(ed.EventType, "Invoke");
-            MethodDefinition evt = new MethodDefinition("Call" + ed.Name, MethodAttributes.Public |
+            MethodDefinition evt = new MethodDefinition("Call" +  ed.Name, MethodAttributes.Public |
                     MethodAttributes.HideBySig,
                     Weaver.voidType);
             // add paramters
@@ -1773,8 +1773,7 @@ namespace Mirror.Weaver
             //create the property
             PropertyDefinition propertyDefinition = new PropertyDefinition("Network" + originalName, PropertyAttributes.None, fd.FieldType)
             {
-                GetMethod = get,
-                SetMethod = set
+                GetMethod = get, SetMethod = set
             };
 
             //add the methods and property to the type.
@@ -1915,7 +1914,7 @@ namespace Mirror.Weaver
             unsafe
             {
                 int length = s.Length;
-                fixed (char* c = s)
+                fixed(char* c = s)
                 {
                     char* cc = c;
                     char* end = cc + length - 1;


### PR DESCRIPTION
To send a message via unreliable channel do:

```
// Start your messages at 50+
short CustomMessageID = 50;

NetworkMessage message = new MyCustomMessage();
connection.Send(CustomMessageID, message, Channels.DefaultUnreliable);
```

Register a handler for CustomMessageID on the other end as usual.

Use LLAPI transport:   in your NetworkManager add this:
```
        public override void InitializeTransport()
        {
            Transport.layer = new LLAPITransport();
        }
```

Note that the channel is ignored if you are using Telepathy.