### PR TITLE
OnServerAddPlayer uses NetworkMessage parameter instead of NetworkReader. Removes last dependency on NetworkReader.ReadMessage

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -78,6 +78,7 @@ namespace Mirror
         }
 
         // use this to implicitly become ready
+        // -> extraMessage can contain character selection, etc.
         public static bool AddPlayer(NetworkConnection readyConn, MessageBase extraMessage)
         {
             // ensure valid ready connection

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -512,8 +512,12 @@ namespace Mirror
 
             if (msg.value != null && msg.value.Length > 0)
             {
-                NetworkReader reader = new NetworkReader(msg.value);
-                OnServerAddPlayer(netMsg.conn, reader);
+                // convert payload to extra message and call OnServerAddPlayer
+                // (usually for character selection information)
+                NetworkMessage extraMessage = new NetworkMessage();
+                extraMessage.reader = new NetworkReader(msg.value);
+                extraMessage.conn = netMsg.conn;
+                OnServerAddPlayer(netMsg.conn, extraMessage);
             }
             else
             {
@@ -623,7 +627,7 @@ namespace Mirror
             NetworkServer.SetClientReady(conn);
         }
 
-        public virtual void OnServerAddPlayer(NetworkConnection conn, NetworkReader extraMessageReader)
+        public virtual void OnServerAddPlayer(NetworkConnection conn, NetworkMessage extraMessage)
         {
             OnServerAddPlayerInternal(conn);
         }


### PR DESCRIPTION
if we merge this then we can move NetworkReader.ReadMessage to NetworkMessage. untangles that complexity once and for all.