### PR TITLE
SyncList callback functionality was incorrectly represented

### DIFF
--- a/docs/Classes/SyncLists.md
+++ b/docs/Classes/SyncLists.md
@@ -25,18 +25,37 @@ A SyncList can only be of the following type
 
 ## Usage
 
-Don't modify them in Awake, use OnStartServer or Start. SyncListStructs use Structs. C\# structs are value types, just like int, float, Vector3 etc. You can't do synclist.value = newvalue; You have to copy the element, assign the new value, assign the new element to the synclist. You can use hooks like this:
+Don't modify them in Awake, use OnStartServer or Start. SyncListStructs use Structs. C\# structs are value types, just like int, float, Vector3 etc. You can't do synclist.value = newvalue; You have to copy the element, assign the new value, assign the new element to the synclist. You can use a callback hook like this:
 
 ```cs
-// for the official things
-[SyncListString(hook="MyHook")] SyncListString mylist;
-void MyHook(SyncListString.Operation op, int index) {
-    // do things
+// In this example we are using String
+// This can also be used for any custom data type 
+SyncListString myStringList;
+SyncListItem myItemList;
+
+void Start()
+{
+	myStringList.Callback += MyStringCallback;
+	myItemList.Callback += MyItemCallback;
 }
-     
-// for custom structs
-[SyncListString(hook="MyHook")] SyncListStructCustom mylist;
-void MyHook(SyncListStructCustom.Operation op, int index) {
-    // do things
+
+void MyStringCallback(SyncListString.Operation op, int index, String item)
+{
+	// Callback functionality here
+}
+
+void MyItemCallback(SyncListItem.Operation op, int index, Item item)
+{
+	// Callback functionality here
+}
+
+public struct Item
+{
+    // Define struct
+}
+
+public class SyncListItem : SyncListSTRUCT<Item>
+{
+
 }
 ```


### PR DESCRIPTION
SyncList callback functionality is achieved through event handling. I've updated the documentation here to better represent a generic SyncList as well as a custom data type.