### PR TITLE
Simplify weaver error handler.

### DIFF
--- a/Weaver/Weaver/Processors/CommandProcessor.cs
+++ b/Weaver/Weaver/Processors/CommandProcessor.cs
@@ -134,15 +134,13 @@ namespace Mirror.Weaver
         {
             if (md.Name.Length > 2 && md.Name.Substring(0, 3) != "Cmd")
             {
-                Log.Error("Command function [" + td.FullName + ":" + md.Name + "] doesnt have 'Cmd' prefix");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("Command function [" + td.FullName + ":" + md.Name + "] doesnt have 'Cmd' prefix");
                 return false;
             }
 
             if (md.IsStatic)
             {
-                Log.Error("Command function [" + td.FullName + ":" + md.Name + "] cant be a static method");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("Command function [" + td.FullName + ":" + md.Name + "] cant be a static method");
                 return false;
             }
 

--- a/Weaver/Weaver/Processors/MessageClassProcessor.cs
+++ b/Weaver/Weaver/Processors/MessageClassProcessor.cs
@@ -41,8 +41,7 @@ namespace Mirror.Weaver
             {
                 if (field.FieldType.FullName == td.FullName)
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateSerialization for " + td.Name + " [" + field.FullName + "]. [MessageBase] member cannot be self referencing.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + field.FullName + "]. [MessageBase] member cannot be self referencing.");
                     return;
                 }
             }
@@ -61,15 +60,13 @@ namespace Mirror.Weaver
 
                 if (field.FieldType.Resolve().HasGenericParameters)
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateSerialization for " + td.Name + " [" + field.FieldType + "/" + field.FieldType.FullName + "]. [MessageBase] member cannot have generic parameters.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + field.FieldType + "/" + field.FieldType.FullName + "]. [MessageBase] member cannot have generic parameters.");
                     return;
                 }
 
                 if (field.FieldType.Resolve().IsInterface)
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateSerialization for " + td.Name + " [" + field.FieldType + "/" + field.FieldType.FullName + "]. [MessageBase] member cannot be an interface.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + field.FieldType + "/" + field.FieldType.FullName + "]. [MessageBase] member cannot be an interface.");
                     return;
                 }
 
@@ -83,8 +80,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateSerialization for " + td.Name + " unknown type [" + field.FieldType + "/" + field.FieldType.FullName + "]. [MessageBase] member variables must be basic types.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " unknown type [" + field.FieldType + "/" + field.FieldType.FullName + "]. [MessageBase] member variables must be basic types.");
                     return;
                 }
             }
@@ -129,8 +125,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateDeSerialization for " + td.Name + " unknown type [" + field.FieldType + "]. [SyncVar] member variables must be basic types.");
+                    Weaver.Error("GenerateDeSerialization for " + td.Name + " unknown type [" + field.FieldType + "]. [SyncVar] member variables must be basic types.");
                     return;
                 }
             }

--- a/Weaver/Weaver/Processors/MonoBehaviourProcessor.cs
+++ b/Weaver/Weaver/Processors/MonoBehaviourProcessor.cs
@@ -20,15 +20,13 @@ namespace Mirror.Weaver
                 {
                     if (ca.AttributeType.FullName == Weaver.SyncVarType.FullName)
                     {
-                        Log.Error("Script " + td.FullName + " uses [SyncVar] " + fd.Name + " but is not a NetworkBehaviour.");
-                        Weaver.WeavingFailed = true;
+                        Weaver.Error("Script " + td.FullName + " uses [SyncVar] " + fd.Name + " but is not a NetworkBehaviour.");
                     }
                 }
 
                 if (SyncObjectProcessor.ImplementsSyncObject(fd.FieldType))
                 {
-                    Log.Error(string.Format("Script {0} defines field {1} with type {2}, but it's not a NetworkBehaviour", td.FullName, fd.Name, Helpers.PrettyPrintType(fd.FieldType)));
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error(string.Format("Script {0} defines field {1} with type {2}, but it's not a NetworkBehaviour", td.FullName, fd.Name, Helpers.PrettyPrintType(fd.FieldType)));
                 }
             }
         }
