### PR TITLE
Simplify add player extra data

### DIFF
--- a/Assets/Mirror/Components/NetworkLobbyManager.cs
+++ b/Assets/Mirror/Components/NetworkLobbyManager.cs
@@ -195,7 +195,7 @@ namespace Mirror
             OnLobbyServerDisconnect(conn);
         }
 
-        public override void OnServerAddPlayer(NetworkConnection conn)
+        public override void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage msg)
         {
             if (SceneManager.GetActiveScene().name != LobbyScene) return;
 

--- a/Assets/Mirror/Components/NetworkLobbyManager.cs
+++ b/Assets/Mirror/Components/NetworkLobbyManager.cs
@@ -195,7 +195,7 @@ namespace Mirror
             OnLobbyServerDisconnect(conn);
         }
 
-        public override void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage msg)
+        public override void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)
         {
             if (SceneManager.GetActiveScene().name != LobbyScene) return;
 

--- a/Assets/Mirror/Examples/Lobby/Scripts/NetworkLobbyPlayerExt.cs
+++ b/Assets/Mirror/Examples/Lobby/Scripts/NetworkLobbyPlayerExt.cs
@@ -18,7 +18,7 @@ namespace Mirror.Examples.NetworkLobby
                 A similar technique would be used if a full canvas layout UI existed and we wanted to show
                 something more visual for each player in that layout, such as a name, avatar, etc.
 
-                Note: LobbyPlayer prefab will be marked DontDestroyOnLoad and carried forward to the game scene.
+                Note: LobbyPAlayer prefab will be marked DontDestroyOnLoad and carried forward to the game scene.
                       Because of this, NetworkLobbyManager must automatically set the parent to null 
                       in ServerChangeScene and OnClientChangeScene.
             */

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -64,7 +64,7 @@ namespace Mirror
 
         // use this to implicitly become ready
         // -> extraMessage can contain character selection, etc.
-        public static bool AddPlayer(NetworkConnection readyConn, MessageBase extraMessage)
+        public static bool AddPlayer(NetworkConnection readyConn, byte[] extraData)
         {
             // ensure valid ready connection
             if (readyConn != null)
@@ -87,13 +87,10 @@ namespace Mirror
 
             if (LogFilter.Debug) { Debug.Log("ClientScene.AddPlayer() called with connection [" + readyConnection + "]"); }
 
-            AddPlayerMessage msg = new AddPlayerMessage();
-            if (extraMessage != null)
+            AddPlayerMessage msg = new AddPlayerMessage()
             {
-                NetworkWriter writer = new NetworkWriter();
-                extraMessage.Serialize(writer);
-                msg.value = writer.ToArray();
-            }
+                value = extraData
+            };
             readyConnection.Send(msg);
             return true;
         }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -550,21 +550,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) { Debug.Log("NetworkManager.OnServerAddPlayerMessageInternal"); }
 
-            if (msg.value != null && msg.value.Length > 0)
-            {
-                // convert payload to extra message and call OnServerAddPlayer
-                // (usually for character selection information)
-                NetworkMessage extraMessage = new NetworkMessage
-                {
-                    reader = new NetworkReader(msg.value),
-                    conn = conn
-                };
-                OnServerAddPlayer(conn, extraMessage);
-            }
-            else
-            {
-                OnServerAddPlayer(conn);
-            }
+            OnServerAddPlayer(conn, msg);
         }
 
         internal void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg)
@@ -659,12 +645,7 @@ namespace Mirror
             NetworkServer.SetClientReady(conn);
         }
 
-        public virtual void OnServerAddPlayer(NetworkConnection conn, NetworkMessage extraMessage)
-        {
-            OnServerAddPlayerInternal(conn);
-        }
-
-        public virtual void OnServerAddPlayer(NetworkConnection conn)
+        public virtual void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage message)
         {
             OnServerAddPlayerInternal(conn);
         }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -645,7 +645,7 @@ namespace Mirror
             NetworkServer.SetClientReady(conn);
         }
 
-        public virtual void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage message)
+        public virtual void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)
         {
             OnServerAddPlayerInternal(conn);
         }


### PR DESCRIPTION
We are getting rid of NetworkMessage,  so the addplayer methods should not pass a NetworkMessage to the user anymore,  but pass the extra data