### PR TITLE
feature: SyncList now support structs

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncListProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncListProcessor.cs
@@ -1,10 +1,10 @@
-// this class generates OnSerialize/OnDeserialize for SyncListStructs
+// this class generates OnSerialize/OnDeserialize for SyncLists
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Mirror.Weaver
 {
-    static class SyncListStructProcessor
+    static class SyncListProcessor
     {
         public static void Process(TypeDefinition td)
         {
@@ -12,12 +12,12 @@ namespace Mirror.Weaver
             GenericInstanceType gt = (GenericInstanceType)td.BaseType;
             if (gt.GenericArguments.Count == 0)
             {
-                Weaver.Error("SyncListStructProcessor no generic args");
+                Weaver.Error("SyncListProcessor no generic args");
                 return;
             }
             TypeReference itemType = Weaver.CurrentAssembly.MainModule.ImportReference(gt.GenericArguments[0]);
 
-            Weaver.DLog(td, "SyncListStructProcessor Start item:" + itemType.FullName);
+            Weaver.DLog(td, "SyncListProcessor Start item:" + itemType.FullName);
 
             Weaver.ResetRecursionCount();
             MethodReference writeItemFunc = GenerateSerialization(td, itemType);
@@ -31,7 +31,7 @@ namespace Mirror.Weaver
             if (readItemFunc == null || writeItemFunc == null)
                 return;
 
-            Weaver.DLog(td, "SyncListStructProcessor Done");
+            Weaver.DLog(td, "SyncListProcessor Done");
         }
 
         // serialization of individual element
@@ -56,7 +56,7 @@ namespace Mirror.Weaver
 
             if (itemType.IsGenericInstance)
             {
-                Weaver.Error("GenerateSerialization for " + Helpers.PrettyPrintType(itemType) + " failed. Struct passed into SyncListStruct<T> can't have generic parameters");
+                Weaver.Error("GenerateSerialization for " + Helpers.PrettyPrintType(itemType) + " failed. Struct passed into SyncList<T> can't have generic parameters");
                 return null;
             }
 
@@ -70,13 +70,13 @@ namespace Mirror.Weaver
 
                 if (ft.HasGenericParameters)
                 {
-                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member cannot have generic parameters.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + ft + "/" + ft.FullName + "]. [SyncList] member cannot have generic parameters.");
                     return null;
                 }
 
                 if (ft.IsInterface)
                 {
-                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member cannot be an interface.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " [" + ft + "/" + ft.FullName + "]. [SyncList] member cannot be an interface.");
                     return null;
                 }
 
@@ -90,7 +90,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.Error("GenerateSerialization for " + td.Name + " unknown type [" + ft + "/" + ft.FullName + "]. [SyncListStruct] member variables must be basic types.");
+                    Weaver.Error("GenerateSerialization for " + td.Name + " unknown type [" + ft + "/" + ft.FullName + "]. [SyncList] member variables must be basic types.");
                     return null;
                 }
             }
@@ -144,7 +144,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.Error("GenerateDeserialization for " + td.Name + " unknown type [" + ft + "]. [SyncListStruct] member variables must be basic types.");
+                    Weaver.Error("GenerateDeserialization for " + td.Name + " unknown type [" + ft + "]. [SyncList] member variables must be basic types.");
                     return null;
                 }
             }

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncListProcessor.cs.meta
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncListProcessor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 93397916cae0248bc9294f863fa49f81
+guid: 4f3445268e45d437fac325837aff3246
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -63,7 +63,7 @@ namespace Mirror.Weaver
         public static TypeReference NetworkConnectionType;
 
         public static TypeReference MessageBaseType;
-        public static TypeReference SyncListStructType;
+        public static TypeReference SyncListType;
 
         public static MethodReference NetworkBehaviourDirtyBitsReference;
         public static TypeReference NetworkClientType;
@@ -1124,7 +1124,7 @@ namespace Mirror.Weaver
             NetworkConnectionType = CurrentAssembly.MainModule.ImportReference(NetworkConnectionType);
 
             MessageBaseType = NetAssembly.MainModule.GetType("Mirror.MessageBase");
-            SyncListStructType = NetAssembly.MainModule.GetType("Mirror.SyncListSTRUCT`1");
+            SyncListType = NetAssembly.MainModule.GetType("Mirror.SyncList`1");
 
             NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "syncVarDirtyBits");
 
@@ -1347,7 +1347,7 @@ namespace Mirror.Weaver
             return didWork;
         }
 
