### PR TITLE
Correct order of Destroy in RemovePlayerMessage

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -755,8 +755,8 @@ namespace Mirror
         {
             if (netMsg.conn.playerController != null)
             {
-                netMsg.conn.RemovePlayerController();
                 Destroy(netMsg.conn.playerController.gameObject);
+                netMsg.conn.RemovePlayerController();
             }
             else
             {


### PR DESCRIPTION
The RemovePlayerController call sets the playerController to null, causing a null dereference
