### PR TITLE
Removed duplicated address storage.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -27,7 +27,8 @@ namespace Mirror
 
         internal static ConnectState connectState = ConnectState.None;
 
-        public static string serverIp { get; internal set; } = "";
+        [Obsolete("Use NetworkClient.connection.address instead.")]
+        public static string serverIp => connection.address;
 
         // active is true while a client is connecting/connected
         // (= while the network is active)
@@ -49,22 +50,20 @@ namespace Mirror
         }
 
         // connect remote
-        public static void Connect(string ip)
+        public static void Connect(string address)
         {
-            if (LogFilter.Debug) Debug.Log("Client Connect: " + ip);
+            if (LogFilter.Debug) Debug.Log("Client Connect: " + address);
 
             active = true;
             RegisterSystemHandlers(false);
             Transport.activeTransport.enabled = true;
             InitializeTransportHandlers();
 
-            serverIp = ip;
-
             connectState = ConnectState.Connecting;
-            Transport.activeTransport.ClientConnect(ip);
+            Transport.activeTransport.ClientConnect(address);
 
             // setup all the handlers
-            connection = new NetworkConnection(serverIp, 0);
+            connection = new NetworkConnection(address, 0);
             connection.SetHandlers(handlers);
         }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -27,7 +27,6 @@ namespace Mirror
 
         internal static ConnectState connectState = ConnectState.None;
 
-        [Obsolete("Use NetworkClient.connection.address instead.")]
         public static string serverIp => connection.address;
 
         // active is true while a client is connecting/connected


### PR DESCRIPTION
Unnecessary duplicated storage of the address in NetworkClient.

Arguably, addresses *could* be removed entirely from Mirror and left to the transports. They aren't actually used except for 1. logging, and 2. exposing to users. Look at NetworkConnection.address.