### PR TITLE
refactor: configure frame rate in a virtual method

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -210,13 +210,8 @@ namespace Mirror
             NetworkServer.RegisterHandler<ErrorMessage>(OnServerErrorInternal);
         }
 
-        public bool StartServer()
+        public virtual void ConfigureServerFramerate()
         {
-            InitializeSingleton();
-
-            if (runInBackground)
-                Application.runInBackground = true;
-
             // set a fixed tick rate instead of updating as often as possible
             // * if not in Editor (it doesn't work in the Editor)
             // * if not in Host mode
@@ -227,6 +222,16 @@ namespace Mirror
                 Debug.Log("Server Tick Rate set to: " + Application.targetFrameRate + " Hz.");
             }
 #endif
+        }
+
+        public bool StartServer()
+        {
+            InitializeSingleton();
+
+            if (runInBackground)
+                Application.runInBackground = true;
+
+            ConfigureServerFramerate();
 
             if (!NetworkServer.Listen(maxConnections))
             {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -210,7 +210,7 @@ namespace Mirror
             NetworkServer.RegisterHandler<ErrorMessage>(OnServerErrorInternal);
         }
 
-        public virtual void ConfigureServerFramerate()
+        public virtual void ConfigureServerFrameRate()
         {
             // set a fixed tick rate instead of updating as often as possible
             // * if not in Editor (it doesn't work in the Editor)
@@ -231,7 +231,7 @@ namespace Mirror
             if (runInBackground)
                 Application.runInBackground = true;
 
-            ConfigureServerFramerate();
+            ConfigureServerFrameRate();
 
             if (!NetworkServer.Listen(maxConnections))
             {


### PR DESCRIPTION
Fixes #567 

If you want to do your own logic for the target frame rate,  override the "ConfigureServerFramerate" in your network manager class.  for example:

```cs
class MyNetworkManager : NetworkManager 
{
    public override void ConfigureServerFrameRate()
    {
         // configure the frame rate however you want
    }
}
```