### PR TITLE
NetworkBehaviour.OnRebuildObservers moved to NetworkProximityChecker

### DIFF
--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -432,22 +432,6 @@ namespace Mirror
         public virtual void OnStartAuthority() {}
         public virtual void OnStopAuthority() {}
 
-        // return true when overwriting so that Mirror knows that we wanted to
-        // rebuild observers ourselves. otherwise it uses built in rebuild.
-        public virtual bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
-        {
-            return false;
-        }
-
-        public virtual void OnSetLocalVisibility(bool vis)
-        {
-        }
-
-        public virtual bool OnCheckObserver(NetworkConnection conn)
-        {
-            return true;
-        }
-
         public virtual float GetNetworkSendInterval()
         {
             return k_DefaultSendInterval;

--- a/Mirror/Runtime/NetworkProximityChecker.cs
+++ b/Mirror/Runtime/NetworkProximityChecker.cs
@@ -44,7 +44,7 @@ namespace Mirror
         }
 
         // called when a new player enters
-        public override bool OnCheckObserver(NetworkConnection newObserver)
+        public virtual bool OnCheckObserver(NetworkConnection newObserver)
         {
             if (forceHidden)
                 return false;
@@ -56,7 +56,7 @@ namespace Mirror
             return false;
         }
 
-        public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initial)
+        public virtual void OnRebuildObservers(HashSet<NetworkConnection> observers, bool initial)
         {
             // only add self as observer if force hidden
             if (forceHidden)
@@ -110,14 +110,10 @@ namespace Mirror
                     }
                 }
             }
-
-            // always return true when overwriting OnRebuildObservers so that
-            // Mirror knows not to use the built in rebuild method.
-            return true;
         }
 
         // called hiding and showing objects on the host
-        public override void OnSetLocalVisibility(bool visible)
+        public virtual void OnSetLocalVisibility(bool visible)
         {
             foreach (Renderer rend in GetComponentsInChildren<Renderer>())
             {


### PR DESCRIPTION
NetworkIdentity doesn't search for rebuild functions in each NetworkBehaviour component anymore, only in the NetworkProximityChecker. Improves performance because we don't loop through all the NetworkBehaviour components anymore. Also makes OnRebuildObservers return value less strange. It's simply void now, instead of 'true' if it was overwritten and 'false' otherwise.