### PR TITLE
Display message name in ConnectionRecv log

### DIFF
--- a/Mirror/Runtime/NetworkConnection.cs
+++ b/Mirror/Runtime/NetworkConnection.cs
@@ -205,7 +205,19 @@ namespace Mirror
             byte[] content;
             if (Protocol.UnpackMessage(buffer, out msgType, out content))
             {
-                if (logNetworkMessages) { Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + msgType + " content:" + BitConverter.ToString(content)); }
+                if (logNetworkMessages) 
+                { 
+                    if (Enum.IsDefined(typeof(MsgType), msgType))
+                    {
+                        // one of Mirror mesage types,  display the message name
+                        Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + (MsgType)msgType + " content:" + BitConverter.ToString(content));
+                    }
+                    else
+                    {
+                        // user defined message,  display the number
+                        Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + msgType + " content:" + BitConverter.ToString(content));
+                    }
+                }
 
                 NetworkMessageDelegate msgDelegate;
                 if (m_MessageHandlers.TryGetValue((short)msgType, out msgDelegate))


### PR DESCRIPTION
This really helps with debugging,  with this PR  you get messages such as:

```
ConnectionRecv con:0 msgType:SpawnPrefab content:8D-DA-08-DC-F2-14-9B-40-A4-99-53-26-37-08-1C-B7-F1-00-00-C0-C2-00-00-00-00-00-00-00-C2-00-00-00-80-00-00-00-80-00-00-00-80-00-00-80-3F-01-20-03-AB-A0-FF-FF-FF-E0-FF-FF-FF-FF-FF-FF-FF-01-08-01-00-00-00-00-00-00-00-00-00-00-00-17-00-00-AB
```

instead of the cryptic
```
ConnectionRecv con:0 msgType:3 content:8D-DA-08-DC-F2-14-9B-40-A4-99-53-26-37-08-1C-B7-F1-00-00-C0-C2-00-00-00-00-00-00-00-C2-00-00-00-80-00-00-00-80-00-00-00-80-00-00-80-3F-01-20-03-AB-A0-FF-FF-FF-E0-FF-FF-FF-FF-FF-FF-FF-01-08-01-00-00-00-00-00-00-00-00-00-00-00-17-00-00-AB
```