### PR TITLE
Don't serialize the object if there are no observers

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -632,6 +632,9 @@ namespace Mirror
         // invoked by unity runtime immediately after the regular "Update()" function.
         internal void UNetUpdate()
         {
+            if (observers.Count == 0)
+                return;
+
             // serialize all the dirty components and send (if any were dirty)
             byte[] payload = OnSerializeAllSafely(false);
             if (payload != null)


### PR DESCRIPTION
If there are no clients connected,  or the object has no observers,  there is no need to serialize the data. 

Here is a test with 1000 objects with 3 components each in server only mode with no client

Before:
<img width="604" alt="screen shot 2019-01-15 at 6 51 53 pm" src="https://user-images.githubusercontent.com/466007/51220852-96108100-18fc-11e9-8f44-565e95577a8d.png">

After:
<img width="592" alt="screen shot 2019-01-15 at 7 31 41 pm" src="https://user-images.githubusercontent.com/466007/51220861-a32d7000-18fc-11e9-9439-3c1ef2550407.png">
