### PR TITLE
Remove List.ForEach on hot path.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using UnityEngine;
+using System.Linq;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -398,8 +398,8 @@ namespace Mirror
             syncVarDirtyBits = 0L;
 
             // flush all unsynchronized changes in syncobjects
-            // note: don't use Linq here, this is a hot path
-            // Linq: 432b/frame
+            // note: don't use List.ForEach here, this is a hot path
+            // List.ForEach: 432b/frame
             // for: 231b/frame
             for (int i = 0; i < m_SyncObjects.Count; ++i)
             {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using UnityEngine;
-using System.Linq;
 
 namespace Mirror
 {
@@ -399,7 +398,13 @@ namespace Mirror
             syncVarDirtyBits = 0L;
 
             // flush all unsynchronized changes in syncobjects
-            m_SyncObjects.ForEach(obj => obj.Flush());
+            // note: don't use Linq here, this is a hot path
+            // Linq: 432b/frame
+            // for: 231b/frame
+            for (int i = 0; i < m_SyncObjects.Count; ++i)
+            {
+                m_SyncObjects[i].Flush();
+            }
         }
 
         internal bool AnySyncObjectDirty()


### PR DESCRIPTION
This fix reduces GC spike frequency by avoiding List.ForEach. Proof:

Before (List.ForEach version)
![gcfix_withlinq](https://user-images.githubusercontent.com/11307157/53480870-e79a4880-3a30-11e9-9cc0-38d66b6f4377.jpg)

After (for loop version)
![gcfix_nolinq](https://user-images.githubusercontent.com/11307157/53480893-f2ed7400-3a30-11e9-8e11-394491ab7e55.jpg)

Here's what a GC spike looks like:
![gc_spike_1](https://user-images.githubusercontent.com/11307157/53480949-11536f80-3a31-11e9-9d87-ddf0889661fa.jpg)
![gc_spike_2](https://user-images.githubusercontent.com/11307157/53480950-11536f80-3a31-11e9-94f0-d64b8928b942.jpg)
![gc_spike_3](https://user-images.githubusercontent.com/11307157/53480951-11536f80-3a31-11e9-825e-eab5116dda7e.jpg)