@@ -42,20 +40,17 @@ namespace Mirror.Weaver
                 {
                     if (ca.AttributeType.FullName == Weaver.CommandType.FullName)
                     {
-                        Log.Error("Script " + td.FullName + " uses [Command] " + md.Name + " but is not a NetworkBehaviour.");
-                        Weaver.WeavingFailed = true;
+                        Weaver.Error("Script " + td.FullName + " uses [Command] " + md.Name + " but is not a NetworkBehaviour.");
                     }
 
                     if (ca.AttributeType.FullName == Weaver.ClientRpcType.FullName)
                     {
-                        Log.Error("Script " + td.FullName + " uses [ClientRpc] " + md.Name + " but is not a NetworkBehaviour.");
-                        Weaver.WeavingFailed = true;
+                        Weaver.Error("Script " + td.FullName + " uses [ClientRpc] " + md.Name + " but is not a NetworkBehaviour.");
                     }
 
                     if (ca.AttributeType.FullName == Weaver.TargetRpcType.FullName)
                     {
-                        Log.Error("Script " + td.FullName + " uses [TargetRpc] " + md.Name + " but is not a NetworkBehaviour.");
-                        Weaver.WeavingFailed = true;
+                        Weaver.Error("Script " + td.FullName + " uses [TargetRpc] " + md.Name + " but is not a NetworkBehaviour.");
                     }
 
                     string attributeName = ca.Constructor.DeclaringType.ToString();
@@ -63,20 +58,16 @@ namespace Mirror.Weaver
                     switch (attributeName)
                     {
                         case "Mirror.ServerAttribute":
-                            Log.Error("Script " + td.FullName + " uses the attribute [Server] on the method " + md.Name + " but is not a NetworkBehaviour.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Script " + td.FullName + " uses the attribute [Server] on the method " + md.Name + " but is not a NetworkBehaviour.");
                             break;
                         case "Mirror.ServerCallbackAttribute":
-                            Log.Error("Script " + td.FullName + " uses the attribute [ServerCallback] on the method " + md.Name + " but is not a NetworkBehaviour.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Script " + td.FullName + " uses the attribute [ServerCallback] on the method " + md.Name + " but is not a NetworkBehaviour.");
                             break;
                         case "Mirror.ClientAttribute":
-                            Log.Error("Script " + td.FullName + " uses the attribute [Client] on the method " + md.Name + " but is not a NetworkBehaviour.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Script " + td.FullName + " uses the attribute [Client] on the method " + md.Name + " but is not a NetworkBehaviour.");
                             break;
                         case "Mirror.ClientCallbackAttribute":
-                            Log.Error("Script " + td.FullName + " uses the attribute [ClientCallback] on the method " + md.Name + " but is not a NetworkBehaviour.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Script " + td.FullName + " uses the attribute [ClientCallback] on the method " + md.Name + " but is not a NetworkBehaviour.");
                             break;
                     }
                 }

--- a/Weaver/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Weaver/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -37,8 +37,7 @@ namespace Mirror.Weaver
         {
             if (m_td.HasGenericParameters)
             {
-                Weaver.WeavingFailed = true;
-                Log.Error("NetworkBehaviour " + m_td.Name + " cannot have generic parameters");
+                Weaver.Error("NetworkBehaviour " + m_td.Name + " cannot have generic parameters");
                 return;
             }
             Weaver.DLog(m_td, "Process Start");
@@ -129,8 +128,7 @@ namespace Mirror.Weaver
                 MethodReference writeFunc = Weaver.GetWriteFunc(pd.ParameterType);
                 if (writeFunc == null)
                 {
-                    Log.Error("WriteArguments for " + md.Name + " type " + pd.ParameterType + " not supported");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error("WriteArguments for " + md.Name + " type " + pd.ParameterType + " not supported");
                     return false;
                 }
                 // use built-in writer func on writer object
@@ -193,8 +191,7 @@ namespace Mirror.Weaver
                     }
                     else
                     {
-                        Log.Error("No cctor for " + m_td.Name);
-                        Weaver.WeavingFailed = true;
+                        Weaver.Error("No cctor for " + m_td.Name);
                         return;
                     }
                 }
