### PR TITLE
Avoid LINQ in NetworkBehaviour.IsDirty

### DIFF
--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -483,8 +483,19 @@ namespace Mirror
         {
             if (Time.time - m_LastSendTime > GetNetworkSendInterval())
             {
-                return m_SyncVarDirtyBits != 0L
-                        || m_SyncObjects.Any(obj => obj.IsDirty);
+                return m_SyncVarDirtyBits != 0L || IsAnySyncObjectDirty();
+            }
+            return false;
+        }
+
+        private bool IsAnySyncObjectDirty()
+        {
+            for (int i = 0; i  < m_SyncObjects.Count; ++i)
+            {
+                if (m_SyncObjects[i].IsDirty)
+                {
+                    return true;
+                }
             }
             return false;
         }


### PR DESCRIPTION
This way we can avoid unnecessary allocations in a hot path.