### PR TITLE
Fix an error when trying to resolve an IP address

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Tcp/Client.cs
+++ b/Assets/Mirror/Runtime/Transport/Tcp/Client.cs
@@ -72,8 +72,15 @@ namespace Mirror.Transport.Tcp
         // resolve the host to an ip address
         private async Task<IPAddress> ResolveAsync(string host)
         {
+            IPAddress ipAddress;
+
+            //if the host is already a valid IP Address then just return that
+            if (IPAddress.TryParse(host, out ipAddress) && (ipAddress.AddressFamily == AddressFamily.InterNetwork || ipAddress.AddressFamily == AddressFamily.InterNetworkV6))
+                return ipAddress;
+
+            //else resolve it
             IPHostEntry ipHostInfo = await Dns.GetHostEntryAsync(host);
-            IPAddress ipAddress = ipHostInfo.AddressList.FirstOrDefault(address => address.AddressFamily == AddressFamily.InterNetwork);
+            ipAddress = ipHostInfo.AddressList.FirstOrDefault(address => address.AddressFamily == AddressFamily.InterNetwork || ipAddress.AddressFamily == AddressFamily.InterNetworkV6);
             if (ipAddress == null)
                 throw new SocketException((int)SocketError.AddressFamilyNotSupported);
 


### PR DESCRIPTION
Alkanov had an error when trying to connect to an IP address. When passing an IP address into Dns.GetHostEntryAsync, it first looks up a reverse DNS for that IP. If that successful it then does a further resolve and returns all ip addresses for that reverse DNS result. In his case the reverse dns name didnt resolve back to his IP address.

The fix first tries to check if the host is already a valid IPAddress and just return it which will be quicker and prevent this error. I also allowed IPV6 as I presume thats also fine.