@@ -226,8 +223,7 @@ namespace Mirror.Weaver
                     }
                     else
                     {
-                        Weaver.WeavingFailed = true;
-                        Log.Error("No ctor for " + m_td.Name);
+                        Weaver.Error("No ctor for " + m_td.Name);
                         return;
                     }
 
@@ -237,8 +233,7 @@ namespace Mirror.Weaver
 
             if (ctor == null)
             {
-                Weaver.WeavingFailed = true;
-                Log.Error("No ctor for " + m_td.Name);
+                Weaver.Error("No ctor for " + m_td.Name);
                 return;
             }
 
@@ -358,8 +353,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateSerialization for " + m_td.Name + " unknown type [" + syncVar.FieldType + "]. Mirror [SyncVar] member variables must be basic types.");
+                    Weaver.Error("GenerateSerialization for " + m_td.Name + " unknown type [" + syncVar.FieldType + "]. Mirror [SyncVar] member variables must be basic types.");
                     return;
                 }
             }
@@ -407,8 +401,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Log.Error("GenerateSerialization for " + m_td.Name + " unknown type [" + syncVar.FieldType + "]. Mirror [SyncVar] member variables must be basic types.");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error("GenerateSerialization for " + m_td.Name + " unknown type [" + syncVar.FieldType + "]. Mirror [SyncVar] member variables must be basic types.");
                     return;
                 }
 
@@ -493,8 +486,7 @@ namespace Mirror.Weaver
                 MethodReference readFunc = Weaver.GetReadFunc(syncVar.FieldType);
                 if (readFunc == null)
                 {
-                    Log.Error("GenerateDeSerialization for " + m_td.Name + " unknown type [" + syncVar.FieldType + "]. Mirror [SyncVar] member variables must be basic types.");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error("GenerateDeSerialization for " + m_td.Name + " unknown type [" + syncVar.FieldType + "]. Mirror [SyncVar] member variables must be basic types.");
                     return;
                 }
 
@@ -635,8 +627,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Log.Error("ProcessNetworkReaderParameters for " + td.Name + ":" + md.Name + " type " + arg.ParameterType + " not supported");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error("ProcessNetworkReaderParameters for " + td.Name + ":" + md.Name + " type " + arg.ParameterType + " not supported");
                     return false;
                 }
             }
@@ -653,20 +644,17 @@ namespace Mirror.Weaver
         {
             if (md.ReturnType.FullName == Weaver.IEnumeratorType.FullName)
             {
-                Log.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] cannot be a coroutine");
-                Weaver.WeavingFailed = true;
+                Weaver.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] cannot be a coroutine");
                 return false;
             }
             if (md.ReturnType.FullName != Weaver.voidType.FullName)
             {
-                Log.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] must have a void return type.");
-                Weaver.WeavingFailed = true;
+                Weaver.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] must have a void return type.");
                 return false;
             }
             if (md.HasGenericParameters)
             {
-                Log.Error(actionType + " [" + td.FullName + ":" + md.Name + "] cannot have generic parameters");
-                Weaver.WeavingFailed = true;
+                Weaver.Error(actionType + " [" + td.FullName + ":" + md.Name + "] cannot have generic parameters");
                 return false;
             }
             return true;
