### PR TITLE
First pass of moving stuff out of UNetwork.

### DIFF
--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Mirror
+{
+    // message packing all in one place, instead of constructing headers in all
+    // kinds of different places
+    //
+    //   MsgType     (1-n bytes)
+    //   Content     (ContentSize bytes)
+    //
+    // -> we use varint for headers because most messages will result in 1 byte
+    //    type/size headers then instead of always
+    //    using 2 bytes for shorts.
+    // -> this reduces bandwidth by 10% if average message size is 20 bytes
+    //    (probably even shorter)
+    public static class MessagePacker
+    {
+        // PackMessage is in hot path. caching the writer is really worth it to
+        // avoid large amounts of allocations.
+        static NetworkWriter packWriter = new NetworkWriter();
+
+        // pack message before sending
+        // -> pass writer instead of byte[] so we can reuse it
+        public static byte[] PackMessage(ushort msgType, MessageBase msg)
+        {
+            // reset cached writer length and position
+            packWriter.SetLength(0);
+
+            // write message type
+            packWriter.WritePackedUInt32(msgType);
+
+            // serialize message into writer
+            msg.Serialize(packWriter);
+
+            // return byte[]
+            return packWriter.ToArray();
+        }
+
+        // unpack message after receiving
+        // -> pass NetworkReader so it's less strange if we create it in here
+        //    and pass it upwards.
+        // -> NetworkReader will point at content afterwards!
+        public static bool UnpackMessage(NetworkReader messageReader, out ushort msgType)
+        {
+            // read message type (varint)
+            msgType = (UInt16)messageReader.ReadPackedUInt32();
+            return true;
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/MessagePacker.cs.meta
+++ b/Assets/Mirror/Runtime/MessagePacker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2db134099f0df4d96a84ae7a0cd9b4bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/NetworkMessage.cs
+++ b/Assets/Mirror/Runtime/NetworkMessage.cs
@@ -1,0 +1,21 @@
+namespace Mirror
+{
+    public struct NetworkMessage
+    {
+        public short msgType;
+        public NetworkConnection conn;
+        public NetworkReader reader;
+
+        public TMsg ReadMessage<TMsg>() where TMsg : MessageBase, new()
+        {
+            TMsg msg = new TMsg();
+            msg.Deserialize(reader);
+            return msg;
+        }
+
+        public void ReadMessage<TMsg>(TMsg msg) where TMsg : MessageBase
+        {
+            msg.Deserialize(reader);
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/NetworkMessage.cs.meta
+++ b/Assets/Mirror/Runtime/NetworkMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb04e4848a2e4452aa2dbd7adb801c51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -58,25 +58,6 @@ namespace Mirror
         Highest = 47
     }
 
-    public struct NetworkMessage
-    {
-        public short msgType;
-        public NetworkConnection conn;
-        public NetworkReader reader;
-
-        public TMsg ReadMessage<TMsg>() where TMsg : MessageBase, new()
-        {
-            TMsg msg = new TMsg();
-            msg.Deserialize(reader);
-            return msg;
-        }
-
-        public void ReadMessage<TMsg>(TMsg msg) where TMsg : MessageBase
-        {
-            msg.Deserialize(reader);
-        }
-    }
-
     public enum Version
     {
         Current = 1
@@ -86,51 +67,5 @@ namespace Mirror
     {
         public const int DefaultReliable = 0;
         public const int DefaultUnreliable = 1;
-    }
-
-    // message packing all in one place, instead of constructing headers in all
-    // kinds of different places
-    //
-    //   MsgType     (1-n bytes)
-    //   Content     (ContentSize bytes)
-    //
-    // -> we use varint for headers because most messages will result in 1 byte
-    //    type/size headers then instead of always
-    //    using 2 bytes for shorts.
-    // -> this reduces bandwidth by 10% if average message size is 20 bytes
-    //    (probably even shorter)
-    public static class MessagePacker
-    {
-        // PackMessage is in hot path. caching the writer is really worth it to
-        // avoid large amounts of allocations.
-        static NetworkWriter packWriter = new NetworkWriter();
-
-        // pack message before sending
-        // -> pass writer instead of byte[] so we can reuse it
-        public static byte[] PackMessage(ushort msgType, MessageBase msg)
-        {
-            // reset cached writer length and position
-            packWriter.SetLength(0);
-
-            // write message type
-            packWriter.WritePackedUInt32(msgType);
-
-            // serialize message into writer
-            msg.Serialize(packWriter);
-
-            // return byte[]
-            return packWriter.ToArray();
-        }
-
-        // unpack message after receiving
-        // -> pass NetworkReader so it's less strange if we create it in here
-        //    and pass it upwards.
-        // -> NetworkReader will point at content afterwards!
-        public static bool UnpackMessage(NetworkReader messageReader, out ushort msgType)
-        {
-            // read message type (varint)
-            msgType = (UInt16)messageReader.ReadPackedUInt32();
-            return true;
-        }
     }
 }


### PR DESCRIPTION
Reduce the responsibility of UNetwork, by moving out NetworkMessage, MessagePacker, and Utils. Utils is a bad name however, so it is renamed to FloatBytePacker. IsHeadless check is moved into NetworkManager, since no one else uses it, and its equally accessible there.