### PR TITLE
Fix NRE when running headless with HUD

### DIFF
--- a/Mirror/Runtime/NetworkManager.cs
+++ b/Mirror/Runtime/NetworkManager.cs
@@ -97,7 +97,6 @@ namespace Mirror
         {
             Debug.Log("Thank you for using Mirror! https://forum.unity.com/threads/unet-hlapi-community-edition.425437/");
             InitializeSingleton();
-            InitializeTransport();
         }
 
         void InitializeSingleton()
@@ -107,6 +106,7 @@ namespace Mirror
                 return;
             }
 
+            InitializeTransport();
             // do this early
             LogFilter.Debug = showDebugMessages;
 


### PR DESCRIPTION
It was possible that the headless HUD would try to start the server before initializing the transport
Now the transport is always initialized when the NetworkManager singleton is initialized