### PR TITLE
Make Guids be byte[] instead.

### DIFF
--- a/Assets/Mirror/Runtime/GuidComparer.cs
+++ b/Assets/Mirror/Runtime/GuidComparer.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+namespace Mirror
+{
+    public class GuidComparer : IEqualityComparer<byte[]>
+    {
+        public const int length = 16;
+        public int GetHashCode(byte[] b)
+        {
+            return (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | b[0];
+        }
+
+        public bool Equals(byte[] a, byte[] b)
+        {
+            for (int i = 0; i < a.Length; i++)
+            {
+                if (a[i] != b[i]) return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/GuidComparer.cs.meta
+++ b/Assets/Mirror/Runtime/GuidComparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea7fb7812b8314aa68699a641968b4f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -197,7 +197,7 @@ namespace Mirror
     class SpawnPrefabMessage : MessageBase
     {
         public uint netId;
-        public Guid assetId;
+        public byte[] assetId;
         public Vector3 position;
         public Quaternion rotation;
         public byte[] payload;
@@ -205,7 +205,7 @@ namespace Mirror
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
-            assetId = reader.ReadGuid();
+            assetId = reader.ReadBytes(GuidComparer.length);
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
             payload = reader.ReadBytesAndSize();
@@ -214,7 +214,7 @@ namespace Mirror
         public override void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
-            writer.Write(assetId);
+            writer.Write(assetId, 0, GuidComparer.length);
             writer.Write(position);
             writer.Write(rotation);
             writer.WriteBytesAndSize(payload);

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -191,12 +191,6 @@ namespace Mirror
             return m;
         }
 
-        public Guid ReadGuid()
-        {
-            byte[] bytes = reader.ReadBytes(16);
-            return new Guid(bytes);
-        }
-
         public Transform ReadTransform()
         {
             uint netId = ReadPackedUInt32();

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -474,11 +474,11 @@ namespace Mirror
             }
         }
 
-        public static bool ReplacePlayerForConnection(NetworkConnection conn, GameObject player, Guid assetId)
+        public static bool ReplacePlayerForConnection(NetworkConnection conn, GameObject player, byte[] assetId)
         {
             if (GetNetworkIdentity(player, out NetworkIdentity identity))
             {
-                identity.SetDynamicAssetId(assetId);
+                identity.assetId = assetId;
             }
             return InternalReplacePlayerForConnection(conn, player);
         }
@@ -488,11 +488,11 @@ namespace Mirror
             return InternalReplacePlayerForConnection(conn, player);
         }
 
-        public static bool AddPlayerForConnection(NetworkConnection conn, GameObject player, Guid assetId)
+        public static bool AddPlayerForConnection(NetworkConnection conn, GameObject player, byte[] assetId)
         {
             if (GetNetworkIdentity(player, out NetworkIdentity identity))
             {
-                identity.SetDynamicAssetId(assetId);
+                identity.assetId = assetId;
             }
             return InternalAddPlayerForConnection(conn, player);
         }
@@ -991,7 +991,7 @@ namespace Mirror
             return identity.AssignClientAuthority(conn);
         }
 
-        public static bool SpawnWithClientAuthority(GameObject obj, Guid assetId, NetworkConnection conn)
+        public static bool SpawnWithClientAuthority(GameObject obj, byte[] assetId, NetworkConnection conn)
         {
             Spawn(obj, assetId);
 
@@ -1005,13 +1005,13 @@ namespace Mirror
             return identity.AssignClientAuthority(conn);
         }
 
-        public static void Spawn(GameObject obj, Guid assetId)
+        public static void Spawn(GameObject obj, byte[] assetId)
         {
             if (VerifyCanSpawn(obj))
             {
                 if (GetNetworkIdentity(obj, out NetworkIdentity identity))
                 {
-                    identity.SetDynamicAssetId(assetId);
+                    identity.assetId = assetId;
                 }
                 SpawnObject(obj);
             }

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -272,11 +272,6 @@ namespace Mirror
             Write(value.m33);
         }
 
-        public void Write(Guid value)
-        {
-            writer.Write(value.ToByteArray());
-        }
-
         public void Write(NetworkIdentity value)
         {
             if (value == null)

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -7,7 +7,7 @@ namespace Mirror
     public delegate void NetworkMessageDelegate(NetworkMessage netMsg);
 
     // Handles requests to spawn objects on the client
-    public delegate GameObject SpawnDelegate(Vector3 position, Guid assetId);
+    public delegate GameObject SpawnDelegate(Vector3 position, byte[] assetId);
 
     // Handles requests to unspawn objects on the client
     public delegate void UnSpawnDelegate(GameObject spawned);

--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -110,18 +110,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void TestGuid()
-        {
-            Guid originalGuid = new Guid("0123456789abcdef9876543210fedcba");
-            NetworkWriter writer = new NetworkWriter();
-            writer.Write(originalGuid);
-
-            NetworkReader reader = new NetworkReader(writer.ToArray());
-            Guid readGuid = reader.ReadGuid();
-            Assert.That(readGuid, Is.EqualTo(originalGuid));
-        }
-
-        [Test]
         public void TestWritingAndReading()
         {
             // write all simple types once

--- a/docs/Concepts/GameObjects/SpawnObjectCustom.md
+++ b/docs/Concepts/GameObjects/SpawnObjectCustom.md
@@ -8,7 +8,7 @@ The spawn / un-spawner need to have this GameObject signature. This is defined i
 
 ```cs
 // Handles requests to spawn GameObjects on the client
-public delegate GameObject SpawnDelegate(Vector3 position, System.Guid assetId);
+public delegate GameObject SpawnDelegate(Vector3 position, byte[] assetId);
 
 // Handles requests to unspawn GameObjects on the client
 public delegate void UnSpawnDelegate(GameObject spawned);
@@ -18,13 +18,13 @@ The asset ID passed to the spawn function can be found on NetworkIdentity.assetI
 
 ```cs
 // generate a new unique assetId 
-System.Guid creatureAssetId = System.Guid.NewGuid();
+byte[] creatureAssetId = System.Guid.NewGuid().ToByteArray();
 
 // register handlers for the new assetId
 ClientScene.RegisterSpawnHandler(creatureAssetId, SpawnCreature, UnSpawnCreature);
 
 // get assetId on an existing prefab
-System.Guid coinAssetId = coinPrefab.GetComponent<NetworkIdentity>().assetId;
+byte[] coinAssetId = coinPrefab.GetComponent<NetworkIdentity>().assetId;
 
 // register handlers for an existing prefab you'd like to custom spawn
 ClientScene.RegisterSpawnHandler(coinAssetId, SpawnCoin, UnSpawnCoin);
@@ -36,7 +36,7 @@ NetworkServer.Spawn(gameObject, coinAssetId);
 The spawn functions themselves are implemented with the delegate signature. Here is the coin spawner. The SpawnCreature would look the same, but have different spawn logic:
 
 ```cs
-public GameObject SpawnCoin(Vector3 position, System.Guid assetId)
+public GameObject SpawnCoin(Vector3 position, byte[] assetId)
 {
     return (GameObject)Instantiate(m_CoinPrefab, position, Quaternion.identity);
 }
@@ -65,10 +65,9 @@ public class SpawnManager : MonoBehaviour
     public GameObject m_Prefab;
     public GameObject[] m_Pool;
 
-    public System.Guid assetId { get; set;
-}
-    
-    public delegate GameObject SpawnDelegate(Vector3 position, System.Guid assetId);
+    public byte[] assetId { get; set; }
+
+    public delegate GameObject SpawnDelegate(Vector3 position, byte[] assetId);
     public delegate void UnSpawnDelegate(GameObject spawned);
 
     void Start()
@@ -101,7 +100,7 @@ public class SpawnManager : MonoBehaviour
         return null;
     }
     
-    public GameObject SpawnObject(Vector3 position, System.Guid assetId)
+    public GameObject SpawnObject(Vector3 position, byte[] assetId)
     {
         return GetFromPool(position);
     }

--- a/docs/General/Migration.md
+++ b/docs/General/Migration.md
@@ -93,7 +93,7 @@ public class SyncListQuest : SyncListSTRUCT<Quest> { }
 
 ### 6. Replace NetworkHash128 and NetworkInstanceId
 
-These have been changed to System.Guid and uint, respectively.
+These have been changed to byte[] and uint, respectively.
 
 For example, if you have something like this:
 
@@ -112,7 +112,7 @@ replace with:
 ```cs
 public sealed class SpawnItemMessage : MessageBase
 {
-    public System.Guid assetID;
+    public byte[] assetID;
     public uint networkInstanceID;
     public Vector3 position;
     public Quaternion rotation;


### PR DESCRIPTION
This is way simpler. No string hacks. No custom serialization code. No tests for the custom serialization code. No extra System references. Just a plain old byte[] with a EqualityComparer for the dictionaries. Less code, less problems. Faster, more memory efficient, easier to modify Guid size. For my project, all I have to do is use 2-byte-long byte arrays. Everyone's happy!


Note: Did not regenerate Weaver files, I'm leaving this to Lymdun's PR. Do not merge this in until Lymdun's PR is accepted or declined. I will then commit in the built weaver files.