### PR TITLE
#418 Send messages without id

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -129,8 +129,7 @@ namespace Mirror
 
             if (conn != null)
             {
-                ReadyMessage msg = new ReadyMessage();
-                conn.Send((short)MsgType.Ready, msg);
+                conn.Send(new ReadyMessage());
                 ready = true;
                 readyConnection = conn;
                 readyConnection.isReady = true;

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -609,19 +609,17 @@ namespace Mirror
         }
 
         // OnClientAddedPlayer?
-        internal static void OnOwnerMessage(NetworkMessage netMsg)
+        internal static void OnOwnerMessage(OwnerMessage msg)
         {
-            OwnerMessage msg = netMsg.ReadMessage<OwnerMessage>();
-
-            if (LogFilter.Debug) { Debug.Log("ClientScene.OnOwnerMessage - connectionId=" + netMsg.conn.connectionId + " netId: " + msg.netId); }
+            if (LogFilter.Debug) { Debug.Log("ClientScene.OnOwnerMessage - connectionId=" + readyConnection.connectionId + " netId: " + msg.netId); }
 
             // is there already an owner that is a different object??
-            netMsg.conn.playerController?.SetNotLocalPlayer();
+            readyConnection.playerController?.SetNotLocalPlayer();
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 // this object already exists
-                localObject.connectionToServer = netMsg.conn;
+                localObject.connectionToServer = readyConnection;
                 localObject.SetLocalPlayer();
                 InternalAddPlayer(localObject);
             }

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -430,10 +430,8 @@ namespace Mirror
             }
         }
 
-        internal static void OnSpawnSceneObject(NetworkMessage netMsg)
+        internal static void OnSpawnSceneObject(SpawnSceneObjectMessage msg)
         {
-            SpawnSceneObjectMessage msg = netMsg.ReadMessage<SpawnSceneObjectMessage>();
-
             if (LogFilter.Debug) { Debug.Log("Client spawn scene handler instantiating [netId:" + msg.netId + " sceneId:" + msg.sceneId + " pos:" + msg.position); }
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
@@ -550,10 +548,8 @@ namespace Mirror
             }
         }
 
-        internal static void OnLocalClientSpawnSceneObject(NetworkMessage netMsg)
+        internal static void OnLocalClientSpawnSceneObject(SpawnSceneObjectMessage msg)
         {
-            SpawnSceneObjectMessage msg = netMsg.ReadMessage<SpawnSceneObjectMessage>();
-
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 localObject.OnSetLocalVisibility(true);

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -94,7 +94,7 @@ namespace Mirror
                 extraMessage.Serialize(writer);
                 msg.value = writer.ToArray();
             }
-            readyConnection.Send((short)MsgType.AddPlayer, msg);
+            readyConnection.Send(msg);
             return true;
         }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -600,11 +600,9 @@ namespace Mirror
             }
         }
 
-        internal static void OnClientAuthority(NetworkMessage netMsg)
+        internal static void OnClientAuthority(ClientAuthorityMessage msg)
         {
-            ClientAuthorityMessage msg = netMsg.ReadMessage<ClientAuthorityMessage>();
-
-            if (LogFilter.Debug) { Debug.Log("ClientScene.OnClientAuthority for  connectionId=" + netMsg.conn.connectionId + " netId: " + msg.netId); }
+            if (LogFilter.Debug) { Debug.Log("ClientScene.OnClientAuthority for netId: " + msg.netId); }
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -371,10 +371,8 @@ namespace Mirror
             }
         }
 
-        internal static void OnSpawnPrefab(NetworkMessage netMsg)
+        internal static void OnSpawnPrefab(SpawnPrefabMessage msg)
         {
-            SpawnPrefabMessage msg = netMsg.ReadMessage<SpawnPrefabMessage>();
-
             if (msg.assetId == Guid.Empty)
             {
                 Debug.LogError("OnObjSpawn netId: " + msg.netId + " has invalid asset Id");
@@ -544,10 +542,8 @@ namespace Mirror
             }
         }
 
-        internal static void OnLocalClientSpawnPrefab(NetworkMessage netMsg)
+        internal static void OnLocalClientSpawnPrefab(SpawnPrefabMessage msg)
         {
-            SpawnPrefabMessage msg = netMsg.ReadMessage<SpawnPrefabMessage>();
-
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 localObject.OnSetLocalVisibility(true);

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -457,7 +457,7 @@ namespace Mirror
             ApplySpawnPayload(spawnedId, msg.position, msg.rotation, msg.payload, msg.netId);
         }
 
-        internal static void OnObjectSpawnStarted(NetworkMessage netMsg)
+        internal static void OnObjectSpawnStarted(ObjectSpawnStartedMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("SpawnStarted"); }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -556,10 +556,8 @@ namespace Mirror
             }
         }
 
-        internal static void OnUpdateVarsMessage(NetworkMessage netMsg)
+        internal static void OnUpdateVarsMessage(UpdateVarsMessage msg)
         {
-            UpdateVarsMessage msg = netMsg.ReadMessage<UpdateVarsMessage>();
-
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnUpdateVarsMessage " + msg.netId); }
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -570,10 +570,8 @@ namespace Mirror
             }
         }
 
-        internal static void OnRPCMessage(NetworkMessage netMsg)
+        internal static void OnRPCMessage(RpcMessage msg)
         {
-            RpcMessage msg = netMsg.ReadMessage<RpcMessage>();
-
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnRPCMessage hash:" + msg.functionHash + " netId:" + msg.netId); }
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -371,7 +371,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnSpawnPrefab(SpawnPrefabMessage msg)
+        internal static void OnSpawnPrefab(NetworkConnection conn, SpawnPrefabMessage msg)
         {
             if (msg.assetId == Guid.Empty)
             {
@@ -430,7 +430,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnSpawnSceneObject(SpawnSceneObjectMessage msg)
+        internal static void OnSpawnSceneObject(NetworkConnection conn, SpawnSceneObjectMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("Client spawn scene handler instantiating [netId:" + msg.netId + " sceneId:" + msg.sceneId + " pos:" + msg.position); }
 
@@ -457,7 +457,7 @@ namespace Mirror
             ApplySpawnPayload(spawnedId, msg.position, msg.rotation, msg.payload, msg.netId);
         }
 
-        internal static void OnObjectSpawnStarted(ObjectSpawnStartedMessage msg)
+        internal static void OnObjectSpawnStarted(NetworkConnection conn, ObjectSpawnStartedMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("SpawnStarted"); }
 
@@ -465,7 +465,7 @@ namespace Mirror
             s_IsSpawnFinished = false;
         }
 
-        internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage msg)
+        internal static void OnObjectSpawnFinished(NetworkConnection conn, ObjectSpawnFinishedMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("SpawnFinished"); }
 
@@ -483,11 +483,11 @@ namespace Mirror
             s_IsSpawnFinished = true;
         }
 
-        internal static void OnObjectHide(ObjectHideMessage msg)
+        internal static void OnObjectHide(NetworkConnection conn, ObjectHideMessage msg)
         {
             DestroyObject(msg.netId);
         }
-        internal static void OnObjectDestroy(ObjectDestroyMessage msg)
+        internal static void OnObjectDestroy(NetworkConnection conn, ObjectDestroyMessage msg)
         {
             DestroyObject(msg.netId);
         }
@@ -523,14 +523,14 @@ namespace Mirror
             }
         }
 
-        internal static void OnLocalClientObjectDestroy(ObjectDestroyMessage msg)
+        internal static void OnLocalClientObjectDestroy(NetworkConnection conn, ObjectDestroyMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnLocalObjectObjDestroy netId:" + msg.netId); }
 
             NetworkIdentity.spawned.Remove(msg.netId);
         }
 
-        internal static void OnLocalClientObjectHide(ObjectHideMessage msg)
+        internal static void OnLocalClientObjectHide(NetworkConnection conn, ObjectHideMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("ClientScene::OnLocalObjectObjHide netId:" + msg.netId); }
 
@@ -540,7 +540,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnLocalClientSpawnPrefab(SpawnPrefabMessage msg)
+        internal static void OnLocalClientSpawnPrefab(NetworkConnection conn, SpawnPrefabMessage msg)
         {
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
@@ -548,7 +548,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnLocalClientSpawnSceneObject(SpawnSceneObjectMessage msg)
+        internal static void OnLocalClientSpawnSceneObject(NetworkConnection conn, SpawnSceneObjectMessage msg)
         {
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
@@ -556,7 +556,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnUpdateVarsMessage(UpdateVarsMessage msg)
+        internal static void OnUpdateVarsMessage(NetworkConnection conn, UpdateVarsMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnUpdateVarsMessage " + msg.netId); }
 
@@ -570,7 +570,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnRPCMessage(RpcMessage msg)
+        internal static void OnRPCMessage(NetworkConnection conn, RpcMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnRPCMessage hash:" + msg.functionHash + " netId:" + msg.netId); }
 
@@ -580,7 +580,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnSyncEventMessage(SyncEventMessage msg)
+        internal static void OnSyncEventMessage(NetworkConnection conn, SyncEventMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnSyncEventMessage " + msg.netId); }
 
@@ -594,7 +594,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnClientAuthority(ClientAuthorityMessage msg)
+        internal static void OnClientAuthority(NetworkConnection conn, ClientAuthorityMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnClientAuthority for netId: " + msg.netId); }
 
@@ -605,7 +605,7 @@ namespace Mirror
         }
 
         // OnClientAddedPlayer?
-        internal static void OnOwnerMessage(OwnerMessage msg)
+        internal static void OnOwnerMessage(NetworkConnection conn, OwnerMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnOwnerMessage - connectionId=" + readyConnection.connectionId + " netId: " + msg.netId); }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -465,7 +465,7 @@ namespace Mirror
             s_IsSpawnFinished = false;
         }
 
-        internal static void OnObjectSpawnFinished(NetworkMessage netMsg)
+        internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("SpawnFinished"); }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -580,10 +580,8 @@ namespace Mirror
             }
         }
 
-        internal static void OnSyncEventMessage(NetworkMessage netMsg)
+        internal static void OnSyncEventMessage(SyncEventMessage msg)
         {
-            SyncEventMessage msg = netMsg.ReadMessage<SyncEventMessage>();
-
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnSyncEventMessage " + msg.netId); }
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -105,7 +105,7 @@ namespace Mirror
             if (readyConnection.playerController != null)
             {
                 RemovePlayerMessage msg = new RemovePlayerMessage();
-                readyConnection.Send((short)MsgType.RemovePlayer, msg);
+                readyConnection.Send(msg);
 
                 Object.Destroy(readyConnection.playerController.gameObject);
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -487,12 +487,20 @@ namespace Mirror
             s_IsSpawnFinished = true;
         }
 
-        internal static void OnObjectDestroy(NetworkMessage netMsg)
+        internal static void OnObjectHide(ObjectHideMessage msg)
         {
-            ObjectDestroyMessage msg = netMsg.ReadMessage<ObjectDestroyMessage>();
-            if (LogFilter.Debug) { Debug.Log("ClientScene.OnObjDestroy netId:" + msg.netId); }
+            DestroyObject(msg.netId);
+        }
+        internal static void OnObjectDestroy(ObjectDestroyMessage msg)
+        {
+            DestroyObject(msg.netId);
+        }
 
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
+        static void DestroyObject(uint netId)
+        {
+            if (LogFilter.Debug) { Debug.Log("ClientScene.OnObjDestroy netId:" + netId); }
+
+            if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity localObject) && localObject != null)
             {
                 localObject.OnNetworkDestroy();
 
@@ -510,27 +518,25 @@ namespace Mirror
                         spawnableObjects[localObject.sceneId] = localObject;
                     }
                 }
-                NetworkIdentity.spawned.Remove(msg.netId);
+                NetworkIdentity.spawned.Remove(netId);
                 localObject.MarkForReset();
             }
             else
             {
-                if (LogFilter.Debug) { Debug.LogWarning("Did not find target for destroy message for " + msg.netId); }
+                if (LogFilter.Debug) { Debug.LogWarning("Did not find target for destroy message for " + netId); }
             }
         }
 
