### PR TITLE
Minor syntax change - duplicated line

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -237,16 +237,13 @@ namespace Mirror
 
 #if UNITY_2018_3_OR_NEWER
             if (!PrefabUtility.IsPartOfPrefabInstance(gameObject))
-            {
                 return false;
-            }
-            prefab = (GameObject)PrefabUtility.GetCorrespondingObjectFromSource(gameObject);
 #else
             PrefabType prefabType = PrefabUtility.GetPrefabType(gameObject);
             if (prefabType == PrefabType.None)
                 return false;
-            prefab = (GameObject)PrefabUtility.GetCorrespondingObjectFromSource(gameObject);
 #endif
+            prefab = (GameObject)PrefabUtility.GetCorrespondingObjectFromSource(gameObject);
 
             if (prefab == null)
             {


### PR DESCRIPTION
`prefab = (GameObject)PrefabUtility.GetCorrespondingObjectFromSource(gameObject);` was repeated in both cases so should be outside the if. Also removed extra unnecessary { } to be more in keeping with the coding style.