### PR TITLE
Correct order of Destroy in RemovePlayer

### DIFF
--- a/Mirror/Runtime/ClientScene.cs
+++ b/Mirror/Runtime/ClientScene.cs
@@ -121,10 +121,11 @@ namespace Mirror
                 RemovePlayerMessage msg = new RemovePlayerMessage();
                 s_ReadyConnection.Send((short)MsgType.RemovePlayer, msg);
 
+                Object.Destroy(s_ReadyConnection.playerController.gameObject);
+
                 s_ReadyConnection.RemovePlayerController();
                 s_LocalPlayer = null;
 
-                Object.Destroy(s_ReadyConnection.playerController.gameObject);
                 return true;
             }
             return false;

--- a/Mirror/Runtime/NetworkServer.cs
+++ b/Mirror/Runtime/NetworkServer.cs
@@ -821,8 +821,8 @@ namespace Mirror
         {
             if (netMsg.conn.playerController != null)
             {
-                netMsg.conn.RemovePlayerController();
                 Destroy(netMsg.conn.playerController.gameObject);
+                netMsg.conn.RemovePlayerController();
             }
             else
             {


### PR DESCRIPTION
The RemovePlayerController call sets the playerController to null, causing a null dereference  (and a memory leak as pointed out by @paulpach, since gameobjects are never destroyed)

I haven't tested this code, I just came across it while digging through the internals to figure out some unrelated question, dont see any reason why it shouldn't work though.
This code is also only triggered when the client explicitly asks for the player controller to be removed, as opposed to just closing the whole connection down, which is probably also why this bug hasn't popped up yet.