@@ -679,46 +667,40 @@ namespace Mirror.Weaver
                 var p = md.Parameters[i];
                 if (p.IsOut)
                 {
-                    Log.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] cannot have out parameters");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] cannot have out parameters");
                     return false;
                 }
                 if (p.IsOptional)
                 {
-                    Log.Error(actionType + "function [" + td.FullName + ":" + md.Name + "] cannot have optional parameters");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error(actionType + "function [" + td.FullName + ":" + md.Name + "] cannot have optional parameters");
                     return false;
                 }
                 if (p.ParameterType.Resolve().IsAbstract)
                 {
-                    Log.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] cannot have abstract parameters");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] cannot have abstract parameters");
                     return false;
                 }
                 if (p.ParameterType.IsByReference)
                 {
-                    Log.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] cannot have ref parameters");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] cannot have ref parameters");
                     return false;
                 }
                 // TargetRPC is an exception to this rule and can have a NetworkConnection as first parameter
                 if (p.ParameterType.FullName == Weaver.NetworkConnectionType.FullName &&
                     !(ca.AttributeType.FullName == Weaver.TargetRpcType.FullName && i == 0))
                 {
-                    Log.Error(actionType + " [" + td.FullName + ":" + md.Name + "] cannot use a NetworkConnection as a parameter. To access a player object's connection on the server use connectionToClient");
-                    Log.Error("Name: " + ca.AttributeType.FullName + " parameter: " + md.Parameters[0].ParameterType.FullName);
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error(actionType + " [" + td.FullName + ":" + md.Name + "] cannot use a NetworkConnection as a parameter. To access a player object's connection on the server use connectionToClient");
+                    Weaver.Error("Name: " + ca.AttributeType.FullName + " parameter: " + md.Parameters[0].ParameterType.FullName);
                     return false;
                 }
                 if (p.ParameterType.Resolve().IsDerivedFrom(Weaver.ComponentType))
                 {
                     if (p.ParameterType.FullName != Weaver.NetworkIdentityType.FullName)
                     {
-                        Log.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] parameter [" + p.Name +
+                        Weaver.Error(actionType + " function [" + td.FullName + ":" + md.Name + "] parameter [" + p.Name +
                             "] is of the type [" +
                             p.ParameterType.Name +
                             "] which is a Component. You cannot pass a Component to a remote call. Try passing data from within the component.");
-                        Weaver.WeavingFailed = true;
                         return false;
                     }
                 }
@@ -743,8 +725,7 @@ namespace Mirror.Weaver
 
                         if (names.Contains(md.Name))
                         {
-                            Log.Error("Duplicate Command name [" + m_td.FullName + ":" + md.Name + "]");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Duplicate Command name [" + m_td.FullName + ":" + md.Name + "]");
                             return;
                         }
                         names.Add(md.Name);
@@ -772,8 +753,7 @@ namespace Mirror.Weaver
 
                         if (names.Contains(md.Name))
                         {
-                            Log.Error("Duplicate Target Rpc name [" + m_td.FullName + ":" + md.Name + "]");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Duplicate Target Rpc name [" + m_td.FullName + ":" + md.Name + "]");
                             return;
                         }
                         names.Add(md.Name);
@@ -801,8 +781,7 @@ namespace Mirror.Weaver
 
                         if (names.Contains(md.Name))
                         {
-                            Log.Error("Duplicate ClientRpc name [" + m_td.FullName + ":" + md.Name + "]");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Duplicate ClientRpc name [" + m_td.FullName + ":" + md.Name + "]");
                             return;
                         }
                         names.Add(md.Name);

--- a/Weaver/Weaver/Processors/RpcProcessor.cs
+++ b/Weaver/Weaver/Processors/RpcProcessor.cs
@@ -91,15 +91,13 @@ namespace Mirror.Weaver
         {
             if (md.Name.Length > 2 && md.Name.Substring(0, 3) != "Rpc")
             {
-                Log.Error("Rpc function [" + td.FullName + ":" + md.Name + "] doesnt have 'Rpc' prefix");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("Rpc function [" + td.FullName + ":" + md.Name + "] doesnt have 'Rpc' prefix");
                 return false;
             }
 
             if (md.IsStatic)
             {
-                Log.Error("ClientRpc function [" + td.FullName + ":" + md.Name + "] cant be a static method");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("ClientRpc function [" + td.FullName + ":" + md.Name + "] cant be a static method");
                 return false;
             }
 

--- a/Weaver/Weaver/Processors/SyncEventProcessor.cs
+++ b/Weaver/Weaver/Processors/SyncEventProcessor.cs
@@ -21,8 +21,7 @@ namespace Mirror.Weaver
             }
             if (eventField == null)
             {
-                Weaver.DLog(td, "ERROR: no event field?!");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("[" + td.Name + "] ERROR: no event field?!");
                 return null;
             }
 
