### PR TITLE
Networkclient refactor2

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -150,7 +150,7 @@ namespace Mirror
         {
             LocalClient newClient = new LocalClient();
             NetworkServer.ActivateLocalClientScene();
-            newClient.InternalConnectLocalServer(true);
+            newClient.InternalConnectLocalServer();
             return newClient;
         }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -198,27 +198,34 @@ namespace Mirror
 
         internal static void RegisterSystemHandlers(NetworkClient client, bool localClient)
         {
+            // local client / regular client react to some messages differently.
+            // but we still need to add handlers for all of them to avoid
+            // 'message id not found' errors.
             if (localClient)
             {
+                client.RegisterHandler(MsgType.LocalClientAuthority, OnClientAuthority);
                 client.RegisterHandler(MsgType.ObjectDestroy, OnLocalClientObjectDestroy);
                 client.RegisterHandler(MsgType.ObjectHide, OnLocalClientObjectHide);
+                client.RegisterHandler(MsgType.Owner, (msg) => {});
+                client.RegisterHandler(MsgType.Pong, (msg) => {});
                 client.RegisterHandler(MsgType.SpawnPrefab, OnLocalClientSpawnPrefab);
                 client.RegisterHandler(MsgType.SpawnSceneObject, OnLocalClientSpawnSceneObject);
-                client.RegisterHandler(MsgType.LocalClientAuthority, OnClientAuthority);
+                client.RegisterHandler(MsgType.SpawnStarted, (msg) => {});
+                client.RegisterHandler(MsgType.SpawnFinished, (msg) => {});
+                client.RegisterHandler(MsgType.UpdateVars, (msg) => {});
             }
             else
             {
-                // LocalClient shares the sim/scene with the server, no need for these events
+                client.RegisterHandler(MsgType.LocalClientAuthority, OnClientAuthority);
+                client.RegisterHandler(MsgType.ObjectDestroy, OnObjectDestroy);
+                client.RegisterHandler(MsgType.ObjectHide, OnObjectDestroy);
+                client.RegisterHandler(MsgType.Owner, OnOwnerMessage);
+                client.RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
                 client.RegisterHandler(MsgType.SpawnPrefab, OnSpawnPrefab);
                 client.RegisterHandler(MsgType.SpawnSceneObject, OnSpawnSceneObject);
                 client.RegisterHandler(MsgType.SpawnStarted, OnObjectSpawnStarted);
                 client.RegisterHandler(MsgType.SpawnFinished, OnObjectSpawnFinished);
-                client.RegisterHandler(MsgType.ObjectDestroy, OnObjectDestroy);
-                client.RegisterHandler(MsgType.ObjectHide, OnObjectDestroy);
                 client.RegisterHandler(MsgType.UpdateVars, OnUpdateVarsMessage);
-                client.RegisterHandler(MsgType.Owner, OnOwnerMessage);
-                client.RegisterHandler(MsgType.LocalClientAuthority, OnClientAuthority);
-                client.RegisterHandler(MsgType.Pong, NetworkTime.OnClientPong);
             }
 
             client.RegisterHandler(MsgType.Rpc, OnRPCMessage);

--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -47,21 +47,7 @@ namespace Mirror
             while (packetQueue.Count > 0)
             {
                 byte[] packet = packetQueue.Dequeue();
-
-                // unpack message
-                NetworkReader reader = new NetworkReader(packet);
-                if (Protocol.UnpackMessage(reader, out ushort msgType))
-                {
-                    NetworkMessage msg = new NetworkMessage
-                    {
-                        msgType = (short)msgType,
-                        reader = reader,
-                        conn = connection
-                    };
-
-                    connection.InvokeHandler(msg);
-                    connection.lastMessageTime = Time.time;
-                }
+                OnDataReceived(packet);
             }
         }
 

--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -24,7 +24,7 @@ namespace Mirror
             NetworkServer.RemoveLocalClient(connection);
         }
 
-        internal void InternalConnectLocalServer(bool generateConnectMsg)
+        internal void InternalConnectLocalServer()
         {
             connection = new ULocalConnectionToServer();
             SetHandlers(connection);
@@ -34,10 +34,8 @@ namespace Mirror
             active = true;
             RegisterSystemHandlers(true);
 
-            if (generateConnectMsg)
-            {
-                packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Connect, new EmptyMessage()));
-            }
+            packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Connect, new EmptyMessage()));
+
             m_Connected = true;
         }
 

