### PR TITLE
Fix Enum and msgType error when set logNetworkMessages to true

### DIFF
--- a/Mirror/Runtime/NetworkConnection.cs
+++ b/Mirror/Runtime/NetworkConnection.cs
@@ -204,7 +204,7 @@ namespace Mirror
             {
                 if (logNetworkMessages)
                 {
-                    if (Enum.IsDefined(typeof(MsgType), msgType))
+                    if (Enum.IsDefined(typeof(MsgType), (short)msgType))
                     {
                         // one of Mirror mesage types,  display the message name
                         Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + (MsgType)msgType + " content:" + BitConverter.ToString(content));


### PR DESCRIPTION
This is en error on the console.

> ArgumentException: Enum underlying type and the object must be same type or object must be a String. Type passed in was 'System.UInt16'; the enum underlying type was 'System.Int16'.
> System.RuntimeType.IsEnumDefined (System.Object value) (at <ac823e2bb42b41bda67924a45a0173c3>:0)
> System.Enum.IsDefined (System.Type enumType, System.Object value) (at <ac823e2bb42b41bda67924a45a0173c3>:0)
> Mirror.NetworkConnection.HandleBytes (System.Byte[] buffer) (at Assets/Mirror/Mirror/Runtime/NetworkConnection.cs:205)
> Mirror.NetworkConnection.TransportReceive (System.Byte[] bytes) (at Assets/Mirror/Mirror/Runtime/NetworkConnection.cs:276)
> Mirror.NetworkServer.OnData (Mirror.NetworkConnection conn, System.Byte[] data) (at Assets/Mirror/Mirror/Runtime/NetworkServer.cs:384)
> Mirror.NetworkServer.HandleData (System.Int32 connectionId, System.Byte[] data) (at Assets/Mirror/Mirror/Runtime/NetworkServer.cs:374)
> Mirror.Transport.MultiplexTransport+<>c__DisplayClass35_0.<InitServer>b__1 (System.Int32 baseConnectionId, System.Byte[] data) (at Assets/Mirror/Mirror/Runtime/Transport/MultiplexTransport.cs:115)
> Mirror.Transport.Tcp.TcpTransport.<.ctor>b__27_2 (System.Int32 id, System.Byte[] data) (at Assets/Mirror/Mirror/Runtime/Transport/Tcp/TcpTransport.cs:31)
> Mirror.Transport.Tcp.Server+<ReceiveLoop>d__21.MoveNext () (at Assets/Mirror/Mirror/Runtime/Transport/Tcp/Server.cs:132)
> UnityEngine.Debug:LogException(Exception, Object)
> Mirror.NetworkManager:OnServerError(NetworkConnection, Exception) (at Assets/Mirror/Mirror/Runtime/NetworkManager.cs:751)
> Mirror.NetworkManager:OnServerErrorInternal(NetworkMessage) (at Assets/Mirror/Mirror/Runtime/NetworkManager.cs:591)
> Mirror.NetworkConnection:InvokeHandler(NetworkMessage) (at Assets/Mirror/Mirror/Runtime/NetworkConnection.cs:127)
> Mirror.NetworkServer:OnError(NetworkConnection, Exception) (at Assets/Mirror/Mirror/Runtime/NetworkServer.cs:410)
> Mirror.NetworkServer:HandleError(Int32, Exception) (at Assets/Mirror/Mirror/Runtime/NetworkServer.cs:392)
> Mirror.Transport.<>c__DisplayClass35_0:<InitServer>b__2(Int32, Exception) (at Assets/Mirror/Mirror/Runtime/Transport/MultiplexTransport.cs:119)
> Mirror.Transport.Tcp.TcpTransport:<.ctor>b__27_3(Int32, Exception) (at Assets/Mirror/Mirror/Runtime/Transport/Tcp/TcpTransport.cs:32)
> Mirror.Transport.Tcp.<ReceiveLoop>d__21:MoveNext() (at Assets/Mirror/Mirror/Runtime/Transport/Tcp/Server.cs:138)
> System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1:SetResult(Byte[])
> Mirror.Transport.Tcp.<ReadMessageAsync>d__3:MoveNext() (at Assets/Mirror/Mirror/Runtime/Transport/Tcp/Common.cs:71)
> System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1:SetResult(Byte[])
> Mirror.Transport.Tcp.<ReadExactlyAsync>d__0:MoveNext() (at Assets/Mirror/Mirror/Runtime/Transport/Tcp/NetworkStreamExtensions.cs:50)
> UnityEngine.UnitySynchronizationContext:ExecuteTasks()

At first, I would like to change enum MsgType to ushort but I decided to cast msgType to short instead because the comment said that "// => we specify the short values so it's easier to look up opcodes when debugging packets". And the code also looks more consistent this way.