### PR TITLE
NetworkManager.s_PendingSingleton removed because script reloads were…

### DIFF
--- a/Mirror/Runtime/NetworkManager.cs
+++ b/Mirror/Runtime/NetworkManager.cs
@@ -77,15 +77,6 @@ namespace Mirror
         // this is used to persist network address between scenes.
         static string s_Address;
 
-#if UNITY_EDITOR
-        static NetworkManager s_PendingSingleton;
-
-        public NetworkManager()
-        {
-            s_PendingSingleton = this;
-        }
-#endif
-
         // protected so that inheriting classes' Awake() can call base.Awake() too
         protected void Awake()
         {
@@ -458,29 +449,6 @@ namespace Mirror
 
         internal static void UpdateScene()
         {
-#if UNITY_EDITOR
-            // In the editor, reloading scripts in play mode causes a Mono Domain Reload.
-            // This gets the transport layer (C++) and HLAPI (C#) out of sync.
-            // This check below detects that problem and shuts down the transport layer to bring both systems back in sync.
-            if (singleton == null && s_PendingSingleton != null)
-            {
-                Debug.LogWarning("NetworkManager detected a script reload in the editor. This has caused the network to be shut down.");
-
-                s_PendingSingleton.InitializeSingleton();
-
-                // destroy network objects
-                var uvs = FindObjectsOfType<NetworkIdentity>();
-                foreach (var uv in uvs)
-                {
-                    Destroy(uv.gameObject);
-                }
-
-                singleton.StopHost();
-
-                Transport.layer.Shutdown();
-            }
-#endif
-
             if (singleton == null)
                 return;
 


### PR DESCRIPTION
… neither detected properly, nor is there any chance of Mirror to continue running properly after script reloads.