### PR TITLE
Changed ChannelIds to bytes

### DIFF
--- a/Mirror/Runtime/CustomAttributes.cs
+++ b/Mirror/Runtime/CustomAttributes.cs
@@ -19,25 +19,25 @@ namespace Mirror
     [AttributeUsage(AttributeTargets.Method)]
     public class CommandAttribute : Attribute
     {
-        public int channel = Channels.DefaultReliable; // this is zero
+        public byte channel = Channels.DefaultReliable; // this is zero
     }
 
     [AttributeUsage(AttributeTargets.Method)]
     public class ClientRpcAttribute : Attribute
     {
-        public int channel = Channels.DefaultReliable; // this is zero
+        public byte channel = Channels.DefaultReliable; // this is zero
     }
 
     [AttributeUsage(AttributeTargets.Method)]
     public class TargetRpcAttribute : Attribute
     {
-        public int channel = Channels.DefaultReliable; // this is zero
+        public byte channel = Channels.DefaultReliable; // this is zero
     }
 
     [AttributeUsage(AttributeTargets.Event)]
     public class SyncEventAttribute : Attribute
     {
-        public int channel = Channels.DefaultReliable; // this is zero
+        public byte channel = Channels.DefaultReliable; // this is zero
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/Mirror/Runtime/LocalConnections.cs
+++ b/Mirror/Runtime/LocalConnections.cs
@@ -16,7 +16,7 @@ namespace Mirror
             m_LocalClient = localClient;
         }
 
