### PR TITLE
Add a way to disable setting of target fps

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -24,7 +24,7 @@ namespace Mirror
         [FormerlySerializedAs("m_DontDestroyOnLoad")] public bool dontDestroyOnLoad = true;
         [FormerlySerializedAs("m_RunInBackground")] public bool runInBackground = true;
         public bool startOnHeadless = true;
-        [Tooltip("Server Update frequency, per second. Use around 60Hz for fast paced games like Counter-Strike to minimize latency. Use around 30Hz for games like WoW to minimize computations. Use around 1-10Hz for slow paced games like EVE.")]
+        [Tooltip("Server Update frequency, per second. Use around 60Hz for fast paced games like Counter-Strike to minimize latency. Use around 30Hz for games like WoW to minimize computations. Use around 1-10Hz for slow paced games like EVE. Set to 0 to disable")]
         public int serverTickRate = 30;
         [FormerlySerializedAs("m_ShowDebugMessages")] public bool showDebugMessages;
 
@@ -202,7 +202,7 @@ namespace Mirror
             // * if not in Editor (it doesn't work in the Editor)
             // * if not in Host mode
 #if !UNITY_EDITOR
-            if (!NetworkClient.active)
+            if (!NetworkClient.active && serverTickRate > 0)
             {
                 Application.targetFrameRate = serverTickRate;
                 Debug.Log("Server Tick Rate set to: " + Application.targetFrameRate + " Hz.");


### PR DESCRIPTION
As mentioned in the original PR for the server tick rate it'd be good to have a way to not touch the  Application.targetFrameRate at all.
This is for (backwards) compatibility with other things that set the fps/tick rate, so setting it to 99999 as suggested does not work.
Having to change existing scripts (and possibly even third party plugins?) to set serverTickRate on the NetworkManager (which will only work before the server has started, so might have to add workarounds for that too) feels kinda bad, so there should be a way to disable it.