--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -11,17 +11,6 @@ namespace Mirror
         // to avoid race conditions. keep packets in Queue until LateUpdate.
         internal Queue<byte[]> packetQueue = new Queue<byte[]>();
 
-        public override void Disconnect()
-        {
-            connectState = ConnectState.Disconnected;
-            ClientScene.HandleClientDisconnect(connection);
-            if (isConnected)
-            {
-                packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Disconnect, new EmptyMessage()));
-            }
-            NetworkServer.RemoveLocalClient();
-        }
-
         internal void InternalConnectLocalServer()
         {
             connection = new ULocalConnectionToServer();
@@ -33,6 +22,17 @@ namespace Mirror
             RegisterSystemHandlers(true);
 
             packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Connect, new EmptyMessage()));
+        }
+
+        public override void Disconnect()
+        {
+            connectState = ConnectState.Disconnected;
+            ClientScene.HandleClientDisconnect(connection);
+            if (isConnected)
+            {
+                packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Disconnect, new EmptyMessage()));
+            }
+            NetworkServer.RemoveLocalClient();
         }
 
         internal override void Update()

--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -10,15 +10,13 @@ namespace Mirror
         // want to apply them in LateUpdate like all other Transport messages
         // to avoid race conditions. keep packets in Queue until LateUpdate.
         internal Queue<byte[]> packetQueue = new Queue<byte[]>();
-        bool m_Connected;
 
         public override void Disconnect()
         {
             ClientScene.HandleClientDisconnect(connection);
-            if (m_Connected)
+            if (isConnected)
             {
                 packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Disconnect, new EmptyMessage()));
-                m_Connected = false;
             }
             connectState = ConnectState.Disconnected;
             NetworkServer.RemoveLocalClient(connection);
@@ -35,8 +33,6 @@ namespace Mirror
             RegisterSystemHandlers(true);
 
             packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Connect, new EmptyMessage()));
-
-            m_Connected = true;
         }
 
         internal override void Update()

--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -13,12 +13,12 @@ namespace Mirror
 
         public override void Disconnect()
         {
+            connectState = ConnectState.Disconnected;
             ClientScene.HandleClientDisconnect(connection);
             if (isConnected)
             {
                 packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Disconnect, new EmptyMessage()));
             }
-            connectState = ConnectState.Disconnected;
             NetworkServer.RemoveLocalClient(connection);
         }
 

--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -19,7 +19,7 @@ namespace Mirror
             {
                 packetQueue.Enqueue(Protocol.PackMessage((ushort)MsgType.Disconnect, new EmptyMessage()));
             }
-            NetworkServer.RemoveLocalClient(connection);
+            NetworkServer.RemoveLocalClient();
         }
 
         internal void InternalConnectLocalServer()

--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -36,7 +36,11 @@ namespace Mirror
                 Debug.LogError("LocalConnection:SendBytes cannot send zero bytes");
                 return false;
             }
-            return NetworkServer.InvokeBytes(this, bytes);
+
+            // handle the server's message directly
+            // TODO any way to do this without NetworkServer.localConnection?
+            NetworkServer.localConnection.TransportReceive(bytes);
+            return true;
         }
     }
 }

--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -7,7 +7,7 @@ namespace Mirror
     // sending messages on this connection causes the client's handler function to be invoked directly
     class ULocalConnectionToClient : NetworkConnection
     {
-        public LocalClient localClient { get; }
+        public LocalClient localClient;
 
         public ULocalConnectionToClient(LocalClient localClient) : base ("localClient")
         {

--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -16,7 +16,7 @@ namespace Mirror
 
         internal override bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
         {
-            localClient.InvokeBytesOnClient(bytes);
+            localClient.packetQueue.Enqueue(bytes);
             return true;
         }
     }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -20,7 +20,7 @@ namespace Mirror
             None,
             Connecting,
             Connected,
-            Disconnected,
+            Disconnected
         }
         protected ConnectState connectState = ConnectState.None;
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -88,7 +88,7 @@ namespace Mirror
             connection?.InvokeHandlerNoData((short)MsgType.Disconnect);
         }
 
-        void OnDataReceived(byte[] data)
+        protected void OnDataReceived(byte[] data)
         {
             if (connection != null)
             {

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -236,10 +236,7 @@ namespace Mirror
                     lastMessageTime = Time.time;
                 }
             }
