### PR TITLE
Dispatch Messages as Events - via UnityEvent

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -141,6 +141,7 @@ namespace Mirror
                 m_Connection.Dispose();
                 m_Connection = null;
                 m_ClientId = -1;
+                RemoveTransportHandlers();
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -11,8 +11,6 @@ namespace Mirror
         public static List<NetworkClient> allClients = new List<NetworkClient>();
         public static bool active { get { return s_IsActive; } }
 
-        public static bool pauseMessageHandling;
-
         string m_ServerIp = "";
         int m_ClientId = -1;
 
@@ -74,12 +72,63 @@ namespace Mirror
             m_Connection.SetHandlers(handlers);
         }
 
+        private void InitializeTransportHandlers()
+        {
+            // TODO do this in inspector?
+            NetworkManager.singleton.transport.OnClientConnected.AddListener(OnConnected);
+            NetworkManager.singleton.transport.OnClientDataReceived.AddListener(OnDataReceived);
+            NetworkManager.singleton.transport.OnClientDisconnected.AddListener(OnDisconnected);
+            NetworkManager.singleton.transport.OnClientError.AddListener(OnError);
+        }
+
+        void OnError(Exception exception)
+        {
+            Debug.LogException(exception);
+        }
+
+        void OnDisconnected()
+        {
+            connectState = ConnectState.Disconnected;
+
+            ClientScene.HandleClientDisconnect(m_Connection);
+            if (m_Connection != null)
+            {
+                m_Connection.InvokeHandlerNoData((short)MsgType.Disconnect);
+            }
+        }
+
+        void OnDataReceived(byte[] data)
+        {
+            if (m_Connection != null)
+            {
+                m_Connection.TransportReceive(data);
+            }
+            else Debug.LogError("Skipped Data message handling because m_Connection is null.");
+        }
+
+        void OnConnected()
+        {
+            if (m_Connection != null)
+            {
+                // reset network time stats
+                NetworkTime.Reset();
+
+                // the handler may want to send messages to the client
+                // thus we should set the connected state before calling the handler
+                connectState = ConnectState.Connected;
+                NetworkTime.UpdateClient(this);
+                m_Connection.InvokeHandlerNoData((short)MsgType.Connect);
+            }
+            else Debug.LogError("Skipped Connect message handling because m_Connection is null.");
+        }
+
         void PrepareForConnect()
         {
             SetActive(true);
             RegisterSystemHandlers(false);
             m_ClientId = 0;
-            pauseMessageHandling = false;
+            NetworkManager.singleton.transport.enabled = true;
+            InitializeTransportHandlers();
         }
 
         public virtual void Disconnect()
@@ -93,6 +142,15 @@ namespace Mirror
                 m_Connection = null;
                 m_ClientId = -1;
             }
+        }
+
+        void RemoveTransportHandlers()
+        {
+            // so that we don't register them more than once
+            NetworkManager.singleton.transport.OnClientConnected.RemoveListener(OnConnected);
+            NetworkManager.singleton.transport.OnClientDataReceived.RemoveListener(OnDataReceived);
+            NetworkManager.singleton.transport.OnClientDisconnected.RemoveListener(OnDisconnected);
+            NetworkManager.singleton.transport.OnClientError.RemoveListener(OnError);
         }
 
         public bool Send(short msgType, MessageBase msg)
@@ -137,75 +195,9 @@ namespace Mirror
                 return;
             }
 
-            // pause message handling while a scene load is in progress
-            //
-            // problem:
-            //   if we handle packets (calling the msgDelegates) while a
-            //   scene load is in progress, then all the handled data and state
-            //   will be lost as soon as the scene load is finished, causing
-            //   state bugs.
-            //
-            // solution:
-            //   don't handle messages until scene load is finished. the
-            //   transport layer will queue it automatically.
-            if (pauseMessageHandling)
-            {
-                Debug.Log("NetworkClient.Update paused during scene load...");
-                return;
-            }
-
             if (connectState == ConnectState.Connected)
             {
                 NetworkTime.UpdateClient(this);
-            }
-
-            // any new message?
-            // -> calling it once per frame is okay, but really why not just
-            //    process all messages and make it empty..
-            TransportEvent transportEvent;
-            byte[] data;
-            while (NetworkManager.singleton.transport.ClientGetNextMessage(out transportEvent, out data))
-            {
-                switch (transportEvent)
-                {
-                    case TransportEvent.Connected:
-                        //Debug.Log("NetworkClient loop: Connected");
-
-                        if (m_Connection != null)
-                        {
-                            // reset network time stats
-                            NetworkTime.Reset();
-
-                            // the handler may want to send messages to the client
-                            // thus we should set the connected state before calling the handler
-                            connectState = ConnectState.Connected;
-                            m_Connection.InvokeHandlerNoData((short) MsgType.Connect);
-                        }
-                        else Debug.LogError("Skipped Connect message handling because m_Connection is null.");
-
-                        break;
-                    case TransportEvent.Data:
-                        //Debug.Log("NetworkClient loop: Data: " + BitConverter.ToString(data));
-
-                        if (m_Connection != null)
-                        {
-                            m_Connection.TransportReceive(data);
-                        }
-                        else Debug.LogError("Skipped Data message handling because m_Connection is null.");
-
-                        break;
-                    case TransportEvent.Disconnected:
-                        //Debug.Log("NetworkClient loop: Disconnected");
-                        connectState = ConnectState.Disconnected;
-
-                        //GenerateDisconnectError(error); TODO which one?
-                        ClientScene.HandleClientDisconnect(m_Connection);
-                        if (m_Connection != null)
-                        {
-                            m_Connection.InvokeHandlerNoData((short)MsgType.Disconnect);
-                        }
-                        break;
-                }
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -396,12 +396,12 @@ namespace Mirror
             }
 
             // vis2k: pause message handling while loading scene. otherwise we will process messages and then lose all
