### PR TITLE
Check if any component is dirty before serializing stuff

### DIFF
--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -654,16 +654,19 @@ namespace Mirror
         // invoked by unity runtime immediately after the regular "Update()" function.
         internal void UNetUpdate()
         {
-            // serialize all the dirty components and send (if any were dirty)
-            NetworkWriter writer = new NetworkWriter();
-            if (OnSerializeAllSafely(m_NetworkBehaviours, writer, false))
+            if (m_NetworkBehaviours.Any(comp => comp.IsDirty()))
             {
-                // construct message and send
-                UpdateVarsMessage message = new UpdateVarsMessage();
-                message.netId = netId;
-                message.payload = writer.ToArray();
+                // serialize all the dirty components and send (if any were dirty)
+                NetworkWriter writer = new NetworkWriter();
+                if (OnSerializeAllSafely(m_NetworkBehaviours, writer, false))
+                {
+                    // construct message and send
+                    UpdateVarsMessage message = new UpdateVarsMessage();
+                    message.netId = netId;
+                    message.payload = writer.ToArray();
 
-                NetworkServer.SendToReady(gameObject, (short)MsgType.UpdateVars, message);
+                    NetworkServer.SendToReady(gameObject, (short)MsgType.UpdateVars, message);
+                }
             }
         }
 


### PR DESCRIPTION
Creating the sync message is expensive to do every frame.

With this change we check if there is anything to send before we make the message.  This should have the  same performance gains than #124 