-            else
-            {
-                Debug.LogError("HandleBytes UnpackMessage failed for: " + BitConverter.ToString(buffer));
-            }
+            else Debug.LogError("HandleBytes UnpackMessage failed for: " + BitConverter.ToString(buffer));
         }
 
         public virtual bool TransportSend(int channelId, byte[] bytes, out byte error)

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -156,7 +156,7 @@ namespace Mirror
         {
             visList.Add(identity);
 
-            // spawn uv for this conn
+            // spawn identity for this conn
             NetworkServer.ShowForConnection(identity, this);
         }
 
@@ -166,7 +166,7 @@ namespace Mirror
 
             if (!isDestroyed)
             {
-                // hide uv for this conn
+                // hide identity for this conn
                 NetworkServer.HideForConnection(identity, this);
             }
         }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -199,7 +199,7 @@ namespace Mirror
                 msgDelegate(message);
                 return true;
             }
-            Debug.LogError("NetworkConnection InvokeHandler no handler for " + msgType);
+            Debug.LogError("Unknown message ID " + msgType + " connId:" + connectionId);
             return false;
         }
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -230,23 +230,10 @@ namespace Mirror
                     }
                 }
 
-                if (m_MessageHandlers.TryGetValue((short)msgType, out NetworkMessageDelegate msgDelegate))
+                // try to invoke the handler for that message
+                if (InvokeHandler((short)msgType, reader))
                 {
-                    // create message here instead of caching it. so we can add it to queue more easily.
-                    NetworkMessage msg = new NetworkMessage
-                    {
-                        msgType = (short)msgType,
-                        reader = reader,
-                        conn = this
-                    };
-
-                    msgDelegate(msg);
                     lastMessageTime = Time.time;
-                }
-                else
-                {
-                    //NOTE: this throws away the rest of the buffer. Need moar error codes
-                    Debug.LogError("Unknown message ID " + msgType + " connId:" + connectionId);
                 }
             }
             else

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -148,16 +148,6 @@ namespace Mirror
             return false;
         }
 
-        public bool InvokeHandler(NetworkMessage netMsg)
-        {
-            if (m_MessageHandlers.TryGetValue(netMsg.msgType, out NetworkMessageDelegate msgDelegate))
-            {
-                msgDelegate(netMsg);
-                return true;
-            }
-            return false;
-        }
-
         // internal because no one except Mirror should send bytes directly to
         // the client. they would be detected as a message. send messages instead.
         internal virtual bool SendBytes( byte[] bytes, int channelId = Channels.DefaultReliable)

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -94,6 +94,37 @@ namespace Mirror
             m_MessageHandlers = handlers;
         }
 
+        public void RegisterHandler(short msgType, NetworkMessageDelegate handler)
+        {
+            if (m_MessageHandlers.ContainsKey(msgType))
+            {
+                if (LogFilter.Debug) { Debug.Log("NetworkConnection.RegisterHandler replacing " + msgType); }
+            }
+            m_MessageHandlers[msgType] = handler;
+        }
+
+        public void UnregisterHandler(short msgType)
+        {
+            m_MessageHandlers.Remove(msgType);
+        }
+
+        internal void SetPlayerController(NetworkIdentity player)
+        {
+            m_PlayerController = player;
+        }
+
+        internal void RemovePlayerController()
+        {
+            m_PlayerController = null;
+        }
+
+        public virtual bool Send(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        {
+            // pack message and send
+            byte[] message = Protocol.PackMessage((ushort)msgType, msg);
+            return SendBytes(message, channelId);
+        }
+
         public bool InvokeHandlerNoData(short msgType)
         {
             return InvokeHandler(msgType, null);
@@ -125,37 +156,6 @@ namespace Mirror
                 return true;
             }
             return false;
-        }
-
-        public void RegisterHandler(short msgType, NetworkMessageDelegate handler)
-        {
-            if (m_MessageHandlers.ContainsKey(msgType))
-            {
-                if (LogFilter.Debug) { Debug.Log("NetworkConnection.RegisterHandler replacing " + msgType); }
-            }
-            m_MessageHandlers[msgType] = handler;
-        }
-
-        public void UnregisterHandler(short msgType)
-        {
-            m_MessageHandlers.Remove(msgType);
-        }
-
-        internal void SetPlayerController(NetworkIdentity player)
-        {
-            m_PlayerController = player;
-        }
-
-        internal void RemovePlayerController()
-        {
-            m_PlayerController = null;
-        }
-
-        public virtual bool Send(short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
-        {
-            // pack message and send
-            byte[] message = Protocol.PackMessage((ushort)msgType, msg);
-            return SendBytes(message, channelId);
         }
 
         // internal because no one except Mirror should send bytes directly to

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -192,8 +192,8 @@ namespace Mirror
                 NetworkMessage message = new NetworkMessage
                 {
                     msgType = msgType,
-                    conn = this,
-                    reader = reader
+                    reader = reader,
+                    conn = this
                 };
 
                 msgDelegate(message);

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -125,29 +125,6 @@ namespace Mirror
             return SendBytes(message, channelId);
         }
 
