### PR TITLE
Removed RequireComponent(Animator)

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -5,7 +5,6 @@ namespace Mirror
     [DisallowMultipleComponent]
     [AddComponentMenu("Network/NetworkAnimator")]
     [RequireComponent(typeof(NetworkIdentity))]
-    [RequireComponent(typeof(Animator))]
     [HelpURL("https://vis2k.github.io/Mirror/Components/NetworkAnimator")]
     public class NetworkAnimator : NetworkBehaviour
     {


### PR DESCRIPTION
NetworkAnimator does not have to be on the same game object as the Animator, no reason to require the component really. It doesn't even auto-assign the Animator reference anyways.