### PR TITLE
Websocket transport should be namespaced

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Websocket/Client.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Client.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Ninja.WebSockets;
 using UnityEngine;
 
-namespace Mirror
+namespace Mirror.Websocket
 {
 
     public class Client 

--- a/Assets/Mirror/Runtime/Transport/Websocket/ClientJs.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/ClientJs.cs
@@ -13,7 +13,7 @@ using AOT;
 using Ninja.WebSockets;
 using UnityEngine;
 
-namespace Mirror
+namespace Mirror.Websocket
 {
     // this is the client implementation used by browsers
     public class Client 

--- a/Assets/Mirror/Runtime/Transport/Websocket/Server.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Server.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using Ninja.WebSockets;
 using UnityEngine;
 
-namespace Mirror
+namespace Mirror.Websocket
 {
     public class Server 
     {

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace Mirror
+namespace Mirror.Websocket
 {
     public class WebsocketTransport : Transport
     {


### PR DESCRIPTION
Otherwise we have classes named Mirror.Client and Mirror.Server which are very misleading because they are only for websockets