-        internal static void OnLocalClientObjectDestroy(NetworkMessage netMsg)
+        internal static void OnLocalClientObjectDestroy(ObjectDestroyMessage msg)
         {
-            ObjectDestroyMessage msg = netMsg.ReadMessage<ObjectDestroyMessage>();
             if (LogFilter.Debug) { Debug.Log("ClientScene.OnLocalObjectObjDestroy netId:" + msg.netId); }
 
             NetworkIdentity.spawned.Remove(msg.netId);
         }
 
-        internal static void OnLocalClientObjectHide(NetworkMessage netMsg)
+        internal static void OnLocalClientObjectHide(ObjectHideMessage msg)
         {
-            ObjectDestroyMessage msg = netMsg.ReadMessage<ObjectDestroyMessage>();
-            if (LogFilter.Debug) { Debug.Log("ClientScene.OnLocalObjectObjHide netId:" + msg.netId); }
+            if (LogFilter.Debug) { Debug.Log("ClientScene::OnLocalObjectObjHide netId:" + msg.netId); }
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {

--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -20,7 +20,7 @@ namespace Mirror
             active = true;
             RegisterSystemHandlers(true);
 
-            packetQueue.Enqueue(MessagePacker.PackMessage((ushort)MsgType.Connect, new EmptyMessage()));
+            packetQueue.Enqueue(MessagePacker.Pack(new ConnectMessage()));
         }
 
         public override void Disconnect()
@@ -29,7 +29,7 @@ namespace Mirror
             ClientScene.HandleClientDisconnect(connection);
             if (isConnected)
             {
-                packetQueue.Enqueue(MessagePacker.PackMessage((ushort)MsgType.Disconnect, new EmptyMessage()));
+                packetQueue.Enqueue(MessagePacker.Pack(new DisconnectMessage()));
             }
             NetworkServer.RemoveLocalClient();
         }

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -22,13 +22,13 @@ namespace Mirror
         // pack message before sending
         // -> pass writer instead of byte[] so we can reuse it
         [Obsolete("Use Pack<T> instead")]
-        public static byte[] PackMessage(ushort msgType, MessageBase msg)
+        public static byte[] PackMessage(int msgType, MessageBase msg)
         {
             // reset cached writer length and position
             packWriter.SetLength(0);
 
             // write message type
-            packWriter.WritePackedUInt32(msgType);
+            packWriter.WritePackedUInt32((uint)msgType);
 
             // serialize message into writer
             msg.Serialize(packWriter);
@@ -44,7 +44,7 @@ namespace Mirror
             packWriter.SetLength(0);
 
             // write message type
-            short msgType = MessageBase.GetId<T>();
+            int msgType = MessageBase.GetId<T>();
             packWriter.WritePackedUInt32((uint)msgType);
 
             // serialize message into writer
@@ -58,10 +58,10 @@ namespace Mirror
         // -> pass NetworkReader so it's less strange if we create it in here
         //    and pass it upwards.
         // -> NetworkReader will point at content afterwards!
-        public static bool UnpackMessage(NetworkReader messageReader, out ushort msgType)
+        public static bool UnpackMessage(NetworkReader messageReader, out int msgType)
         {
             // read message type (varint)
-            msgType = (ushort)messageReader.ReadPackedUInt32();
+            msgType = (int)messageReader.ReadPackedUInt32();
             return true;
         }
     }

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mirror
 {
     // message packing all in one place, instead of constructing headers in all
@@ -19,6 +21,7 @@ namespace Mirror
 
         // pack message before sending
         // -> pass writer instead of byte[] so we can reuse it
+        [Obsolete("Use Pack<T> instead")]
         public static byte[] PackMessage(ushort msgType, MessageBase msg)
         {
             // reset cached writer length and position
@@ -29,6 +32,23 @@ namespace Mirror
 
             // serialize message into writer
             msg.Serialize(packWriter);
+
+            // return byte[]
+            return packWriter.ToArray();
+        }
+
+        // pack message before sending
+        public static byte[] Pack<T>(T message) where T : MessageBase
+        {
+            // reset cached writer length and position
+            packWriter.SetLength(0);
+
+            // write message type
+            short msgType = MessageBase.GetId<T>();
+            packWriter.WritePackedUInt32((uint)msgType);
+
+            // serialize message into writer
+            message.Serialize(packWriter);
 
             // return byte[]
             return packWriter.ToArray();

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -28,7 +28,7 @@ namespace Mirror
             packWriter.SetLength(0);
 
             // write message type
-            packWriter.WritePackedUInt32((uint)msgType);
+            packWriter.Write((short)msgType);
 
             // serialize message into writer
             msg.Serialize(packWriter);
@@ -45,7 +45,7 @@ namespace Mirror
 
             // write message type
             int msgType = MessageBase.GetId<T>();
-            packWriter.WritePackedUInt32((uint)msgType);
+            packWriter.Write((ushort)msgType);
 
             // serialize message into writer
             message.Serialize(packWriter);
@@ -61,7 +61,7 @@ namespace Mirror
         public static bool UnpackMessage(NetworkReader messageReader, out int msgType)
         {
             // read message type (varint)
-            msgType = (int)messageReader.ReadPackedUInt32();
+            msgType = (int)messageReader.ReadUInt16();
             return true;
         }
     }

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -15,7 +15,10 @@ namespace Mirror
 
         public static int GetId<T>() where T: MessageBase
         {
-            return typeof(T).FullName.GetStableHashCode();
+            // paul: 16 bits is enough to avoid collisions
+            //  - keeps the message size small because it gets varinted
+            //  - in case of collisions,  Mirror will display an error
+            return typeof(T).FullName.GetStableHashCode() & 0xFFFF;
         }
     }
 

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -170,6 +170,16 @@ namespace Mirror
     public class DisconnectMessage : EmptyMessage { }
 
     public class ConnectMessage : EmptyMessage { }
+
+    public class SceneMessage : StringMessage 
+    {
+        public SceneMessage(string value) : base(value)
+        {
+        }
+
+        public SceneMessage() { }
+    }
+
     // ---------- System Messages requried for code gen path -------------------
 
     // remote calls like Rpc/Cmd/SyncEvent all use the same message type

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -13,10 +13,9 @@ namespace Mirror
         // Serialize the contents of this message into the writer
         public virtual void Serialize(NetworkWriter writer) {}
 
-        public static short GetId<T>() where T: MessageBase
+        public static int GetId<T>() where T: MessageBase
         {
-            // TODO use int instead of short for less collissions
-            return (short)typeof(T).FullName.GetStableHashCode();
+            return typeof(T).FullName.GetStableHashCode();
         }
     }
 

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -273,7 +273,22 @@ namespace Mirror
         }
     }
 
-    class OwnerMessage : MessageBase
+    class ObjectHideMessage : MessageBase
+    {
+        public uint netId;
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            netId = reader.ReadPackedUInt32();
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            writer.WritePackedUInt32(netId);
+        }
+    }
+
+        class OwnerMessage : MessageBase
     {
         public uint netId;
 

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -12,6 +12,12 @@ namespace Mirror
 
         // Serialize the contents of this message into the writer
         public virtual void Serialize(NetworkWriter writer) {}
+
+        public static short GetId<T>() where T: MessageBase
+        {
+            // TODO use int instead of short for less collissions
+            return (short)typeof(T).FullName.GetStableHashCode();
+        }
     }
 
     // ---------- General Typed Messages -------------------

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -169,6 +169,7 @@ namespace Mirror
 
     public class DisconnectMessage : EmptyMessage { }
 
+    public class ConnectMessage : EmptyMessage { }
     // ---------- System Messages requried for code gen path -------------------
 
     // remote calls like Rpc/Cmd/SyncEvent all use the same message type

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -167,6 +167,8 @@ namespace Mirror
 
     public class RemovePlayerMessage : EmptyMessage {}
 
+    public class DisconnectMessage : EmptyMessage { }
+
     // ---------- System Messages requried for code gen path -------------------
 
     // remote calls like Rpc/Cmd/SyncEvent all use the same message type

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -203,7 +203,7 @@ namespace Mirror
                 payload = writer.ToArray()
             };
 
-            NetworkServer.SendToReady(netIdentity, (short)MsgType.SyncEvent, message, channelId);
+            NetworkServer.SendToReady(netIdentity,message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -104,7 +104,7 @@ namespace Mirror
                 payload = writer.ToArray()
             };
 
-            ClientScene.readyConnection.Send((short)MsgType.Command, message, channelId);
+            ClientScene.readyConnection.Send(message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -140,7 +140,7 @@ namespace Mirror
                 payload = writer.ToArray()
             };
 
-            NetworkServer.SendToReady(netIdentity, (short)MsgType.Rpc, message, channelId);
+            NetworkServer.SendToReady(netIdentity, message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -174,7 +174,7 @@ namespace Mirror
                 payload = writer.ToArray()
             };
 
-            conn.Send((short)MsgType.Rpc, message, channelId);
+            conn.Send(message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -242,7 +242,7 @@ namespace Mirror
             {
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnLocalClientObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnLocalClientObjectHide);
-                RegisterHandler(MsgType.Owner, (msg) => {});
+                RegisterHandler<OwnerMessage>((msg) => {});
                 RegisterHandler(MsgType.Pong, (msg) => {});
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnLocalClientSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnLocalClientSpawnSceneObject);
@@ -254,7 +254,7 @@ namespace Mirror
             {
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnObjectHide);
-                RegisterHandler(MsgType.Owner, ClientScene.OnOwnerMessage);
+                RegisterHandler<OwnerMessage>(ClientScene.OnOwnerMessage);
                 RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnSpawnSceneObject);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -111,7 +111,7 @@ namespace Mirror
                 // thus we should set the connected state before calling the handler
                 connectState = ConnectState.Connected;
                 NetworkTime.UpdateClient(this);
-                connection.InvokeHandlerNoData((int)MsgType.Connect);
+                connection.InvokeHandler(new ConnectMessage());
             }
             else Debug.LogError("Skipped Connect message handling because m_Connection is null.");
         }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -248,7 +248,7 @@ namespace Mirror
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnLocalClientSpawnSceneObject);
                 RegisterHandler<ObjectSpawnStartedMessage>((msg) => {});
                 RegisterHandler<ObjectSpawnFinishedMessage>((msg) => {});
-                RegisterHandler(MsgType.UpdateVars, (msg) => {});
+                RegisterHandler<UpdateVarsMessage>((msg) => {});
             }
             else
             {
@@ -260,7 +260,7 @@ namespace Mirror
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnSpawnSceneObject);
                 RegisterHandler<ObjectSpawnStartedMessage>(ClientScene.OnObjectSpawnStarted);
                 RegisterHandler<ObjectSpawnFinishedMessage>(ClientScene.OnObjectSpawnFinished);
-                RegisterHandler(MsgType.UpdateVars, ClientScene.OnUpdateVarsMessage);
+                RegisterHandler<UpdateVarsMessage>(ClientScene.OnUpdateVarsMessage);
             }
             RegisterHandler<ClientAuthorityMessage>(ClientScene.OnClientAuthority);
             RegisterHandler(MsgType.Rpc, ClientScene.OnRPCMessage);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -246,8 +246,8 @@ namespace Mirror
                 RegisterHandler(MsgType.Pong, (msg) => {});
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnLocalClientSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnLocalClientSpawnSceneObject);
-                RegisterHandler<ObjectSpawnStartedMessage>( (msg) => {});
-                RegisterHandler(MsgType.SpawnFinished, (msg) => {});
+                RegisterHandler<ObjectSpawnStartedMessage>((msg) => {});
+                RegisterHandler<ObjectSpawnFinishedMessage>((msg) => {});
                 RegisterHandler(MsgType.UpdateVars, (msg) => {});
             }
             else
