### PR TITLE
zeros getting stored against the m_AssetId in Unity 2018.3

### DIFF
--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -101,7 +101,7 @@ namespace Mirror
 
         public static bool Listen(int serverPort, int maxConnections)
         {
-            return InternalListen(null, serverPort, maxConnections);
+            return InternalListen("127.0.0.1", serverPort, maxConnections);
         }
 
         public static bool Listen(string ipAddress, int serverPort, int maxConnections)
@@ -134,7 +134,7 @@ namespace Mirror
                     return false;
                 }
 
-                if (LogFilter.Debug) { Debug.Log("Server listen: " + (ipAddress != null ? ipAddress : "") + ":" + s_ServerPort); }
+                if (LogFilter.Debug) { Debug.Log("Server listen: " + ipAddress + ":" + s_ServerPort); }
             }
 
             s_Active = true;

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -101,7 +101,7 @@ namespace Mirror
 
         public static bool Listen(int serverPort, int maxConnections)
         {
-            return InternalListen("127.0.0.1", serverPort, maxConnections);
+            return InternalListen(null, serverPort, maxConnections);
         }
 
         public static bool Listen(string ipAddress, int serverPort, int maxConnections)
@@ -134,7 +134,7 @@ namespace Mirror
                     return false;
                 }
 
-                if (LogFilter.Debug) { Debug.Log("Server listen: " + ipAddress + ":" + s_ServerPort); }
+                if (LogFilter.Debug) { Debug.Log("Server listen: " + (ipAddress != null ? ipAddress : "") + ":" + s_ServerPort); }
             }
 
             s_Active = true;


### PR DESCRIPTION
This for discussion only and not a final solution.

Resolves an issue with zeros getting stored against the m_AssetId in Unity 2018.3 in the new Prefab mode editor. I have also kept 2017 backward compatibility.

Its currently using the Experimental function to get the current prefab stage in 2018.3 - this should be updated when it moves out of experimental.

I have had to update UnityEditor.dll to 2018.3.0b8 so the new bindings are available. It still works with 2017 and doesnt cause errors as I make sure we dont call new methods if on a older version. It was throwing errors however in 2017 if the new methods were in a called methods even if those lines were not executed so I had to move those methods into a separate method only called in 2018.3. The method names are temporary and up for suggestion

Tested in Unity 2018.3.0b8 and 2017.4.14f1 LTS