-            // the sate as soon as the load is finishing, causing all kinds of bugs because of missing state.
+            // the state as soon as the load is finishing, causing all kinds of bugs because of missing state.
             // (client may be null after StopClient etc.)
             if (client != null)
             {
                 if (LogFilter.Debug) { Debug.Log("ClientChangeScene: pausing handlers while scene is loading to avoid data loss after scene was loaded."); }
-                NetworkClient.pauseMessageHandling = true;
+                NetworkManager.singleton.transport.enabled = false;
             }
 
             s_LoadingSceneAsync = SceneManager.LoadSceneAsync(newSceneName);
@@ -416,7 +416,7 @@ namespace Mirror
             {
                 // process queued messages that we received while loading the scene
                 if (LogFilter.Debug) { Debug.Log("FinishLoadScene: resuming handlers after scene was loading."); }
-                NetworkClient.pauseMessageHandling = false;
+                NetworkManager.singleton.transport.enabled = true;
 
                 if (s_ClientReadyConnection != null)
                 {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -53,6 +53,11 @@ namespace Mirror
                     s_ServerHostId = -1;
                 }
 
+                NetworkManager.singleton.transport.OnServerDisconnected.RemoveListener(OnDisconnected);
+                NetworkManager.singleton.transport.OnServerConnected.RemoveListener(OnConnected);
+                NetworkManager.singleton.transport.OnServerDataReceived.RemoveListener(OnDataReceived);
+                NetworkManager.singleton.transport.OnServerError.RemoveListener(OnError);
+
                 s_Initialized = false;
             }
             dontListen = false;
@@ -69,6 +74,11 @@ namespace Mirror
 
             //Make sure connections are cleared in case any old connections references exist from previous sessions
             connections.Clear();
+            NetworkManager.singleton.transport.OnServerDisconnected.AddListener(OnDisconnected);
+            NetworkManager.singleton.transport.OnServerConnected.AddListener(OnConnected);
+            NetworkManager.singleton.transport.OnServerDataReceived.AddListener(OnDataReceived);
+            NetworkManager.singleton.transport.OnServerError.AddListener(OnError);
+
         }
 
         internal static void RegisterMessageHandlers()
@@ -269,40 +279,12 @@ namespace Mirror
             if (s_ServerHostId == -1)
                 return;
 
-            int connectionId;
-            TransportEvent transportEvent;
-            byte[] data;
-            while (NetworkManager.singleton.transport.ServerGetNextMessage(out connectionId, out transportEvent, out data))
-            {
-                switch (transportEvent)
-                {
-                    case TransportEvent.Connected:
-                        //Debug.Log("NetworkServer loop: Connected");
-                        HandleConnect(connectionId, 0);
-                        break;
-                    case TransportEvent.Data:
-                        //Debug.Log("NetworkServer loop: clientId: " + message.connectionId + " Data: " + BitConverter.ToString(message.data));
-                        HandleData(connectionId, data, 0);
-                        break;
-                    case TransportEvent.Disconnected:
-                        //Debug.Log("NetworkServer loop: Disconnected");
-                        HandleDisconnect(connectionId, 0);
-                        break;
-                }
-            }
-
             UpdateServerObjects();
         }
 