@@ -259,7 +259,7 @@ namespace Mirror
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnSpawnSceneObject);
                 RegisterHandler<ObjectSpawnStartedMessage>(ClientScene.OnObjectSpawnStarted);
-                RegisterHandler(MsgType.SpawnFinished, ClientScene.OnObjectSpawnFinished);
+                RegisterHandler<ObjectSpawnFinishedMessage>(ClientScene.OnObjectSpawnFinished);
                 RegisterHandler(MsgType.UpdateVars, ClientScene.OnUpdateVarsMessage);
             }
             RegisterHandler<ClientAuthorityMessage>(ClientScene.OnClientAuthority);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -205,7 +205,8 @@ namespace Mirror
 
         void GenerateError(byte error)
         {
-            if (handlers.TryGetValue((short)MsgType.Error, out NetworkMessageDelegate msgDelegate))
+            short msgId = MessageBase.GetId<ErrorMessage>();
+            if (handlers.TryGetValue(msgId, out NetworkMessageDelegate msgDelegate))
             {
                 ErrorMessage msg = new ErrorMessage
                 {
@@ -218,7 +219,7 @@ namespace Mirror
 
                 NetworkMessage netMsg = new NetworkMessage
                 {
-                    msgType = (short)MsgType.Error,
+                    msgType = msgId,
                     reader = new NetworkReader(writer.ToArray()),
                     conn = connection
                 };

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -240,7 +240,6 @@ namespace Mirror
             // 'message id not found' errors.
             if (localClient)
             {
-                RegisterHandler(MsgType.LocalClientAuthority, ClientScene.OnClientAuthority);
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnLocalClientObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnLocalClientObjectHide);
                 RegisterHandler(MsgType.Owner, (msg) => {});
@@ -253,7 +252,6 @@ namespace Mirror
             }
             else
             {
-                RegisterHandler(MsgType.LocalClientAuthority, ClientScene.OnClientAuthority);
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnObjectHide);
                 RegisterHandler(MsgType.Owner, ClientScene.OnOwnerMessage);
@@ -264,7 +262,7 @@ namespace Mirror
                 RegisterHandler(MsgType.SpawnFinished, ClientScene.OnObjectSpawnFinished);
                 RegisterHandler(MsgType.UpdateVars, ClientScene.OnUpdateVarsMessage);
             }
-
+            RegisterHandler<ClientAuthorityMessage>(ClientScene.OnClientAuthority);
             RegisterHandler(MsgType.Rpc, ClientScene.OnRPCMessage);
             RegisterHandler(MsgType.SyncEvent, ClientScene.OnSyncEventMessage);
         }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -88,7 +88,7 @@ namespace Mirror
 
             ClientScene.HandleClientDisconnect(connection);
 
-            connection?.InvokeHandlerNoData((int)MsgType.Disconnect);
+            connection?.InvokeHandler(new DisconnectMessage());
         }
 
         protected void OnDataReceived(byte[] data)

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -242,13 +242,13 @@ namespace Mirror
             {
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnLocalClientObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnLocalClientObjectHide);
-                RegisterHandler<OwnerMessage>((msg) => {});
-                RegisterHandler<NetworkPongMessage>((msg) => {});
+                RegisterHandler<OwnerMessage>((conn, msg) => {});
+                RegisterHandler<NetworkPongMessage>((conn, msg) => {});
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnLocalClientSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnLocalClientSpawnSceneObject);
-                RegisterHandler<ObjectSpawnStartedMessage>((msg) => {});
-                RegisterHandler<ObjectSpawnFinishedMessage>((msg) => {});
-                RegisterHandler<UpdateVarsMessage>((msg) => {});
+                RegisterHandler<ObjectSpawnStartedMessage>((conn, msg) => {});
+                RegisterHandler<ObjectSpawnFinishedMessage>((conn, msg) => {});
+                RegisterHandler<UpdateVarsMessage>((conn, msg) => {});
             }
             else
             {
@@ -283,7 +283,7 @@ namespace Mirror
             RegisterHandler((int)msgType, handler);
         }
 
-        public void RegisterHandler<T>(Action<T> handler) where T : MessageBase, new()
+        public void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T : MessageBase, new()
         {
             int msgType = MessageBase.GetId<T>();
             if (handlers.ContainsKey(msgType))
@@ -292,7 +292,7 @@ namespace Mirror
             }
             handlers[msgType] = (networkMessage) =>
             {
-                handler(networkMessage.ReadMessage<T>());
+                handler(networkMessage.conn, networkMessage.ReadMessage<T>());
             };
         }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -264,7 +264,7 @@ namespace Mirror
             }
             RegisterHandler<ClientAuthorityMessage>(ClientScene.OnClientAuthority);
             RegisterHandler<RpcMessage>(ClientScene.OnRPCMessage);
-            RegisterHandler(MsgType.SyncEvent, ClientScene.OnSyncEventMessage);
+            RegisterHandler<SyncEventMessage>(ClientScene.OnSyncEventMessage);
         }
 
         [Obsolete("Use RegisterHandler<T> instead")]

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -245,7 +245,7 @@ namespace Mirror
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnLocalClientObjectHide);
                 RegisterHandler(MsgType.Owner, (msg) => {});
                 RegisterHandler(MsgType.Pong, (msg) => {});
-                RegisterHandler(MsgType.SpawnPrefab, ClientScene.OnLocalClientSpawnPrefab);
+                RegisterHandler<SpawnPrefabMessage>(ClientScene.OnLocalClientSpawnPrefab);
                 RegisterHandler(MsgType.SpawnSceneObject, ClientScene.OnLocalClientSpawnSceneObject);
                 RegisterHandler(MsgType.SpawnStarted, (msg) => {});
                 RegisterHandler(MsgType.SpawnFinished, (msg) => {});
@@ -258,7 +258,7 @@ namespace Mirror
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnObjectHide);
                 RegisterHandler(MsgType.Owner, ClientScene.OnOwnerMessage);
                 RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
-                RegisterHandler(MsgType.SpawnPrefab, ClientScene.OnSpawnPrefab);
+                RegisterHandler<SpawnPrefabMessage>(ClientScene.OnSpawnPrefab);
                 RegisterHandler(MsgType.SpawnSceneObject, ClientScene.OnSpawnSceneObject);
                 RegisterHandler(MsgType.SpawnStarted, ClientScene.OnObjectSpawnStarted);
                 RegisterHandler(MsgType.SpawnFinished, ClientScene.OnObjectSpawnFinished);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -12,7 +12,7 @@ namespace Mirror
         [Obsolete("Use NetworkClient.singleton instead. There is always exactly one client.")]
         public static List<NetworkClient> allClients => new List<NetworkClient>{singleton};
 
-        public readonly Dictionary<short, NetworkMessageDelegate> handlers = new Dictionary<short, NetworkMessageDelegate>();
+        public readonly Dictionary<int, NetworkMessageDelegate> handlers = new Dictionary<int, NetworkMessageDelegate>();
 
         public NetworkConnection connection { get; protected set; }
 
@@ -88,7 +88,7 @@ namespace Mirror
 
             ClientScene.HandleClientDisconnect(connection);
 
-            connection?.InvokeHandlerNoData((short)MsgType.Disconnect);
+            connection?.InvokeHandlerNoData((int)MsgType.Disconnect);
         }
 
         protected void OnDataReceived(byte[] data)
@@ -111,7 +111,7 @@ namespace Mirror
                 // thus we should set the connected state before calling the handler
                 connectState = ConnectState.Connected;
                 NetworkTime.UpdateClient(this);
-                connection.InvokeHandlerNoData((short)MsgType.Connect);
+                connection.InvokeHandlerNoData((int)MsgType.Connect);
             }
             else Debug.LogError("Skipped Connect message handling because m_Connection is null.");
         }
@@ -159,7 +159,6 @@ namespace Mirror
 
         public bool Send<T>(T message) where T : MessageBase
         {
-            // TODO use int instead to avoid collisions
             if (connection != null)
             {
                 if (connectState != ConnectState.Connected)
@@ -205,7 +204,7 @@ namespace Mirror
 
         void GenerateError(byte error)
         {
-            short msgId = MessageBase.GetId<ErrorMessage>();
+            int msgId = MessageBase.GetId<ErrorMessage>();
             if (handlers.TryGetValue(msgId, out NetworkMessageDelegate msgDelegate))
             {
                 ErrorMessage msg = new ErrorMessage
@@ -269,7 +268,7 @@ namespace Mirror
         }
 
         [Obsolete("Use RegisterHandler<T> instead")]
-        public void RegisterHandler(short msgType, NetworkMessageDelegate handler)
+        public void RegisterHandler(int msgType, NetworkMessageDelegate handler)
         {
             if (handlers.ContainsKey(msgType))
             {
@@ -281,13 +280,12 @@ namespace Mirror
         [Obsolete("Use RegisterHandler<T> instead")]
         public void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
         {
-            RegisterHandler((short)msgType, handler);
+            RegisterHandler((int)msgType, handler);
         }
 
         public void RegisterHandler<T>(Action<T> handler) where T : MessageBase, new()
         {
-            // TODO use int instead to avoid collisions
-            short msgType = MessageBase.GetId<T>();
+            int msgType = MessageBase.GetId<T>();
             if (handlers.ContainsKey(msgType))
             {
                 if (LogFilter.Debug) { Debug.Log("NetworkClient.RegisterHandler replacing " + msgType); }
@@ -299,7 +297,7 @@ namespace Mirror
         }
 
         [Obsolete("Use UnregisterHandler<T> instead")]
-        public void UnregisterHandler(short msgType)
+        public void UnregisterHandler(int msgType)
         {
             handlers.Remove(msgType);
         }
@@ -307,13 +305,13 @@ namespace Mirror
         [Obsolete("Use UnregisterHandler<T> instead")]
         public void UnregisterHandler(MsgType msgType)
         {
-            UnregisterHandler((short)msgType);
+            UnregisterHandler((int)msgType);
         }
 
         public void UnregisterHandler<T>() where T : MessageBase
         {
             // use int to minimize collisions
-            short msgType = MessageBase.GetId<T>();
+            int msgType = MessageBase.GetId<T>();
             handlers.Remove(msgType);
         }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -246,7 +246,7 @@ namespace Mirror
                 RegisterHandler(MsgType.Owner, (msg) => {});
                 RegisterHandler(MsgType.Pong, (msg) => {});
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnLocalClientSpawnPrefab);
-                RegisterHandler(MsgType.SpawnSceneObject, ClientScene.OnLocalClientSpawnSceneObject);
+                RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnLocalClientSpawnSceneObject);
                 RegisterHandler(MsgType.SpawnStarted, (msg) => {});
                 RegisterHandler(MsgType.SpawnFinished, (msg) => {});
                 RegisterHandler(MsgType.UpdateVars, (msg) => {});
@@ -259,7 +259,7 @@ namespace Mirror
                 RegisterHandler(MsgType.Owner, ClientScene.OnOwnerMessage);
                 RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnSpawnPrefab);
-                RegisterHandler(MsgType.SpawnSceneObject, ClientScene.OnSpawnSceneObject);
+                RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnSpawnSceneObject);
                 RegisterHandler(MsgType.SpawnStarted, ClientScene.OnObjectSpawnStarted);
                 RegisterHandler(MsgType.SpawnFinished, ClientScene.OnObjectSpawnFinished);
                 RegisterHandler(MsgType.UpdateVars, ClientScene.OnUpdateVarsMessage);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -243,7 +243,7 @@ namespace Mirror
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnLocalClientObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnLocalClientObjectHide);
                 RegisterHandler<OwnerMessage>((msg) => {});
-                RegisterHandler(MsgType.Pong, (msg) => {});
+                RegisterHandler<NetworkPongMessage>((msg) => {});
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnLocalClientSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnLocalClientSpawnSceneObject);
                 RegisterHandler<ObjectSpawnStartedMessage>((msg) => {});
@@ -255,7 +255,7 @@ namespace Mirror
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnObjectHide);
                 RegisterHandler<OwnerMessage>(ClientScene.OnOwnerMessage);