@@ -114,15 +113,13 @@ namespace Mirror.Weaver
                     {
                         if (ed.Name.Length > 4 && ed.Name.Substring(0, 5) != "Event")
                         {
-                            Log.Error("Event  [" + td.FullName + ":" + ed.FullName + "] doesnt have 'Event' prefix");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Event  [" + td.FullName + ":" + ed.FullName + "] doesnt have 'Event' prefix");
                             return;
                         }
 
                         if (ed.EventType.Resolve().HasGenericParameters)
                         {
-                            Log.Error("Event  [" + td.FullName + ":" + ed.FullName + "] cannot have generic parameters");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Event  [" + td.FullName + ":" + ed.FullName + "] cannot have generic parameters");
                             return;
                         }
 

--- a/Weaver/Weaver/Processors/SyncListProcessor.cs
+++ b/Weaver/Weaver/Processors/SyncListProcessor.cs
@@ -35,8 +35,7 @@ namespace Mirror.Weaver
             }
             catch (Exception)
             {
-                Weaver.WeavingFailed = true;
-                Log.Error("Missing parameter-less constructor for:" + fd.FieldType.Name);
+                Weaver.Error("Missing parameter-less constructor for:" + fd.FieldType.Name);
                 return;
             }
 

--- a/Weaver/Weaver/Processors/SyncListStructProcessor.cs
+++ b/Weaver/Weaver/Processors/SyncListStructProcessor.cs
@@ -12,8 +12,7 @@ namespace Mirror.Weaver
             GenericInstanceType gt = (GenericInstanceType)td.BaseType;
             if (gt.GenericArguments.Count == 0)
             {
-                Weaver.WeavingFailed = true;
-                Log.Error("SyncListStructProcessor no generic args");
+                Weaver.Error("SyncListStructProcessor no generic args");
                 return;
             }
             TypeReference itemType = Weaver.CurrentAssembly.MainModule.ImportReference(gt.GenericArguments[0]);
@@ -57,8 +56,7 @@ namespace Mirror.Weaver
 
             if (itemType.IsGenericInstance)
             {
-                Weaver.WeavingFailed = true;
-                Log.Error("GenerateSerialization for " + Helpers.PrettyPrintType(itemType) + " failed. Struct passed into SyncListStruct<T> can't have generic parameters");
+                Weaver.Error("GenerateSerialization for " + Helpers.PrettyPrintType(itemType) + " failed. Struct passed into SyncListStruct<T> can't have generic parameters");
                 return null;
             }
 
@@ -72,15 +70,13 @@ namespace Mirror.Weaver
 
                 if (ft.HasGenericParameters)
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateSerialization for " + td.Name + " [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member cannot have generic parameters.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member cannot have generic parameters.");
                     return null;
                 }
 
                 if (ft.IsInterface)
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateSerialization for " + td.Name + " [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member cannot be an interface.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member cannot be an interface.");
                     return null;
                 }
 
@@ -94,8 +90,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateSerialization for " + td.Name + " unknown type [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member variables must be basic types.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " unknown type [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member variables must be basic types.");
                     return null;
                 }
             }
@@ -149,8 +144,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.WeavingFailed = true;
-                    Log.Error("GenerateDeserialization for " + td.Name + " unknown type [" + ft + "]. [SyncListStruct] member variables must be basic types.");
+                    Weaver.Error("GenerateDeserialization for " + td.Name + " unknown type [" + ft + "]. [SyncListStruct] member variables must be basic types.");
                     return null;
                 }
             }

--- a/Weaver/Weaver/Processors/SyncVarProcessor.cs
+++ b/Weaver/Weaver/Processors/SyncVarProcessor.cs
@@ -31,20 +31,17 @@ namespace Mirror.Weaver
                                     {
                                         if (m.Parameters[0].ParameterType != syncVar.FieldType)
                                         {
-                                            Log.Error("SyncVar Hook function " + hookFunctionName + " has wrong type signature for " + td.Name);
-                                            Weaver.WeavingFailed = true;
+                                            Weaver.Error("SyncVar Hook function " + hookFunctionName + " has wrong type signature for " + td.Name);
                                             return false;
                                         }
                                         foundMethod = m;
                                         return true;
                                     }
-                                    Log.Error("SyncVar Hook function " + hookFunctionName + " must have one argument " + td.Name);
-                                    Weaver.WeavingFailed = true;
+                                    Weaver.Error("SyncVar Hook function " + hookFunctionName + " must have one argument " + td.Name);
                                     return false;
                                 }
                             }
