### PR TITLE
Superfluous Code

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -584,11 +584,6 @@ namespace Mirror
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager:OnClientDisconnectInternal"); }
 
-            if (!string.IsNullOrEmpty(offlineScene))
-            {
-                ClientChangeScene(offlineScene, false);
-            }
-
             OnClientDisconnect(netMsg.conn);
         }
 


### PR DESCRIPTION
Immediately after the deleted lines is a call to `OnClientDisconnect(netMsg.conn);` which calls `StopClient();` which has the exact same code on line 344 as what I'm proposing be deleted here.