### PR TITLE
Network server stale connections

### DIFF
--- a/Mirror/Runtime/NetworkClient.cs
+++ b/Mirror/Runtime/NetworkClient.cs
@@ -112,6 +112,7 @@ namespace Mirror
             SetActive(true);
             RegisterSystemHandlers(false);
             m_ClientId = 0;
+            NetworkClient.pauseMessageHandling = false;
         }
 
         public virtual void Disconnect()

--- a/Mirror/Runtime/NetworkClient.cs
+++ b/Mirror/Runtime/NetworkClient.cs
@@ -112,7 +112,6 @@ namespace Mirror
             SetActive(true);
             RegisterSystemHandlers(false);
             m_ClientId = 0;
-            NetworkClient.pauseMessageHandling = false;
         }
 
         public virtual void Disconnect()

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -84,6 +84,9 @@ namespace Mirror
 
             s_Initialized = true;
             if (LogFilter.Debug) { Debug.Log("NetworkServer Created version " + Version.Current); }
+
+            //Make sure connections are cleared in case any old connections references exist from previous sessions
+            connections.Clear();
         }
 
         internal static void RegisterMessageHandlers()
@@ -112,8 +115,6 @@ namespace Mirror
         internal static bool InternalListen(string ipAddress, int serverPort, int maxConnections)
         {
             Initialize();
-
-            connections.Clear();
 
             // only start server if we want to listen
             if (!s_DontListen)

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -113,6 +113,8 @@ namespace Mirror
         {
             Initialize();
 
+            connections.Clear();
+
             // only start server if we want to listen
             if (!s_DontListen)
             {
@@ -295,6 +297,7 @@ namespace Mirror
                 conn.Disconnect();
                 conn.Dispose();
             }
+            connections.Clear();
         }
 
         internal static void InternalDisconnectAll()


### PR DESCRIPTION
NetworkServer.cs was not clearing connections on stopping. This meant when then starting again it was trying to communicate with old connections. Simply clear the list in DisconnectAllConnections. Also put in InternalListen for just in case as there should never be any connections at that point.