### PR TITLE
Allow for passing NetworkBehaviours in Commands and Rpcs

### DIFF
--- a/Mirror/Runtime/NetworkReader.cs
+++ b/Mirror/Runtime/NetworkReader.cs
@@ -265,6 +265,40 @@ namespace Mirror
             return go.GetComponent<NetworkIdentity>();
         }
 
+        public NetworkBehaviour ReadNetworkBehaviour()
+        {
+            uint netId = ReadPackedUInt32();
+            if (netId == 0)
+            {
+                return null;
+            }
+            GameObject go;
+            if (NetworkServer.active)
+            {
+                go = NetworkServer.FindLocalObject(netId);
+            }
+            else
+            {
+                go = ClientScene.FindLocalObject(netId);
+            }
+            uint componentIndex = ReadPackedUInt32();
+
+            if (go == null)
+            {
+                if (LogFilter.Debug) { Debug.Log("ReadNetworkBehaviour netId:" + netId + "go: null"); }
+                return null;
+            }
+            NetworkIdentity uv = go.GetComponent<NetworkIdentity>();
+            NetworkBehaviour[] behaviours = uv.NetworkBehaviours;
+
+            if (componentIndex < 0 || componentIndex >= behaviours.Length)
+            {
+                Debug.LogError("ReadNetworkBehaviour netId:" + netId + " component: null"); 
+                return null;
+            }
+
+            return behaviours[componentIndex];
+        }
         public override string ToString()
         {
             return reader.ToString();

--- a/Mirror/Runtime/NetworkWriter.cs
+++ b/Mirror/Runtime/NetworkWriter.cs
@@ -322,6 +322,26 @@ namespace Mirror
             }
         }
 
+        public void Write(NetworkBehaviour value)
+        {
+            if (value == null)
+            {
+                WritePackedUInt32(0);
+                return;
+            }
+            var uv = value.GetComponent<NetworkIdentity>();
+            if (uv != null)
+            {
+                WritePackedUInt32(uv.netId);
+                WritePackedUInt32((uint)value.ComponentIndex);
+            }
+            else
+            {
+                Debug.LogWarning("NetworkWriter " + value + " has no NetworkIdentity");
+                WritePackedUInt32(0);
+            }
+        }
+
         public void Write(MessageBase msg)
         {
             msg.Serialize(this);

--- a/Mirror/Weaver/UNetBehaviourProcessor.cs
+++ b/Mirror/Weaver/UNetBehaviourProcessor.cs
@@ -1248,8 +1248,13 @@ namespace Mirror.Weaver
                     Weaver.fail = true;
                     return false;
                 }
-                if (Weaver.IsDerivedFrom(p.ParameterType.Resolve(), Weaver.ComponentType))
+                if (Weaver.IsNetworkBehaviour(p.ParameterType.Resolve()))
                 {
+                    // no problem,  we can pass NetworkBehaviours
+                }
+                else if (Weaver.IsDerivedFrom(p.ParameterType.Resolve(), Weaver.ComponentType))
+                {
+
                     if (p.ParameterType.FullName != Weaver.NetworkIdentityType.FullName)
                     {
                         Log.Error(actionType + " function [" + m_td.FullName + ":" + md.Name + "] parameter [" + p.Name +

--- a/Mirror/Weaver/Weaver.cs
+++ b/Mirror/Weaver/Weaver.cs
@@ -268,6 +268,10 @@ namespace Mirror.Weaver
                     return foundFunc;
                 }
             }
+            if (IsNetworkBehaviour(variable.Resolve()))
+            {
+                return lists.writeFuncs[NetworkBehaviourType.FullName];
+            }
 
             if (variable.IsByReference)
             {
@@ -332,6 +336,11 @@ namespace Mirror.Weaver
             {
                 Log.Error("GetReadFunc unsupported type " + variable.FullName);
                 return null;
+            }
+
+            if (Weaver.IsNetworkBehaviour(td))
+            {
+                return lists.readFuncs[NetworkBehaviourType.FullName];
             }
 
             if (variable.IsByReference)
@@ -1420,6 +1429,7 @@ namespace Mirror.Weaver
                 { guidType.FullName, ResolveMethod(NetworkReaderType, "ReadGuid") },
                 { gameObjectType.FullName, ResolveMethod(NetworkReaderType, "ReadGameObject") },
                 { NetworkIdentityType.FullName, ResolveMethod(NetworkReaderType, "ReadNetworkIdentity") },
+                { NetworkBehaviourType.FullName, ResolveMethod(NetworkReaderType, "ReadNetworkBehaviour") },
                 { transformType.FullName, ResolveMethod(NetworkReaderType, "ReadTransform") },
                 { "System.Byte[]", ResolveMethod(NetworkReaderType, "ReadBytesAndSize") },
             };
@@ -1456,12 +1466,13 @@ namespace Mirror.Weaver
                 { guidType.FullName, ResolveMethodWithArg(NetworkWriterType, "Write", guidType) },
                 { gameObjectType.FullName, ResolveMethodWithArg(NetworkWriterType, "Write", gameObjectType) },
                 { NetworkIdentityType.FullName, ResolveMethodWithArg(NetworkWriterType, "Write", NetworkIdentityType) },
+                { NetworkBehaviourType.FullName, ResolveMethodWithArg(NetworkWriterType, "Write", NetworkBehaviourType) },
                 { transformType.FullName, ResolveMethodWithArg(NetworkWriterType, "Write", transformType) },
                 { "System.Byte[]", ResolveMethodWithArg(NetworkWriterType, "WriteBytesAndSize", "System.Byte[]") }
             };
         }
 
-        static bool IsNetworkBehaviour(TypeDefinition td)
+        static public bool IsNetworkBehaviour(TypeDefinition td)
         {
             if (!td.IsClass)
                 return false;


### PR DESCRIPTION
With this code now this is possible:

```cs
class Loot:  NetworkBehaviour
{
    //  code for an object sitting on the floor
}

class Player:  NetworkBehaviour
{

    [Command]
    public void CmdPickup(Loot loot)
    {
        // pick up the loot
    }
}
```