-        static bool CheckSyncListStruct(TypeDefinition td)
+        static bool CheckSyncList(TypeDefinition td)
         {
             if (!td.IsClass)
                 return false;
@@ -1358,9 +1358,9 @@ namespace Mirror.Weaver
             TypeReference parent = td.BaseType;
             while (parent != null)
             {
-                if (parent.FullName.StartsWith(SyncListStructType.FullName))
+                if (parent.FullName.StartsWith(SyncListType.FullName))
                 {
-                    SyncListStructProcessor.Process(td);
+                    SyncListProcessor.Process(td);
                     didWork = true;
                     break;
                 }
@@ -1379,7 +1379,7 @@ namespace Mirror.Weaver
             // check for embedded types
             foreach (TypeDefinition embedded in td.NestedTypes)
             {
-                didWork |= CheckSyncListStruct(embedded);
+                didWork |= CheckSyncList(embedded);
             }
 
             return didWork;
@@ -1414,7 +1414,7 @@ namespace Mirror.Weaver
                             {
                                 if (pass == 0)
                                 {
-                                    didWork |= CheckSyncListStruct(td);
+                                    didWork |= CheckSyncList(td);
                                 }
                                 else
                                 {

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -43,6 +43,7 @@ namespace Mirror
     // in Unity 2019.1.
     //
     // TODO rename back to SyncListStruct after 2019.1!
+    [Obsolete("Use SyncList<MyStruct> instead")]
     public class SyncListSTRUCT<T> : SyncList<T> where T : struct
     {
         protected override void SerializeItem(NetworkWriter writer, T item) {}
@@ -86,8 +87,8 @@ namespace Mirror
         // so we need to skip them
         int changesAhead = 0;
 
-        protected abstract void SerializeItem(NetworkWriter writer, T item);
-        protected abstract T DeserializeItem(NetworkReader reader);
+        protected virtual void SerializeItem(NetworkWriter writer, T item) { }
+        protected virtual T DeserializeItem(NetworkReader reader) => default(T);
 
         public bool IsDirty => Changes.Count > 0;
 

--- a/Assets/Mirror/Tests/WeaverTest.cs
+++ b/Assets/Mirror/Tests/WeaverTest.cs
@@ -278,7 +278,7 @@ namespace Mirror
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(m_weaverErrors.Count, Is.EqualTo(1));
-            Assert.That(m_weaverErrors[0], Does.Match("Struct passed into SyncListStruct<T> can't have generic parameters"));
+            Assert.That(m_weaverErrors[0], Does.Match("Struct passed into SyncList<T> can't have generic parameters"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/WeaverTests~/SyncListStructGenericGeneric.cs
+++ b/Assets/Mirror/Tests/WeaverTests~/SyncListStructGenericGeneric.cs
@@ -20,7 +20,7 @@ namespace MirrorTest
             MyGenericStruct<MyPODStruct> potato;
         }
 
-        class MyStructClass : SyncListSTRUCT<MyGenericStruct<float>> {};
+        class MyStructClass : SyncList<MyGenericStruct<float>> {};
 
         MyStructClass harpseals;
     }

--- a/Assets/Mirror/Tests/WeaverTests~/SyncListStructMemberBasicType.cs
+++ b/Assets/Mirror/Tests/WeaverTests~/SyncListStructMemberBasicType.cs
@@ -16,7 +16,7 @@ namespace MirrorTest
             public object nonbasicpotato;
         }
 
-        class MyStructClass : SyncListSTRUCT<MyStruct>
+        class MyStructClass : SyncList<MyStruct>
         {
             int potatoCount;
             public MyStructClass(int numberOfPotatoes)

--- a/Assets/Mirror/Tests/WeaverTests~/SyncListStructMemberGeneric.cs
+++ b/Assets/Mirror/Tests/WeaverTests~/SyncListStructMemberGeneric.cs
@@ -20,7 +20,7 @@ namespace MirrorTest
             public MyGenericStruct<float> potato;
         }
 
-        class MyStructClass : SyncListSTRUCT<MyStruct> {};
+        class MyStructClass : SyncList<MyStruct> {};
 
         MyStructClass harpseals;
     }

--- a/Assets/Mirror/Tests/WeaverTests~/SyncListStructMemberInterface.cs
+++ b/Assets/Mirror/Tests/WeaverTests~/SyncListStructMemberInterface.cs
@@ -15,7 +15,7 @@ namespace MirrorTest
             public IPotato potato;
         }
 
-        class MyStructClass : SyncListSTRUCT<MyStruct> {};
+        class MyStructClass : SyncList<MyStruct> {};
 
         MyStructClass harpseals;
     }

--- a/Assets/Mirror/Tests/WeaverTests~/SyncListStructValid.cs
+++ b/Assets/Mirror/Tests/WeaverTests~/SyncListStructValid.cs
@@ -11,7 +11,7 @@ namespace MirrorTest
             float floatingpotato;
             double givemetwopotatoes;
         }
-        class MyStructClass : SyncListSTRUCT<MyStruct> {};
+        class MyStructClass : SyncList<MyStruct> {};
         MyStructClass Foo;
     }
 }


### PR DESCRIPTION
Previously, if you wanted a synclist of structures,  you would do:  `SyncListSTRUCT<MyStruct>`
Now you can use `SyncList<MyStruct>`
SyncListSTRUCT is left there, but obsolete