### PR TITLE
Dictionary 'objects' is no longer present in NetworkServer class

### DIFF
--- a/docs/Classes/NetworkServer.md
+++ b/docs/Classes/NetworkServer.md
@@ -26,8 +26,6 @@ NetworkServer is a High-Level-API class that manages connections from multiple c
     The class to be used when creating new network connections.
 -   **numChannels**  
     The number of channels the network is configure with.
--   **objects**  
-    This is a dictionary of networked objects that have been spawned on the server.
 -   **serverHostId**  
     The transport layer hostId used by this server.
 -   **useWebSockets**  


### PR DESCRIPTION
Please see commit https://github.com/vis2k/Mirror/commit/d979a458706077921cabc8bd52efab90a23e7c34

The objects property has been deprecated and is handled by `NetworkIdentity.spawned` dictionary at this time.