### PR TITLE
fixed weaver using unity cecil, added cleanup method to guarantee dis…

### DIFF
--- a/Assets/Mirror/Weaver/Program.cs
+++ b/Assets/Mirror/Weaver/Program.cs
@@ -25,13 +25,19 @@ namespace Mirror.Weaver
     {
         public static bool Process(string unityEngine, string unetDLL, string outputDirectory, string[] assemblies, string[] extraAssemblyPaths, IAssemblyResolver assemblyResolver, Action<string> printWarning, Action<string> printError)
         {
+            bool rv = false;
+
             CheckDLLPath(unityEngine);
             CheckDLLPath(unetDLL);
             CheckOutputDirectory(outputDirectory);
             CheckAssemblies(assemblies);
             Log.WarningMethod = printWarning;
             Log.ErrorMethod = printError;
-            return Weaver.WeaveAssemblies(assemblies, extraAssemblyPaths, assemblyResolver, outputDirectory, unityEngine, unetDLL);
+
+            rv = Weaver.WeaveAssemblies(assemblies, extraAssemblyPaths, assemblyResolver, outputDirectory, unityEngine, unetDLL);
+            Weaver.Cleanup();
+
+            return rv;
         }
 
         private static void CheckDLLPath(string path)


### PR DESCRIPTION
- fixed weaver using unity cecil
- added cleanup method to guarantee disposals
- removed unnecessary disposals
- increased readability of static fail member

I don't yet have the know how to test this extensively. What I did was add another SyncVar to Mirror.Examples.Basic.Player and confirm it is working. I strongly advise more testing in the hands of a non-noob before merging

Note: this doesn't yet allow us to move away from Unity's Cecil but it takes us a step closer. I tried and failed at restructuring Weaver's disposables with using syntax :( There is a lot more going on in this library than I first thought!