### PR TITLE
OnEnable added to hot change transport

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -79,5 +79,13 @@ namespace Mirror
         //            ShoulderRotation.LateUpdate, resulting in projectile
         //            spawns at the point before shoulder rotation.
         public void Update() {}
+        
+        //We want the last enabled transport
+        //for example to have steam transport and local telepathy transport
+        //and change in hot
+        public virtual void OnEnable()
+        {
+            Transport.activeTransport = this;
+        }
     }
 }


### PR DESCRIPTION
I reached a situation in my project where I wanted to have SteamyFizzyTransport for online play but also telepathy to LAN matches.
It was weird to disable TelepathyTransport and then on trying to start steamfizzy transport I got Telepathy enabled again, so, watching through the code I discovered that NetworkManager enables the Transport.activeTransport, so I was thinking that if anyone Enable a transport that will have to change to be the active