### PR TITLE
Fix #133, destroy all objects when server shutdowns

### DIFF
--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -296,6 +296,7 @@ namespace Mirror
             {
                 NetworkConnection conn = kvp.Value;
                 conn.Disconnect();
+                OnDisconnected(conn);
                 conn.Dispose();
             }
             connections.Clear();


### PR DESCRIPTION
When the server shut down,  all clients are disconnected,  but we were not calling OnDisconnect for the in the server
so we did not clean up their objects