### PR TITLE
Update ClientsServers.md

### DIFF
--- a/docs/Concepts/ClientsServers.md
+++ b/docs/Concepts/ClientsServers.md
@@ -60,7 +60,7 @@ public void SetupClient()
 {
     myClient = new NetworkClient();
     myClient.RegisterHandler(MsgType.Connect, OnConnected);     
-    myClient.Connect("127.0.0.1", 4444);
+    myClient.Connect("127.0.0.1");
     isAtStartup = false;
 }
 


### PR DESCRIPTION
NetworkClient.Connect() only supports a single argument - string serverIp. This documentation should be updated to reflect that difference. I'm not familiar enough with the platform yet to properly adjust the doco to reflect this change. Please see ticket https://github.com/vis2k/Mirror/issues/341