### PR TITLE
Make sceneId public since ForceSceneId already allows public setting.

### DIFF
--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -183,7 +183,7 @@ namespace Mirror
                     continue;
 
                 uint offset = (uint)identity.gameObject.scene.buildIndex * offsetPerScene;
-                identity.ForceSceneId(offset + nextSceneId++);
+                identity.sceneId = offset + nextSceneId++;
                 if (LogFilter.Debug) { Debug.Log("PostProcess sceneid assigned: name=" + identity.name + " scene=" + identity.gameObject.scene.name + " sceneid=" + identity.sceneId); }
 
                 // disable it AFTER assigning the sceneId.


### PR DESCRIPTION
I'm honestly not too sure about this one, ForceSceneId keeps it a tad more hidden, so less potential for someone to use it accidentally. But then again, who even uses sceneId outside of Mirror in userland at all, plus this code is simpler.