### PR TITLE
fix: #609 by spawning observers in NetworkServer.AddPlayerForConnection after setting the controller. There is no point in trying to spawn with a null controller in SetReady, because by definition no one can observe something that is null.

### DIFF
--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -59,11 +59,7 @@ namespace Mirror
             if (forceHidden)
                 return false;
 
-            if (newObserver.playerController != null)
-            {
-                return Vector3.Distance(newObserver.playerController.transform.position, transform.position) < visRange;
-            }
-            return false;
+            return Vector3.Distance(newObserver.playerController.transform.position, transform.position) < visRange;
         }
 
         public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initial)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -684,6 +684,11 @@ namespace Mirror
             // set ready if not set yet
             SetClientReady(conn);
 
+            // add connection to observers AFTER the playerController was set.
+            // by definition, there is nothing to observe if there is no player
+            // controller.
+            SpawnObserversForConnection(conn);
+
             if (SetupLocalPlayerForConnection(conn, identity))
             {
                 return true;
@@ -805,24 +810,8 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("SetClientReadyInternal for conn:" + conn.connectionId);
 
-            // do nothing if ready was set before
-            if (conn.isReady)
-            {
-                if (LogFilter.Debug) Debug.Log("SetClientReady conn " + conn.connectionId + " already ready");
-                return;
-            }
-
             // set ready
             conn.isReady = true;
-
-            if (conn.playerController == null)
-            {
-                // this is now allowed
-                if (LogFilter.Debug) Debug.LogWarning("Ready with no player object");
-            }
-
-            // spawn observers for this connection
-            SpawnObserversForConnection(conn);
         }
 
         internal static void ShowForConnection(NetworkIdentity identity, NetworkConnection conn)


### PR DESCRIPTION
available for review before I merge.
fixes mrgadget's bug.
testing in my assets now.
