### PR TITLE
ProximityChecker NonAlloc to avoid GC

### DIFF
--- a/Mirror/Runtime/NetworkProximityChecker.cs
+++ b/Mirror/Runtime/NetworkProximityChecker.cs
@@ -36,8 +36,8 @@ namespace Mirror
         // -> this is worth it because proximity checking happens for just about
         //    every entity on the server!
         // -> should be big enough to work in just about all cases
-        Collider[] hitsBuffer3D = new Collider[10000];
-        Collider2D[] hitsBuffer2D = new Collider2D[10000];
+        static Collider[] hitsBuffer3D = new Collider[10000];
+        static Collider2D[] hitsBuffer2D = new Collider2D[10000];
 
         void Update()
         {


### PR DESCRIPTION
Tested in uMMORPG with 800 monsters, proximity cast layers set to Everything.

Alloc:
![ummorpg 800 monsters - alloc](https://user-images.githubusercontent.com/16416509/50609384-c2c1a300-0ecf-11e9-9bf6-104292d5230a.png)

NonAlloc:
![ummorpg 800 monsters - nonalloc](https://user-images.githubusercontent.com/16416509/50609378-be958580-0ecf-11e9-89c8-3e2cfdf71b65.png)

5MB less GC. No real performance difference though.

Thoughts?