### PR TITLE
Transports now give ArraySegment<byte> instead of byte[]

### DIFF
--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -40,7 +41,7 @@ namespace Mirror
             while (packetQueue.Count > 0)
             {
                 byte[] packet = packetQueue.Dequeue();
-                OnDataReceived(packet);
+                OnDataReceived(new ArraySegment<byte>(packet));
             }
         }
 

--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Mirror
@@ -36,7 +37,7 @@ namespace Mirror
 
             // handle the server's message directly
             // TODO any way to do this without NetworkServer.localConnection?
-            NetworkServer.localConnection.TransportReceive(bytes);
+            NetworkServer.localConnection.TransportReceive(new ArraySegment<byte>(bytes));
             return true;
         }
     }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -91,7 +91,7 @@ namespace Mirror
             connection?.InvokeHandler(new DisconnectMessage());
         }
 
-        protected void OnDataReceived(byte[] data)
+        protected void OnDataReceived(ArraySegment<byte> data)
         {
             if (connection != null)
             {

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -232,7 +232,7 @@ namespace Mirror
         //       -> in other words, we always receive 1 message per Receive call, never two.
         //       -> can be tested easily with a 1000ms send delay and then logging amount received in while loops here
         //          and in NetworkServer/Client Update. HandleBytes already takes exactly one.
-        public virtual void TransportReceive(byte[] buffer)
+        public virtual void TransportReceive(ArraySegment<byte> buffer)
         {
             // unpack message
             NetworkReader reader = new NetworkReader(buffer);
@@ -240,7 +240,10 @@ namespace Mirror
             {
                 if (logNetworkMessages)
                 {
-                    Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer));
+                    Debug.Log(
+                        "ConnectionRecv con:" + connectionId + 
+                        " msgType:" + msgType + 
+                        " content:" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));
                 }
 
                 // try to invoke the handler for that message
@@ -249,7 +252,9 @@ namespace Mirror
                     lastMessageTime = Time.time;
                 }
             }
-            else Debug.LogError("HandleBytes UnpackMessage failed for: " + BitConverter.ToString(buffer));
+            else 
+                Debug.LogError(
+                    "HandleBytes UnpackMessage failed for: " + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));
         }
 
         public virtual bool TransportSend(int channelId, byte[] bytes, out byte error)

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -13,6 +13,11 @@ namespace Mirror
             reader = new BinaryReader(new MemoryStream(buffer));
         }
 
+        public NetworkReader(ArraySegment<byte> buffer)
+        {
+            reader = new BinaryReader(new MemoryStream(buffer.Array, buffer.Offset, buffer.Count));
+        }
+
         // 'int' is the best type for .Position. 'short' is too small if we send >32kb which would result in negative .Position
         // -> converting long to int is fine until 2GB of data (MAX_INT), so we don't have to worry about overflows here
         public int Position { get { return (int)reader.BaseStream.Position; }  set { reader.BaseStream.Position = value; } }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -419,7 +419,7 @@ namespace Mirror
             conn.Dispose();
         }
 
