### PR TITLE
Start server if headless mode

### DIFF
--- a/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Mirror/Runtime/NetworkManagerHUD.cs
@@ -23,7 +23,7 @@ namespace Mirror
 
             if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null)
             {
-                // headless mode.   Just start the server
+                // headless mode. Just start the server
                 manager.StartServer();
             }
         }

--- a/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Mirror/Runtime/NetworkManagerHUD.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Mirror
 {
@@ -19,6 +20,12 @@ namespace Mirror
         void Awake()
         {
             manager = GetComponent<NetworkManager>();
+
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null)
+            {
+                // headless mode.   Just start the server
+                manager.StartServer();
+            }
         }
 
         void OnGUI()


### PR DESCRIPTION
If the application starts in headless mode,   the HUD should just start a server immediately since nobody can click the buttons.
