### PR TITLE
Transport.activeTransport instead of NetworkManager.singleton.transport

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -35,7 +35,7 @@ namespace Mirror
             ready = false;
             s_IsSpawnFinished = false;
 
-            NetworkManager.singleton.transport.ClientDisconnect();
+            Transport.activeTransport.ClientDisconnect();
         }
 
         // this is called from message handler for Owner message

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -59,7 +59,7 @@ namespace Mirror
             serverIp = ip;
 
             connectState = ConnectState.Connecting;
-            NetworkManager.singleton.transport.ClientConnect(ip);
+            Transport.activeTransport.ClientConnect(ip);
 
             // setup all the handlers
             connection = new NetworkConnection(serverIp, 0);
@@ -69,10 +69,10 @@ namespace Mirror
         private void InitializeTransportHandlers()
         {
             // TODO do this in inspector?
-            NetworkManager.singleton.transport.OnClientConnected.AddListener(OnConnected);
-            NetworkManager.singleton.transport.OnClientDataReceived.AddListener(OnDataReceived);
-            NetworkManager.singleton.transport.OnClientDisconnected.AddListener(OnDisconnected);
-            NetworkManager.singleton.transport.OnClientError.AddListener(OnError);
+            Transport.activeTransport.OnClientConnected.AddListener(OnConnected);
+            Transport.activeTransport.OnClientDataReceived.AddListener(OnDataReceived);
+            Transport.activeTransport.OnClientDisconnected.AddListener(OnDisconnected);
+            Transport.activeTransport.OnClientError.AddListener(OnError);
         }
 
         void OnError(Exception exception)
@@ -118,7 +118,7 @@ namespace Mirror
         {
             active = true;
             RegisterSystemHandlers(false);
-            NetworkManager.singleton.transport.enabled = true;
+            Transport.activeTransport.enabled = true;
             InitializeTransportHandlers();
         }
 
@@ -141,10 +141,10 @@ namespace Mirror
         void RemoveTransportHandlers()
         {
             // so that we don't register them more than once
-            NetworkManager.singleton.transport.OnClientConnected.RemoveListener(OnConnected);
-            NetworkManager.singleton.transport.OnClientDataReceived.RemoveListener(OnDataReceived);
-            NetworkManager.singleton.transport.OnClientDisconnected.RemoveListener(OnDisconnected);
-            NetworkManager.singleton.transport.OnClientError.RemoveListener(OnError);
+            Transport.activeTransport.OnClientConnected.RemoveListener(OnConnected);
+            Transport.activeTransport.OnClientDataReceived.RemoveListener(OnDataReceived);
+            Transport.activeTransport.OnClientDisconnected.RemoveListener(OnDisconnected);
+            Transport.activeTransport.OnClientError.RemoveListener(OnError);
         }
 
         public bool Send(short msgType, MessageBase msg)

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -85,12 +85,12 @@ namespace Mirror
 
             // paul:  we may be connecting or connected,  either way, we need to disconnect
             // transport should not do anything if it is not connecting/connected
-            NetworkManager.singleton.transport.ClientDisconnect();
+            Transport.activeTransport.ClientDisconnect();
 
             // server? then disconnect that client
-            if (NetworkManager.singleton.transport.ServerActive())
+            if (Transport.activeTransport.ServerActive())
             {
-                NetworkManager.singleton.transport.ServerDisconnect(connectionId);
+                Transport.activeTransport.ServerDisconnect(connectionId);
             }
 
             // remove observers
@@ -139,9 +139,9 @@ namespace Mirror
         {
             if (logNetworkMessages) { Debug.Log("ConnectionSend con:" + connectionId + " bytes:" + BitConverter.ToString(bytes)); }
 
-            if (bytes.Length > NetworkManager.singleton.transport.GetMaxPacketSize(channelId))
+            if (bytes.Length > Transport.activeTransport.GetMaxPacketSize(channelId))
             {
-                Debug.LogError("NetworkConnection:SendBytes cannot send packet larger than " + NetworkManager.singleton.transport.GetMaxPacketSize(channelId) + " bytes");
+                Debug.LogError("NetworkConnection:SendBytes cannot send packet larger than " + Transport.activeTransport.GetMaxPacketSize(channelId) + " bytes");
                 return false;
             }
 
@@ -250,13 +250,13 @@ namespace Mirror
         public virtual bool TransportSend(int channelId, byte[] bytes, out byte error)
         {
             error = 0;
-            if (NetworkManager.singleton.transport.ClientConnected())
+            if (Transport.activeTransport.ClientConnected())
             {
-                return NetworkManager.singleton.transport.ClientSend(channelId, bytes);
+                return Transport.activeTransport.ClientSend(channelId, bytes);
             }
-            else if (NetworkManager.singleton.transport.ServerActive())
+            else if (Transport.activeTransport.ServerActive())
             {
-                return NetworkManager.singleton.transport.ServerSend(connectionId, channelId, bytes);
+                return Transport.activeTransport.ServerSend(connectionId, channelId, bytes);
             }
             return false;
         }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -36,7 +36,7 @@ namespace Mirror
 
         [Header("Network Info")]
         // transport layer
-        public Transport transport;
+        [SerializeField] Transport transport;
         [FormerlySerializedAs("m_NetworkAddress")] public string networkAddress = "localhost";
         [FormerlySerializedAs("m_MaxConnections")] public int maxConnections = 4;
 
@@ -99,6 +99,8 @@ namespace Mirror
                 return;
             }
 
+            Transport.activeTransport = transport;
+
             // do this early
             LogFilter.Debug = showDebugMessages;
 
