### PR TITLE
Add port number getter to transport

### DIFF
--- a/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -10,6 +10,7 @@ namespace Mirror
     public class LLAPITransport : Transport
     {
         public ushort port = 7777;
+        public override int PortNumber { get { return port; } }
 
         [Tooltip("Enable for WebGL games. Can only do either WebSockets or regular Sockets, not both (yet).")]
         public bool useWebsockets;

--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -8,6 +8,8 @@ namespace Mirror
     // a transport that can listen to multiple underlying transport at the same time
     public class MultiplexTransport : Transport
     {
+        public override int PortNumber { get { return transports.Length > 0 && transports[0] != null ? transports[0].PortNumber : 0; } }
+
         public Transport[] transports;
 
         public void Awake()

--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -6,6 +6,7 @@ namespace Mirror
     public class TelepathyTransport : Transport
     {
         public ushort port = 7777;
+        public override int PortNumber { get { return port; } }
 
         [Tooltip("Nagle Algorithm can be disabled by enabling NoDelay")]
         public bool NoDelay = true;

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -50,6 +50,8 @@ namespace Mirror
         public abstract bool ServerSend(int connectionId, int channelId, byte[] data);
         public abstract bool ServerDisconnect(int connectionId);
 
+        public abstract int PortNumber { get; }
+
         [Obsolete("Use ServerGetClientAddress(int connectionId) instead")]
         public virtual bool GetConnectionInfo(int connectionId, out string address)
         {

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -10,6 +10,7 @@ namespace Mirror.Websocket
         protected Server server = new Server();
 
         public int port = 7778;
+        public override int PortNumber { get { return port; } }
 
         [Tooltip("Nagle Algorithm can be disabled by enabling NoDelay")]
         public bool NoDelay = true;


### PR DESCRIPTION
I need current server port number for other services (web server, matchmaking, etc). I can't just cast current transport to `TelepathyTransport`, because transports can change. Don't know why was the port number removed from NetworkManager in the first place, when most of the transports use this variable.