### PR TITLE
Move GetId<T> to MessagePacker

### DIFF
--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -19,6 +19,14 @@ namespace Mirror
         // avoid large amounts of allocations.
         static NetworkWriter packWriter = new NetworkWriter();
 
+        public static int GetId<T>() where T : MessageBase
+        {
+            // paul: 16 bits is enough to avoid collisions
+            //  - keeps the message size small because it gets varinted
+            //  - in case of collisions,  Mirror will display an error
+            return typeof(T).FullName.GetStableHashCode() & 0xFFFF;
+        }
+
         // pack message before sending
         // -> pass writer instead of byte[] so we can reuse it
         [Obsolete("Use Pack<T> instead")]
@@ -44,7 +52,7 @@ namespace Mirror
             packWriter.SetLength(0);
 
             // write message type
-            int msgType = MessageBase.GetId<T>();
+            int msgType = GetId<T>();
             packWriter.Write((ushort)msgType);
 
             // serialize message into writer

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -12,14 +12,6 @@ namespace Mirror
 
         // Serialize the contents of this message into the writer
         public virtual void Serialize(NetworkWriter writer) {}
-
-        public static int GetId<T>() where T: MessageBase
-        {
-            // paul: 16 bits is enough to avoid collisions
-            //  - keeps the message size small because it gets varinted
-            //  - in case of collisions,  Mirror will display an error
-            return typeof(T).FullName.GetStableHashCode() & 0xFFFF;
-        }
     }
 
     // ---------- General Typed Messages -------------------

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -285,7 +285,7 @@ namespace Mirror
 
         public void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T : MessageBase, new()
         {
-            int msgType = MessageBase.GetId<T>();
+            int msgType = MessagePacker.GetId<T>();
             if (handlers.ContainsKey(msgType))
             {
                 if (LogFilter.Debug) { Debug.Log("NetworkClient.RegisterHandler replacing " + msgType); }
@@ -311,7 +311,7 @@ namespace Mirror
         public void UnregisterHandler<T>() where T : MessageBase
         {
             // use int to minimize collisions
-            int msgType = MessageBase.GetId<T>();
+            int msgType = MessagePacker.GetId<T>();
             handlers.Remove(msgType);
         }
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -220,7 +220,7 @@ namespace Mirror
 
         public bool InvokeHandler<T>(T msg) where T : MessageBase
         {
-            int msgType = MessageBase.GetId<T>();
+            int msgType = MessagePacker.GetId<T>();
             byte[] data = MessagePacker.Pack(msg);
             return InvokeHandler(msgType, new NetworkReader(data));
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -466,7 +466,7 @@ namespace Mirror
 
         static void GenerateError(NetworkConnection conn, byte error)
         {
-            int msgId = MessageBase.GetId<ErrorMessage>();
+            int msgId = MessagePacker.GetId<ErrorMessage>();
             if (handlers.ContainsKey(msgId))
             {
                 ErrorMessage msg = new ErrorMessage
@@ -502,7 +502,7 @@ namespace Mirror
 
         public static void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T: MessageBase, new()
         {
-            int msgType = MessageBase.GetId<T>();
+            int msgType = MessagePacker.GetId<T>();
             if (handlers.ContainsKey(msgType))
             {
                 if (LogFilter.Debug) { Debug.Log("NetworkServer.RegisterHandler replacing " + msgType); }
@@ -528,7 +528,7 @@ namespace Mirror
 
         public static void UnregisterHandler<T>() where T:MessageBase
         {
-            int msgType = MessageBase.GetId<T>();
+            int msgType = MessagePacker.GetId<T>();
             handlers.Remove(msgType);
         }
 


### PR DESCRIPTION
Now we have the logic of how many bits in just one place and we free up MessageBase for eventually converting to an interface