### PR TITLE
Fix #182,  use Stopwatch to keep track of NetworkTime

### DIFF
--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace Mirror
 {
@@ -16,7 +17,13 @@ namespace Mirror
 
 
         // Date and time when the application started
-        static readonly DateTime epoch = DateTime.Now;
+        static readonly Stopwatch stopwatch;
+
+        static NetworkTime()
+        {
+            stopwatch = new Stopwatch();
+            stopwatch.Start();
+        }
 
         static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(10);
         static ExponentialMovingAverage _offset = new ExponentialMovingAverage(10);
@@ -24,8 +31,7 @@ namespace Mirror
         // returns the clock time _in this system_
         static double LocalTime()
         {
-            TimeSpan span = DateTime.Now.Subtract(epoch);
-            return span.TotalSeconds;
+            return stopwatch.Elapsed.TotalSeconds;
         }
 
         public static void Reset()

--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -17,11 +17,10 @@ namespace Mirror
 
 
         // Date and time when the application started
-        static readonly Stopwatch stopwatch;
+        static readonly Stopwatch stopwatch = new Stopwatch();
 
         static NetworkTime()
         {
-            stopwatch = new Stopwatch();
             stopwatch.Start();
         }
 


### PR DESCRIPTION
DateTime has potential issues with daylights savings time,  it is not as accurate and is very slow.

Use Stopwatch instead to keep track of server uptime and calculate NetworkTime