### PR TITLE
Remove NetworkConnection.isConnected because it's pointless. It was always true when called from NetworkConnection(address, connId) constructor and always false when called from NetworkConnection(address) constructor, which was for the local connection.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -19,10 +19,6 @@ namespace Mirror
         public HashSet<uint> clientOwnedObjects;
         public bool logNetworkMessages;
 
-        // this is always true for regular connections, false for local
-        // connections because it's set in the constructor and never reset.
-        public bool isConnected { get; protected set; }
-
         public NetworkConnection(string networkAddress)
         {
             address = networkAddress;
@@ -31,7 +27,6 @@ namespace Mirror
         {
             address = networkAddress;
             connectionId = networkConnectionId;
-            isConnected = true;
         }
 
         ~NetworkConnection()


### PR DESCRIPTION
after removing hostId, it turns out that this field is useless unless I am missing something.
will test in my assets now..