### PR TITLE
Remove unused method.

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -25,21 +25,6 @@ namespace Mirror
         internal static Dictionary<Guid, SpawnDelegate> spawnHandlers = new Dictionary<Guid, SpawnDelegate>();
         internal static Dictionary<Guid, UnSpawnDelegate> unspawnHandlers = new Dictionary<Guid, UnSpawnDelegate>();
 
-        // this is never called, and if we do call it in NetworkClient.Shutdown
-        // then the client's player object won't be removed after disconnecting!
-        internal static void Shutdown()
-        {
-            NetworkIdentity.spawned.Clear();
-            ClearSpawners();
-            pendingOwnerNetIds.Clear();
-            spawnableObjects = null;
-            readyConnection = null;
-            ready = false;
-            isSpawnFinished = false;
-
-            Transport.activeTransport.ClientDisconnect();
-        }
-
         // this is called from message handler for Owner message
         internal static void InternalAddPlayer(NetworkIdentity identity)
         {


### PR DESCRIPTION
The comments themselves say this isn't used, and they are correct. It is not used, and it is internal, no obsoletion needed.