### PR TITLE
Remove navigation to Contributions

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -12,8 +12,6 @@
       url: "/General/Deprecations"
     - title: "Support"
       url: "/General/Support"
-    - title: "Contributions"
-      url: "/General/Contributions"
 - title: "Concepts"
   children:
     - title: "Overview"


### PR DESCRIPTION
Part of removing the redundant Contributions page in docs - no point in having two of them.