### PR TITLE
feature(synclist): allow SyncList of primitive types

### DIFF
--- a/Assets/Mirror/Tests/WeaverTest.cs
+++ b/Assets/Mirror/Tests/WeaverTest.cs
@@ -263,6 +263,13 @@ namespace Mirror
             Assert.That(m_weaverErrors.Count, Is.EqualTo(1));
             Assert.That(m_weaverErrors[0], Does.Match("Missing parameter-less constructor"));
         }
+
+        [Test]
+        public void SyncListByteValid() {
+            Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
+            Assert.That(m_weaverErrors.Count, Is.EqualTo(0));
+        }
+        
         #endregion
 
         #region SyncListStruct tests

--- a/Assets/Mirror/Tests/WeaverTest.cs
+++ b/Assets/Mirror/Tests/WeaverTest.cs
@@ -292,25 +292,25 @@ namespace Mirror
         public void SyncListStructMemberGeneric()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(m_weaverErrors.Count, Is.EqualTo(1));
-            Assert.That(m_weaverErrors[0], Does.Match("member cannot have generic parameters"));
+            Assert.That(m_weaverErrors.Count, Is.EqualTo(2));
+            Assert.That(m_weaverErrors[0], Is.EqualTo("Mirror.Weaver error: WriteReadFunc for potato [MirrorTest.MirrorTestPlayer/MyGenericStruct`1<System.Single>/MirrorTest.MirrorTestPlayer/MyGenericStruct`1<System.Single>]. Cannot have generic parameters."));
         }
 
         [Test]
         public void SyncListStructMemberInterface()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(m_weaverErrors.Count, Is.EqualTo(1));
-            Assert.That(m_weaverErrors[0], Does.Match("member cannot be an interface"));
+            Assert.That(m_weaverErrors.Count, Is.EqualTo(2));
+            Assert.That(m_weaverErrors[0], Is.EqualTo( "Mirror.Weaver error: WriteReadFunc for potato [MirrorTest.MirrorTestPlayer/IPotato/MirrorTest.MirrorTestPlayer/IPotato]. Cannot be an interface."));
         }
 
         [Test]
         public void SyncListStructMemberBasicType()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(m_weaverErrors.Count, Is.EqualTo(2));
+            Assert.That(m_weaverErrors.Count, Is.EqualTo(3));
             Assert.That(m_weaverErrors[0], Does.Match("please make sure to use a valid type"));
-            Assert.That(m_weaverErrors[1], Does.Match("member variables must be basic types"));
+            Assert.That(m_weaverErrors[1], Does.Match("Mirror.Weaver error: WriteReadFunc for nonbasicpotato type System.Object no supported"));
         }
         #endregion
 


### PR DESCRIPTION
As it turns out this never really worked:
```cs
class SyncListByte : SyncList<byte> {};
```

You had to write your own serializeItem / deserialize item for native types.

This change lifts the restriction, now you can use a synclist of anything that mirror can serialize/deserialize