### PR TITLE
Add virtual to port so that it can be overrided

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -45,7 +45,7 @@ namespace Mirror
         // only really valid on the server
         public int numPlayers { get { return NetworkServer.connections.Count(kv => kv.Value.playerController != null); } }
 
-        public ushort port {
+        public virtual ushort port {
             get
             {
                 if (Application.platform != RuntimePlatform.WebGLPlayer && useTcp)


### PR DESCRIPTION
I'm using Ignorance which is udp. I can specify my own udp port to use when the transport is initialized in my network manager. But the problem is that I cannot change it at runtime. From my testing, I can change it if I override port to return my udp port instead. I need to be able to change port at runtime in order to connect to different game server port.