### PR TITLE
Use Length instead of position for getting the written data

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using UnityEngine;
 using System.Linq;
+using UnityEngine.Profiling;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using UnityEngine;
 using System.Linq;
-using UnityEngine.Profiling;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -455,8 +455,8 @@ namespace Mirror
         // -> returns serialized data of everything dirty,  null if nothing was dirty
         internal byte[] OnSerializeAllSafely(bool initialState)
         {
-            // reset cached writer's position
-            onSerializeWriter.Position = 0;
+            // reset cached writer length and position
+            onSerializeWriter.Reset();
 
             if (m_NetworkBehaviours.Length > 64)
             {

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -106,8 +106,8 @@ namespace Mirror
         // -> pass writer instead of byte[] so we can reuse it
         public static byte[] PackMessage(ushort msgType, MessageBase msg)
         {
-            // reset cached writer's position
-            packWriter.Position = 0;
+            // reset cached writer length and position
+            packWriter.Reset();
 
             // write message type
             packWriter.WritePackedUInt32(msgType);

--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -54,9 +54,8 @@ namespace Mirror.Tests
             // set position back by one
             writer.Position = 1;
 
-            // .ToArray() length is 1, even though the internal array contains 2 bytes?
-            // (see .ToArray() function comments)
-            Assert.That(writer.ToArray().Length, Is.EqualTo(1));
+            // Changing the position should not alter the size of the data
+            Assert.That(writer.ToArray().Length, Is.EqualTo(2));
         }
 
         [Test]


### PR DESCRIPTION
MemoryStream has 3 values:
* Position indicates where we are writing,  useful if you want to go back and rewrite a value such as message length
* Length indicates how much data we have written.  Notice that Position<= Length 
* Capacity indicates how much memory is allocated in the stream.  Notice that Length <= Capacity

When we get the data in a NetworkWriter,  we should always get all the data that was written regardless of position.  When we reset a NetworkWriter.  We should reset the length and position,  but leave the capacity intact so that we can reuse the NetworkWriter without reallocations.

Notice this gets rid of a low hanging fruit allocation in NetworkWriter.  ToArray was allocating the array twice.

Before:
<img width="643" alt="screen shot 2019-02-25 at 5 43 36 pm" src="https://user-images.githubusercontent.com/466007/53377266-014f6900-3927-11e9-815f-c046573a2791.png">
After:
<img width="642" alt="screen shot 2019-02-25 at 5 52 53 pm" src="https://user-images.githubusercontent.com/466007/53377273-057b8680-3927-11e9-9a04-2ecb3064ac8c.png">

That is a single message sent in the Basic example.
That is about 10-20% of allocations for every single message that Mirror sends

Notice this fix has been in 2018 for ever.