-        protected override bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
+        protected override bool SendBytes(byte[] bytes, byte channelId = Channels.DefaultReliable)
         {
             m_LocalClient.InvokeBytesOnClient(bytes);
             return true;
@@ -31,7 +31,7 @@ namespace Mirror
         {
         }
 
-        protected override bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
+        protected override bool SendBytes(byte[] bytes, byte channelId = Channels.DefaultReliable)
         {
             if (bytes.Length == 0)
             {

--- a/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Mirror/Runtime/NetworkBehaviour.cs
@@ -77,7 +77,7 @@ namespace Mirror
         // ----------------------------- Commands --------------------------------
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendCommandInternal(Type invokeClass, string cmdName, NetworkWriter writer, int channelId)
+        protected void SendCommandInternal(Type invokeClass, string cmdName, NetworkWriter writer, byte channelId)
         {
             // local players can always send commands, regardless of authority, other objects must have authority.
             if (!(isLocalPlayer || hasAuthority))
@@ -111,7 +111,7 @@ namespace Mirror
         // ----------------------------- Client RPCs --------------------------------
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendRPCInternal(Type invokeClass, string rpcName, NetworkWriter writer, int channelId)
+        protected void SendRPCInternal(Type invokeClass, string rpcName, NetworkWriter writer, byte channelId)
         {
             // This cannot use NetworkServer.active, as that is not specific to this object.
             if (!isServer)
@@ -131,7 +131,7 @@ namespace Mirror
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendTargetRPCInternal(NetworkConnection conn, Type invokeClass, string rpcName, NetworkWriter writer, int channelId)
+        protected void SendTargetRPCInternal(NetworkConnection conn, Type invokeClass, string rpcName, NetworkWriter writer, byte channelId)
         {
             // This cannot use NetworkServer.active, as that is not specific to this object.
             if (!isServer)
@@ -159,7 +159,7 @@ namespace Mirror
         // ----------------------------- Sync Events --------------------------------
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendEventInternal(Type invokeClass, string eventName, NetworkWriter writer, int channelId)
+        protected void SendEventInternal(Type invokeClass, string eventName, NetworkWriter writer, byte channelId)
         {
             if (!NetworkServer.active)
             {

--- a/Mirror/Runtime/NetworkConnection.cs
+++ b/Mirror/Runtime/NetworkConnection.cs
@@ -155,7 +155,7 @@ namespace Mirror
             m_PlayerController = null;
         }
 
-        public virtual bool Send(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        public virtual bool Send(short msgType, MessageBase msg, byte channelId = Channels.DefaultReliable)
         {
             NetworkWriter writer = new NetworkWriter();
             msg.Serialize(writer);
@@ -167,7 +167,7 @@ namespace Mirror
 
         // protected because no one except NetworkConnection should ever send bytes directly to the client, as they
         // would be detected as some kind of message. send messages instead.
-        protected virtual bool SendBytes( byte[] bytes, int channelId = Channels.DefaultReliable)
+        protected virtual bool SendBytes( byte[] bytes, byte channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) { Debug.Log("ConnectionSend con:" + connectionId + " bytes:" + BitConverter.ToString(bytes)); }
 
@@ -278,7 +278,7 @@ namespace Mirror
             HandleBytes(bytes);
         }
 
-        public virtual bool TransportSend(int channelId, byte[] bytes, out byte error)
+        public virtual bool TransportSend(byte channelId, byte[] bytes, out byte error)
         {
             error = 0;
             if (Transport.layer.ClientConnected())

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -214,7 +214,7 @@ namespace Mirror
             return false;
         }
 
-        public static bool SendToAll(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        public static bool SendToAll(short msgType, MessageBase msg, byte channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) { Debug.Log("Server.SendToAll id:" + msgType); }
 
@@ -227,7 +227,7 @@ namespace Mirror
             return result;
         }
 
-        public static bool SendToReady(GameObject contextObj, short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        public static bool SendToReady(GameObject contextObj, short msgType, MessageBase msg, byte channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) { Debug.Log("Server.SendToReady msgType:" + msgType); }
 

--- a/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -10,7 +10,7 @@ namespace Mirror
     {
         readonly ConnectionConfig connectionConfig;
         readonly GlobalConfig globalConfig;
-        readonly int channelId; // always use first channel
+        readonly byte channelId; // always use first channel
         byte error;
 
         int clientId = -1;
@@ -101,7 +101,7 @@ namespace Mirror
             }
         }
 
-        public bool ClientSend(int channelId, byte[] data)
+        public bool ClientSend(byte channelId, byte[] data)
         {
             return NetworkTransport.Send(clientId, clientConnectionId, channelId, data, data.Length, out error);
         }
@@ -176,7 +176,7 @@ namespace Mirror
             //Debug.Log("LLAPITransport.ServerStartWebsockets port=" + port + " max=" + maxConnections + " hostid=" + serverHostId);
         }
 
-        public bool ServerSend(int connectionId, int channelId, byte[] data)
+        public bool ServerSend(int connectionId, byte channelId, byte[] data)
         {
             return NetworkTransport.Send(serverHostId, connectionId, channelId, data, data.Length, out error);
         }
@@ -260,7 +260,7 @@ namespace Mirror
             Debug.Log("LLAPITransport.Shutdown");
         }
 
-        public int GetMaxPacketSize(int channelId)
+        public int GetMaxPacketSize(byte channelId)
         {
             return globalConfig.MaxPacketSize;
         }

--- a/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -25,7 +25,7 @@ namespace Mirror
         // client
         public virtual bool ClientConnected() { return client.Connected; }
         public virtual void ClientConnect(string address, int port) { client.Connect(address, port); }
-        public virtual bool ClientSend(int channelId, byte[] data) { return client.Send(data); }
+        public virtual bool ClientSend(byte channelId, byte[] data) { return client.Send(data); }
         public virtual bool ClientGetNextMessage(out TransportEvent transportEvent, out byte[] data)
         {
             Telepathy.Message message;
@@ -66,7 +66,7 @@ namespace Mirror
         {
             Debug.LogWarning("TelepathyTransport.ServerStartWebsockets not implemented yet!");
         }
-        public virtual bool ServerSend(int connectionId, int channelId, byte[] data) { return server.Send(connectionId, data); }
+        public virtual bool ServerSend(int connectionId, byte channelId, byte[] data) { return server.Send(connectionId, data); }
         public virtual bool ServerGetNextMessage(out int connectionId, out TransportEvent transportEvent, out byte[] data)
         {
             Telepathy.Message message;
@@ -115,7 +115,7 @@ namespace Mirror
             server.Stop();
         }
 
-        public int GetMaxPacketSize(int channelId)
+        public int GetMaxPacketSize(byte channelId)
         {
             // Telepathy's limit is Array.Length, which is int
             return int.MaxValue;

--- a/Mirror/Runtime/Transport/TelepathyWebsocketsMultiplexTransport.cs
+++ b/Mirror/Runtime/Transport/TelepathyWebsocketsMultiplexTransport.cs
@@ -36,7 +36,7 @@ namespace Mirror
         {
             client.ClientConnect(address, port);
         }
-        public bool ClientSend(int channelId, byte[] data)
+        public bool ClientSend(byte channelId, byte[] data)
         {
             return client.ClientSend(channelId, data);
         }
@@ -81,7 +81,7 @@ namespace Mirror
             else Debug.LogWarning("ServerStartWebsockets can't be called in WebGL.");
         }
 
-        public bool ServerSend(int connectionId, int channelId, byte[] data)
+        public bool ServerSend(int connectionId, byte channelId, byte[] data)
         {
             return server != null && server.ServerSend(connectionId, channelId, data);
         }
@@ -117,7 +117,7 @@ namespace Mirror
             if (server != null) server.Shutdown();
         }
 
-        public int GetMaxPacketSize(int channelId)
+        public int GetMaxPacketSize(byte channelId)
         {
             if (server != null) return server.GetMaxPacketSize(channelId);
             if (client != null) return client.GetMaxPacketSize(channelId);

--- a/Mirror/Runtime/Transport/Transport.cs
+++ b/Mirror/Runtime/Transport/Transport.cs
@@ -20,7 +20,7 @@ namespace Mirror
         // client
         bool ClientConnected();
         void ClientConnect(string address, int port);
-        bool ClientSend(int channelId, byte[] data);
+        bool ClientSend(byte channelId, byte[] data);
         bool ClientGetNextMessage(out TransportEvent transportEvent, out byte[] data);
         void ClientDisconnect();
 
@@ -28,7 +28,7 @@ namespace Mirror
         bool ServerActive();
         void ServerStart(string address, int port, int maxConnections);
         void ServerStartWebsockets(string address, int port, int maxConnections);
-        bool ServerSend(int connectionId, int channelId, byte[] data);
+        bool ServerSend(int connectionId, byte channelId, byte[] data);
         bool ServerGetNextMessage(out int connectionId, out TransportEvent transportEvent, out byte[] data);
         bool ServerDisconnect(int connectionId);
         bool GetConnectionInfo(int connectionId, out string address);
@@ -36,6 +36,6 @@ namespace Mirror
 
         // common
         void Shutdown();
-        int GetMaxPacketSize(int channelId=Channels.DefaultReliable);
+        int GetMaxPacketSize(byte channelId=Channels.DefaultReliable);
     }
 }

--- a/Mirror/Runtime/UNetwork.cs
+++ b/Mirror/Runtime/UNetwork.cs
@@ -84,8 +84,8 @@ namespace Mirror
 
     public class Channels
     {
-        public const int DefaultReliable = 0;
-        public const int DefaultUnreliable = 1;
+        public const byte DefaultReliable = 0;
+        public const byte DefaultUnreliable = 1;
     }
 
     // network protocol all in one place, instead of constructing headers in all kinds of different places

--- a/Mirror/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Mirror/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -434,13 +434,13 @@ namespace Mirror.Weaver
             m_td.Methods.Add(serialize);
         }
 
-        public static int GetChannelId(CustomAttribute ca)
+        public static byte GetChannelId(CustomAttribute ca)
         {
             foreach (CustomAttributeNamedArgument customField in ca.Fields)
             {
                 if (customField.Name == "channel")
                 {
-                    return (int)customField.Argument.Value;
+                    return (byte)customField.Argument.Value;
                 }
             }
 


### PR DESCRIPTION
Cause:
1. we shouldn't have negative channel ids
2. nobody needs that much channels as int may have, 255 should be enough (if not, we can change it to ushort, 65k should be more than enough)