### PR TITLE
Add SetNetworkPort() to ITransport

### DIFF
--- a/Assets/Mirror/Runtime/Transport/ITransport.cs
+++ b/Assets/Mirror/Runtime/Transport/ITransport.cs
@@ -28,5 +28,6 @@ namespace Mirror
         // common
         void Shutdown();
         int GetMaxPacketSize(int channelId=Channels.DefaultReliable);
+        void SetNetworkPort();
     }
 }


### PR DESCRIPTION
Utilized by about half of the transport options. Would provide easy access.