### PR TITLE
extending msbuild to automatically protect against cecil issues

### DIFF
--- a/Weaver/Weaver/Mirror.Weaver.csproj
+++ b/Weaver/Weaver/Mirror.Weaver.csproj
@@ -17,7 +17,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <LangVersion>4</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -26,7 +26,7 @@
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -67,15 +67,31 @@
     <Compile Include="CompilationFinishedHook.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <WeaverPluginDir>$(ProjectDir)..\..\Assets\Mirror\Plugins\</WeaverPluginDir>
+  </PropertyGroup>
   <ItemGroup>
     <CecilFiles Include="$(TargetDir)Unity.Cecil.*" />
+    <WeaverFiles Include="$(WeaverPluginDir)$(TargetName).pdb*;$(WeaverPluginDir)$(TargetName).mdb*" />
   </ItemGroup>
   <Target Name="AfterBuild">
-    <MakeDir Directories="$(ProjectDir)..\..\Assets\Mirror\Plugins" />
-    <MakeDir Directories="$(ProjectDir)..\..\Assets\Mirror\Plugins\Unity.Cecil" />
-    <Copy SourceFiles="$(TargetDir)$(TargetName).dll" DestinationFiles="$(ProjectDir)..\..\Assets\Mirror\Plugins\$(TargetName).dll" />
-    <Copy SourceFiles="@(CecilFiles)" DestinationFolder="$(ProjectDir)..\..\Assets\Mirror\Plugins\Unity.Cecil" />
-    <Copy Condition="Exists('$(TargetDir)$(TargetName).dll.mdb')" SourceFiles="$(TargetDir)$(TargetName).dll.mdb" DestinationFiles="$(ProjectDir)..\..\Assets\Mirror\Plugins\$(TargetName).dll.mdb" />
-    <Copy Condition="Exists('$(TargetDir)$(TargetName).pdb')" SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(ProjectDir)..\..\Assets\Mirror\Plugins\$(TargetName).pdb" />
+    <Message Text="AfterBuild Target running -----------------------------------" Importance="high" />
+    <Message Text="Copying Cecil assemblies to Unity project" Importance="high" />
+    <MakeDir Directories="$(WeaverPluginDir)" />
+    <MakeDir Directories="$(WeaverPluginDir)Unity.Cecil" />
+    <Copy SourceFiles="@(CecilFiles)" DestinationFolder="$(WeaverPluginDir)Unity.Cecil" />
+  </Target>
+  <Target Name="AfterDebugBuild" AfterTargets="AfterBuild" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <Message Text="AfterDebugBuild Target running ------------------------------" Importance="high" />
+    <Message Text="Copying Weaver assembly and symbol files to Unity project" Importance="high" />
+    <Copy Condition="Exists('$(TargetDir)$(TargetName).dll.mdb')" SourceFiles="$(TargetDir)$(TargetName).dll.mdb" DestinationFiles="$(WeaverPluginDir)$(TargetName).dll.mdb" />
+    <Copy Condition="Exists('$(TargetDir)$(TargetName).pdb')" SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(WeaverPluginDir)$(TargetName).pdb" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).dll" DestinationFiles="$(WeaverPluginDir)$(TargetName).dll" />
+  </Target>
+  <Target Name="AfterReleaseBuild" AfterTargets="AfterBuild" Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Message Text="AfterReleaseBuild Target running ----------------------------" Importance="high" />
+    <Message Text="Copying Weaver assembly and removing symbol files from Unity project" Importance="high" />
+    <Delete Files="@(WeaverFiles)" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).dll" DestinationFiles="$(WeaverPluginDir)$(TargetName).dll" />
   </Target>
 </Project>


### PR DESCRIPTION
So there exists a possibility to crash Unity by:
- Doing a weaver debug build for testing
- Doing a weaver release build for pushing
- Waiting for the explosion when Unity runs the AssemblyUpdater.exe

AssemblyUpdater.exe uses Cecil and when it finds your release weaver dll with non matching debug symbols file it will explode. It might just error into console if you are lucky, but it can crash the editor. The exception is:
```
System.InvalidOperationException: Operation is not valid due to the current state of the object.
   at Mono.Cecil.ModuleDefinition.ReadSymbols(ISymbolReader reader)
```
And traces all the way back up to AssemblyUpdater's entry point

These new msbuild post build targets in the Weaver csproj file simply delete any symbol files that might exist in our plugin folder of the Unity project any time a new release assembly is built. Oh and also unsafe flag was enabled which we don't need so I took it out. Obviously this is not critical, but it will save us future heart attacks when we are testing Weaver updates and suddenly our console is full of familiar looking Cecil errors :D
