### PR TITLE
Allow users to unpack messages too

### DIFF
--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -62,6 +62,22 @@ namespace Mirror
             return packWriter.ToArray();
         }
 
+        // unpack a message we received
+        public static T Unpack<T>(byte[] data) where T : MessageBase, new()
+        {
+            NetworkReader reader = new NetworkReader(data);
+
+            int msgType = GetId<T>();
+
+            int id = reader.ReadUInt16();
+            if (id != msgType)
+                throw new FormatException("Invalid message,  could not unpack " + typeof(T).FullName);
+
+            T message = new T();
+            message.Deserialize(reader);
+            return message;
+        }
+
         // unpack message after receiving
         // -> pass NetworkReader so it's less strange if we create it in here
         //    and pass it upwards.

--- a/Assets/Mirror/Tests/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/MessagePackerTest.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+namespace Mirror
+{
+    [TestFixture]
+    public class MessagePackerTest
+    {
+        [Test]
+        public void TestPacking()
+        {
+            SceneMessage message = new SceneMessage()
+            {
+                value = "Hello world"
+            };
+
+            byte[] data = MessagePacker.Pack(message);
+
+            SceneMessage unpacked = MessagePacker.Unpack<SceneMessage>(data);
+
+            Assert.That(unpacked.value, Is.EqualTo("Hello world"));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/MessagePackerTest.cs.meta
+++ b/Assets/Mirror/Tests/MessagePackerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d57c17d9ee7c49e6bacc54ddbeac751
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Provide a convenient method for unpacking messages.  This is useful for OnServerAddPlayer.

This is how you call AddPlayer:

```cs
class Credentials : MessageBase
{
     public string username;
     public string password;
}

// now add a player
Credentials credentials = new Credentials() 
{
      username = "Joe",
      password = "Gabagaba"
};
client.AddPlayer(connection,  MessagePacker.pack(credentials));


// and this is how you receive it:
public override void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)
{
    Credentials credentials = MessagePacker.Unpack<Credentials>(extraMessage.value);
    ...
}
```

This PR also adds a unit test for packing/unpacking