### PR TITLE
[broken] Persistent sceneid v7

### DIFF
--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -10,8 +10,8 @@ namespace Mirror
     {
         // Unity has a persistent 'fileID' for all GameObjects & components.
         // -> we can see it in Inspector Debug View as 'Local Identifier in File'
-        //  -> the only way to access it is via SerializedObject
-        //     (https://forum.unity.com/threads/how-to-get-the-local-identifier-in-file-for-scene-objects.265686/)
+        // -> the only way to access it is via SerializedObject
+        //    (https://forum.unity.com/threads/how-to-get-the-local-identifier-in-file-for-scene-objects.265686/)
         static uint GetFileID(UnityEngine.Object obj)
         {
             SerializedObject serializedObject = new SerializedObject(obj);

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -18,6 +18,9 @@ namespace Mirror
             PropertyInfo inspectorModeInfo = typeof(SerializedObject).GetProperty("inspectorMode", BindingFlags.NonPublic | BindingFlags.Instance);
             inspectorModeInfo.SetValue(serializedObject, InspectorMode.Debug, null);
             SerializedProperty localIdProp = serializedObject.FindProperty("m_LocalIdentfierInFile"); // note the misspelling!
+
+            // Unity seems to use 64 bit for prefab fileIDs and 32 bit for scene
+            // fileIDs, so this is fine:
             return (uint)localIdProp.intValue;
         }
 

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -12,6 +12,9 @@ namespace Mirror
         // -> we can see it in Inspector Debug View as 'Local Identifier in File'
         // -> the only way to access it is via SerializedObject
         //    (https://forum.unity.com/threads/how-to-get-the-local-identifier-in-file-for-scene-objects.265686/)
+        // note: local identifier is somtimes 0 in debug view until Play was
+        //       pressed, which is fine since we only need it in
+        //       OnPostProcessScene here.
         static uint GetFileID(UnityEngine.Object obj)
         {
             SerializedObject serializedObject = new SerializedObject(obj);

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -51,7 +51,7 @@ namespace Mirror
         //   => hash(scene.name) doesn't care
         // * Ids need to be deterministic or saved if randomly generated
         //   => saving ids is always difficult and full of edge cases
-        //   => generated a deterministic id in OnPostProcessScene is the
+        //   => generating a deterministic id in OnPostProcessScene is the
         //      perfect(!) fail safe solution. doing this in OnValidate would be
         //      very difficult to get right, especially for scenes that were
         //      never opened (where OnValidate wasn't called yet).

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -1,84 +1,24 @@
-using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Mirror
 {
     public class NetworkScenePostProcess : MonoBehaviour
     {
-        // persistent sceneId assignment to fix readstring bug that occurs when restarting the editor and
-        // connecting to a build again. sceneids were then different because FindObjectsOfType's order
-        // is not guranteed to be the same.
-        // -> we need something unique and persistent, aka always the same when pressing play/building the first time
-        // -> Unity has no built in unique id for GameObjects in the scene
-
-        // helper function to figure out a unique, persistent scene id for a GameObject in the hierarchy
-        // -> Unity's instanceId is unique but not persistent
-        // -> hashing the whole GameObject is not enough either since a duplicate would have the same hash
-        // -> we definitely need the transform sibling index in the hierarchy
-        // -> so we might as well use just that
-        // -> transforms have children too so we need a list of sibling indices like 0->3->5
-        public static List<int> SiblingPathFor(Transform t)
+        // Unity has a persistent 'fileID' for all GameObjects & components.
+        // -> we can see it in Inspector Debug View as 'Local Identifier in File'
+        //  -> the only way to access it is via SerializedObject
+        //     (https://forum.unity.com/threads/how-to-get-the-local-identifier-in-file-for-scene-objects.265686/)
+        static uint GetFileID(UnityEngine.Object obj)
         {
-            List<int> result = new List<int>();
-            while (t != null)
-            {
-                result.Add(t.GetSiblingIndex());
-                t = t.parent;
-            }
-
-            result.Reverse(); // parent to child instead of child to parent order
-            return result;
-        }
-
-        // we need to compare by using the whole sibling list
-        // comparing the string won't work work because:
-        //  "1->2"
-        //  "20->2"
-        // would compare '1' vs '2', then '-' vs '0'
-        //
-        // tests:
-        //   CompareSiblingPaths(new List<int>(){0}, new List<int>(){0}) => 0
-        //   CompareSiblingPaths(new List<int>(){0}, new List<int>(){1}) => -1
-        //   CompareSiblingPaths(new List<int>(){1}, new List<int>(){0}) => 1
-        //   CompareSiblingPaths(new List<int>(){0,1}, new List<int>(){0,2}) => -1
-        //   CompareSiblingPaths(new List<int>(){0,2}, new List<int>(){0,1}) => 1
-        //   CompareSiblingPaths(new List<int>(){1}, new List<int>(){0,1}) => 1
-        //   CompareSiblingPaths(new List<int>(){1}, new List<int>(){2,1}) => -1
-        public static int CompareSiblingPaths(List<int> left, List<int> right)
-        {
-            // compare [0], remove it, compare next, etc.
-            while (left.Count > 0 && right.Count > 0)
-            {
-                if (left[0] < right[0])
-                {
-                    return -1;
-                }
-                else if (left[0] > right[0])
-                {
-                    return 1;
-                }
-                else
-                {
-                    // equal, so they are both children of the same transform
-                    // -> which also means that they both must have one more
-                    //    entry, so we can remove both without checking size
-                    left.RemoveAt(0);
-                    right.RemoveAt(0);
-                }
-            }
-
-            // equal if both were empty or both had the same entry without any
-            // more children (should never happen in practice)
-            return 0;
-        }
-
-        public static int CompareNetworkIdentitySiblingPaths(NetworkIdentity left, NetworkIdentity right)
-        {
-            return CompareSiblingPaths(SiblingPathFor(left.transform), SiblingPathFor(right.transform));
+            SerializedObject serializedObject = new SerializedObject(obj);
+            PropertyInfo inspectorModeInfo = typeof(SerializedObject).GetProperty("inspectorMode", BindingFlags.NonPublic | BindingFlags.Instance);
+            inspectorModeInfo.SetValue(serializedObject, InspectorMode.Debug, null);
+            SerializedProperty localIdProp = serializedObject.FindProperty("m_LocalIdentfierInFile"); // note the misspelling!
+            return (uint)localIdProp.intValue;
         }
 
         // we might have inactive scenes in the Editor's build settings, which
@@ -105,72 +45,8 @@ namespace Mirror
             //     the wrong objects, causing all kinds of weird errors like
             //     'ReadString out of range'
             //
-            // solution:
-            //   sort by sibling-index path, e.g. [0,1,2] vs [1]
-            //   this is the only deterministic way to sort a list of objects in
-            //   the scene.
-            //   -> it's the same result every single time, even after restarts
-            //
-            // note: there is a reason why we 'sort by' sibling path instead of
-            //   using it as sceneId directly. networkmanager etc. use Dont-
-            //   DestroyOnLoad, which changes the hierarchy:
-            //
-            //     World:
-            //       NetworkManager
-            //       Player
-            //
-            //     ..becomes..
-            //
-            //     World:
-            //       Player
-            //     DontDestroyOnLoad:
-            //       NetworkManager
-            //
-            //   so the player's siblingindex would be decreased by one.
-            //   -> this is a problem because when building, OnPostProcessScene
-            //      is called before any dontdestroyonload happens, but when
-            //      entering play mode, it's called after
-            //   -> hence sceneids would differ by one
-            //
-            //   => but if we only SORT it, then it doesn't matter if one
-            //      inbetween disappeared. as long as no NetworkIdentity used
-            //      DontDestroyOnLoad.
-            //
-            // note: assigning a GUID in NetworkIdentity.OnValidate would be way
-            //   cooler, but OnValidate isn't called for other unopened scenes
-            //   when building or pressing play, so the bug would still happen
-            //   there.
-            //
-            // note: this can still fail if DontDestroyOnLoad is called for a
-            // NetworkIdentity - but no one should ever do that anyway.
-            List<NetworkIdentity> identities = FindObjectsOfType<NetworkIdentity>().ToList();
-            identities.Sort(CompareNetworkIdentitySiblingPaths);
-
-            // sceneId assignments need to work with additive scene loading, so
-            // it can't always start at 1,2,3,4,..., otherwise there will be
-            // sceneId duplicates.
-            // -> we need an offset to start at 1000+1,+2,+3, etc.
-            // -> the most robust way is to split uint value range by sceneCount
-            // -> only if more than one scene. otherwise use offset 0 to avoid
-            //    DivisionByZero if no scene in build settings, and to avoid
-            //    different offsets in editor/build if scene wasn't added to
-            //    build settings.
-            uint offsetPerScene = 0;
-            if (SceneManager.sceneCountInBuildSettings > 1)
-            {
-                offsetPerScene = uint.MaxValue / (uint)GetSceneCount();
-
-                // make sure that there aren't more sceneIds than offsetPerScene
-                // -> only if we have multiple scenes. otherwise offset is 0, in
-                //    which case it doesn't matter.
-                if (identities.Count >= offsetPerScene)
-                {
-                    Debug.LogWarning(">=" + offsetPerScene + " NetworkIdentities in scene. Additive scene loading will cause duplicate ids.");
-                }
-            }
-
-            uint nextSceneId = 1;
-            foreach (NetworkIdentity identity in identities)
+            // solution: use a persistent scene id (see GetFileID())
+            foreach (NetworkIdentity identity in FindObjectsOfType<NetworkIdentity>())
             {
                 // if we had a [ConflictComponent] attribute that would be better than this check.
                 // also there is no context about which scene this is in.
@@ -181,8 +57,10 @@ namespace Mirror
                 if (identity.isClient || identity.isServer)
                     continue;
 
-                uint offset = (uint)identity.gameObject.scene.buildIndex * offsetPerScene;
-                identity.ForceSceneId(offset + nextSceneId++);
+                // assign sceneId to fileID
+                // TODO add scene index into it somehow (has to work with disabled too)
+                uint fileID = GetFileID(identity);
+                identity.ForceSceneId(fileID);
                 if (LogFilter.Debug) Debug.Log("PostProcess sceneid assigned: name=" + identity.name + " scene=" + identity.gameObject.scene.name + " sceneid=" + identity.sceneId);
 
                 // disable it AFTER assigning the sceneId.


### PR DESCRIPTION
reopened in case someone has more ideas.

fileID in scene.unity file is what we need.
localIdentifierInFile is equal to that most of the time, except when it's not.

- it's '0' until we press play or build once
- it becomes a different value after pressing play