### PR TITLE
Fix network animator doesn't sync float value as expected

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -230,7 +230,7 @@ namespace Mirror
                 else if (par.type == AnimatorControllerParameterType.Float)
                 {
                     float newFloatValue = m_Animator.GetFloat(par.nameHash);
-                    if (Mathf.Abs(newFloatValue - lastFloatParameters[i]) < 0.001f)
+                    if (Mathf.Abs(newFloatValue - lastFloatParameters[i]) > 0.001f)
                     {
                         writer.Write(newFloatValue);
                         dirtyBits |= 1u << i;


### PR DESCRIPTION
Maybe we should do float sync when the Abs of newValue - lastValue > 0.001f