### PR TITLE
Persistent sceneid

### DIFF
--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -215,7 +215,7 @@ namespace Mirror
                 m_Info = new List<NetworkIdentityInfo>
                 {
                     GetAssetId(),
-                    GetString("Scene ID", m_Identity.sceneId.ToString())
+                    GetString("Scene ID", m_Identity.sceneId.ToString("X"))
                 };
 
                 if (!Application.isPlaying)

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -32,19 +32,18 @@ namespace Mirror
                 if (identity.isClient || identity.isServer)
                     continue;
 
-                // check if the sceneId was set properly
-                // it might not if the scene wasn't opened with new sceneId
-                // Mirror version yet.
-                // => show error for each object where this applies.
-                //    the user should get lots of errors to notice it!
-                // => throwing an exception would only show it for one object
-                //    because this function would return afterwards.
+                // valid scene id? then set build index byte
+                //   otherwise it might be an unopened scene that still has null
+                //   sceneIds. builds are interrupted if they contain 0 sceneIds,
+                //   but it's still possible that we call LoadScene in Editor
+                //   for a previously unopened scene.
+                //   => throwing an exception would only show it for one object
+                //      because this function would return afterwards.
                 if (identity.sceneId != 0)
                 {
-                    // set scene id build index byte
                     identity.SetSceneIdSceneIndexByteInternal();
                 }
