### PR TITLE
Add MIRROR define and version

### DIFF
--- a/Assets/Mirror/Editor/PreprocessorDefine.cs
+++ b/Assets/Mirror/Editor/PreprocessorDefine.cs
@@ -5,9 +5,8 @@ using UnityEngine;
 
 namespace Mirror
 {
-    class PreprocessorDefine
+    static class PreprocessorDefine
     {
-
         /// <summary>
         /// Symbols that will be added to the editor
         /// </summary>
@@ -29,6 +28,5 @@ namespace Mirror
                 EditorUserBuildSettings.selectedBuildTargetGroup,
                 string.Join(";", allDefines.ToArray()));
         }
-
     }
 }

--- a/Assets/Mirror/Editor/PreprocessorDefine.cs
+++ b/Assets/Mirror/Editor/PreprocessorDefine.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Mirror
+{
+    class PreprocessorDefine
+    {
+
+        /// <summary>
+        /// Symbols that will be added to the editor
+        /// </summary>
+        public static readonly string[] Symbols = new string[] {
+            "MIRROR",
+            "MIRROR_1726_OR_NEWER"
+        };
+
+        /// <summary>
+        /// Add define symbols as soon as Unity gets done compiling.
+        /// </summary>
+        [InitializeOnLoadMethod]
+        static void AddDefineSymbols()
+        {
+            string definesString = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+            List<string> allDefines = definesString.Split(';').ToList();
+            allDefines.AddRange(Symbols.Except(allDefines));
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(
+                EditorUserBuildSettings.selectedBuildTargetGroup,
+                string.Join(";", allDefines.ToArray()));
+        }
+
+    }
+}

--- a/Assets/Mirror/Editor/PreprocessorDefine.cs.meta
+++ b/Assets/Mirror/Editor/PreprocessorDefine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1d66fe74ec6f42dd974cba37d25d453
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fix #431 

Adds MIRROR and versioned mirror define so asset developers can easily detect if mirror is available

This is an alternative to #437 