-                            Log.Error("SyncVar Hook function " + hookFunctionName + " not found for " + td.Name);
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("SyncVar Hook function " + hookFunctionName + " not found for " + td.Name);
                             return false;
                         }
                     }
@@ -256,36 +253,31 @@ namespace Mirror.Weaver
 
                         if (resolvedField.IsDerivedFrom(Weaver.NetworkBehaviourType))
                         {
-                            Log.Error("SyncVar [" + fd.FullName + "] cannot be derived from NetworkBehaviour.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("SyncVar [" + fd.FullName + "] cannot be derived from NetworkBehaviour.");
                             return;
                         }
 
                         if (resolvedField.IsDerivedFrom(Weaver.ScriptableObjectType))
                         {
-                            Log.Error("SyncVar [" + fd.FullName + "] cannot be derived from ScriptableObject.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("SyncVar [" + fd.FullName + "] cannot be derived from ScriptableObject.");
                             return;
                         }
 
                         if ((fd.Attributes & FieldAttributes.Static) != 0)
                         {
-                            Log.Error("SyncVar [" + fd.FullName + "] cannot be static.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("SyncVar [" + fd.FullName + "] cannot be static.");
                             return;
                         }
 
                         if (resolvedField.HasGenericParameters)
                         {
-                            Log.Error("SyncVar [" + fd.FullName + "] cannot have generic parameters.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("SyncVar [" + fd.FullName + "] cannot have generic parameters.");
                             return;
                         }
 
                         if (resolvedField.IsInterface)
                         {
-                            Log.Error("SyncVar [" + fd.FullName + "] cannot be an interface.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("SyncVar [" + fd.FullName + "] cannot be an interface.");
                             return;
                         }
 
@@ -298,15 +290,13 @@ namespace Mirror.Weaver
                             fieldModuleName != "netstandard.dll" // handle built-in types when weaving new C#7 compiler assemblies
                             )
                         {
-                            Log.Error("SyncVar [" + fd.FullName + "] from " + resolvedField.Module.ToString() + " cannot be a different module.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("SyncVar [" + fd.FullName + "] from " + resolvedField.Module.ToString() + " cannot be a different module.");
                             return;
                         }
 
                         if (fd.FieldType.IsArray)
                         {
-                            Log.Error("SyncVar [" + fd.FullName + "] cannot be an array. Use a SyncList instead.");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("SyncVar [" + fd.FullName + "] cannot be an array. Use a SyncList instead.");
                             return;
                         }
 
@@ -324,8 +314,7 @@ namespace Mirror.Weaver
 
                         if (dirtyBitCounter == k_SyncVarLimit)
                         {
-                            Log.Error("Script class [" + td.FullName + "] has too many SyncVars (" + k_SyncVarLimit + "). (This could include base classes)");
-                            Weaver.WeavingFailed = true;
+                            Weaver.Error("Script class [" + td.FullName + "] has too many SyncVars (" + k_SyncVarLimit + "). (This could include base classes)");
                             return;
                         }
                         break;
@@ -334,8 +323,7 @@ namespace Mirror.Weaver
 
                 if (fd.FieldType.FullName.Contains("Mirror.SyncListStruct"))
                 {
-                    Log.Error("SyncListStruct member variable [" + fd.FullName + "] must use a dervied class, like \"class MySyncList : SyncListStruct<MyStruct> {}\".");
-                    Weaver.WeavingFailed = true;
+                    Weaver.Error("SyncListStruct member variable [" + fd.FullName + "] must use a dervied class, like \"class MySyncList : SyncListStruct<MyStruct> {}\".");
                     return;
                 }
 
@@ -343,8 +331,7 @@ namespace Mirror.Weaver
                 {
                     if (fd.IsStatic)
                     {
-                        Log.Error("SyncList [" + td.FullName + ":" + fd.FullName + "] cannot be a static");
-                        Weaver.WeavingFailed = true;
+                        Weaver.Error("SyncList [" + td.FullName + ":" + fd.FullName + "] cannot be a static");
                         return;
                     }
 

--- a/Weaver/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Weaver/Weaver/Processors/TargetRpcProcessor.cs
@@ -98,15 +98,13 @@ namespace Mirror.Weaver
 
             if (md.Name.Length > prefixLen && md.Name.Substring(0, prefixLen) != targetPrefix)
             {
-                Log.Error("Target Rpc function [" + td.FullName + ":" + md.Name + "] doesnt have 'Target' prefix");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("Target Rpc function [" + td.FullName + ":" + md.Name + "] doesnt have 'Target' prefix");
                 return false;
             }
 
             if (md.IsStatic)
             {
-                Log.Error("TargetRpc function [" + td.FullName + ":" + md.Name + "] cant be a static method");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("TargetRpc function [" + td.FullName + ":" + md.Name + "] cant be a static method");
                 return false;
             }
 
@@ -117,15 +115,13 @@ namespace Mirror.Weaver
 
             if (md.Parameters.Count < 1)
             {
-                Log.Error("Target Rpc function [" + td.FullName + ":" + md.Name + "] must have a NetworkConnection as the first parameter");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("Target Rpc function [" + td.FullName + ":" + md.Name + "] must have a NetworkConnection as the first parameter");
                 return false;
             }
 
             if (md.Parameters[0].ParameterType.FullName != Weaver.NetworkConnectionType.FullName)
             {
-                Log.Error("Target Rpc function [" + td.FullName + ":" + md.Name + "] first parameter must be a NetworkConnection");
-                Weaver.WeavingFailed = true;
+                Weaver.Error("Target Rpc function [" + td.FullName + ":" + md.Name + "] first parameter must be a NetworkConnection");
                 return false;
             }
 

--- a/Weaver/Weaver/Resolvers.cs
+++ b/Weaver/Weaver/Resolvers.cs
@@ -15,8 +15,7 @@ namespace Mirror.Weaver
             //Console.WriteLine("ResolveMethod " + t.ToString () + " " + name);
             if (tr == null)
             {
-                Log.Error("Type missing for " + name);
-                Weaver.WeavingFailed = true;
+                Weaver.Error("Type missing for " + name);
                 return null;
             }
             foreach (MethodDefinition methodRef in tr.Resolve().Methods)
@@ -26,15 +25,14 @@ namespace Mirror.Weaver
                     return scriptDef.MainModule.ImportReference(methodRef);
                 }
             }
-            Log.Error("ResolveMethod failed " + tr.Name + "::" + name + " " + tr.Resolve());
+            Weaver.Error("ResolveMethod failed " + tr.Name + "::" + name + " " + tr.Resolve());
 
             // why did it fail!?
             foreach (MethodDefinition methodRef in tr.Resolve().Methods)
             {
-                Log.Error("Method " + methodRef.Name);
+                Weaver.Error("Method " + methodRef.Name);
             }
 
-            Weaver.WeavingFailed = true;
             return null;
         }
 
@@ -43,8 +41,7 @@ namespace Mirror.Weaver
         {
             if (tr == null)
             {
-                Log.Error("Type missing for " + name);
-                Weaver.WeavingFailed = true;
+                Weaver.Error("Type missing for " + name);
                 return null;
             }
             foreach (MethodDefinition methodRef in tr.Resolve().Methods)
@@ -74,8 +71,7 @@ namespace Mirror.Weaver
                     }
                 }
             }
-            Log.Error("ResolveMethodWithArg failed " + tr.Name + "::" + name + " " + argTypeFullName);
-            Weaver.WeavingFailed = true;
+            Weaver.Error("ResolveMethodWithArg failed " + tr.Name + "::" + name + " " + argTypeFullName);
             return null;
         }
 
@@ -121,8 +117,7 @@ namespace Mirror.Weaver
                 }
             }
 
-            Log.Error("ResolveMethodGeneric failed " + t.Name + "::" + name + " " + genericType);
-            Weaver.WeavingFailed = true;
+            Weaver.Error("ResolveMethodGeneric failed " + t.Name + "::" + name + " " + genericType);
             return null;
         }
 


### PR DESCRIPTION
Rather than sprinkling WeaverFailed=true all over the place,  we call a Weaver.Error(message)  where an error occurs.
This way we can enforce consistency in weaver error reporting