@@ -155,7 +157,7 @@ namespace Mirror
         // virtual so that inheriting classes' OnApplicationQuit() can call base.OnApplicationQuit() too
         public virtual void OnApplicationQuit()
         {
-            transport.Shutdown();
+            Transport.activeTransport.Shutdown();
         }
 
         // virtual so that inheriting classes' OnValidate() can call base.OnValidate() too
@@ -419,7 +421,7 @@ namespace Mirror
             if (client != null)
             {
                 if (LogFilter.Debug) { Debug.Log("ClientChangeScene: pausing handlers while scene is loading to avoid data loss after scene was loaded."); }
-                NetworkManager.singleton.transport.enabled = false;
+                Transport.activeTransport.enabled = false;
             }
 
             // Let client prepare for scene change
@@ -437,7 +439,7 @@ namespace Mirror
             {
                 // process queued messages that we received while loading the scene
                 if (LogFilter.Debug) { Debug.Log("FinishLoadScene: resuming handlers after scene was loading."); }
-                NetworkManager.singleton.transport.enabled = true;
+                Transport.activeTransport.enabled = true;
 
                 if (s_ClientReadyConnection != null)
                 {

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -80,7 +80,7 @@ namespace Mirror
                 // server / client status message
                 if (NetworkServer.active)
                 {
-                    GUILayout.Label("Server: active. Transport: " + manager.transport);
+                    GUILayout.Label("Server: active. Transport: " + Transport.activeTransport);
                 }
                 if (manager.IsClientConnected())
                 {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -43,13 +43,13 @@ namespace Mirror
                 }
                 else
                 {
-                    NetworkManager.singleton.transport.ServerStop();
+                    Transport.activeTransport.ServerStop();
                 }
 
-                NetworkManager.singleton.transport.OnServerDisconnected.RemoveListener(OnDisconnected);
-                NetworkManager.singleton.transport.OnServerConnected.RemoveListener(OnConnected);
-                NetworkManager.singleton.transport.OnServerDataReceived.RemoveListener(OnDataReceived);
-                NetworkManager.singleton.transport.OnServerError.RemoveListener(OnError);
+                Transport.activeTransport.OnServerDisconnected.RemoveListener(OnDisconnected);
+                Transport.activeTransport.OnServerConnected.RemoveListener(OnConnected);
+                Transport.activeTransport.OnServerDataReceived.RemoveListener(OnDataReceived);
+                Transport.activeTransport.OnServerError.RemoveListener(OnError);
 
                 s_Initialized = false;
             }
@@ -67,10 +67,10 @@ namespace Mirror
 
             //Make sure connections are cleared in case any old connections references exist from previous sessions
             connections.Clear();
-            NetworkManager.singleton.transport.OnServerDisconnected.AddListener(OnDisconnected);
-            NetworkManager.singleton.transport.OnServerConnected.AddListener(OnConnected);
-            NetworkManager.singleton.transport.OnServerDataReceived.AddListener(OnDataReceived);
-            NetworkManager.singleton.transport.OnServerError.AddListener(OnError);
+            Transport.activeTransport.OnServerDisconnected.AddListener(OnDisconnected);
+            Transport.activeTransport.OnServerConnected.AddListener(OnConnected);
+            Transport.activeTransport.OnServerDataReceived.AddListener(OnDataReceived);
+            Transport.activeTransport.OnServerError.AddListener(OnError);
 
         }
 
@@ -90,7 +90,7 @@ namespace Mirror
             // only start server if we want to listen
             if (!dontListen)
             {
-                NetworkManager.singleton.transport.ServerStart();
+                Transport.activeTransport.ServerStart();
                 if (LogFilter.Debug) { Debug.Log("Server started listening"); }
             }
 
@@ -288,14 +288,14 @@ namespace Mirror
             if (connectionId <= 0)
             {
                 Debug.LogError("Server.HandleConnect: invalid connectionId: " + connectionId + " . Needs to be >0, because 0 is reserved for local player.");
-                NetworkManager.singleton.transport.ServerDisconnect(connectionId);
+                Transport.activeTransport.ServerDisconnect(connectionId);
                 return;
             }
 
             // connectionId not in use yet?
             if (connections.ContainsKey(connectionId))
             {
-                NetworkManager.singleton.transport.ServerDisconnect(connectionId);
+                Transport.activeTransport.ServerDisconnect(connectionId);
                 if (LogFilter.Debug) { Debug.Log("Server connectionId " + connectionId + " already in use. kicked client:" + connectionId); }
                 return;
             }
@@ -308,7 +308,7 @@ namespace Mirror
             if (connections.Count < s_MaxConnections)
             {
                 // get ip address from connection
-                string address = NetworkManager.singleton.transport.ServerGetClientAddress(connectionId);
+                string address = Transport.activeTransport.ServerGetClientAddress(connectionId);
 
                 // add player info
                 NetworkConnection conn = new NetworkConnection(address, connectionId);
@@ -317,7 +317,7 @@ namespace Mirror
             else
             {
                 // kick
-                NetworkManager.singleton.transport.ServerDisconnect(connectionId);
+                Transport.activeTransport.ServerDisconnect(connectionId);
                 if (LogFilter.Debug) { Debug.Log("Server full, kicked client:" + connectionId); }
             }
         }

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -15,6 +15,10 @@ namespace Mirror
 
     public abstract class Transport : MonoBehaviour
     {
+        // static Transport which receives all network events
+        // this is usually set by NetworkManager, but doesn't have to be.
+        public static Transport activeTransport;
+
         // determines if the transport is available for this platform
         // by default a transport is available in all platforms except webgl
         public virtual bool Available()


### PR DESCRIPTION
This is a very simple fix which allows NetworkManager to be more easily replaced. This is the bulk of the references to it.