-        static void HandleConnect(int connectionId, byte error)
+        static void OnConnected(int connectionId)
         {
             if (LogFilter.Debug) { Debug.Log("Server accepted client:" + connectionId); }
-
-            if (error != 0)
-            {
-                GenerateConnectError(error);
-                return;
-            }
 
             // connectionId needs to be > 0 because 0 is reserved for local player
             if (connectionId <= 0)
@@ -350,7 +332,7 @@ namespace Mirror
             conn.InvokeHandlerNoData((short)MsgType.Connect);
         }
 
-        static void HandleDisconnect(int connectionId, byte error)
+        static void OnDisconnected(int connectionId)
         {
             if (LogFilter.Debug) { Debug.Log("Server disconnect client:" + connectionId); }
 
@@ -380,7 +362,7 @@ namespace Mirror
             conn.Dispose();
         }
 
-        static void HandleData(int connectionId, byte[] data, byte error)
+        static void OnDataReceived(int connectionId, byte[] data)
         {
             NetworkConnection conn;
             if (connections.TryGetValue(connectionId, out conn))
@@ -391,6 +373,12 @@ namespace Mirror
             {
                 Debug.LogError("HandleData Unknown connectionId:" + connectionId);
             }
+        }
+
+        private static void OnError(int connectionId, Exception exception)
+        {
+            // TODO Let's discuss how we will handle errors
+            Debug.LogException(exception);
         }
 
         static void OnData(NetworkConnection conn, byte[] data)

--- a/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -110,10 +110,8 @@ namespace Mirror
             return NetworkTransport.Send(clientId, clientConnectionId, channelId, data, data.Length, out error);
         }
 
-        public override bool ClientGetNextMessage(out TransportEvent transportEvent, out byte[] data)
+        public bool ProcessClientMessage()
         {
-            transportEvent = TransportEvent.Disconnected;
-            data = null;
             int connectionId;
             int channel;
             int receivedSize;
@@ -128,27 +126,36 @@ namespace Mirror
             NetworkError networkError = (NetworkError)error;
             if (networkError != NetworkError.Ok)
             {
-                Debug.Log("NetworkTransport.Receive failed: hostid=" + clientId + " connId=" + connectionId + " channelId=" + channel + " error=" + networkError);
+                string message = "NetworkTransport.Receive failed: hostid=" + clientId + " connId=" + connectionId + " channelId=" + channel + " error=" + networkError;
+                OnClientError.Invoke(new Exception(message));
             }
 
+            // raise events
             switch (networkEvent)
             {
                 case NetworkEventType.ConnectEvent:
-                    transportEvent = TransportEvent.Connected;
+                    OnClientConnected.Invoke();
                     break;
                 case NetworkEventType.DataEvent:
-                    transportEvent = TransportEvent.Data;
-                    data = new byte[receivedSize];
+                    byte [] data = new byte[receivedSize];
                     Array.Copy(clientReceiveBuffer, data, receivedSize);
+                    OnClientDataReceived.Invoke(data);
                     break;
                 case NetworkEventType.DisconnectEvent:
-                    transportEvent = TransportEvent.Disconnected;
+                    OnClientDisconnected.Invoke();
                     break;
                 default:
                     return false;
             }
 
             return true;
+        }
+
+        public void Update()
+        {
+            // process all messages
+            while (ProcessClientMessage()) { }
+            while (ProcessServerMessage()) { }
         }
 
         public override void ClientDisconnect()
@@ -187,11 +194,9 @@ namespace Mirror
             return NetworkTransport.Send(serverHostId, connectionId, channelId, data, data.Length, out error);
         }
 
