### PR TITLE
Reduce garbage in NetworkBehaviour.IsDirty

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -414,8 +414,15 @@ namespace Mirror
         {
             if (Time.time - m_LastSendTime >= syncInterval)
             {
-                return m_SyncVarDirtyBits != 0L
-                        || m_SyncObjects.Any(obj => obj.IsDirty);
+                if (m_SyncVarDirtyBits != 0L) {
+                    return true;
+                }
+
+                for (var i = 0; i < m_SyncObjects.Count; i++) {
+                    if (m_SyncObjects[i].IsDirty) {
+                        return true;
+                    }
+                }
             }
             return false;
         }


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/1426904/51201808-5d24dc00-18fd-11e9-89da-57ff8b7c712b.png)
After: 
![image](https://user-images.githubusercontent.com/1426904/51201906-9fe6b400-18fd-11e9-870e-3b04c58f598c.png)

This change removes ~180KB of garbage per frame and shaves off 1.3ms of the NetworkManager.LateUpdate time, cutting it in half.
This is with about 1200 networked objects, so your gains might vary