### PR TITLE
update max packet size to INT_MAX

### DIFF
--- a/Mirror/Runtime/Transport/Transport.cs
+++ b/Mirror/Runtime/Transport/Transport.cs
@@ -7,7 +7,7 @@ namespace Mirror
     public static class Transport
     {
         // hlapi needs to know max packet size to show warnings
-        public static int MaxPacketSize = ushort.MaxValue;
+        public static int MaxPacketSize = int.MaxValue;
 
         // selected transport layer
         // the transport is normally initialized in NetworkManager InitializeTransport


### PR DESCRIPTION
Fixes #42. The previous fix #45 didn't change behavior, as any attempt to send a packet bigger than 65k would result in the NetworkWriter catching an error here: https://github.com/vis2k/Mirror/blob/b14957fbc8b4cb12ce41d517ab295c0842fa3b90/Mirror/Runtime/NetworkWriter.cs#L77

This updates the max packet size constant so that we can send bigger packets.