-        static void OnDataReceived(int connectionId, byte[] data)
+        static void OnDataReceived(int connectionId, ArraySegment<byte> data)
         {
             if (connections.TryGetValue(connectionId, out NetworkConnection conn))
             {
@@ -437,7 +437,7 @@ namespace Mirror
             Debug.LogException(exception);
         }
 
-        static void OnData(NetworkConnection conn, byte[] data)
+        static void OnData(NetworkConnection conn, ArraySegment<byte> data)
         {
             conn.TransportReceive(data);
         }

--- a/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -119,7 +119,7 @@ namespace Mirror
         {
             if (clientId == -1) return false;
 
-            NetworkEventType networkEvent = NetworkTransport.ReceiveFromHost(clientId, out int connectionId, out int channel, clientReceiveBuffer, clientReceiveBuffer.Length, out int receivedSize, out error);
+            NetworkEventType networkEvent = NetworkTransport.ReceiveFromHost(clientId, out int connectionId, out int channel, clientReceiveBuffer, clientReceiveBuffer.Length, out int  receivedSize, out error);
 
             // note: 'error' is used for extra information, e.g. the reason for
             // a disconnect. we don't necessarily have to throw an error if
@@ -141,8 +141,7 @@ namespace Mirror
                     OnClientConnected.Invoke();
                     break;
                 case NetworkEventType.DataEvent:
-                    byte[] data = new byte[receivedSize];
-                    Array.Copy(clientReceiveBuffer, data, receivedSize);
+                    ArraySegment<byte> data = new ArraySegment<byte>(clientReceiveBuffer, 0, receivedSize);
                     OnClientDataReceived.Invoke(data);
                     break;
                 case NetworkEventType.DisconnectEvent:
@@ -233,8 +232,7 @@ namespace Mirror
                     OnServerConnected.Invoke(connectionId);
                     break;
                 case NetworkEventType.DataEvent:
-                    byte[] data = new byte[receivedSize];
-                    Array.Copy(serverReceiveBuffer, data, receivedSize);
+                    ArraySegment<byte> data = new ArraySegment<byte>(serverReceiveBuffer, 0, receivedSize);
                     OnServerDataReceived.Invoke(connectionId, data);
                     break;
                 case NetworkEventType.DisconnectEvent:

--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -1,4 +1,5 @@
 // wraps Telepathy for use as HLAPI TransportLayer
+using System;
 using UnityEngine;
 namespace Mirror
 {
@@ -47,7 +48,7 @@ namespace Mirror
                         OnClientConnected.Invoke();
                         break;
                     case Telepathy.EventType.Data:
-                        OnClientDataReceived.Invoke(message.data);
+                        OnClientDataReceived.Invoke(new ArraySegment<byte>(message.data));
                         break;
                     case Telepathy.EventType.Disconnected:
                         OnClientDisconnected.Invoke();
@@ -92,7 +93,7 @@ namespace Mirror
                         OnServerConnected.Invoke(message.connectionId);
                         break;
                     case Telepathy.EventType.Data:
-                        OnServerDataReceived.Invoke(message.connectionId, message.data);
+                        OnServerDataReceived.Invoke(message.connectionId, new ArraySegment<byte>(message.data));
                         break;
                     case Telepathy.EventType.Disconnected:
                         OnServerDisconnected.Invoke(message.connectionId);

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -7,10 +7,10 @@ using UnityEngine.Events;
 namespace Mirror
 {
     // UnityEvent definitions
-    [Serializable] public class UnityEventByteArray : UnityEvent<byte[]> {}
+    [Serializable] public class UnityEventArraySegment : UnityEvent<ArraySegment<byte>> {}
     [Serializable] public class UnityEventException : UnityEvent<Exception> {}
     [Serializable] public class UnityEventInt : UnityEvent<int> {}
-    [Serializable] public class UnityEventIntByteArray : UnityEvent<int, byte[]> {}
+    [Serializable] public class UnityEventIntArraySegment : UnityEvent<int, ArraySegment<byte>> {}
     [Serializable] public class UnityEventIntException : UnityEvent<int, Exception> {}
 
     public abstract class Transport : MonoBehaviour
@@ -28,7 +28,7 @@ namespace Mirror
 
         // client
         [HideInInspector] public UnityEvent OnClientConnected;
-        [HideInInspector] public UnityEventByteArray OnClientDataReceived;
+        [HideInInspector] public UnityEventArraySegment OnClientDataReceived;
         [HideInInspector] public UnityEventException OnClientError;
         [HideInInspector] public UnityEvent OnClientDisconnected;
 
@@ -39,7 +39,7 @@ namespace Mirror
 
         // server
         [HideInInspector] public UnityEventInt OnServerConnected;
-        [HideInInspector] public UnityEventIntByteArray OnServerDataReceived;
+        [HideInInspector] public UnityEventIntArraySegment OnServerDataReceived;
         [HideInInspector] public UnityEventIntException OnServerError;
 
 

--- a/Assets/Mirror/Runtime/Transport/Websocket/Client.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Client.cs
@@ -16,7 +16,7 @@ namespace Mirror.Websocket
     public class Client
     {
         public event Action Connected;
-        public event Action<byte[]> ReceivedData;
+        public event Action<ArraySegment<byte>> ReceivedData;
         public event Action Disconnected;
         public event Action<Exception> ReceivedError;
 
@@ -97,9 +97,9 @@ namespace Mirror.Websocket
                     break;
 
                 // we got a text or binary message,  need the full message
-                byte[] data = await ReadFrames(result, webSocket, buffer);
+                ArraySegment<byte> data = await ReadFrames(result, webSocket, buffer);
 
-                if (data == null)
+                if (data.Count == 0)
                     break;
 
                 try
@@ -115,7 +115,7 @@ namespace Mirror.Websocket
 
         // a message might come splitted in multiple frames
         // collect all frames
-        private async Task<byte[]> ReadFrames(WebSocketReceiveResult result, WebSocket webSocket, byte[] buffer)
+        private async Task<ArraySegment<byte>> ReadFrames(WebSocketReceiveResult result, WebSocket webSocket, byte[] buffer)
         {
             int count = result.Count;
 
@@ -126,14 +126,14 @@ namespace Mirror.Websocket
                     string closeMessage = string.Format("Maximum message size: {0} bytes.", MaxMessageSize);
                     await webSocket.CloseAsync(WebSocketCloseStatus.MessageTooBig, closeMessage, CancellationToken.None);
                     ReceivedError?.Invoke(new WebSocketException(WebSocketError.HeaderError));
-                    return null;
+                    return new ArraySegment<byte>();
                 }
 
                 result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer, count, MaxMessageSize - count), CancellationToken.None);
                 count += result.Count;
 
             }
-            return new ArraySegment<byte>(buffer, 0, count).ToArray();
+            return new ArraySegment<byte>(buffer, 0, count);
         }
 
         public void Disconnect()

--- a/Assets/Mirror/Runtime/Transport/Websocket/Server.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Server.cs
@@ -16,7 +16,7 @@ namespace Mirror.Websocket
     public class Server
     {
         public event Action<int> Connected;
-        public event Action<int, byte[]> ReceivedData;
+        public event Action<int, ArraySegment<byte>> ReceivedData;
         public event Action<int> Disconnected;
         public event Action<int, Exception> ReceivedError;
 
@@ -196,9 +196,9 @@ namespace Mirror.Websocket
                         break;
                     }
 
-                    byte[] data = await ReadFrames(connectionId, result, webSocket, buffer, token);
+                    ArraySegment<byte> data = await ReadFrames(connectionId, result, webSocket, buffer, token);
 
-                    if (data == null)
+                    if (data.Count == 0)
                         break;
 
                     try
@@ -226,7 +226,7 @@ namespace Mirror.Websocket
 
         // a message might come splitted in multiple frames
         // collect all frames
-        private async Task<byte[]> ReadFrames(int connectionId, WebSocketReceiveResult result, WebSocket webSocket, byte[] buffer, CancellationToken token)
+        private async Task<ArraySegment<byte>> ReadFrames(int connectionId, WebSocketReceiveResult result, WebSocket webSocket, byte[] buffer, CancellationToken token)
         {
             int count = result.Count;
 
@@ -237,14 +237,14 @@ namespace Mirror.Websocket
                     string closeMessage = string.Format("Maximum message size: {0} bytes.", MaxMessageSize);
                     await webSocket.CloseAsync(WebSocketCloseStatus.MessageTooBig, closeMessage, CancellationToken.None);
                     ReceivedError?.Invoke(connectionId, new WebSocketException(WebSocketError.HeaderError));
-                    return null;
+                    return new ArraySegment<byte>();
                 }
 
                 result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer, count, MaxMessageSize - count), CancellationToken.None);
                 count += result.Count;
 
             }
-            return new ArraySegment<byte>(buffer, 0, count).ToArray();
+            return new ArraySegment<byte>(buffer, 0, count);
         }
 
         public void Stop()


### PR DESCRIPTION
This allows LLAPITransport, Websocket and TcpTransport to operate allocation free

Inspired by #569 but replacing the current event instead of adding a new one.