### PR TITLE
Avoids clients disconnection on exception

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -588,25 +588,33 @@ namespace Mirror
         // helper function to handle SyncEvent/Command/Rpc
         internal void HandleRemoteCall(int componentIndex, int functionHash, UNetInvokeType invokeType, NetworkReader reader)
         {
-            if (gameObject == null)
+            try
             {
-                Debug.LogWarning(invokeType + " [" + functionHash + "] received for deleted object [netId=" + netId + "]");
-                return;
-            }
-
-            // find the right component to invoke the function on
-            if (0 <= componentIndex && componentIndex < m_NetworkBehaviours.Length)
-            {
-                NetworkBehaviour invokeComponent = m_NetworkBehaviours[componentIndex];
-                if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader))
+                if (gameObject == null)
                 {
-                    Debug.LogError("Found no receiver for incoming " + invokeType + " [" + functionHash + "] on " + gameObject + ",  the server and client should have the same NetworkBehaviour instances [netId=" + netId + "].");
+                    Debug.LogWarning(invokeType + " [" + functionHash + "] received for deleted object [netId=" + netId + "]");
+                    return;
+                }
+
+                // find the right component to invoke the function on
+                if (0 <= componentIndex && componentIndex < m_NetworkBehaviours.Length)
+                {
+                    NetworkBehaviour invokeComponent = m_NetworkBehaviours[componentIndex];
+                    if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader))
+                    {
+                        Debug.LogError("Found no receiver for incoming " + invokeType + " [" + functionHash + "] on " + gameObject + ",  the server and client should have the same NetworkBehaviour instances [netId=" + netId + "].");
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning("Component [" + componentIndex + "] not found for [netId=" + netId + "]");
                 }
             }
-            else
-            {
-                Debug.LogWarning("Component [" + componentIndex + "] not found for [netId=" + netId + "]");
+            catch (Exception ex)
+            {               
+                Debug.LogError(ex);                
             }
+            
         }
 
         // happens on client


### PR DESCRIPTION
When there is an exception on HandleRemoteCall() the client drops - this avoids client losing connection to server while at the same time logs the error for further investigation.

This solution is working fine in my live clients in Laurum Online

Error log of the exact exception that causes clients to disconnect: https://pastebin.com/CRT75Jh1