### PR TITLE
BUG: TelepathyTransport delivers messages even when this.enabled == false across scene loads

### DIFF
--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -68,8 +68,11 @@ namespace Mirror
 
         public void LateUpdate()
         {
-            while (this.enabled && ProcessClientMessage()) { }
-            while (this.enabled && ProcessServerMessage()) { }
+            // note: we need to check enabled in case we set it to false
+            // when LateUpdate already started.
+            // (https://github.com/vis2k/Mirror/pull/379)
+            while (enabled && ProcessClientMessage()) { }
+            while (enabled && ProcessServerMessage()) { }
         }
 
         // server

--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -68,8 +68,8 @@ namespace Mirror
 
         public void LateUpdate()
         {
-            while (ProcessClientMessage()) { }
-            while (ProcessServerMessage()) { }
+            while (this.enabled && ProcessClientMessage()) { }
+            while (this.enabled && ProcessServerMessage()) { }
         }
 
         // server


### PR DESCRIPTION
Found this bug when joining a server using Unity 2018.3 
TelepathyTransport delivers the first message which tells the client to change scenes and load the next scene.
However because the LateUpdate has already started, it doesn't check that this.enabled and processes the rest of the message queue during the scene transition.

Debugged and diagnosed with Paul to find this issue.