### PR TITLE
refactor: Generic `IMessageBase` to allow struct message types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ bin/
 .idea/
 Mirror/packages
 .mfractor
-_ReSharper.Caches
 
 # Unity generated
 Library

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ bin/
 .idea/
 Mirror/packages
 .mfractor
+_ReSharper.Caches
 
 # Unity generated
 Library

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -19,7 +19,7 @@ namespace Mirror
         // avoid large amounts of allocations.
         static NetworkWriter packWriter = new NetworkWriter();
 
-        public static int GetId<T>() where T : MessageBase
+        public static int GetId<T>() where T : IMessageBase
         {
             // paul: 16 bits is enough to avoid collisions
             //  - keeps the message size small because it gets varinted
@@ -46,7 +46,7 @@ namespace Mirror
         }
 
         // pack message before sending
-        public static byte[] Pack<T>(T message) where T : MessageBase
+        public static byte[] Pack<T>(T message) where T : IMessageBase
         {
             // reset cached writer length and position
             packWriter.SetLength(0);
@@ -63,7 +63,7 @@ namespace Mirror
         }
 
         // unpack a message we received
-        public static T Unpack<T>(byte[] data) where T : MessageBase, new()
+        public static T Unpack<T>(byte[] data) where T : IMessageBase, new()
         {
             NetworkReader reader = new NetworkReader(data);
 

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -3,9 +3,15 @@ using UnityEngine;
 
 namespace Mirror
 {
-    // This can't be an interface because users don't need to implement the
-    // serialization functions, we'll code generate it for them when they omit it.
+    public interface IMessageBase
+    {
+        void Deserialize(NetworkReader reader);
+
+        void Serialize(NetworkWriter writer);
+    }
+
     public abstract class MessageBase
+        : IMessageBase
     {
         // De-serialize the contents of the reader into this message
         public virtual void Deserialize(NetworkReader reader) {}

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -10,8 +10,7 @@ namespace Mirror
         void Serialize(NetworkWriter writer);
     }
 
-    public abstract class MessageBase
-        : IMessageBase
+    public abstract class MessageBase : IMessageBase
     {
         // De-serialize the contents of the reader into this message
         public virtual void Deserialize(NetworkReader reader) {}

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -157,7 +157,7 @@ namespace Mirror
             return false;
         }
 
-        public bool Send<T>(T message) where T : MessageBase
+        public bool Send<T>(T message) where T : IMessageBase
         {
             if (connection != null)
             {
@@ -283,7 +283,7 @@ namespace Mirror
             RegisterHandler((int)msgType, handler);
         }
 
-        public void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T : MessageBase, new()
+        public void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T : IMessageBase, new()
         {
             int msgType = MessagePacker.GetId<T>();
             if (handlers.ContainsKey(msgType))
@@ -308,7 +308,7 @@ namespace Mirror
             UnregisterHandler((int)msgType);
         }
 
-        public void UnregisterHandler<T>() where T : MessageBase
+        public void UnregisterHandler<T>() where T : IMessageBase
         {
             // use int to minimize collisions
             int msgType = MessagePacker.GetId<T>();

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -134,7 +134,7 @@ namespace Mirror
             return SendBytes(message, channelId);
         }
 
-        public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T: MessageBase
+        public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T: IMessageBase
         {
             // pack message and send
             byte[] message = MessagePacker.Pack(msg);
@@ -143,7 +143,7 @@ namespace Mirror
 
         // internal because no one except Mirror should send bytes directly to
         // the client. they would be detected as a message. send messages instead.
-        internal virtual bool SendBytes( byte[] bytes, int channelId = Channels.DefaultReliable)
+        internal virtual bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend con:" + connectionId + " bytes:" + BitConverter.ToString(bytes));
 
@@ -219,7 +219,7 @@ namespace Mirror
             return false;
         }
 
-        public bool InvokeHandler<T>(T msg) where T : MessageBase
+        public bool InvokeHandler<T>(T msg) where T : IMessageBase
         {
             int msgType = MessagePacker.GetId<T>();
             byte[] data = MessagePacker.Pack(msg);

--- a/Assets/Mirror/Runtime/NetworkMessage.cs
+++ b/Assets/Mirror/Runtime/NetworkMessage.cs
@@ -6,14 +6,14 @@ namespace Mirror
         public NetworkConnection conn;
         public NetworkReader reader;
 
-        public TMsg ReadMessage<TMsg>() where TMsg : MessageBase, new()
+        public TMsg ReadMessage<TMsg>() where TMsg : IMessageBase, new()
         {
             TMsg msg = new TMsg();
             msg.Deserialize(reader);
             return msg;
         }
 
-        public void ReadMessage<TMsg>(TMsg msg) where TMsg : MessageBase
+        public void ReadMessage<TMsg>(TMsg msg) where TMsg : IMessageBase
         {
             msg.Deserialize(reader);
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -189,7 +189,7 @@ namespace Mirror
 
         // this is like SendToReady - but it doesn't check the ready flag on the connection.
         // this is used for ObjectDestroy messages.
-        static bool SendToObservers<T>(NetworkIdentity identity, T msg) where T: MessageBase
+        static bool SendToObservers<T>(NetworkIdentity identity, T msg) where T: IMessageBase
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToObservers id:" + typeof(T));
 
@@ -225,7 +225,7 @@ namespace Mirror
             return result;
         }
 
-        public static bool SendToAll<T>(T msg, int channelId = Channels.DefaultReliable) where T : MessageBase
+        public static bool SendToAll<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToAll id:" + typeof(T));
 
@@ -264,7 +264,7 @@ namespace Mirror
             return false;
         }
 
-        public static bool SendToReady<T>(NetworkIdentity identity,T msg, int channelId = Channels.DefaultReliable) where T: MessageBase
+        public static bool SendToReady<T>(NetworkIdentity identity,T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + typeof(T));
 
@@ -494,7 +494,7 @@ namespace Mirror
             RegisterHandler((int)msgType, handler);
         }
 
-        public static void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T: MessageBase, new()
+        public static void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T: IMessageBase, new()
         {
             int msgType = MessagePacker.GetId<T>();
             if (handlers.ContainsKey(msgType))
@@ -520,7 +520,7 @@ namespace Mirror
             UnregisterHandler((int)msgType);
         }
 
-        public static void UnregisterHandler<T>() where T:MessageBase
+        public static void UnregisterHandler<T>() where T : IMessageBase
         {
             int msgType = MessagePacker.GetId<T>();
             handlers.Remove(msgType);
@@ -542,7 +542,7 @@ namespace Mirror
             Debug.LogError("Failed to send message to connection ID '" + connectionId + ", not found in connection list");
         }
 
-        public static void SendToClient<T>(int connectionId, T msg) where T : MessageBase
+        public static void SendToClient<T>(int connectionId, T msg) where T : IMessageBase
         {
             NetworkConnection conn;
             if (connections.TryGetValue(connectionId, out conn))
@@ -568,7 +568,7 @@ namespace Mirror
         }
 
         // send this message to the player only
-        public static void SendToClientOfPlayer<T>(NetworkIdentity identity, T msg) where T: MessageBase
+        public static void SendToClientOfPlayer<T>(NetworkIdentity identity, T msg) where T: IMessageBase
         {
             if (identity != null)
             {

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -331,7 +331,7 @@ namespace Mirror
             }
         }
 
-        public void Write(MessageBase msg)
+        public void Write<T>(T msg) where T : IMessageBase
         {
             msg.Serialize(this);
         }

--- a/Assets/Mirror/Tests/MessageBaseTests.cs
+++ b/Assets/Mirror/Tests/MessageBaseTests.cs
@@ -39,10 +39,10 @@ namespace Mirror
             NetworkWriter w = new NetworkWriter();
             w.Write(new TestMessage(1, "2", 3.3));
 
-            var arr = w.ToArray();
+            byte[] arr = w.ToArray();
 
-            var r = new NetworkReader(arr);
-            var t = new TestMessage();
+            NetworkReader r = new NetworkReader(arr);
+            TestMessage t = new TestMessage();
             t.Deserialize(r);
 
             Assert.AreEqual(1, t.IntValue);

--- a/Assets/Mirror/Tests/MessageBaseTests.cs
+++ b/Assets/Mirror/Tests/MessageBaseTests.cs
@@ -36,7 +36,7 @@ namespace Mirror
         [Test]
         public void Roundtrip()
         {
-            var w = new NetworkWriter();
+            NetworkWriter w = new NetworkWriter();
             w.Write(new TestMessage(1, "2", 3.3));
 
             var arr = w.ToArray();

--- a/Assets/Mirror/Tests/MessageBaseTests.cs
+++ b/Assets/Mirror/Tests/MessageBaseTests.cs
@@ -1,0 +1,52 @@
+using NUnit.Framework;
+
+namespace Mirror
+{
+    struct TestMessage
+        : IMessageBase
+    {
+        public int I;
+        public string S;
+        public double D;
+
+        public TestMessage(int i, string s, double d)
+        {
+            I = i;
+            S = s;
+            D = d;
+        }
+
+        public void Deserialize(NetworkReader reader)
+        {
+            I = reader.ReadInt32();
+            S = reader.ReadString();
+            D = reader.ReadDouble();
+        }
+
+        public void Serialize(NetworkWriter writer)
+        {
+            writer.Write(I);
+            writer.Write(S);
+            writer.Write(D);
+        }
+    }
+
+    [TestFixture]
+    public class MessageBaseTests
+    {
+        [Test]
+        public void Roundtrip()
+        {
+            var w = new NetworkWriter();
+            w.Write(new TestMessage(1, "2", 3.3));
+
+            var arr = w.ToArray();
+
+            var r = new NetworkReader(arr);
+            var t = new TestMessage();
+            t.Deserialize(r);
+
+            Assert.AreEqual(1, t.I);
+        }
+    }
+}

--- a/Assets/Mirror/Tests/MessageBaseTests.cs
+++ b/Assets/Mirror/Tests/MessageBaseTests.cs
@@ -2,32 +2,31 @@ using NUnit.Framework;
 
 namespace Mirror
 {
-    struct TestMessage
-        : IMessageBase
+    struct TestMessage : IMessageBase
     {
-        public int I;
-        public string S;
-        public double D;
+        public int IntValue;
+        public string StringValue;
+        public double DoubleValue;
 
         public TestMessage(int i, string s, double d)
         {
-            I = i;
-            S = s;
-            D = d;
+            IntValue = i;
+            StringValue = s;
+            DoubleValue = d;
         }
 
         public void Deserialize(NetworkReader reader)
         {
-            I = reader.ReadInt32();
-            S = reader.ReadString();
-            D = reader.ReadDouble();
+            IntValue = reader.ReadInt32();
+            StringValue = reader.ReadString();
+            DoubleValue = reader.ReadDouble();
         }
 
         public void Serialize(NetworkWriter writer)
         {
-            writer.Write(I);
-            writer.Write(S);
-            writer.Write(D);
+            writer.Write(IntValue);
+            writer.Write(StringValue);
+            writer.Write(DoubleValue);
         }
     }
 
@@ -46,7 +45,7 @@ namespace Mirror
             var t = new TestMessage();
             t.Deserialize(r);
 
-            Assert.AreEqual(1, t.I);
+            Assert.AreEqual(1, t.IntValue);
         }
     }
 }

--- a/Assets/Mirror/Tests/MessageBaseTests.cs.meta
+++ b/Assets/Mirror/Tests/MessageBaseTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ecf93fcf0386fee4e85f981d5ca9259d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
 - Added a `IMessageBase` as an interface to `MessageBase`. Existing messages which inherit `MessageBase` (including ones which do not implement Serialize/Deserialize and rely on the weaver) will continue to work in exactly the same way as before.
 - Modified any methods which were generic `T where T : MessageBase` to be `T where T : IMessageBase`. This does not change things at all for all existing usages of the methods.

These changes allow messages to be structs instead of classes. This itself does not make any improvements to performance, but allows a much more efficient use of the API (currently anyone sending a message is forced into allocating). As discussed with @paulpach on Discord, this is a necessary step in his ongoing efforts to replace all Mirror built in messages with structs, which should improve performance.

A concrete example of how this can improve things is how Dissonance sends messages:

```
NetworkManager.singleton.client.connection.Send(TypeCode, new DissonanceMessage(packet), channel);

class DissonanceMessage
    : MessageBase
{
     // ...
}
```

That `DissonanceMessage` allocation is unecessary and after this PR can be replaced with a struct for one less allocation per packet (that's 50 allocations a second in this example).

