### PR TITLE
This doesn't sync slow rotating objects

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -297,10 +297,13 @@ namespace Mirror
             bool rotated = lastRotation != targetComponent.transform.rotation;
 
             // save last for next frame to compare
-            lastPosition = targetComponent.transform.position;
-            lastRotation = targetComponent.transform.rotation;
-
-            return moved || rotated;
+            bool change = moved || rotated;
+            if (change)
+            {
+                lastPosition = targetComponent.transform.position;
+                lastRotation = targetComponent.transform.rotation;
+            }
+            return change;
         }
 
         // set position carefully depending on the target component

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -297,6 +297,9 @@ namespace Mirror
             bool rotated = lastRotation != targetComponent.transform.rotation;
 
             // save last for next frame to compare
+            // (only if change was detected. otherwise slow moving objects might
+            //  never sync because of C#'s float comparison tolerance. see also:
+            //  https://github.com/vis2k/Mirror/pull/428)
             bool change = moved || rotated;
             if (change)
             {


### PR DESCRIPTION
The function sets lastRotation to the current rotation every frame, regardless of whether or not it detected a change. Because comparing two similar, but different Quaternions return true, only quickly rotating objects will return true; slow turning objects will return false, and the rotation will not be synced. By not updating lastRotation until a difference is spotted, any rotation will be synced.
This fix allowed my slow rotating spaceship to sync rotation.
TL;DR
lastRotation should be the last time this function returned true, not the rotation last frame.