### PR TITLE
Dramatically improve accuracy of network time

### DIFF
--- a/Mirror/Runtime/NetworkTime.cs
+++ b/Mirror/Runtime/NetworkTime.cs
@@ -21,6 +21,10 @@ namespace Mirror
         static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(10);
         static ExponentialMovingAverage _offset = new ExponentialMovingAverage(10);
 
+        // the true offset guaranteed to be in this range
+        private static double offsetMin = Double.MinValue;
+        private static double offsetMax = Double.MaxValue;
+
         // returns the clock time _in this system_
         static double LocalTime()
         {
@@ -73,16 +77,33 @@ namespace Mirror
         internal static void OnClientPong(NetworkMessage netMsg)
         {
             NetworkPongMessage pongMsg = netMsg.ReadMessage<NetworkPongMessage>();
+            double now = LocalTime();
 
             // how long did this message take to come back
-            double rtt = LocalTime() - pongMsg.clientTime;
+            double rtt = now - pongMsg.clientTime;
+            _rtt.Add(rtt);
+
             // the difference in time between the client and the server
             // but subtract half of the rtt to compensate for latency
             // half of rtt is the best approximation we have
-            double offset = LocalTime() - rtt * 0.5f - pongMsg.serverTime;
+            double offset = now - rtt * 0.5f - pongMsg.serverTime;
 
-            _rtt.Add(rtt);
-            _offset.Add(offset);
+            double newOffsetMin = now - rtt - pongMsg.serverTime;
+            double newOffsetMax = now - pongMsg.serverTime;
+            offsetMin = Math.Max(offsetMin, newOffsetMin);
+            offsetMax = Math.Min(offsetMax, newOffsetMax);
+
+            if (_offset.Value < offsetMin || _offset.Value > offsetMax)
+            {
+                // the old offset was offrange,  throw it away and use new one
+                _offset = new ExponentialMovingAverage(PingWindowSize);
+                _offset.Add(offset);
+            }
+            else if (offset >= offsetMin || offset <= offsetMax)
+            {
+                // new offset looks reasonable,  add to the average
+                _offset.Add(offset);
+            }
         }
 
         // returns the same time in both client and server


### PR DESCRIPTION
When synchronizing time,  keep an upper and lower bound for the time offset and discard values that are not in range.   This can dramatically improve accuracy by eliminating noise introduced by network latency.

Before:
<img width="652" alt="screen shot 2018-12-27 at 1 27 43 am" src="https://user-images.githubusercontent.com/466007/50470573-a88b4080-0976-11e9-8b6d-0fff78befdfd.png">

after: 
<img width="656" alt="screen shot 2018-12-27 at 1 28 29 am" src="https://user-images.githubusercontent.com/466007/50470597-c2c51e80-0976-11e9-8b6b-bad9bcbaf9be.png">


In the before chart,  the time offset slowly converges towards the optimal time offset.   It takes 40 seconds to synchronize time with the server as it gradually adjusts the offset towards the optimal value.

In the after chart,  you can see that it takes roughly 2 seconds to synchronize time with the server.