-                else Debug.LogError(identity.name + "'s sceneId wasn't generated yet. This can happen if a scene was last saved with an older version of Mirror. Please open the scene " + identity.gameObject.scene.name + " and click on the " + identity.name + " object in the Hierarchy once, so that OnValidate is called and the sceneId is set. Afterwards resave the scene.");
+                else Debug.LogError("Scene " + identity.gameObject.scene.path + " needs to be opened and resaved, because the scene object " + identity.name + " has no valid sceneId yet.");
 
                 // disable it
                 // note: NetworkIdentity.OnDisable adds itself to the

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -1,17 +1,27 @@
-using System;
+using System.Linq;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Mirror
 {
     public class NetworkScenePostProcess : MonoBehaviour
     {
+        // helper function to check if a NetworkIdentity is in the active scene
+        static bool InActiveScene(NetworkIdentity identity) =>
+            identity.gameObject.scene == SceneManager.GetActiveScene();
+
         [PostProcessScene]
         public static void OnPostProcessScene()
         {
-            // check and disable all NetworkIdentities in scene on load.
-            foreach (NetworkIdentity identity in FindObjectsOfType<NetworkIdentity>())
+            // find all NetworkIdentities in this scene
+            // => but really only from this scene. this avoids weird situations
+            //    like in NetworkZones when we destroy the local player and
+            //    load another scene afterwards, yet the local player is still
+            //    in the FindObjectsOfType result with scene=DontDestroyOnLoad
+            //    for some reason
+            foreach (NetworkIdentity identity in FindObjectsOfType<NetworkIdentity>().Where(InActiveScene))
             {
                 // if we had a [ConflictComponent] attribute that would be better than this check.
                 // also there is no context about which scene this is in.

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -1,176 +1,16 @@
-using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Mirror
 {
     public class NetworkScenePostProcess : MonoBehaviour
     {
-        // persistent sceneId assignment to fix readstring bug that occurs when restarting the editor and
-        // connecting to a build again. sceneids were then different because FindObjectsOfType's order
-        // is not guranteed to be the same.
-        // -> we need something unique and persistent, aka always the same when pressing play/building the first time
-        // -> Unity has no built in unique id for GameObjects in the scene
-
-        // helper function to figure out a unique, persistent scene id for a GameObject in the hierarchy
-        // -> Unity's instanceId is unique but not persistent
-        // -> hashing the whole GameObject is not enough either since a duplicate would have the same hash
-        // -> we definitely need the transform sibling index in the hierarchy
-        // -> so we might as well use just that
-        // -> transforms have children too so we need a list of sibling indices like 0->3->5
-        public static List<int> SiblingPathFor(Transform t)
-        {
-            List<int> result = new List<int>();
-            while (t != null)
-            {
-                result.Add(t.GetSiblingIndex());
-                t = t.parent;
-            }
-
-            result.Reverse(); // parent to child instead of child to parent order
-            return result;
-        }
-
-        // we need to compare by using the whole sibling list
-        // comparing the string won't work work because:
-        //  "1->2"
-        //  "20->2"
-        // would compare '1' vs '2', then '-' vs '0'
-        //
-        // tests:
-        //   CompareSiblingPaths(new List<int>(){0}, new List<int>(){0}) => 0
-        //   CompareSiblingPaths(new List<int>(){0}, new List<int>(){1}) => -1
-        //   CompareSiblingPaths(new List<int>(){1}, new List<int>(){0}) => 1
-        //   CompareSiblingPaths(new List<int>(){0,1}, new List<int>(){0,2}) => -1
-        //   CompareSiblingPaths(new List<int>(){0,2}, new List<int>(){0,1}) => 1
-        //   CompareSiblingPaths(new List<int>(){1}, new List<int>(){0,1}) => 1
-        //   CompareSiblingPaths(new List<int>(){1}, new List<int>(){2,1}) => -1
-        public static int CompareSiblingPaths(List<int> left, List<int> right)
-        {
-            // compare [0], remove it, compare next, etc.
-            while (left.Count > 0 && right.Count > 0)
-            {
-                if (left[0] < right[0])
-                {
-                    return -1;
-                }
-                else if (left[0] > right[0])
-                {
-                    return 1;
-                }
-                else
-                {
-                    // equal, so they are both children of the same transform
-                    // -> which also means that they both must have one more
-                    //    entry, so we can remove both without checking size
-                    left.RemoveAt(0);
-                    right.RemoveAt(0);
-                }
-            }
-
-            // equal if both were empty or both had the same entry without any
-            // more children (should never happen in practice)
-            return 0;
-        }
-
-        public static int CompareNetworkIdentitySiblingPaths(NetworkIdentity left, NetworkIdentity right)
-        {
-            return CompareSiblingPaths(SiblingPathFor(left.transform), SiblingPathFor(right.transform));
-        }
-
-        // we might have inactive scenes in the Editor's build settings, which
-        // aren't actually included in builds.
-        // so we have to only count the active ones when in Editor, otherwise
-        // editor and build sceneIds might get out of sync.
-        public static int GetSceneCount()
-        {
-#if UNITY_EDITOR
-            return EditorBuildSettings.scenes.Count(scene => scene.enabled);
-#else
-            return SceneManager.sceneCountInBuildSettings;
-#endif
-        }
-
         [PostProcessScene]
         public static void OnPostProcessScene()
         {
-            // vis2k: MISMATCHING SCENEID BUG FIX
-            // problem:
-            //   * FindObjectsOfType order is not guaranteed. restarting the
-            //     editor results in a different order
-            //   * connecting to a build again would cause Mirror to deserialize
-            //     the wrong objects, causing all kinds of weird errors like
-            //     'ReadString out of range'
-            //
-            // solution:
-            //   sort by sibling-index path, e.g. [0,1,2] vs [1]
-            //   this is the only deterministic way to sort a list of objects in
-            //   the scene.
-            //   -> it's the same result every single time, even after restarts
-            //
-            // note: there is a reason why we 'sort by' sibling path instead of
-            //   using it as sceneId directly. networkmanager etc. use Dont-
-            //   DestroyOnLoad, which changes the hierarchy:
-            //
-            //     World:
-            //       NetworkManager
-            //       Player
-            //
-            //     ..becomes..
-            //
-            //     World:
-            //       Player
-            //     DontDestroyOnLoad:
-            //       NetworkManager
-            //
-            //   so the player's siblingindex would be decreased by one.
-            //   -> this is a problem because when building, OnPostProcessScene
-            //      is called before any dontdestroyonload happens, but when
-            //      entering play mode, it's called after
-            //   -> hence sceneids would differ by one
-            //
-            //   => but if we only SORT it, then it doesn't matter if one
-            //      inbetween disappeared. as long as no NetworkIdentity used
-            //      DontDestroyOnLoad.
-            //
-            // note: assigning a GUID in NetworkIdentity.OnValidate would be way
-            //   cooler, but OnValidate isn't called for other unopened scenes
-            //   when building or pressing play, so the bug would still happen
-            //   there.
-            //
-            // note: this can still fail if DontDestroyOnLoad is called for a
-            // NetworkIdentity - but no one should ever do that anyway.
-            List<NetworkIdentity> identities = FindObjectsOfType<NetworkIdentity>().ToList();
-            identities.Sort(CompareNetworkIdentitySiblingPaths);
-
-            // sceneId assignments need to work with additive scene loading, so
-            // it can't always start at 1,2,3,4,..., otherwise there will be
-            // sceneId duplicates.
-            // -> we need an offset to start at 1000+1,+2,+3, etc.
-            // -> the most robust way is to split uint value range by sceneCount
-            // -> only if more than one scene. otherwise use offset 0 to avoid
-            //    DivisionByZero if no scene in build settings, and to avoid
-            //    different offsets in editor/build if scene wasn't added to
-            //    build settings.
-            uint offsetPerScene = 0;
-            if (SceneManager.sceneCountInBuildSettings > 1)
-            {
-                offsetPerScene = uint.MaxValue / (uint)GetSceneCount();
-
-                // make sure that there aren't more sceneIds than offsetPerScene
-                // -> only if we have multiple scenes. otherwise offset is 0, in
-                //    which case it doesn't matter.
-                if (identities.Count >= offsetPerScene)
-                {
-                    Debug.LogWarning(">=" + offsetPerScene + " NetworkIdentities in scene. Additive scene loading will cause duplicate ids.");
-                }
-            }
-
-            uint nextSceneId = 1;
-            foreach (NetworkIdentity identity in identities)
+            // check and disable all NetworkIdentities in scene on load.
+            foreach (NetworkIdentity identity in FindObjectsOfType<NetworkIdentity>())
             {
                 // if we had a [ConflictComponent] attribute that would be better than this check.
                 // also there is no context about which scene this is in.
@@ -181,13 +21,9 @@ namespace Mirror
                 if (identity.isClient || identity.isServer)
                     continue;
 
-                uint offset = (uint)identity.gameObject.scene.buildIndex * offsetPerScene;
-                identity.ForceSceneId(offset + nextSceneId++);
-                if (LogFilter.Debug) Debug.Log("PostProcess sceneid assigned: name=" + identity.name + " scene=" + identity.gameObject.scene.name + " sceneid=" + identity.sceneId);
-
-                // disable it AFTER assigning the sceneId.
-                // -> this way NetworkIdentity.OnDisable adds itself to the
-                //    spawnableObjects dictionary (only if sceneId != 0)
+                // disable it
+                // note: NetworkIdentity.OnDisable adds itself to the
+                //       spawnableObjects dictionary (only if sceneId != 0)
                 identity.gameObject.SetActive(false);
 
                 // safety check for prefabs with more than one NetworkIdentity

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -21,6 +21,9 @@ namespace Mirror
                 if (identity.isClient || identity.isServer)
                     continue;
 
+                // set scene id build index byte
+                identity.SetSceneIdSceneIndexByteInternal();
+
                 // disable it
                 // note: NetworkIdentity.OnDisable adds itself to the
                 //       spawnableObjects dictionary (only if sceneId != 0)

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
@@ -21,8 +22,19 @@ namespace Mirror
                 if (identity.isClient || identity.isServer)
                     continue;
 
-                // set scene id build index byte
-                identity.SetSceneIdSceneIndexByteInternal();
+                // check if the sceneId was set properly
+                // it might not if the scene wasn't opened with new sceneId
+                // Mirror version yet.
+                // => show error for each object where this applies.
+                //    the user should get lots of errors to notice it!
+                // => throwing an exception would only show it for one object
+                //    because this function would return afterwards.
+                if (identity.sceneId != 0)
+                {
+                    // set scene id build index byte
+                    identity.SetSceneIdSceneIndexByteInternal();
+                }
+                else Debug.LogError(identity.name + "'s sceneId wasn't generated yet. This can happen if a scene was last saved with an older version of Mirror. Please open the scene " + identity.gameObject.scene.name + " and click on the " + identity.name + " object in the Hierarchy once, so that OnValidate is called and the sceneId is set. Afterwards resave the scene.");
 
                 // disable it
                 // note: NetworkIdentity.OnDisable adds itself to the

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -163,6 +163,7 @@ namespace Mirror
 #if UNITY_EDITOR
         void AssignAssetID(GameObject prefab) => AssignAssetID(AssetDatabase.GetAssetPath(prefab));
         void AssignAssetID(string path) => m_AssetId = AssetDatabase.AssetPathToGUID(path);
+
         bool ThisIsAPrefab() => PrefabUtility.IsPartOfPrefabAsset(gameObject);
 
         bool ThisIsASceneObjectWithPrefabParent(out GameObject prefab)

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -225,10 +225,30 @@ namespace Mirror
             if (Application.isPlaying)
                 return;
 
+            // copy into a temporary variable first to detect changes
+            uint newSceneId = m_SceneId;
+
             // no valid sceneId yet, or duplicate?
             NetworkIdentity existing;
             bool duplicate = sceneIds.TryGetValue(m_SceneId, out existing) && existing != null && existing != this;
             if (m_SceneId == 0 || duplicate)
+            {
+
+                // generate random sceneId
+                // range: 3 bytes to fill 0x00FFFFFF
+                newSceneId = (uint)UnityEngine.Random.Range(0, 0xFFFFFF);
+            }
+
+            // ALWAYS copy scene build index into sceneId for scene objects.
+            // this is the only way for scene file duplication to not contain
+            // duplicate sceneIds as it seems.
+            // -> sceneId before: 0x00AABBCCDD
+            // -> then we put buildIndex into the 0x00 part
+            byte buildIndex = (byte)gameObject.scene.buildIndex;
+            newSceneId |= (uint)(buildIndex << 24);
+
+            // did we change anything? then set dirty to force the user to resave
+            if (newSceneId != m_SceneId)
             {
                 // if we generate the sceneId then we MUST be sure to set dirty
                 // in order to save the scene object properly. otherwise it
@@ -238,19 +258,9 @@ namespace Mirror
                 // -> we need to call it before changing.
                 Undo.RecordObject(this, "Generated SceneId");
 
-                // generate random sceneId
-                // range: 3 bytes to fill 0x00FFFFFF
-                m_SceneId = (uint)UnityEngine.Random.Range(0, 0xFFFFFF);
+                m_SceneId = newSceneId;
                 Debug.Log("Assigned sceneId to : " + name + " in scene=" + gameObject.scene.name + (duplicate ? " because duplicated" : ""));
             }
-
-            // ALWAYS copy scene build index into sceneId for scene objects.
-            // this is the only way for scene file duplication to not contain
-            // duplicate sceneIds as it seems.
-            // -> sceneId before: 0x00AABBCCDD
-            // -> then we put buildIndex into the 0x00 part
-            byte buildIndex = (byte)gameObject.scene.buildIndex;
-            m_SceneId |= (uint)(buildIndex << 24);
 
             // add to sceneIds dict no matter what
             // -> even if we didn't generate anything new, because we still need

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -201,6 +201,7 @@ namespace Mirror
         // * it needs to be only assigned in edit time, not at runtime because
         //   only the objects that were in the scene since beginning should have
         //   a scene id.
+        //   => Application.isPlaying check solves that
         // * it needs to detect duplicated sceneIds after duplicating scene
         //   objects
         //   => sceneIds dict takes care of that
@@ -217,6 +218,13 @@ namespace Mirror
         //   => Undo.RecordObject does that perfectly.
         void AssignSceneID()
         {
+            // we only ever assign sceneIds at edit time, never at runtime.
+            // by definition, only the original scene objects should get one.
+            // -> if we assign at runtime then server and client would generate
+            //    different random numbers!
+            if (Application.isPlaying)
+                return;
+
             // no valid sceneId yet, or duplicate?
             NetworkIdentity existing;
             bool duplicate = sceneIds.TryGetValue(m_SceneId, out existing) && existing != null && existing != this;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -270,7 +270,7 @@ namespace Mirror
         {
             byte buildIndex = (byte)gameObject.scene.buildIndex;
             m_SceneId |= (uint)(buildIndex << 24);
-            Debug.Log(name + " scene index byte(" + buildIndex.ToString("X") + ") copied into sceneId: " + m_SceneId.ToString("X"));
+            Debug.Log(name + " in scene=" + gameObject.scene.name + " scene index byte(" + buildIndex.ToString("X") + ") copied into sceneId: " + m_SceneId.ToString("X"));
         }
 
         void SetupIDs()

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -277,12 +277,13 @@ namespace Mirror
         // this is the only way for scene file duplication to not contain
         // duplicate sceneIds as it seems.
         // -> sceneId before: 0x00AABBCCDD
-        // -> then we put buildIndex into the 0x00 part
+        // -> then we clear the left most byte, so that our 'OR' uses 0x00
+        // -> then we OR buildIndex into the 0x00 part
         // => ONLY USE THIS FROM POSTPROCESSSCENE!
         public void SetSceneIdSceneIndexByteInternal()
         {
             byte buildIndex = (byte)gameObject.scene.buildIndex;
-            m_SceneId |= (uint)(buildIndex << 24);
+            m_SceneId = (m_SceneId & 0x00FFFFFF) | (uint)(buildIndex << 24);
             Debug.Log(name + " in scene=" + gameObject.scene.name + " scene index byte(" + buildIndex.ToString("X") + ") copied into sceneId: " + m_SceneId.ToString("X"));
         }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -259,7 +259,7 @@ namespace Mirror
                 Undo.RecordObject(this, "Generated SceneId");
 
                 m_SceneId = newSceneId;
-                Debug.Log("Assigned sceneId to : " + name + " in scene=" + gameObject.scene.name + (duplicate ? " because duplicated" : ""));
+                Debug.Log(name + " in scene=" + gameObject.scene.name + " sceneId assigned to: " + m_SceneId.ToString("X") + (duplicate ? " because duplicated" : ""));
             }
 
             // add to sceneIds dict no matter what

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -250,7 +250,7 @@ namespace Mirror
             // -> sceneId before: 0x00AABBCCDD
             // -> then we put buildIndex into the 0x00 part
             byte buildIndex = (byte)gameObject.scene.buildIndex;
-            m_SceneId = (uint)(m_SceneId | (buildIndex << 24));
+            m_SceneId = (uint)(m_SceneId | (uint)(buildIndex << 24));
 
             // add to sceneIds dict no matter what
             // -> even if we didn't generate anything new, because we still need

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -250,7 +250,7 @@ namespace Mirror
             // -> sceneId before: 0x00AABBCCDD
             // -> then we put buildIndex into the 0x00 part
             byte buildIndex = (byte)gameObject.scene.buildIndex;
-            m_SceneId = (uint)(m_SceneId | (uint)(buildIndex << 24));
+            m_SceneId |= (uint)(buildIndex << 24);
 
             // add to sceneIds dict no matter what
             // -> even if we didn't generate anything new, because we still need

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -218,6 +218,10 @@ namespace Mirror
         //   => OnPostProcessScene is the only function that gets called for
         //      each scene before runtime, so this is where we set the scene
         //      byte.
+        // * disabled scenes in build settings should result in same scene index
+        //   in editor and in build
+        //   => .gameObject.scene.buildIndex filters out disabled scenes by
+        //      default
         // * generated sceneIds absolutely need to set scene dirty and force the
         //   user to resave.
         //   => Undo.RecordObject does that perfectly.

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -89,7 +89,7 @@ namespace Mirror
         }
 
         // persistent scene id
-        [SerializeField] uint m_SceneId;
+        [SerializeField] uint m_SceneId = 0;
 
         // keep track of all sceneIds to detect scene duplicates
         static Dictionary<uint, NetworkIdentity> sceneIds = new Dictionary<uint, NetworkIdentity>();


### PR DESCRIPTION
Fix sceneId bugs once and for all, hopefully.

This version generates a random sceneId of form 0x00FFFFFF in OnValidate and sets the scene dirty to force the user to save it.

OnPostProcessScene then copies a buildIndex byte into it, so 0x00FFFFFF becomes 0x12FFFFFF or similar. This makes sure that sceneIds are unique across scenes.

This works perfectly fine with uMMORPG and NetworkZones.

**Note:** when building a scene that wasn't opened with this Mirror version yet (where the sceneIds weren't set yet), the generated sceneIds won't be saved but an error message will be shown at runtime in OnPostProcessScene that tells the user to resave that scene. 