### PR TITLE
ArraySegment Send

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ bin/
 .idea/
 Mirror/packages
 .mfractor
+_ReSharper.Caches
 
 # Unity generated
 Library

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -281,6 +281,11 @@ namespace Mirror
 
         public virtual bool TransportSend(int channelId, byte[] bytes, out byte error)
         {
+            return TransportSend(channelId, new ArraySegment<byte>(bytes), out error);
+        }
+
+        public virtual bool TransportSend(int channelId, ArraySegment<byte> bytes, out byte error)
+        {
             error = 0;
             if (NetworkManager.singleton.transport.ClientConnected())
             {

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -26,6 +26,24 @@ namespace Mirror
         public abstract bool ClientSend(int channelId, byte[] data);
         public abstract void ClientDisconnect();
 
+        public virtual bool ClientSend(int channelId, ArraySegment<byte> data)
+        {
+            if (data.Array == null)
+                throw new ArgumentNullException("data");
+
+            //If the underlying array is the same size as the segment just directly send it
+            if (data.Count == data.Array.Length)
+                return ClientSend(channelId, data.Array);
+            else
+            {
+                //Copy data into an array of exactly the right size
+                byte[] packet = new byte[data.Count];
+                Array.Copy(data.Array, data.Offset, packet, 0, data.Count);
+
+                return ClientSend(channelId, packet);
+            }
+        }
+
         // determines if the transport is available for this platform
         // by default a transport is available in all platforms except webgl
         public virtual bool Available()
@@ -48,6 +66,24 @@ namespace Mirror
         public abstract bool ServerDisconnect(int connectionId);
         public abstract bool GetConnectionInfo(int connectionId, out string address);
         public abstract void ServerStop();
+
+        public virtual bool ServerSend(int connectionId, int channelId, ArraySegment<byte> data)
+        {
+            if (data.Array == null)
+                throw new ArgumentNullException("data");
+
+            //If the underlying array is the same size as the segment just directly send it
+            if (data.Count == data.Array.Length)
+                return ServerSend(connectionId, channelId, data.Array);
+            else
+            {
+                //Copy data into an array of exactly the right size
+                byte[] packet = new byte[data.Count];
+                Array.Copy(data.Array, data.Offset, packet, 0, data.Count);
+
+                return ServerSend(connectionId, channelId, packet);
+            }
+        }
 
         // common
         public abstract void Shutdown();


### PR DESCRIPTION
Added methods to NetworkConnection and Transport for sending ArraySegments, see discussion in #400.

This isn't a complete solution, there's no clean way to build packets to send via this at the moment (Using `Protocol.PackMessage` allocates a lot), I could fairly easily fix that by writing the header into the start of the `ArraySegment` if there is space, only allocating a bigger segment if there is insufficient space for the header. For now I just wanted to get this in to clarify exactly what API changes I'm proposing :)