-                RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
+                RegisterHandler<NetworkPongMessage>(NetworkTime.OnClientPong);
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnSpawnSceneObject);
                 RegisterHandler<ObjectSpawnStartedMessage>(ClientScene.OnObjectSpawnStarted);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -241,8 +241,8 @@ namespace Mirror
             if (localClient)
             {
                 RegisterHandler(MsgType.LocalClientAuthority, ClientScene.OnClientAuthority);
-                RegisterHandler(MsgType.ObjectDestroy, ClientScene.OnLocalClientObjectDestroy);
-                RegisterHandler(MsgType.ObjectHide, ClientScene.OnLocalClientObjectHide);
+                RegisterHandler<ObjectDestroyMessage>(ClientScene.OnLocalClientObjectDestroy);
+                RegisterHandler<ObjectHideMessage>(ClientScene.OnLocalClientObjectHide);
                 RegisterHandler(MsgType.Owner, (msg) => {});
                 RegisterHandler(MsgType.Pong, (msg) => {});
                 RegisterHandler(MsgType.SpawnPrefab, ClientScene.OnLocalClientSpawnPrefab);
@@ -254,8 +254,8 @@ namespace Mirror
             else
             {
                 RegisterHandler(MsgType.LocalClientAuthority, ClientScene.OnClientAuthority);
-                RegisterHandler(MsgType.ObjectDestroy, ClientScene.OnObjectDestroy);
-                RegisterHandler(MsgType.ObjectHide, ClientScene.OnObjectDestroy);
+                RegisterHandler<ObjectDestroyMessage>(ClientScene.OnObjectDestroy);
+                RegisterHandler<ObjectHideMessage>(ClientScene.OnObjectHide);
                 RegisterHandler(MsgType.Owner, ClientScene.OnOwnerMessage);
                 RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
                 RegisterHandler(MsgType.SpawnPrefab, ClientScene.OnSpawnPrefab);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -157,10 +157,9 @@ namespace Mirror
             return false;
         }
 
-        public bool SendMessage<T>(T message) where T : MessageBase
+        public bool Send<T>(T message) where T : MessageBase
         {
             // TODO use int instead to avoid collisions
-            short msgType = (short)typeof(T).FullName.GetStableHashCode();
             if (connection != null)
             {
                 if (connectState != ConnectState.Connected)
@@ -168,7 +167,7 @@ namespace Mirror
                     Debug.LogError("NetworkClient Send when not connected to a server");
                     return false;
                 }
-                return connection.Send(msgType, message);
+                return connection.Send(message);
             }
             Debug.LogError("NetworkClient Send with no connection");
             return false;

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -289,7 +289,7 @@ namespace Mirror
         public void RegisterHandler<T>(Action<T> handler) where T : MessageBase, new()
         {
             // TODO use int instead to avoid collisions
-            short msgType = (short)typeof(T).FullName.GetStableHashCode();
+            short msgType = MessageBase.GetId<T>();
             if (handlers.ContainsKey(msgType))
             {
                 if (LogFilter.Debug) { Debug.Log("NetworkClient.RegisterHandler replacing " + msgType); }
@@ -312,10 +312,10 @@ namespace Mirror
             UnregisterHandler((short)msgType);
         }
 
-        public void UnregisterHandler<T>()
+        public void UnregisterHandler<T>() where T : MessageBase
         {
             // use int to minimize collisions
-            short msgType = (short)typeof(T).FullName.GetStableHashCode();
+            short msgType = MessageBase.GetId<T>();
             handlers.Remove(msgType);
         }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -246,7 +246,7 @@ namespace Mirror
                 RegisterHandler(MsgType.Pong, (msg) => {});
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnLocalClientSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnLocalClientSpawnSceneObject);
-                RegisterHandler(MsgType.SpawnStarted, (msg) => {});
+                RegisterHandler<ObjectSpawnStartedMessage>( (msg) => {});
                 RegisterHandler(MsgType.SpawnFinished, (msg) => {});
                 RegisterHandler(MsgType.UpdateVars, (msg) => {});
             }
@@ -258,7 +258,7 @@ namespace Mirror
                 RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
                 RegisterHandler<SpawnPrefabMessage>(ClientScene.OnSpawnPrefab);
                 RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnSpawnSceneObject);
-                RegisterHandler(MsgType.SpawnStarted, ClientScene.OnObjectSpawnStarted);
+                RegisterHandler<ObjectSpawnStartedMessage>(ClientScene.OnObjectSpawnStarted);
                 RegisterHandler(MsgType.SpawnFinished, ClientScene.OnObjectSpawnFinished);
                 RegisterHandler(MsgType.UpdateVars, ClientScene.OnUpdateVarsMessage);
             }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -263,7 +263,7 @@ namespace Mirror
                 RegisterHandler<UpdateVarsMessage>(ClientScene.OnUpdateVarsMessage);
             }
             RegisterHandler<ClientAuthorityMessage>(ClientScene.OnClientAuthority);
-            RegisterHandler(MsgType.Rpc, ClientScene.OnRPCMessage);
+            RegisterHandler<RpcMessage>(ClientScene.OnRPCMessage);
             RegisterHandler(MsgType.SyncEvent, ClientScene.OnSyncEventMessage);
         }
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -125,8 +125,19 @@ namespace Mirror
             playerController = null;
         }
 
+        [Obsolete("use Send<T> instead")]
         public virtual bool Send(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
+            // pack message and send
+            byte[] message = MessagePacker.PackMessage((ushort)msgType, msg);
+            return SendBytes(message, channelId);
+        }
+
+        public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T: MessageBase
+        {
+            // TODO use int to reduce collisions
+            short msgType = (short)typeof(T).FullName.GetStableHashCode();
+
             // pack message and send
             byte[] message = MessagePacker.PackMessage((ushort)msgType, msg);
             return SendBytes(message, channelId);

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -242,16 +242,7 @@ namespace Mirror
             {
                 if (logNetworkMessages)
                 {
-                    if (Enum.IsDefined(typeof(MsgType), msgType))
-                    {
-                        // one of Mirror mesage types,  display the message name
-                        Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + (MsgType)msgType + " buffer:" + BitConverter.ToString(buffer));
-                    }
-                    else
-                    {
-                        // user defined message,  display the number
-                        Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + msgType + " buffer:" + BitConverter.ToString(buffer));
-                    }
+                    Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer));
                 }
 
                 // try to invoke the handler for that message

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -8,7 +8,7 @@ namespace Mirror
     {
         public HashSet<NetworkIdentity> visList = new HashSet<NetworkIdentity>();
 
-        Dictionary<short, NetworkMessageDelegate> m_MessageHandlers;
+        Dictionary<int, NetworkMessageDelegate> m_MessageHandlers;
 
         public int connectionId = -1;
         public bool isReady;
@@ -96,7 +96,7 @@ namespace Mirror
             RemoveObservers();
         }
 
-        internal void SetHandlers(Dictionary<short, NetworkMessageDelegate> handlers)
+        internal void SetHandlers(Dictionary<int, NetworkMessageDelegate> handlers)
         {
             m_MessageHandlers = handlers;
         }
@@ -126,20 +126,19 @@ namespace Mirror
         }
 
         [Obsolete("use Send<T> instead")]
-        public virtual bool Send(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        public virtual bool Send(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             // pack message and send
-            byte[] message = MessagePacker.PackMessage((ushort)msgType, msg);
+            byte[] message = MessagePacker.PackMessage(msgType, msg);
             return SendBytes(message, channelId);
         }
 
         public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T: MessageBase
         {
-            // TODO use int to reduce collisions
-            short msgType = MessageBase.GetId<T>();
+            int msgType = MessageBase.GetId<T>();
 
             // pack message and send
-            byte[] message = MessagePacker.PackMessage((ushort)msgType, msg);
+            byte[] message = MessagePacker.PackMessage(msgType, msg);
             return SendBytes(message, channelId);
         }
 
@@ -198,12 +197,12 @@ namespace Mirror
             visList.Clear();
         }
 
-        public bool InvokeHandlerNoData(short msgType)
+        public bool InvokeHandlerNoData(int msgType)
         {
             return InvokeHandler(msgType, null);
         }
 
-        public bool InvokeHandler(short msgType, NetworkReader reader)
+        public bool InvokeHandler(int msgType, NetworkReader reader)
         {
             if (m_MessageHandlers.TryGetValue(msgType, out NetworkMessageDelegate msgDelegate))
             {
@@ -232,7 +231,7 @@ namespace Mirror
         {
             // unpack message
             NetworkReader reader = new NetworkReader(buffer);
-            if (MessagePacker.UnpackMessage(reader, out ushort msgType))
+            if (MessagePacker.UnpackMessage(reader, out int msgType))
             {
                 if (logNetworkMessages)
                 {
@@ -249,7 +248,7 @@ namespace Mirror
                 }
 
                 // try to invoke the handler for that message
-                if (InvokeHandler((short)msgType, reader))
+                if (InvokeHandler(msgType, reader))
                 {
                     lastMessageTime = Time.time;
                 }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -135,10 +135,8 @@ namespace Mirror
 
         public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T: MessageBase
         {
-            int msgType = MessageBase.GetId<T>();
-
             // pack message and send
-            byte[] message = MessagePacker.PackMessage(msgType, msg);
+            byte[] message = MessagePacker.Pack(msg);
             return SendBytes(message, channelId);
         }
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -220,6 +220,13 @@ namespace Mirror
             return false;
         }
 
+        public bool InvokeHandler<T>(T msg) where T : MessageBase
+        {
+            int msgType = MessageBase.GetId<T>();
+            byte[] data = MessagePacker.Pack(msg);
+            return InvokeHandler(msgType, new NetworkReader(data));
+        }
+
         // handle this message
         // note: original HLAPI HandleBytes function handled >1 message in a while loop, but this wasn't necessary
         //       anymore because NetworkServer/NetworkClient.Update both use while loops to handle >1 data events per

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -136,7 +136,7 @@ namespace Mirror
         public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T: MessageBase
         {
             // TODO use int to reduce collisions
-            short msgType = (short)typeof(T).FullName.GetStableHashCode();
+            short msgType = MessageBase.GetId<T>();
 
             // pack message and send
             byte[] message = MessagePacker.PackMessage((ushort)msgType, msg);

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -779,7 +779,7 @@ namespace Mirror
                 netId = netId,
                 authority = false
             };
-            conn.Send((short)MsgType.LocalClientAuthority, msg);
+            conn.Send(msg);
 
             clientAuthorityCallback?.Invoke(conn, this, false);
             return true;
@@ -822,7 +822,7 @@ namespace Mirror
                 netId = netId,
                 authority = true
             };
-            conn.Send((short)MsgType.LocalClientAuthority, msg);
+            conn.Send(msg);
 
             clientAuthorityCallback?.Invoke(conn, this, true);
             return true;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -874,7 +874,7 @@ namespace Mirror
                 // populate cached UpdateVarsMessage and send
                 varsMessage.netId = netId;
                 varsMessage.payload = payload;
-                NetworkServer.SendToReady(this, (short)MsgType.UpdateVars, varsMessage);
+                NetworkServer.SendToReady(this, varsMessage);
             }
         }
     }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -196,7 +196,7 @@ namespace Mirror
         {
             NetworkServer.RegisterHandler(MsgType.Connect, OnServerConnectInternal);
             NetworkServer.RegisterHandler(MsgType.Disconnect, OnServerDisconnectInternal);
-            NetworkServer.RegisterHandler(MsgType.Ready, OnServerReadyMessageInternal);
+            NetworkServer.RegisterHandler<ReadyMessage>(OnServerReadyMessageInternal);
             NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerMessageInternal);
             NetworkServer.RegisterHandler<RemovePlayerMessage>(OnServerRemovePlayerMessageInternal);
             NetworkServer.RegisterHandler(MsgType.Error, OnServerErrorInternal);
