### PR TITLE
feature: Add NoRotation to NetworkTransform

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -30,7 +30,7 @@ namespace Mirror
         //    but would cause errors immediately and be pretty obvious.
         [Tooltip("Compresses 16 Byte Quaternion into None=12, Much=3, Lots=2 Byte")]
         [SerializeField] Compression compressRotation = Compression.Much;
-        public enum Compression { None, Much, Lots }; // easily understandable and funny
+        public enum Compression { None, Much, Lots , NoRotation }; // easily understandable and funny
 
         // server
         Vector3 lastPosition;
@@ -312,7 +312,10 @@ namespace Mirror
         void ApplyPositionAndRotation(Vector3 position, Quaternion rotation)
         {
             targetComponent.transform.position = position;
-            targetComponent.transform.rotation = rotation;
+            if (Compression.NoRotation != compressRotation)
+            {
+                targetComponent.transform.rotation = rotation;
+            }
         }
 
         void Update()


### PR DESCRIPTION
This allows you to leave rotation out of the NetworkTransform if you only need position.

Right now if you don't need to sync rotation and you set compression to Lots, it can move your object in ways not expected. This forces you to use no compression as a fix. Using more bandwidth for something you don't need. I think this is all that is needed, tested it in my game and it works.