### PR TITLE
NetworkMessage can be value type.  It eliminates per message allocation

### DIFF
--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -57,7 +57,7 @@ namespace Mirror
         Highest = 47
     }
 
-    public class NetworkMessage
+    public struct NetworkMessage
     {
         public short msgType;
         public NetworkConnection conn;


### PR DESCRIPTION
Low hanging fruit,

make NetworkMessage a value type to eliminate allocations.

It does not add any complication.

It works for me,  but needs more testing
