### PR TITLE
Added int channelId to GetMaxPacketSize

### DIFF
--- a/Mirror/Runtime/NetworkConnection.cs
+++ b/Mirror/Runtime/NetworkConnection.cs
@@ -174,9 +174,9 @@ namespace Mirror
         {
             if (logNetworkMessages) { Debug.Log("ConnectionSend con:" + connectionId + " bytes:" + BitConverter.ToString(bytes)); }
 
-            if (bytes.Length > Transport.layer.GetMaxPacketSize())
+            if (bytes.Length > Transport.layer.GetMaxPacketSize(channelId))
             {
-                Debug.LogError("NetworkConnection:SendBytes cannot send packet larger than " + Transport.layer.GetMaxPacketSize() + " bytes");
+                Debug.LogError("NetworkConnection:SendBytes cannot send packet larger than " + Transport.layer.GetMaxPacketSize(channelId) + " bytes");
                 return false;
             }
 

--- a/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -260,7 +260,7 @@ namespace Mirror
             Debug.Log("LLAPITransport.Shutdown");
         }
 
-        public int GetMaxPacketSize()
+        public int GetMaxPacketSize(int channelId)
         {
             return globalConfig.MaxPacketSize;
         }

--- a/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -101,7 +101,7 @@ namespace Mirror
             server.Stop();
         }
 
-        public int GetMaxPacketSize()
+        public int GetMaxPacketSize(int channelId)
         {
             // Telepathy's limit is Array.Length, which is int
             return int.MaxValue;

--- a/Mirror/Runtime/Transport/TelepathyWebsocketsMultiplexTransport.cs
+++ b/Mirror/Runtime/Transport/TelepathyWebsocketsMultiplexTransport.cs
@@ -117,10 +117,10 @@ namespace Mirror
             if (server != null) server.Shutdown();
         }
 
-        public int GetMaxPacketSize()
+        public int GetMaxPacketSize(int channelId)
         {
-            if (server != null) return server.GetMaxPacketSize();
-            if (client != null) return client.GetMaxPacketSize();
+            if (server != null) return server.GetMaxPacketSize(channelId);
+            if (client != null) return client.GetMaxPacketSize(channelId);
             return 0;
         }
     }

--- a/Mirror/Runtime/Transport/Transport.cs
+++ b/Mirror/Runtime/Transport/Transport.cs
@@ -36,6 +36,6 @@ namespace Mirror
 
         // common
         void Shutdown();
-        int GetMaxPacketSize();
+        int GetMaxPacketSize(int channelId=Channels.DefaultReliable);
     }
 }


### PR DESCRIPTION
so different channels can have different max packet sizes.

Useful for transports where you have an unreliable channel that's limited differently, for example to MTU size.