### PR TITLE
Start on Headless is optional

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -17,11 +17,14 @@ namespace Mirror
         public int offsetX;
         public int offsetY;
 
+        [Tooltip("Start the server automatically when running in headless mode")]
+        public bool startOnHeadless = true;
+
         void Awake()
         {
             manager = GetComponent<NetworkManager>();
 
-            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null)
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null && startOnHeadless)
             {
                 // headless mode. Just start the server
                 manager.StartServer();


### PR DESCRIPTION
Users can now turn off that behavior.

This is useful if people want to customize transports before it is auto started