### PR TITLE
Initialize() is internal and should not be called externally

### DIFF
--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -77,7 +77,7 @@ namespace Mirror
             s_Active = false;
         }
 
-        public static void Initialize()
+        static void Initialize()
         {
             if (s_Initialized)
                 return;


### PR DESCRIPTION
Initialize() is internal and should not be called externally so shouldn't be public