@@ -540,10 +540,10 @@ namespace Mirror
             OnServerDisconnect(netMsg.conn);
         }
 
-        internal void OnServerReadyMessageInternal(NetworkMessage netMsg)
+        internal void OnServerReadyMessageInternal(NetworkConnection conn, ReadyMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnServerReadyMessageInternal"); }
-            OnServerReady(netMsg.conn);
+            OnServerReady(conn);
         }
 
         internal void OnServerAddPlayerMessageInternal(NetworkConnection conn, AddPlayerMessage msg)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -259,7 +259,7 @@ namespace Mirror
         {
             client.RegisterHandler<ConnectMessage>(OnClientConnectInternal);
             client.RegisterHandler<DisconnectMessage>(OnClientDisconnectInternal);
-            client.RegisterHandler(MsgType.NotReady, OnClientNotReadyMessageInternal);
+            client.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal);
             client.RegisterHandler<ErrorMessage>(OnClientErrorInternal);
             client.RegisterHandler(MsgType.Scene, OnClientSceneInternal);
 
@@ -609,12 +609,12 @@ namespace Mirror
             OnClientDisconnect(client.connection);
         }
 
-        internal void OnClientNotReadyMessageInternal(NetworkMessage netMsg)
+        internal void OnClientNotReadyMessageInternal(NotReadyMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientNotReadyMessageInternal"); }
 
             ClientScene.ready = false;
-            OnClientNotReady(netMsg.conn);
+            OnClientNotReady(client.connection);
 
             // NOTE: s_ClientReadyConnection is not set here! don't want OnClientConnect to be invoked again after scene changes.
         }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -195,7 +195,7 @@ namespace Mirror
         internal void RegisterServerMessages()
         {
             NetworkServer.RegisterHandler(MsgType.Connect, OnServerConnectInternal);
-            NetworkServer.RegisterHandler(MsgType.Disconnect, OnServerDisconnectInternal);
+            NetworkServer.RegisterHandler<DisconnectMessage>(OnServerDisconnectInternal);
             NetworkServer.RegisterHandler<ReadyMessage>(OnServerReadyMessageInternal);
             NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerMessageInternal);
             NetworkServer.RegisterHandler<RemovePlayerMessage>(OnServerRemovePlayerMessageInternal);
@@ -258,7 +258,7 @@ namespace Mirror
         internal void RegisterClientMessages(NetworkClient client)
         {
             client.RegisterHandler(MsgType.Connect, OnClientConnectInternal);
-            client.RegisterHandler(MsgType.Disconnect, OnClientDisconnectInternal);
+            client.RegisterHandler<DisconnectMessage>(OnClientDisconnectInternal);
             client.RegisterHandler(MsgType.NotReady, OnClientNotReadyMessageInternal);
             client.RegisterHandler<ErrorMessage>(OnClientErrorInternal);
             client.RegisterHandler(MsgType.Scene, OnClientSceneInternal);
@@ -534,10 +534,10 @@ namespace Mirror
             OnServerConnect(netMsg.conn);
         }
 
-        internal void OnServerDisconnectInternal(NetworkMessage netMsg)
+        internal void OnServerDisconnectInternal(NetworkConnection conn, DisconnectMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnServerDisconnectInternal"); }
-            OnServerDisconnect(netMsg.conn);
+            OnServerDisconnect(conn);
         }
 
         internal void OnServerReadyMessageInternal(NetworkConnection conn, ReadyMessage msg)
@@ -603,11 +603,10 @@ namespace Mirror
             }
         }
 
-        internal void OnClientDisconnectInternal(NetworkMessage netMsg)
+        internal void OnClientDisconnectInternal(DisconnectMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientDisconnectInternal"); }
-
-            OnClientDisconnect(netMsg.conn);
+            OnClientDisconnect(client.connection);
         }
 
         internal void OnClientNotReadyMessageInternal(NetworkMessage netMsg)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -199,7 +199,7 @@ namespace Mirror
             NetworkServer.RegisterHandler<ReadyMessage>(OnServerReadyMessageInternal);
             NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerMessageInternal);
             NetworkServer.RegisterHandler<RemovePlayerMessage>(OnServerRemovePlayerMessageInternal);
-            NetworkServer.RegisterHandler(MsgType.Error, OnServerErrorInternal);
+            NetworkServer.RegisterHandler<ErrorMessage>(OnServerErrorInternal);
         }
 
         public bool StartServer()
@@ -260,7 +260,7 @@ namespace Mirror
             client.RegisterHandler(MsgType.Connect, OnClientConnectInternal);
             client.RegisterHandler(MsgType.Disconnect, OnClientDisconnectInternal);
             client.RegisterHandler(MsgType.NotReady, OnClientNotReadyMessageInternal);
-            client.RegisterHandler(MsgType.Error, OnClientErrorInternal);
+            client.RegisterHandler<ErrorMessage>(OnClientErrorInternal);
             client.RegisterHandler(MsgType.Scene, OnClientSceneInternal);
 
             if (playerPrefab != null)
@@ -578,12 +578,10 @@ namespace Mirror
             }
         }
 
-        internal void OnServerErrorInternal(NetworkMessage netMsg)
+        internal void OnServerErrorInternal(NetworkConnection conn, ErrorMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnServerErrorInternal"); }
-
-            ErrorMessage msg = netMsg.ReadMessage<ErrorMessage>();
-            OnServerError(netMsg.conn, msg.value);
+            OnServerError(conn, msg.value);
         }
 
         // ----------------------------- Client Internal Message Handlers  --------------------------------
@@ -622,12 +620,10 @@ namespace Mirror
             // NOTE: s_ClientReadyConnection is not set here! don't want OnClientConnect to be invoked again after scene changes.
         }
 
-        internal void OnClientErrorInternal(NetworkMessage netMsg)
+        internal void OnClientErrorInternal(ErrorMessage msg)
         {
-            if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientErrorInternal"); }
-
-            ErrorMessage msg = netMsg.ReadMessage<ErrorMessage>();
-            OnClientError(netMsg.conn, msg.value);
+            if (LogFilter.Debug) { Debug.Log("NetworkManager:OnClientErrorInternal"); }
+            OnClientError(client.connection, msg.value);
         }
 
         internal void OnClientSceneInternal(NetworkMessage netMsg)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -197,7 +197,7 @@ namespace Mirror
             NetworkServer.RegisterHandler(MsgType.Connect, OnServerConnectInternal);
             NetworkServer.RegisterHandler(MsgType.Disconnect, OnServerDisconnectInternal);
             NetworkServer.RegisterHandler(MsgType.Ready, OnServerReadyMessageInternal);
-            NetworkServer.RegisterHandler(MsgType.AddPlayer, OnServerAddPlayerMessageInternal);
+            NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerMessageInternal);
             NetworkServer.RegisterHandler(MsgType.RemovePlayer, OnServerRemovePlayerMessageInternal);
             NetworkServer.RegisterHandler(MsgType.Error, OnServerErrorInternal);
         }
@@ -546,11 +546,9 @@ namespace Mirror
             OnServerReady(netMsg.conn);
         }
 
-        internal void OnServerAddPlayerMessageInternal(NetworkMessage netMsg)
+        internal void OnServerAddPlayerMessageInternal(NetworkConnection conn, AddPlayerMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnServerAddPlayerMessageInternal"); }
-
-            AddPlayerMessage msg = netMsg.ReadMessage<AddPlayerMessage>();
 
             if (msg.value != null && msg.value.Length > 0)
             {
@@ -559,13 +557,13 @@ namespace Mirror
                 NetworkMessage extraMessage = new NetworkMessage
                 {
                     reader = new NetworkReader(msg.value),
-                    conn = netMsg.conn
+                    conn = conn
                 };
-                OnServerAddPlayer(netMsg.conn, extraMessage);
+                OnServerAddPlayer(conn, extraMessage);
             }
             else
             {
-                OnServerAddPlayer(netMsg.conn);
+                OnServerAddPlayer(conn);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -387,7 +387,7 @@ namespace Mirror
             s_LoadingSceneAsync = SceneManager.LoadSceneAsync(newSceneName);
 
             StringMessage msg = new StringMessage(networkSceneName);
-            NetworkServer.SendToAll((short)MsgType.Scene, msg);
+            NetworkServer.SendToAll((int)MsgType.Scene, msg);
 
             s_StartPositionIndex = 0;
             startPositions.Clear();
@@ -528,7 +528,7 @@ namespace Mirror
             if (networkSceneName != "" && networkSceneName != offlineScene)
             {
                 StringMessage msg = new StringMessage(networkSceneName);
-                netMsg.conn.Send((short)MsgType.Scene, msg);
+                netMsg.conn.Send((int)MsgType.Scene, msg);
             }
 
             OnServerConnect(netMsg.conn);

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -198,7 +198,7 @@ namespace Mirror
             NetworkServer.RegisterHandler(MsgType.Disconnect, OnServerDisconnectInternal);
             NetworkServer.RegisterHandler(MsgType.Ready, OnServerReadyMessageInternal);
             NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerMessageInternal);
-            NetworkServer.RegisterHandler(MsgType.RemovePlayer, OnServerRemovePlayerMessageInternal);
+            NetworkServer.RegisterHandler<RemovePlayerMessage>(OnServerRemovePlayerMessageInternal);
             NetworkServer.RegisterHandler(MsgType.Error, OnServerErrorInternal);
         }
 
@@ -567,14 +567,14 @@ namespace Mirror
             }
         }
 
-        internal void OnServerRemovePlayerMessageInternal(NetworkMessage netMsg)
+        internal void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnServerRemovePlayerMessageInternal"); }
 
-            if (netMsg.conn.playerController != null)
+            if (conn.playerController != null)
             {
-                OnServerRemovePlayer(netMsg.conn, netMsg.conn.playerController);
-                netMsg.conn.RemovePlayerController();
+                OnServerRemovePlayer(conn, conn.playerController);
+                conn.RemovePlayerController();
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -261,7 +261,7 @@ namespace Mirror
             client.RegisterHandler<DisconnectMessage>(OnClientDisconnectInternal);
             client.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal);
             client.RegisterHandler<ErrorMessage>(OnClientErrorInternal);
-            client.RegisterHandler(MsgType.Scene, OnClientSceneInternal);
+            client.RegisterHandler<SceneMessage>(OnClientSceneInternal);
 
             if (playerPrefab != null)
             {
@@ -386,8 +386,8 @@ namespace Mirror
 
             s_LoadingSceneAsync = SceneManager.LoadSceneAsync(newSceneName);
 
-            StringMessage msg = new StringMessage(networkSceneName);
-            NetworkServer.SendToAll((int)MsgType.Scene, msg);
+            SceneMessage msg = new SceneMessage(networkSceneName);
+            NetworkServer.SendToAll(msg);
 
             s_StartPositionIndex = 0;
             startPositions.Clear();
@@ -527,8 +527,8 @@ namespace Mirror
 
             if (networkSceneName != "" && networkSceneName != offlineScene)
             {
-                StringMessage msg = new StringMessage(networkSceneName);
-                conn.Send((int)MsgType.Scene, msg);
+                SceneMessage msg = new SceneMessage(networkSceneName);
+                conn.Send(msg);
             }
 
             OnServerConnect(conn);
@@ -625,11 +625,11 @@ namespace Mirror
             OnClientError(client.connection, msg.value);
         }
 
