### PR TITLE
Moved High rotation compression to Low. Added new High

### DIFF
--- a/Mirror/Runtime/NetworkTransform.cs
+++ b/Mirror/Runtime/NetworkTransform.cs
@@ -1219,8 +1219,10 @@ namespace Mirror
                     writer.Write(angle);
                     break;
                 case CompressionSyncMode.Low:
-                case CompressionSyncMode.High:
                     writer.Write((short)angle);
+                    break;
+                case CompressionSyncMode.High:
+                    writer.Write((byte)angle);
                     break;
             }
         }
@@ -1232,8 +1234,9 @@ namespace Mirror
                 case CompressionSyncMode.None:
                     return reader.ReadSingle();
                 case CompressionSyncMode.Low:
-                case CompressionSyncMode.High:
                     return reader.ReadInt16();
+                case CompressionSyncMode.High:
+                    return reader.ReadByte();
             }
             return 0;
         }


### PR DESCRIPTION
See the attached video for a comparison of all three compression at different rotation rates. If you cant tell a difference then hopefully that means its not an issue to compress a little more :). The cubes are rotating between 50/100/200 speed*deltaTime in an Update with no VSync. Video at 60fps.

Video: https://www.dropbox.com/s/h2op1du6qdk8gg2/RotationCompressionTest.flv?dl=0

Hint:
Left = No Compression (Float)
Middle = Low Compression (Int16)
Right = High Compression (byte)