### PR TITLE
Fixed offline scene reload on client connection fails.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -67,6 +67,10 @@ namespace Mirror
                     "https://github.com/vis2k/Mirror/tree/2018");
             }
 
+            // Set the networkSceneName to prevent a scene reload
+            // if client connection to server fails.
+            networkSceneName = offlineScene;
+
             InitializeSingleton();
         }
 


### PR DESCRIPTION
If a client tries to connect a server that doesn't exist, it will fail and reload the offline scene (if it's set). It is caused by the `if (newSceneName == networkSceneName)` check in ClientChangeScene and since networkSceneName is empty from the start, it goes ahead and reloads the scene.   
By setting the networkSceneName variable in Awake to the offline scene, it prevents that reload from happening.