### PR TITLE
Do not pollute default namespace with examples

### DIFF
--- a/Assets/Mirror/Examples/Movement/Scripts/Move.cs
+++ b/Assets/Mirror/Examples/Movement/Scripts/Move.cs
@@ -1,22 +1,25 @@
 ﻿using UnityEngine;
 using Mirror;
 
-public class Move : NetworkBehaviour
+namespace Mirror.Examples.Movement
 {
-    public CharacterController controller;
-    public float speed = 300;
-    public float rotationSpeed = 400;
-
-    void Update()
+    public class Move : NetworkBehaviour
     {
-        // movement for local player
-        if (!isLocalPlayer) return;
+        public CharacterController controller;
+        public float speed = 300;
+        public float rotationSpeed = 400;
 
-        // rotate
-        transform.Rotate(0, Input.GetAxis("Horizontal") * rotationSpeed * Time.deltaTime, 0);
+        void Update()
+        {
+            // movement for local player
+            if (!isLocalPlayer) return;
 
-        // move
-        Vector3 forward = transform.TransformDirection(Vector3.forward);
-        controller.SimpleMove(forward * Input.GetAxis("Vertical") * speed * Time.deltaTime);
+            // rotate
+            transform.Rotate(0, Input.GetAxis("Horizontal") * rotationSpeed * Time.deltaTime, 0);
+
+            // move
+            Vector3 forward = transform.TransformDirection(Vector3.forward);
+            controller.SimpleMove(forward * Input.GetAxis("Vertical") * speed * Time.deltaTime);
+        }
     }
 }

--- a/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
@@ -1,53 +1,58 @@
 ﻿using UnityEngine;
 using Mirror;
 
-public class Ball : NetworkBehaviour
+namespace Mirror.Examples.Pong
 {
-    public float speed = 30;
 
-    [ServerCallback] // only call this on server
-    void Start()
+
+    public class Ball : NetworkBehaviour
     {
-        // Initial Velocity
-        GetComponent<Rigidbody2D>().velocity = Vector2.right * speed;
-    }
+        public float speed = 30;
 
-    float HitFacgtor(Vector2 ballPos, Vector2 racketPos, float racketHeight)
-    {
-        // ascii art:
-        // ||  1 <- at the top of the racket
-        // ||
-        // ||  0 <- at the middle of the racket
-        // ||
-        // || -1 <- at the bottom of the racket
-        return (ballPos.y - racketPos.y) / racketHeight;
-    }
-
-    [ServerCallback] // only call this on server
-    void OnCollisionEnter2D(Collision2D col)
-    {
-        // Note: 'col' holds the collision information. If the
-        // Ball collided with a racket, then:
-        //   col.gameObject is the racket
-        //   col.transform.position is the racket's position
-        //   col.collider is the racket's collider
-
-        // did we hit a racket? then we need to calculate the hit factor
-        if (col.transform.GetComponent<Player>())
+        [ServerCallback] // only call this on server
+        void Start()
         {
-            // Calculate y direction via hit Factor
-            float y = HitFacgtor(transform.position,
-                                col.transform.position,
-                                col.collider.bounds.size.y);
+            // Initial Velocity
+            GetComponent<Rigidbody2D>().velocity = Vector2.right * speed;
+        }
 
-            // Calculate x direction via opposite collision
-            float x = col.relativeVelocity.x > 0 ? 1 : -1;
+        float HitFacgtor(Vector2 ballPos, Vector2 racketPos, float racketHeight)
+        {
+            // ascii art:
+            // ||  1 <- at the top of the racket
+            // ||
+            // ||  0 <- at the middle of the racket
+            // ||
+            // || -1 <- at the bottom of the racket
+            return (ballPos.y - racketPos.y) / racketHeight;
+        }
 
-            // Calculate direction, make length=1 via .normalized
-            Vector2 dir = new Vector2(x, y).normalized;
+        [ServerCallback] // only call this on server
+        void OnCollisionEnter2D(Collision2D col)
+        {
+            // Note: 'col' holds the collision information. If the
+            // Ball collided with a racket, then:
+            //   col.gameObject is the racket
+            //   col.transform.position is the racket's position
+            //   col.collider is the racket's collider
 
-            // Set Velocity with dir * speed
-            GetComponent<Rigidbody2D>().velocity = dir * speed;
+            // did we hit a racket? then we need to calculate the hit factor
+            if (col.transform.GetComponent<Player>())
+            {
+                // Calculate y direction via hit Factor
+                float y = HitFacgtor(transform.position,
+                                    col.transform.position,
+                                    col.collider.bounds.size.y);
+
+                // Calculate x direction via opposite collision
+                float x = col.relativeVelocity.x > 0 ? 1 : -1;
+
+                // Calculate direction, make length=1 via .normalized
+                Vector2 dir = new Vector2(x, y).normalized;
+
+                // Set Velocity with dir * speed
+                GetComponent<Rigidbody2D>().velocity = dir * speed;
+            }
         }
     }
 }

--- a/Assets/Mirror/Examples/Pong/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/Player.cs
@@ -1,18 +1,21 @@
 ﻿using UnityEngine;
 using Mirror;
 
-public class Player : NetworkBehaviour
+namespace Mirror.Examples.Pong
 {
-    public float speed = 30;
-
-    // need to use FixedUpdate for rigidbody
-    void FixedUpdate()
+    public class Player : NetworkBehaviour
     {
-        // only let the local player control the racket.
-        // don't control other player's rackets
-        if (!isLocalPlayer) return;
+        public float speed = 30;
 
-        float vertical = Input.GetAxisRaw("Vertical");
-        GetComponent<Rigidbody2D>().velocity = new Vector2(0, vertical) * speed;
+        // need to use FixedUpdate for rigidbody
+        void FixedUpdate()
+        {
+            // only let the local player control the racket.
+            // don't control other player's rackets
+            if (!isLocalPlayer) return;
+
+            float vertical = Input.GetAxisRaw("Vertical");
+            GetComponent<Rigidbody2D>().velocity = new Vector2(0, vertical) * speed;
+        }
     }
 }


### PR DESCRIPTION
Having objects like "Player" in the default namespace will interfere with a lot of people's code.

Make sure the examples are in their namespace to avoid name collisions with user's scripts.

Note the real change is 3 LOC,  which is the namespaces for the classes.   The rest the patch is just indentation