### PR TITLE
Rename NetworkWriter.Reset to SetLength(value). Seems more obvious. Reset could mean a lot of things.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -456,7 +456,7 @@ namespace Mirror
         internal byte[] OnSerializeAllSafely(bool initialState)
         {
             // reset cached writer length and position
-            onSerializeWriter.Reset();
+            onSerializeWriter.SetLength(0);
 
             if (m_NetworkBehaviours.Length > 64)
             {

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -14,7 +14,7 @@ namespace Mirror
         // -> converting long to int is fine until 2GB of data (MAX_INT), so we don't have to worry about overflows here
         public int Position { get { return (int)writer.BaseStream.Position; } set { writer.BaseStream.Position = value; } }
 
-        // MemoryStream has 3 values: Position, Length and Capacity.  
+        // MemoryStream has 3 values: Position, Length and Capacity.
         // Position is used to indicate where we are writing
         // Length is how much data we have written
         // capacity is how much memory we have allocated
@@ -27,9 +27,9 @@ namespace Mirror
 
         // reset both the position and length of the stream,  but leaves the capacity the same
         // so that we can reuse this writer without extra allocations
-        public void Reset()
+        public void SetLength(long value)
         {
-            ((MemoryStream)writer.BaseStream).SetLength(0);
+            ((MemoryStream)writer.BaseStream).SetLength(value);
         }
 
         public void Write(byte value)  { writer.Write(value); }

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -107,7 +107,7 @@ namespace Mirror
         public static byte[] PackMessage(ushort msgType, MessageBase msg)
         {
             // reset cached writer length and position
-            packWriter.Reset();
+            packWriter.SetLength(0);
 
             // write message type
             packWriter.WritePackedUInt32(msgType);


### PR DESCRIPTION
I found .Reset really confusing when the pr was around the first time, but couldn't tell why.
SetLength(0) actually makes a lot of sense. it sets the internal .length. I think it's valuable to have that as function name instead, so everyone knows exactly what it does by just looking at it.