### PR TITLE
Add NetworkConnection.lastError, sometimes used for disconnect messages (2018 branch)

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -23,6 +23,8 @@ namespace Mirror
         public bool logNetworkMessages;
         public bool isConnected { get { return hostId != -1; }}
 
+        public NetworkError lastError; //sometimes used for disconnect message
+
         public virtual void Initialize(string networkAddress, int networkHostId, int networkConnectionId)
         {
             address = networkAddress;

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -540,6 +540,7 @@ namespace Mirror
             if (LogFilter.Debug) { Debug.Log("NetworkManager:OnServerErrorInternal"); }
 
             NetworkError errorMessage = (NetworkError)netMsg;
+            netMsg.conn.lastError = errorMessage;
             OnServerError(netMsg.conn, errorMessage.exception);
         }
 
@@ -589,6 +590,7 @@ namespace Mirror
             if (LogFilter.Debug) { Debug.Log("NetworkManager:OnClientErrorInternal"); }
 
             NetworkError networkError = (NetworkError)netMsg;
+            netMsg.conn.lastError = networkError;
             OnClientError(netMsg.conn, networkError.exception);
         }
 


### PR DESCRIPTION
Allows us to close #28 