-        public override bool ServerGetNextMessage(out int connectionId, out TransportEvent transportEvent, out byte[] data)
+        public bool ProcessServerMessage()
         {
-            connectionId = -1;
-            transportEvent = TransportEvent.Disconnected;
-            data = null;
+            int connectionId = -1;
             int channel;
             int receivedSize;
             NetworkEventType networkEvent = NetworkTransport.ReceiveFromHost(serverHostId, out connectionId, out channel, serverReceiveBuffer, serverReceiveBuffer.Length, out receivedSize, out error);
@@ -205,7 +210,10 @@ namespace Mirror
             NetworkError networkError = (NetworkError)error;
             if (networkError != NetworkError.Ok)
             {
-                Debug.Log("NetworkTransport.Receive failed: hostid=" + serverHostId + " connId=" + connectionId + " channelId=" + channel + " error=" + networkError);
+                string message = "NetworkTransport.Receive failed: hostid=" + serverHostId + " connId=" + connectionId + " channelId=" + channel + " error=" + networkError;
+
+                // TODO write a TransportException or better
+                OnServerError.Invoke(connectionId, new Exception(message));
             }
 
             // LLAPI client sends keep alive messages (75-6C-6C) on channel=110.
@@ -218,15 +226,15 @@ namespace Mirror
             switch (networkEvent)
             {
                 case NetworkEventType.ConnectEvent:
-                    transportEvent = TransportEvent.Connected;
+                    OnServerConnected.Invoke(connectionId);
                     break;
                 case NetworkEventType.DataEvent:
-                    transportEvent = TransportEvent.Data;
-                    data = new byte[receivedSize];
+                    byte[] data = new byte[receivedSize];
                     Array.Copy(serverReceiveBuffer, data, receivedSize);
+                    OnServerDataReceived.Invoke(connectionId, data);
                     break;
                 case NetworkEventType.DisconnectEvent:
-                    transportEvent = TransportEvent.Disconnected;
+                    OnServerDisconnected.Invoke(connectionId);
                     break;
                 default:
                     // nothing or a message we don't recognize

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -16,11 +16,10 @@ namespace Mirror
     public abstract class Transport : MonoBehaviour
     {
         // client
-        [Header("Client Events")]
-        public UnityEvent OnClientConnected;
-        public UnityEventByteArray OnClientDataReceived;
-        public UnityEventException OnClientError;
-        public UnityEvent OnClientDisconnected;
+        [HideInInspector] public UnityEvent OnClientConnected;
+        [HideInInspector] public UnityEventByteArray OnClientDataReceived;
+        [HideInInspector] public UnityEventException OnClientError;
+        [HideInInspector] public UnityEvent OnClientDisconnected;
 
         public abstract bool ClientConnected();
         public abstract void ClientConnect(string address);
@@ -28,11 +27,10 @@ namespace Mirror
         public abstract void ClientDisconnect();
 
         // server
-        [Header("Server Events")]
-        public UnityEventInt OnServerConnected;
-        public UnityEventIntByteArray OnServerDataReceived;
-        public UnityEventIntException OnServerError;
-        public UnityEventInt OnServerDisconnected;
+        [HideInInspector] public UnityEventInt OnServerConnected;
+        [HideInInspector] public UnityEventIntByteArray OnServerDataReceived;
+        [HideInInspector] public UnityEventIntException OnServerError;
+        [HideInInspector] public UnityEventInt OnServerDisconnected;
 
         public abstract bool ServerActive();
         public abstract void ServerStart();

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -1,26 +1,42 @@
 ﻿// abstract transport layer component
 // note: not all transports need a port, so add it to yours if needed.
+using System;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Mirror
 {
-    // note: 'address' is ip / websocket url / ...
-    public enum TransportEvent { Connected, Data, Disconnected }
+    // UnityEvent definitions
+    [Serializable] public class UnityEventByteArray : UnityEvent<byte[]> {}
+    [Serializable] public class UnityEventException : UnityEvent<Exception> {}
+    [Serializable] public class UnityEventInt : UnityEvent<int> {}
+    [Serializable] public class UnityEventIntByteArray : UnityEvent<int, byte[]> {}
+    [Serializable] public class UnityEventIntException : UnityEvent<int, Exception> {}
 
     public abstract class Transport : MonoBehaviour
     {
         // client
+        [Header("Client Events")]
+        public UnityEvent OnClientConnected;
+        public UnityEventByteArray OnClientDataReceived;
+        public UnityEventException OnClientError;
+        public UnityEvent OnClientDisconnected;
+
         public abstract bool ClientConnected();
         public abstract void ClientConnect(string address);
         public abstract bool ClientSend(int channelId, byte[] data);
-        public abstract bool ClientGetNextMessage(out TransportEvent transportEvent, out byte[] data);
         public abstract void ClientDisconnect();
 
         // server
+        [Header("Server Events")]
+        public UnityEventInt OnServerConnected;
+        public UnityEventIntByteArray OnServerDataReceived;
+        public UnityEventIntException OnServerError;
+        public UnityEventInt OnServerDisconnected;
+
         public abstract bool ServerActive();
         public abstract void ServerStart();
         public abstract bool ServerSend(int connectionId, int channelId, byte[] data);
-        public abstract bool ServerGetNextMessage(out int connectionId, out TransportEvent transportEvent, out byte[] data);
         public abstract bool ServerDisconnect(int connectionId);
         public abstract bool GetConnectionInfo(int connectionId, out string address);
         public abstract void ServerStop();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16416509/51799186-cae6d700-221e-11e9-991b-99b518f90597.png)

-> only 1 extra LOC
-> people can hook into transport events easily
-> it might be worth making NetworkServer/NetworkClient a component too later, in which case we could setup the callbacks right in the Inspector without any extra code

Note: we could also hide the Transport.cs callbacks in Inspector if that's too much at the moment.


![image](https://user-images.githubusercontent.com/16416509/51799179-a25edd00-221e-11e9-8399-142795ba3f0f.png)
