### PR TITLE
Onserialize improvements

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -451,9 +451,8 @@ namespace Mirror
             // write placeholder length bytes
             // (jumping back later is WAY faster than allocating a temporary
             //  writer for the payload, then writing payload.size, payload)
-            int sizePosition = writer.Position;
+            int startPosition = writer.Position;
             writer.Write((int)0);
-            int payloadPosition = writer.Position;
 
             // write payload
             bool result = false;
@@ -466,13 +465,12 @@ namespace Mirror
                 // show a detailed error and let the user know what went wrong
                 Debug.LogError("OnSerialize failed for: object=" + name + " component=" + comp.GetType() + " sceneId=" + m_SceneId + "\n\n" + e.ToString());
             }
-            int endPosition = writer.Position;
-            int payloadSize = endPosition - payloadPosition;
+            int payloadSize = writer.Position - startPosition - 4;
 
             // fill in length now
-            writer.Position = sizePosition;
+            writer.Position = startPosition;
             writer.Write(payloadSize);
-            writer.Position = endPosition;
+            writer.Position = startPosition + payloadSize + 4;
 
             if (LogFilter.Debug) { Debug.Log("OnSerializeSafely written for object=" + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId + " length=" + payloadSize); }
 


### PR DESCRIPTION
did some more tests. I can get it down to 0.6MB GC and time closer to barriers time.
+100% safe. will never fail.
+no barrier magic
-not as fast as barrier

**current:**
![current](https://user-images.githubusercontent.com/16416509/51258711-e0e8d200-19aa-11e9-87ba-de06f0bf5f52.png)

**barriers:**
![barriers](https://user-images.githubusercontent.com/16416509/51258690-d8909700-19aa-11e9-91dc-4184af419d7a.png)

**current-optimized:**
![positionmagic_optimized and no lengthcheck for maxpacketsize](https://user-images.githubusercontent.com/16416509/51258723-e9d9a380-19aa-11e9-85cd-badc28170b65.png)

extra: **current-optimized + static writer caching:**
![positionmagic_optimized_cachedwriter](https://user-images.githubusercontent.com/16416509/51258760-fc53dd00-19aa-11e9-8985-616abefdfe0f.png)

this old UNET bug caused me so much pain, I'd really like to keep this fail safe so that a component can never touch another component's data, no matter what. or do you guys think the few ms there are worth it for barriers?