### PR TITLE
Use standard C# events instead of one callback

### DIFF
--- a/Mirror/Tests/SyncListTest.cs
+++ b/Mirror/Tests/SyncListTest.cs
@@ -166,7 +166,7 @@ namespace Mirror.Tests
         public void CallbackTest()
         {
             bool called = false;
-            clientSyncList.Callback = (op, index) => { called = true; };
+            clientSyncList.Callback += (op, index) => { called = true; };
 
             serverSyncList.Add("yay");
             SerializeDeltaTo(serverSyncList, clientSyncList);

--- a/Mirror/Tests/SyncListTest.cs
+++ b/Mirror/Tests/SyncListTest.cs
@@ -167,6 +167,7 @@ namespace Mirror.Tests
         {
             bool called = false;
             clientSyncList.Callback += (op, index) => { called = true; };
+           
             serverSyncList.Add("yay");
             SerializeDeltaTo(serverSyncList, clientSyncList);
 

--- a/Mirror/Tests/SyncListTest.cs
+++ b/Mirror/Tests/SyncListTest.cs
@@ -167,7 +167,6 @@ namespace Mirror.Tests
         {
             bool called = false;
             clientSyncList.Callback += (op, index) => { called = true; };
-           
             serverSyncList.Add("yay");
             SerializeDeltaTo(serverSyncList, clientSyncList);
 

--- a/Mirror/Tests/SyncListTest.cs
+++ b/Mirror/Tests/SyncListTest.cs
@@ -167,7 +167,6 @@ namespace Mirror.Tests
         {
             bool called = false;
             clientSyncList.Callback += (op, index) => { called = true; };
-
             serverSyncList.Add("yay");
             SerializeDeltaTo(serverSyncList, clientSyncList);
 


### PR DESCRIPTION
C# has events for this kind of things.

The problem with callback is that if 2 separate objects want to get called back,  they will override each other's callbacks, a subtle and difficult to debug problem.
