### PR TITLE
Fix language version to use one used by unity

### DIFF
--- a/Mirror/Editor/Mirror.Editor.csproj
+++ b/Mirror/Editor/Mirror.Editor.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>TRACE;DEBUG;ENABLE_UNET</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>4</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Mirror/Runtime/Mirror.Runtime.csproj
+++ b/Mirror/Runtime/Mirror.Runtime.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>TRACE;DEBUG;ENABLE_UNET</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>4</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>pdbonly</DebugType>

--- a/Mirror/Tests/Mirror.Tests.csproj
+++ b/Mirror/Tests/Mirror.Tests.csproj
@@ -18,6 +18,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>4</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/Mirror/Weaver/Mirror.Weaver.csproj
+++ b/Mirror/Weaver/Mirror.Weaver.csproj
@@ -18,6 +18,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>4</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>

--- a/Mirror/Weaver/Weaver.cs
+++ b/Mirror/Weaver/Weaver.cs
@@ -1802,7 +1802,7 @@ namespace Mirror.Weaver
                     catch (Exception ex)
                     {
                         // workaround until Unity fixes C#7 compiler compability with the UNET weaver
-                        UnityEngine.Debug.LogWarning($"Unable to delete file {pdb}: {ex.Message}");
+                        UnityEngine.Debug.LogWarning(string.Format("Unable to delete file {0}: {1}", pdb, ex.Message));
                     }
                 }
 


### PR DESCRIPTION
Unity uses c# 4 with old scripting runtime, we should switch mirror projects to use it to be 100% safe that'll be working.