-        internal void OnClientSceneInternal(NetworkMessage netMsg)
+        internal void OnClientSceneInternal(SceneMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientSceneInternal"); }
 
-            string newSceneName = netMsg.reader.ReadString();
+            string newSceneName = msg.value;
 
             if (IsClientConnected() && !NetworkServer.active)
             {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -194,7 +194,7 @@ namespace Mirror
 
         internal void RegisterServerMessages()
         {
-            NetworkServer.RegisterHandler(MsgType.Connect, OnServerConnectInternal);
+            NetworkServer.RegisterHandler<ConnectMessage>(OnServerConnectInternal);
             NetworkServer.RegisterHandler<DisconnectMessage>(OnServerDisconnectInternal);
             NetworkServer.RegisterHandler<ReadyMessage>(OnServerReadyMessageInternal);
             NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerMessageInternal);
@@ -257,7 +257,7 @@ namespace Mirror
 
         internal void RegisterClientMessages(NetworkClient client)
         {
-            client.RegisterHandler(MsgType.Connect, OnClientConnectInternal);
+            client.RegisterHandler<ConnectMessage>(OnClientConnectInternal);
             client.RegisterHandler<DisconnectMessage>(OnClientDisconnectInternal);
             client.RegisterHandler(MsgType.NotReady, OnClientNotReadyMessageInternal);
             client.RegisterHandler<ErrorMessage>(OnClientErrorInternal);
@@ -521,17 +521,17 @@ namespace Mirror
 
         // ----------------------------- Server Internal Message Handlers  --------------------------------
 
-        internal void OnServerConnectInternal(NetworkMessage netMsg)
+        internal void OnServerConnectInternal(NetworkConnection conn, ConnectMessage connectMsg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnServerConnectInternal"); }
 
             if (networkSceneName != "" && networkSceneName != offlineScene)
             {
                 StringMessage msg = new StringMessage(networkSceneName);
-                netMsg.conn.Send((int)MsgType.Scene, msg);
+                conn.Send((int)MsgType.Scene, msg);
             }
 
-            OnServerConnect(netMsg.conn);
+            OnServerConnect(conn);
         }
 
         internal void OnServerDisconnectInternal(NetworkConnection conn, DisconnectMessage msg)
@@ -586,7 +586,7 @@ namespace Mirror
 
         // ----------------------------- Client Internal Message Handlers  --------------------------------
 
-        internal void OnClientConnectInternal(NetworkMessage netMsg)
+        internal void OnClientConnectInternal(ConnectMessage message)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientConnectInternal"); }
 
@@ -594,12 +594,12 @@ namespace Mirror
             if (string.IsNullOrEmpty(onlineScene) || onlineScene == offlineScene || loadedSceneName == onlineScene)
             {
                 clientLoadedScene = false;
-                OnClientConnect(netMsg.conn);
+                OnClientConnect(client.connection);
             }
             else
             {
                 // will wait for scene id to come from the server.
-                s_ClientReadyConnection = netMsg.conn;
+                s_ClientReadyConnection = client.connection;
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -586,7 +586,7 @@ namespace Mirror
 
         // ----------------------------- Client Internal Message Handlers  --------------------------------
 
-        internal void OnClientConnectInternal(ConnectMessage message)
+        internal void OnClientConnectInternal(NetworkConnection conn, ConnectMessage message)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientConnectInternal"); }
 
@@ -594,38 +594,38 @@ namespace Mirror
             if (string.IsNullOrEmpty(onlineScene) || onlineScene == offlineScene || loadedSceneName == onlineScene)
             {
                 clientLoadedScene = false;
-                OnClientConnect(client.connection);
+                OnClientConnect(conn);
             }
             else
             {
                 // will wait for scene id to come from the server.
-                s_ClientReadyConnection = client.connection;
+                s_ClientReadyConnection = conn;
             }
         }
 
-        internal void OnClientDisconnectInternal(DisconnectMessage msg)
+        internal void OnClientDisconnectInternal(NetworkConnection conn, DisconnectMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientDisconnectInternal"); }
-            OnClientDisconnect(client.connection);
+            OnClientDisconnect(conn);
         }
 
-        internal void OnClientNotReadyMessageInternal(NotReadyMessage msg)
+        internal void OnClientNotReadyMessageInternal(NetworkConnection conn, NotReadyMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientNotReadyMessageInternal"); }
 
             ClientScene.ready = false;
-            OnClientNotReady(client.connection);
+            OnClientNotReady(conn);
 
             // NOTE: s_ClientReadyConnection is not set here! don't want OnClientConnect to be invoked again after scene changes.
         }
 
-        internal void OnClientErrorInternal(ErrorMessage msg)
+        internal void OnClientErrorInternal(NetworkConnection conn, ErrorMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager:OnClientErrorInternal"); }
-            OnClientError(client.connection, msg.value);
+            OnClientError(conn, msg.value);
         }
 
-        internal void OnClientSceneInternal(SceneMessage msg)
+        internal void OnClientSceneInternal(NetworkConnection conn, SceneMessage msg)
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnClientSceneInternal"); }
 

--- a/Assets/Mirror/Runtime/NetworkMessage.cs
+++ b/Assets/Mirror/Runtime/NetworkMessage.cs
@@ -2,7 +2,7 @@ namespace Mirror
 {
     public struct NetworkMessage
     {
-        public short msgType;
+        public int msgType;
         public NetworkConnection conn;
         public NetworkReader reader;
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -77,7 +77,7 @@ namespace Mirror
             RegisterHandler<ReadyMessage>(OnClientReadyMessage);
             RegisterHandler<CommandMessage>(OnCommandMessage);
             RegisterHandler<RemovePlayerMessage>(OnRemovePlayerMessage);
-            RegisterHandler(MsgType.Ping, NetworkTime.OnServerPing);
+            RegisterHandler<NetworkPingMessage>(NetworkTime.OnServerPing);
         }
 
         public static bool Listen(int maxConnections)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -451,7 +451,7 @@ namespace Mirror
         static void GenerateError(NetworkConnection conn, byte error)
         {
             short msgId = MessageBase.GetId<ErrorMessage>();
-            if (handlers.ContainsKey((short)MsgType.Error))
+            if (handlers.ContainsKey(msgId))
             {
                 ErrorMessage msg = new ErrorMessage
                 {
@@ -464,7 +464,7 @@ namespace Mirror
 
                 // pass a reader (attached to local buffer) to handler
                 NetworkReader reader = new NetworkReader(writer.ToArray());
-                conn.InvokeHandler((short)MsgType.Error, reader);
+                conn.InvokeHandler(msgId, reader);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -784,7 +784,7 @@ namespace Mirror
                 }
             }
 
-            conn.Send((short)MsgType.SpawnFinished, new ObjectSpawnFinishedMessage());
+            conn.Send(new ObjectSpawnFinishedMessage());
         }
 
         internal static void ShowForConnection(NetworkIdentity identity, NetworkConnection conn)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -422,6 +422,7 @@ namespace Mirror
             }
         }
 
+        [Obsolete("Use RegisterHandler<T> instead")]
         public static void RegisterHandler(short msgType, NetworkMessageDelegate handler)
         {
             if (handlers.ContainsKey(msgType))
@@ -431,19 +432,42 @@ namespace Mirror
             handlers[msgType] = handler;
         }
 
+        [Obsolete("Use RegisterHandler<T> instead")]
         public static void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
         {
             RegisterHandler((short)msgType, handler);
         }
 
+        public static void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T: MessageBase, new()
+        {
+            short msgType = (short)typeof(T).FullName.GetStableHashCode();
+            if (handlers.ContainsKey(msgType))
+            {
+                if (LogFilter.Debug) { Debug.Log("NetworkServer.RegisterHandler replacing " + msgType); }
+            }
+            handlers[msgType] = networkMessage =>
+            {
+                T message = networkMessage.ReadMessage<T>();
+                handler(networkMessage.conn, message);
+            };
+        }
+
+        [Obsolete("Use UnregisterHandler<T> instead")]
         public static void UnregisterHandler(short msgType)
         {
             handlers.Remove(msgType);
         }
 
+        [Obsolete("Use UnregisterHandler<T> instead")]
         public static void UnregisterHandler(MsgType msgType)
         {
             UnregisterHandler((short)msgType);
+        }
+
+        public static void UnregisterHandler<T>() where T:MessageBase
+        {
+            short msgType = (short)typeof(T).FullName.GetStableHashCode();
+            handlers.Remove(msgType);
         }
 
         public static void ClearHandlers()

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -537,6 +537,7 @@ namespace Mirror
             handlers.Clear();
         }
 
+        [Obsolete("Use SendToClient<T> instead")]
         public static void SendToClient(int connectionId, int msgType, MessageBase msg)
         {
             if (connections.TryGetValue(connectionId, out NetworkConnection conn))
@@ -547,12 +548,37 @@ namespace Mirror
             Debug.LogError("Failed to send message to connection ID '" + connectionId + ", not found in connection list");
         }
 
-        // send this message to the player only
+        public static void SendToClient<T>(int connectionId, T msg) where T : MessageBase
+        {
+            NetworkConnection conn;
+            if (connections.TryGetValue(connectionId, out conn))
+            {
+                conn.Send(msg);
+                return;
+            }
+            Debug.LogError("Failed to send message to connection ID '" + connectionId + ", not found in connection list");
+        }
+
+
+        [Obsolete("Use SendToClientOfPlayer<T> instead")]
         public static void SendToClientOfPlayer(NetworkIdentity identity, int msgType, MessageBase msg)
         {
             if (identity != null)
             {
                 identity.connectionToClient.Send(msgType, msg);
+            }
+            else
+            {
+                Debug.LogError("SendToClientOfPlayer: player has no NetworkIdentity: " + identity.name);
+            }
+        }
+
+        // send this message to the player only
+        public static void SendToClientOfPlayer<T>(NetworkIdentity identity, T msg) where T: MessageBase
+        {
+            if (identity != null)
+            {
+                identity.connectionToClient.Send(msg);
             }
             else
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -826,8 +826,7 @@ namespace Mirror
                 conn.isReady = false;
                 conn.RemoveObservers();
 
-                NotReadyMessage msg = new NotReadyMessage();
-                conn.Send((int)MsgType.NotReady, msg);
+                conn.Send(new NotReadyMessage());
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -371,7 +371,7 @@ namespace Mirror
 
             // add connection and invoke connected event
             AddConnection(conn);
-            conn.InvokeHandlerNoData((int)MsgType.Connect);
+            conn.InvokeHandler(new ConnectMessage());
         }
 
         static void OnDisconnected(int connectionId)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -74,7 +74,7 @@ namespace Mirror
 
         internal static void RegisterMessageHandlers()
         {
-            RegisterHandler(MsgType.Ready, OnClientReadyMessage);
+            RegisterHandler<ReadyMessage>(OnClientReadyMessage);
             RegisterHandler(MsgType.Command, OnCommandMessage);
             RegisterHandler<RemovePlayerMessage>(OnRemovePlayerMessage);
             RegisterHandler(MsgType.Ping, NetworkTime.OnServerPing);
@@ -786,10 +786,10 @@ namespace Mirror
         }
 
         // default ready handler.
-        static void OnClientReadyMessage(NetworkMessage netMsg)
+        static void OnClientReadyMessage(NetworkConnection conn, ReadyMessage msg)
         {
-            if (LogFilter.Debug) { Debug.Log("Default handler for ready message from " + netMsg.conn); }
-            SetClientReady(netMsg.conn);
+            if (LogFilter.Debug) { Debug.Log("Default handler for ready message from " + conn); }
+            SetClientReady(conn);
         }
 
         // default remove player handler

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -390,7 +390,7 @@ namespace Mirror
 
         static void OnDisconnected(NetworkConnection conn)
         {
-            conn.InvokeHandlerNoData((int)MsgType.Disconnect);
+            conn.InvokeHandler(new DisconnectMessage());
 
             if (conn.playerController != null)
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -440,7 +440,7 @@ namespace Mirror
 
         public static void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T: MessageBase, new()
         {
-            short msgType = (short)typeof(T).FullName.GetStableHashCode();
+            short msgType = MessageBase.GetId<T>();
             if (handlers.ContainsKey(msgType))
             {
                 if (LogFilter.Debug) { Debug.Log("NetworkServer.RegisterHandler replacing " + msgType); }
@@ -466,7 +466,7 @@ namespace Mirror
 
         public static void UnregisterHandler<T>() where T:MessageBase
         {
-            short msgType = (short)typeof(T).FullName.GetStableHashCode();
+            short msgType = MessageBase.GetId<T>();
             handlers.Remove(msgType);
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -951,12 +951,12 @@ namespace Mirror
                 // conn is != null when spawning it for a client
                 if (conn != null)
                 {
-                    conn.Send((short)MsgType.SpawnSceneObject, msg);
+                    conn.Send(msg);
                 }
                 // conn is == null when spawning it for the local player
                 else
                 {
-                    SendToReady(identity, (short)MsgType.SpawnSceneObject, msg);
+                    SendToReady(identity, msg);
                 }
             }
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -761,7 +761,7 @@ namespace Mirror
             // Spawn/update all current server objects
             if (LogFilter.Debug) { Debug.Log("Spawning " + NetworkIdentity.spawned.Count + " objects for conn " + conn.connectionId); }
 
-            conn.Send((short)MsgType.SpawnStarted, new ObjectSpawnStartedMessage());
+            conn.Send(new ObjectSpawnStartedMessage());
 
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -76,7 +76,7 @@ namespace Mirror
         {
             RegisterHandler(MsgType.Ready, OnClientReadyMessage);
             RegisterHandler(MsgType.Command, OnCommandMessage);
-            RegisterHandler(MsgType.RemovePlayer, OnRemovePlayerMessage);
+            RegisterHandler<RemovePlayerMessage>(OnRemovePlayerMessage);
             RegisterHandler(MsgType.Ping, NetworkTime.OnServerPing);
         }
 
@@ -793,12 +793,12 @@ namespace Mirror
         }
 
         // default remove player handler
-        static void OnRemovePlayerMessage(NetworkMessage netMsg)
+        static void OnRemovePlayerMessage(NetworkConnection conn, RemovePlayerMessage msg)
         {
-            if (netMsg.conn.playerController != null)
+            if (conn.playerController != null)
             {
-                Destroy(netMsg.conn.playerController.gameObject);
-                netMsg.conn.RemovePlayerController();
+                Destroy(conn.playerController.gameObject);
+                conn.RemovePlayerController();
             }
             else
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -224,6 +224,7 @@ namespace Mirror
             return result;
         }
 
+        [Obsolete("Use SendToReady<T> instead")]
         public static bool SendToReady(NetworkIdentity identity, short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) { Debug.Log("Server.SendToReady msgType:" + msgType); }
@@ -234,6 +235,28 @@ namespace Mirror
                 byte[] bytes = MessagePacker.PackMessage((ushort)msgType, msg);
 
                 // send to all ready observers
+                bool result = true;
+                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                {
+                    if (kvp.Value.isReady)
+                    {
+                        result &= kvp.Value.SendBytes(bytes, channelId);
+                    }
+                }
+                return result;
+            }
+            return false;
+        }
+
+        public static bool SendToReady<T>(NetworkIdentity identity,T msg, int channelId = Channels.DefaultReliable) where T: MessageBase
+        {
+            if (LogFilter.Debug) { Debug.Log("Server.SendToReady msgType:" + typeof(T)); }
+
+            if (identity != null && identity.observers != null)
+            {
+                // pack message into byte[] once
+                byte[] bytes = MessagePacker.Pack(msg);
+
                 bool result = true;
                 foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
                 {
@@ -903,12 +926,12 @@ namespace Mirror
                 // conn is != null when spawning it for a client
                 if (conn != null)
                 {
-                    conn.Send((short)MsgType.SpawnPrefab, msg);
+                    conn.Send(msg);
                 }
                 // conn is == null when spawning it for the local player
                 else
                 {
-                    SendToReady(identity, (short)MsgType.SpawnPrefab, msg);
+                    SendToReady(identity, msg);
                 }
             }
             // 'identity' is a scene object that should be spawned again

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -17,7 +17,7 @@ namespace Mirror
 
         // <connectionId, NetworkConnection>
         public static Dictionary<int, NetworkConnection> connections = new Dictionary<int, NetworkConnection>();
-        public static Dictionary<short, NetworkMessageDelegate> handlers = new Dictionary<short, NetworkMessageDelegate>();
+        public static Dictionary<int, NetworkMessageDelegate> handlers = new Dictionary<int, NetworkMessageDelegate>();
 
         public static bool dontListen;
 
@@ -208,7 +208,7 @@ namespace Mirror
             return false;
         }
 
-        public static bool SendToAll(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        public static bool SendToAll(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) { Debug.Log("Server.SendToAll id:" + msgType); }
 
@@ -371,7 +371,7 @@ namespace Mirror
 
             // add connection and invoke connected event
             AddConnection(conn);
-            conn.InvokeHandlerNoData((short)MsgType.Connect);
+            conn.InvokeHandlerNoData((int)MsgType.Connect);
         }
 
         static void OnDisconnected(int connectionId)
@@ -390,7 +390,7 @@ namespace Mirror
 
         static void OnDisconnected(NetworkConnection conn)
         {
-            conn.InvokeHandlerNoData((short)MsgType.Disconnect);
+            conn.InvokeHandlerNoData((int)MsgType.Disconnect);
 
             if (conn.playerController != null)
             {
@@ -450,7 +450,7 @@ namespace Mirror
 
         static void GenerateError(NetworkConnection conn, byte error)
         {
-            short msgId = MessageBase.GetId<ErrorMessage>();
+            int msgId = MessageBase.GetId<ErrorMessage>();
             if (handlers.ContainsKey(msgId))
             {
                 ErrorMessage msg = new ErrorMessage
@@ -469,7 +469,7 @@ namespace Mirror
         }
 
         [Obsolete("Use RegisterHandler<T> instead")]
-        public static void RegisterHandler(short msgType, NetworkMessageDelegate handler)
+        public static void RegisterHandler(int msgType, NetworkMessageDelegate handler)
         {
             if (handlers.ContainsKey(msgType))
             {
@@ -481,12 +481,12 @@ namespace Mirror
         [Obsolete("Use RegisterHandler<T> instead")]
         public static void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
         {
-            RegisterHandler((short)msgType, handler);
+            RegisterHandler((int)msgType, handler);
         }
 
         public static void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T: MessageBase, new()
         {
-            short msgType = MessageBase.GetId<T>();
+            int msgType = MessageBase.GetId<T>();
             if (handlers.ContainsKey(msgType))
             {
                 if (LogFilter.Debug) { Debug.Log("NetworkServer.RegisterHandler replacing " + msgType); }
@@ -499,7 +499,7 @@ namespace Mirror
         }
 
         [Obsolete("Use UnregisterHandler<T> instead")]
-        public static void UnregisterHandler(short msgType)
+        public static void UnregisterHandler(int msgType)
         {
             handlers.Remove(msgType);
         }
@@ -507,12 +507,12 @@ namespace Mirror
         [Obsolete("Use UnregisterHandler<T> instead")]
         public static void UnregisterHandler(MsgType msgType)
         {
-            UnregisterHandler((short)msgType);
+            UnregisterHandler((int)msgType);
         }
 
         public static void UnregisterHandler<T>() where T:MessageBase
         {
-            short msgType = MessageBase.GetId<T>();
+            int msgType = MessageBase.GetId<T>();
             handlers.Remove(msgType);
         }
 
@@ -521,7 +521,7 @@ namespace Mirror
             handlers.Clear();
         }
 
-        public static void SendToClient(int connectionId, short msgType, MessageBase msg)
+        public static void SendToClient(int connectionId, int msgType, MessageBase msg)
         {
             if (connections.TryGetValue(connectionId, out NetworkConnection conn))
             {
@@ -532,7 +532,7 @@ namespace Mirror
         }
 
         // send this message to the player only
-        public static void SendToClientOfPlayer(NetworkIdentity identity, short msgType, MessageBase msg)
+        public static void SendToClientOfPlayer(NetworkIdentity identity, int msgType, MessageBase msg)
         {
             if (identity != null)
             {
@@ -827,7 +827,7 @@ namespace Mirror
                 conn.RemoveObservers();
 
                 NotReadyMessage msg = new NotReadyMessage();
-                conn.Send((short)MsgType.NotReady, msg);
+                conn.Send((int)MsgType.NotReady, msg);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -208,6 +208,7 @@ namespace Mirror
             return false;
         }
 
+        [Obsolete("Use SendToAll<T> instead")]
         public static bool SendToAll(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) { Debug.Log("Server.SendToAll id:" + msgType); }
@@ -216,6 +217,21 @@ namespace Mirror
             byte[] bytes = MessagePacker.PackMessage((ushort)msgType, msg);
 
             // send to all
+            bool result = true;
+            foreach (KeyValuePair<int, NetworkConnection> kvp in connections)
+            {
+                result &= kvp.Value.SendBytes(bytes, channelId);
+            }
+            return result;
+        }
+
+        public static bool SendToAll<T>(T msg, int channelId = Channels.DefaultReliable) where T : MessageBase
+        {
+            if (LogFilter.Debug) { Debug.Log("Server.SendToAll id:" + typeof(T)); }
+
+            // pack message into byte[] once
+            byte[] bytes = MessagePacker.Pack(msg);
+
             bool result = true;
             foreach (KeyValuePair<int, NetworkConnection> kvp in connections)
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -655,7 +655,7 @@ namespace Mirror
             {
                 netId = identity.netId
             };
-            conn.Send((short)MsgType.Owner, owner);
+            conn.Send(owner);
         }
 
         internal static bool InternalReplacePlayerForConnection(NetworkConnection conn, GameObject playerGameObject)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -450,6 +450,7 @@ namespace Mirror
 
         static void GenerateError(NetworkConnection conn, byte error)
         {
+            short msgId = MessageBase.GetId<ErrorMessage>();
             if (handlers.ContainsKey((short)MsgType.Error))
             {
                 ErrorMessage msg = new ErrorMessage

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -75,7 +75,7 @@ namespace Mirror
         internal static void RegisterMessageHandlers()
         {
             RegisterHandler<ReadyMessage>(OnClientReadyMessage);
-            RegisterHandler(MsgType.Command, OnCommandMessage);
+            RegisterHandler<CommandMessage>(OnCommandMessage);
             RegisterHandler<RemovePlayerMessage>(OnRemovePlayerMessage);
             RegisterHandler(MsgType.Ping, NetworkTime.OnServerPing);
         }
@@ -852,30 +852,28 @@ namespace Mirror
         }
 
         // Handle command from specific player, this could be one of multiple players on a single client
-        static void OnCommandMessage(NetworkMessage netMsg)
+        static void OnCommandMessage(NetworkConnection conn, CommandMessage msg)
         {
-            CommandMessage message = netMsg.ReadMessage<CommandMessage>();
-
-            if (!NetworkIdentity.spawned.TryGetValue(message.netId, out NetworkIdentity identity))
+            if (!NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
-                Debug.LogWarning("Spawned object not found when handling Command message [netId=" + message.netId + "]");
+                Debug.LogWarning("Spawned object not found when handling Command message [netId=" + msg.netId + "]");
                 return;
             }
 
             // Commands can be for player objects, OR other objects with client-authority
             // -> so if this connection's controller has a different netId then
             //    only allow the command if clientAuthorityOwner
-            if (netMsg.conn.playerController != null && netMsg.conn.playerController.netId != identity.netId)
+            if (conn.playerController != null && conn.playerController.netId != identity.netId)
             {
-                if (identity.clientAuthorityOwner != netMsg.conn)
+                if (identity.clientAuthorityOwner != conn)
                 {
-                    Debug.LogWarning("Command for object without authority [netId=" + message.netId + "]");
+                    Debug.LogWarning("Command for object without authority [netId=" + msg.netId + "]");
                     return;
                 }
             }
 
-            if (LogFilter.Debug) { Debug.Log("OnCommandMessage for netId=" + message.netId + " conn=" + netMsg.conn); }
-            identity.HandleCommand(message.componentIndex, message.functionHash, new NetworkReader(message.payload));
+            if (LogFilter.Debug) { Debug.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn); }
+            identity.HandleCommand(msg.componentIndex, msg.functionHash, new NetworkReader(msg.payload));
         }
 
         internal static void SpawnObject(GameObject obj)

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -79,7 +79,7 @@ namespace Mirror
         // Executed at the client when we receive a Pong message
         // find out how long it took since we sent the Ping
         // and update time offset
-        internal static void OnClientPong(NetworkPongMessage msg)
+        internal static void OnClientPong(NetworkConnection conn, NetworkPongMessage msg)
         {
             double now = LocalTime();
 

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -75,28 +75,27 @@ namespace Mirror
                 serverTime = LocalTime()
             };
 
-            netMsg.conn.Send((short)MsgType.Pong, pongMsg);
+            netMsg.conn.Send(pongMsg);
         }
 
         // Executed at the client when we receive a Pong message
         // find out how long it took since we sent the Ping
         // and update time offset
-        internal static void OnClientPong(NetworkMessage netMsg)
+        internal static void OnClientPong(NetworkPongMessage msg)
         {
-            NetworkPongMessage pongMsg = netMsg.ReadMessage<NetworkPongMessage>();
             double now = LocalTime();
 
             // how long did this message take to come back
-            double rtt = now - pongMsg.clientTime;
+            double rtt = now - msg.clientTime;
             _rtt.Add(rtt);
 
             // the difference in time between the client and the server
             // but subtract half of the rtt to compensate for latency
             // half of rtt is the best approximation we have
-            double offset = now - rtt * 0.5f - pongMsg.serverTime;
+            double offset = now - rtt * 0.5f - msg.serverTime;
 
-            double newOffsetMin = now - rtt - pongMsg.serverTime;
-            double newOffsetMax = now - pongMsg.serverTime;
+            double newOffsetMin = now - rtt - msg.serverTime;
+            double newOffsetMax = now - msg.serverTime;
             offsetMin = Math.Max(offsetMin, newOffsetMin);
             offsetMax = Math.Min(offsetMax, newOffsetMax);
 

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -55,7 +55,7 @@ namespace Mirror
             if (Time.time - lastPingTime >= PingFrequency)
             {
                 NetworkPingMessage pingMessage = GetPing();
-                networkClient.Send((short)MsgType.Ping, pingMessage);
+                networkClient.Send(pingMessage);
                 lastPingTime = Time.time;
             }
         }
@@ -63,19 +63,17 @@ namespace Mirror
         // executed at the server when we receive a ping message
         // reply with a pong containing the time from the client
         // and time from the server
-        internal static void OnServerPing(NetworkMessage netMsg)
+        internal static void OnServerPing(NetworkConnection conn, NetworkPingMessage msg)
         {
-            NetworkPingMessage pingMsg = netMsg.ReadMessage<NetworkPingMessage>();
-
-            if (LogFilter.Debug) { Debug.Log("OnPingServerMessage  conn=" + netMsg.conn); }
+            if (LogFilter.Debug) { Debug.Log("OnPingServerMessage  conn=" + conn); }
 
             NetworkPongMessage pongMsg = new NetworkPongMessage
             {
-                clientTime = pingMsg.value,
+                clientTime = msg.value,
                 serverTime = LocalTime()
             };
 
-            netMsg.conn.Send(pongMsg);
+            conn.Send(pongMsg);
         }
 
         // Executed at the client when we receive a Pong message

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -24,6 +24,7 @@ namespace Mirror
     // original HLAPI uses short, so let's keep short to not break packet header etc.
     // => use .ToString() to get the field name from the field value
     // => we specify the short values so it's easier to look up opcodes when debugging packets
+    [Obsolete("Use Send<T>  with no message id instead")]
     public enum MsgType : short
     {
         // internal system messages - cannot be replaced by user code

--- a/docs/Concepts/Communications/NetworkMessages.md
+++ b/docs/Concepts/Communications/NetworkMessages.md
@@ -1,9 +1,9 @@
 # Network Messages
 
-In addition to “high-level” Commands and RPC calls, you can also send raw network messages.
+For the most part we recommend the high level [Commands and RPC](RemoteActions.md) calls and [SyncVar](../StateSync.md) . But you can also send low level network messages.  This can be useful if you want clients to send messages that are not tied to gameobjects, such as logging, analytics or profiling information.
 
-There is a class called MessageBase that you can extend to make serializable network message classes. This class has Serialize and Deserialize functions that take writer and reader objects. You can implement these functions yourself, or you can rely on code-generated implementations that are automatically created by the networking  
-system. The base class looks like this:
+There is a class called MessageBase that you can extend to make serializable network message classes. This class has Serialize and Deserialize functions that take writer and reader objects. You can implement these functions yourself, but we recommend you let Mirror generate them for you.
+The base class looks like this:
 
 ```
 public abstract class MessageBase
@@ -16,45 +16,9 @@ public abstract class MessageBase
 }
 ```
 
-Message classes can contain members that are basic types, structs, and arrays, including most of the common Unity Engine types (such as Vector3). They cannot contain members that are complex classes or generic containers. Remember that if you want to rely on the code-generated implementations, you must make sure your types are publicly visible.
+The auto generated Serialize/Deserialize can efficiently deal with basic types, structs, arrays and common Unity value types such as Color, Vector3, Quaternion. Make your members public. If you need class members or complex containers such as List and Dictionary, you must implement the Serialize and Deserialize methods yourself.
 
-There are built-in message classes for common types of network messages:
-
--   EmptyMessage
--   StringMessage
--   IntegerMessage
-
-To send a message, use the `Send()` method on the NetworkClient, NetworkServer, and NetworkConnection classes which work the same way. It takes a message ID, and a message object that is derived from MessageBase. The code below demonstrates how to send and handle a message using one of the built-in message classes:
-
-```
-using UnityEngine;
-using Mirror;
-
-public class Begin : NetworkBehaviour
-{
-    const short MyBeginMsg = 1002;
-
-    NetworkClient m_client;
-
-    public void SendReadyToBeginMessage(int myId)
-    {
-        var msg = new IntegerMessage(myId);
-        m_client.Send(MyBeginMsg, msg);
-    }
-
-    public void Init(NetworkClient client)
-    {
-        m_client = client;
-        NetworkServer.RegisterHandler(MyBeginMsg, OnServerReadyToBeginMessage);
-    }
-
-    void OnServerReadyToBeginMessage(NetworkMessage netMsg)
-    {
-        var beginMessage = netMsg.ReadMessage<IntegerMessage>();
-        Debug.Log("received OnServerReadyToBeginMessage " + beginMessage.value);
-    }
-}
-```
+To send a message, use the `Send()` method on the NetworkClient, NetworkServer, and NetworkConnection classes which work the same way. It takes a message object that is derived from MessageBase. The code below demonstrates how to send and handle a message:
 
 To declare a custom network message class and use it:
 
@@ -66,11 +30,6 @@ public class Scores : MonoBehaviour
 {
     NetworkClient myClient;
 
-    public class MyMsgType
-    {
-        public static short Score = MsgType.Highest + 1;
-    };
-
     public class ScoreMessage : MessageBase
     {
         public int score;
@@ -80,32 +39,27 @@ public class Scores : MonoBehaviour
 
     public void SendScore(int score, Vector3 scorePos, int lives)
     {
-        ScoreMessage msg = new ScoreMessage();
-        msg.score = score;
-        msg.scorePos = scorePos;
-        msg.lives = lives;
-
-        NetworkServer.SendToAll(MyMsgType.Score, msg);
+        ScoreMessage msg = new ScoreMessage() 
+        {
+            score = score,
+            scorePos = scorePos,
+            lives = lives
+        };
+        
+        NetworkServer.SendToAll(msg);
     }
 
     // Create a client and connect to the server port
     public void SetupClient()
     {
         myClient = new NetworkClient();
-        myClient.RegisterHandler(MsgType.Connect, OnConnected);
-        myClient.RegisterHandler(MyMsgType.Score, OnScore);
+        myClient.RegisterHandler<ScoreMessage>(OnScore);
         myClient.Connect("127.0.0.1", 4444);
     }
 
-    public void OnScore(NetworkMessage netMsg)
+    public void OnScore(ScoreMessage msg)
     {
-        ScoreMessage msg = netMsg.ReadMessage<ScoreMessage>();
         Debug.Log("OnScoreMessage " + msg.score);
-    }
-
-    public void OnConnected(NetworkMessage netMsg)
-    {
-        Debug.Log("Connected to server");
     }
 }
 ```
@@ -126,12 +80,11 @@ class MyClient
     void Start()
     {
         client = new NetworkClient();
-        client.RegisterHandler(MsgType.Error, OnError);
+        client.RegisterHandler<ErrorMessage>(OnError);
     }
     
-    void OnError(NetworkMessage netMsg)
+    void OnError(ErrorMessage errorMsg)
     {
-        var errorMsg = netMsg.ReadMessage<ErrorMessage>();
         Debug.Log("Error:" + errorMsg.errorCode);
     }
 }

--- a/docs/Concepts/Communications/NetworkMessages.md
+++ b/docs/Concepts/Communications/NetworkMessages.md
@@ -5,7 +5,7 @@ For the most part we recommend the high level [Commands and RPC](RemoteActions.m
 There is a class called MessageBase that you can extend to make serializable network message classes. This class has Serialize and Deserialize functions that take writer and reader objects. You can implement these functions yourself, but we recommend you let Mirror generate them for you.
 The base class looks like this:
 
-```
+```cs
 public abstract class MessageBase
 {
     // De-serialize the contents of the reader into this message
@@ -22,7 +22,7 @@ To send a message, use the `Send()` method on the NetworkClient, NetworkServer, 
 
 To declare a custom network message class and use it:
 
-```
+```cs
 using UnityEngine;
 using Mirror;
 
@@ -72,7 +72,7 @@ There is also an ErrorMessage class that is derived from `MessageBase`. This cla
 
 The errorCode in the ErrorMessage class corresponds to the Networking.NetworkError enumeration.
 
-```
+```cs
 class MyClient
 {
     NetworkClient client;

--- a/docs/Concepts/Communications/NetworkMessages.md
+++ b/docs/Concepts/Communications/NetworkMessages.md
@@ -1,14 +1,15 @@
 # Network Messages
 
-For the most part we recommend the high level [Commands and RPC](RemoteActions.md) calls and [SyncVar](../StateSync.md) . But you can also send low level network messages.  This can be useful if you want clients to send messages that are not tied to gameobjects, such as logging, analytics or profiling information.
+For the most part we recommend the high level [Commands and RPC](RemoteActions.md) calls and [SyncVar](../StateSync.md), but you can also send low level network messages.  This can be useful if you want clients to send messages that are not tied to gameobjects, such as logging, analytics or profiling information.
 
 There is a class called MessageBase that you can extend to make serializable network message classes. This class has Serialize and Deserialize functions that take writer and reader objects. You can implement these functions yourself, but we recommend you let Mirror generate them for you.
+
 The base class looks like this:
 
 ```cs
 public abstract class MessageBase
 {
-    // De-serialize the contents of the reader into this message
+    // Deserialize the contents of the reader into this message
     public virtual void Deserialize(NetworkReader reader) {}
 
     // Serialize the contents of this message into the writer


### PR DESCRIPTION
Currently,  sending a message looks like this:

```cs
// sending
MyMessage msg = new MyMessage();
connection.send(MsgId, msg);

...
// receiving
public void MsgHandler(NetworkMessage netMsg) {
    MyMessage msg= netMsg.ReadMessage<MyMessage>();
    ...
}

connection.RegisterHandler(MsgId, MsgHandler);
```

This PR makes it so that we can send and receive messages without an explicit message id.  For example:

```cs
// sending
MyMessage msg = new MyMessage();
connection.send(msg);

...
// receiving
public void MsgHandler(MyMessage msg) {
    ...
}

connection.RegisterHandler<MyMessage>(MsgHandler);
```

This eliminates the possibility of mismatch between the message id and the data values, and makes it a lot easier to add custom messages since the user does not need to ensure message ids are unique or try to extend the enum.