-        public bool InvokeHandlerNoData(short msgType)
-        {
-            return InvokeHandler(msgType, null);
-        }
-
-        public bool InvokeHandler(short msgType, NetworkReader reader)
-        {
-            if (m_MessageHandlers.TryGetValue(msgType, out NetworkMessageDelegate msgDelegate))
-            {
-                NetworkMessage message = new NetworkMessage
-                {
-                    msgType = msgType,
-                    conn = this,
-                    reader = reader
-                };
-
-                msgDelegate(message);
-                return true;
-            }
-            Debug.LogError("NetworkConnection InvokeHandler no handler for " + msgType);
-            return false;
-        }
-
         // internal because no one except Mirror should send bytes directly to
         // the client. they would be detected as a message. send messages instead.
         internal virtual bool SendBytes( byte[] bytes, int channelId = Channels.DefaultReliable)
@@ -201,6 +178,29 @@ namespace Mirror
                 identity.RemoveObserverInternal(this);
             }
             visList.Clear();
+        }
+
+        public bool InvokeHandlerNoData(short msgType)
+        {
+            return InvokeHandler(msgType, null);
+        }
+
+        public bool InvokeHandler(short msgType, NetworkReader reader)
+        {
+            if (m_MessageHandlers.TryGetValue(msgType, out NetworkMessageDelegate msgDelegate))
+            {
+                NetworkMessage message = new NetworkMessage
+                {
+                    msgType = msgType,
+                    conn = this,
+                    reader = reader
+                };
+
+                msgDelegate(message);
+                return true;
+            }
+            Debug.LogError("NetworkConnection InvokeHandler no handler for " + msgType);
+            return false;
         }
 
         // handle this message

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1084,22 +1084,6 @@ namespace Mirror
             }
         }
 
-        internal static bool InvokeBytes(ULocalConnectionToServer conn, byte[] buffer)
-        {
-            NetworkReader reader = new NetworkReader(buffer);
-            if (Protocol.UnpackMessage(reader, out ushort msgType))
-            {
-                if (handlers.ContainsKey((short)msgType) && s_LocalConnection != null)
-                {
-                    // this must be invoked with the connection to the client, not the client's connection to the server
-                    s_LocalConnection.InvokeHandler((short)msgType, reader);
-                    return true;
-                }
-            }
-            Debug.LogError("InvokeBytes: failed to unpack message:" + BitConverter.ToString(buffer));
-            return false;
-        }
-
         [Obsolete("Use NetworkIdentity.spawned[netId] instead.")]
         public static GameObject FindLocalObject(uint netId)
         {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -142,8 +142,7 @@ namespace Mirror
                 connectionId = 0
             };
             AddConnection(s_LocalConnection);
-
-            s_LocalConnection.InvokeHandlerNoData((short)MsgType.Connect);
+            OnConnected(s_LocalConnection);
             return 0;
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -141,7 +141,6 @@ namespace Mirror
             {
                 connectionId = 0
             };
-            AddConnection(s_LocalConnection);
             OnConnected(s_LocalConnection);
             return 0;
         }
@@ -323,7 +322,6 @@ namespace Mirror
 
                 // add player info
                 NetworkConnection conn = new NetworkConnection(address, serverHostId, connectionId);
-                AddConnection(conn);
                 OnConnected(conn);
             }
             else
@@ -337,6 +335,9 @@ namespace Mirror
         static void OnConnected(NetworkConnection conn)
         {
             if (LogFilter.Debug) { Debug.Log("Server accepted client:" + conn.connectionId); }
+
+            // add connection and invoke connected event
+            AddConnection(conn);
             conn.InvokeHandlerNoData((short)MsgType.Connect);
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -147,7 +147,7 @@ namespace Mirror
             return 0;
         }
 
-        internal static void RemoveLocalClient(NetworkConnection localClientConnection)
+        internal static void RemoveLocalClient()
         {
             if (s_LocalConnection != null)
             {


### PR DESCRIPTION
work in progress.
will probably submit one commit after another to master later.

@paulpach localclient and regular client using same message handlers is needed because there should only be one networkconnection.invokebytes function. previously there were two, one of them didn't log errors if handler not found. 