### PR TITLE
Fixes 2 bugs regarding connections

### DIFF
--- a/Mirror/Runtime/NetworkClient.cs
+++ b/Mirror/Runtime/NetworkClient.cs
@@ -112,6 +112,7 @@ namespace Mirror
             SetActive(true);
             RegisterSystemHandlers(false);
             m_ClientId = 0;
+            NetworkClient.pauseMessageHandling = false;
         }
 
         public virtual void Disconnect()

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -113,6 +113,8 @@ namespace Mirror
         {
             Initialize();
 
+            connections.Clear();
+
             // only start server if we want to listen
             if (!s_DontListen)
             {
@@ -295,6 +297,7 @@ namespace Mirror
                 conn.Disconnect();
                 conn.Dispose();
             }
+            connections.Clear();
         }
 
         internal static void InternalDisconnectAll()


### PR DESCRIPTION
NetworkServer.cs was not clearing connections on stopping. This meant when then starting again it was trying to communicate with old connections. Simply clear the list in DisconnectAllConnections. Also put in InternalListen for just in case as there should never be any connections at that point.

NetworkClient.cs was unable to load the scene on connect under certain circumstances. This was because NetworkClient.pauseMessageHandling had been set to false on a previous failed connection attempt. On a subsequent connect it would then never accept messages after it connected successfully so didnt know to load the scene. Simple fix to set NetworkClient.pauseMessageHandling to false when connecting. It should never be true at this point.