### PR TITLE
NetID Spawning Issue Fix

### DIFF
--- a/Mirror/Runtime/NetworkIdentity.cs
+++ b/Mirror/Runtime/NetworkIdentity.cs
@@ -769,7 +769,7 @@ namespace Mirror
 
             foreach (NetworkConnection conn in oldObservers)
             {
-                if (!newObservers.Contains(conn))
+                if (!newObservers.Contains(conn) && NetworkServer.localConnection!=null)
                 {
                     // removed observer
                     conn.RemoveFromVisList(this, false);


### PR DESCRIPTION
Fixs NetID going missing when spawning Player. Not sure if it causes other problems.