### PR TITLE
Moved Obsoletes to Single File

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -7,7 +7,7 @@ using Object = UnityEngine.Object;
 
 namespace Mirror
 {
-    public static class ClientScene
+    public static partial class ClientScene
     {
         static bool isSpawnFinished;
 
@@ -320,16 +320,6 @@ namespace Mirror
                 }
             }
             NetworkIdentity.spawned.Clear();
-        }
-
-        [Obsolete("Use NetworkIdentity.spawned[netId] instead.")]
-        public static GameObject FindLocalObject(uint netId)
-        {
-            if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
-            {
-                return identity.gameObject;
-            }
-            return null;
         }
 
         static void ApplySpawnPayload(NetworkIdentity identity, Vector3 position, Quaternion rotation, Vector3 scale, byte[] payload, uint netId)

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -3,13 +3,6 @@ using UnityEngine;
 
 namespace Mirror
 {
-    [Obsolete("Use NetworkBehaviour.syncInterval field instead. Can be modified in the Inspector too.")]
-    [AttributeUsage(AttributeTargets.Class)]
-    public class NetworkSettingsAttribute : Attribute
-    {
-        public float sendInterval = 0.1f;
-    }
-
     [AttributeUsage(AttributeTargets.Field)]
     public class SyncVarAttribute : Attribute
     {

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -13,7 +13,7 @@ namespace Mirror
     //    using 2 bytes for shorts.
     // -> this reduces bandwidth by 10% if average message size is 20 bytes
     //    (probably even shorter)
-    public static class MessagePacker
+    public static partial class MessagePacker
     {
         // PackMessage is in hot path. caching the writer is really worth it to
         // avoid large amounts of allocations.
@@ -25,24 +25,6 @@ namespace Mirror
             //  - keeps the message size small because it gets varinted
             //  - in case of collisions,  Mirror will display an error
             return typeof(T).FullName.GetStableHashCode() & 0xFFFF;
-        }
-
-        // pack message before sending
-        // -> pass writer instead of byte[] so we can reuse it
-        [Obsolete("Use Pack<T> instead")]
-        public static byte[] PackMessage(int msgType, MessageBase msg)
-        {
-            // reset cached writer length and position
-            packWriter.SetLength(0);
-
-            // write message type
-            packWriter.Write((short)msgType);
-
-            // serialize message into writer
-            msg.Serialize(packWriter);
-
-            // return byte[]
-            return packWriter.ToArray();
         }
 
         // pack message before sending

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -13,14 +13,8 @@ namespace Mirror
     }
 
     // TODO make fully static after removing obsoleted singleton!
-    public class NetworkClient
+    public partial class NetworkClient
     {
-        [Obsolete("Use NetworkClient directly. Singleton isn't needed anymore, all functions are static now. For example: NetworkClient.Send(message) instead of NetworkClient.singleton.Send(message).")]
-        public static NetworkClient singleton = new NetworkClient();
-
-        [Obsolete("Use NetworkClient directly instead. There is always exactly one client.")]
-        public static List<NetworkClient> allClients => new List<NetworkClient>{singleton};
-
         public static readonly Dictionary<int, NetworkMessageDelegate> handlers = new Dictionary<int, NetworkMessageDelegate>();
 
         public static NetworkConnection connection { get; internal set; }
@@ -187,22 +181,6 @@ namespace Mirror
             Transport.activeTransport.OnClientError.RemoveListener(OnError);
         }
 
-        [Obsolete("Use SendMessage<T> instead with no message id instead")]
-        public static bool Send(short msgType, MessageBase msg)
-        {
-            if (connection != null)
-            {
-                if (connectState != ConnectState.Connected)
-                {
-                    Debug.LogError("NetworkClient Send when not connected to a server");
-                    return false;
-                }
-                return connection.Send(msgType, msg);
-            }
-            Debug.LogError("NetworkClient Send with no connection");
-            return false;
-        }
-
         public static bool Send<T>(T message) where T : IMessageBase
         {
             if (connection != null)
@@ -286,12 +264,6 @@ namespace Mirror
         }
         */
 
-        [Obsolete("Use NetworkTime.rtt instead")]
-        public static float GetRTT()
-        {
-            return (float)NetworkTime.rtt;
-        }
-
         internal static void RegisterSystemHandlers(bool localClient)
         {
             // local client / regular client react to some messages differently.
@@ -326,22 +298,6 @@ namespace Mirror
             RegisterHandler<SyncEventMessage>(ClientScene.OnSyncEventMessage);
         }
 
-        [Obsolete("Use RegisterHandler<T> instead")]
-        public static void RegisterHandler(int msgType, NetworkMessageDelegate handler)
-        {
-            if (handlers.ContainsKey(msgType))
-            {
-                if (LogFilter.Debug) Debug.Log("NetworkClient.RegisterHandler replacing " + handler.ToString() + " - " + msgType);
-            }
-            handlers[msgType] = handler;
-        }
-
-        [Obsolete("Use RegisterHandler<T> instead")]
-        public static void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
-        {
-            RegisterHandler((int)msgType, handler);
-        }
-
         public static void RegisterHandler<T>(Action<NetworkConnection, T> handler) where T : IMessageBase, new()
         {
             int msgType = MessagePacker.GetId<T>();
@@ -355,18 +311,6 @@ namespace Mirror
             };
         }
 
-        [Obsolete("Use UnregisterHandler<T> instead")]
-        public static void UnregisterHandler(int msgType)
-        {
-            handlers.Remove(msgType);
-        }
-
-        [Obsolete("Use UnregisterHandler<T> instead")]
-        public static void UnregisterHandler(MsgType msgType)
-        {
-            UnregisterHandler((int)msgType);
-        }
-
         public static void UnregisterHandler<T>() where T : IMessageBase
         {
             // use int to minimize collisions
@@ -378,12 +322,6 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("Shutting down client.");
             active = false;
-        }
-
-        [Obsolete("Call NetworkClient.Shutdown() instead. There is only one client.")]
-        public static void ShutdownAll()
-        {
-            Shutdown();
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Mirror
 {
-    public class NetworkConnection : IDisposable
+    public partial class NetworkConnection : IDisposable
     {
         public HashSet<NetworkIdentity> visList = new HashSet<NetworkIdentity>();
 
@@ -17,16 +17,6 @@ namespace Mirror
         public NetworkIdentity playerController { get; internal set; }
         public HashSet<uint> clientOwnedObjects;
         public bool logNetworkMessages;
-
-        // this is always true for regular connections, false for local
-        // connections because it's set in the constructor and never reset.
-        [Obsolete("isConnected will be removed because it's pointless. A NetworkConnection is always connected.")]
-        public bool isConnected { get; protected set; }
-
-        // this is always 0 for regular connections, -1 for local
-        // connections because it's set in the constructor and never reset.
-        [Obsolete("hostId will be removed because it's not needed ever since we removed LLAPI as default. It's always 0 for regular connections and -1 for local connections. Use connection.GetType() == typeof(NetworkConnection) to check if it's a regular or local connection.")]
-        public int hostId = -1;
 
         public NetworkConnection(string networkAddress)
         {
@@ -113,14 +103,6 @@ namespace Mirror
         public void UnregisterHandler(short msgType)
         {
             m_MessageHandlers.Remove(msgType);
-        }
-
-        [Obsolete("use Send<T> instead")]
-        public virtual bool Send(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
-        {
-            // pack message and send
-            byte[] message = MessagePacker.PackMessage(msgType, msg);
-            return SendBytes(message, channelId);
         }
 
         public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T: IMessageBase

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -16,7 +16,7 @@ namespace Mirror
 
     [AddComponentMenu("Network/NetworkManager")]
     [HelpURL("https://vis2k.github.io/Mirror/Components/NetworkManager")]
-    public class NetworkManager : MonoBehaviour
+    public partial class NetworkManager : MonoBehaviour
     {
 
         // configuration
@@ -61,8 +61,6 @@ namespace Mirror
         public static string networkSceneName = "";
         [NonSerialized]
         public bool isNetworkActive;
-        [Obsolete("Use NetworkClient directly, it will be made static soon. For example, use NetworkClient.Send(message) instead of NetworkManager.client.Send(message)")]
-        public NetworkClient client => NetworkClient.singleton;
         static int s_StartPositionIndex;
 
         public static NetworkManager singleton;
@@ -527,11 +525,6 @@ namespace Mirror
             startPositions.Remove(start);
         }
 
-        [Obsolete("Use NetworkClient.isConnected instead")]
-        public bool IsClientConnected()
-        {
-            return NetworkClient.isConnected;
-        }
         // this is the only way to clear the singleton, so another instance can be created.
         public static void Shutdown()
         {
@@ -662,18 +655,6 @@ namespace Mirror
             NetworkServer.SetClientReady(conn);
         }
 
-        [Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
-        public virtual void OnServerAddPlayer(NetworkConnection conn, NetworkMessage extraMessage)
-        {
-            OnServerAddPlayer(conn, null);
-        }
-
-        [Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
-        public virtual void OnServerAddPlayer(NetworkConnection conn)
-        {
-            OnServerAddPlayer(conn, null);
-        }
-
         public virtual void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerAddPlayer");
@@ -793,8 +774,6 @@ namespace Mirror
 
         public virtual void OnStartHost() {}
         public virtual void OnStartServer() {}
-        [Obsolete("Use OnStartClient() instead of OnStartClient(NetworkClient client). All NetworkClient functions are static now, so you can use NetworkClient.Send(message) instead of client.Send(message) directly now.")]
-        public virtual void OnStartClient(NetworkClient client) {}
         public virtual void OnStartClient() {}
         public virtual void OnStopServer() {}
         public virtual void OnStopClient() {}

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -774,7 +774,13 @@ namespace Mirror
 
         public virtual void OnStartHost() {}
         public virtual void OnStartServer() {}
-        public virtual void OnStartClient() {}
+        public virtual void OnStartClient()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            OnStartClient(NetworkClient.singleton);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+        
         public virtual void OnStopServer() {}
         public virtual void OnStopClient() {}
         public virtual void OnStopHost() {}

--- a/Assets/Mirror/Runtime/Obsolete.cs
+++ b/Assets/Mirror/Runtime/Obsolete.cs
@@ -1,0 +1,384 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using UnityEngine;
+
+/// <summary>
+/// This file contains all classes with deprecated methods and properties.
+/// We created this as a convenient reference, and to make it easier for users
+/// migrating from UNet to Mirror.  This is the only file that is packed with
+/// multiple classes, otherwise we follow the practice of one class per file in
+/// the project.
+/// 
+/// In many cases the methods here are written to directly call their replacements
+/// so you likley can copy that code to your own project to clear the obsolete warnings.
+/// 
+/// Those wishing to submit a PR that would obsolete something in a core class must move
+/// the obsoleted property or method to this file with appropriate comments and include
+/// the changes here with the PR.
+/// </summary>
+namespace Mirror
+{
+    // built-in system network messages
+    // original HLAPI uses short, so let's keep short to not break packet header etc.
+    // => use .ToString() to get the field name from the field value
+    // => we specify the short values so it's easier to look up opcodes when debugging packets
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use Send<T>  with no message id instead")]
+    public enum MsgType : short
+    {
+        // internal system messages - cannot be replaced by user code
+        ObjectDestroy = 1,
+        Rpc = 2,
+        Owner = 4,
+        Command = 5,
+        SyncEvent = 7,
+        UpdateVars = 8,
+        SpawnPrefab = 3,
+        SpawnSceneObject = 10,
+        SpawnStarted = 11,
+        SpawnFinished = 12,
+        ObjectHide = 13,
+        LocalClientAuthority = 15,
+
+        // public system messages - can be replaced by user code
+        Connect = 32,
+        Disconnect = 33,
+        Error = 34,
+        Ready = 35,
+        NotReady = 36,
+        AddPlayer = 37,
+        RemovePlayer = 38,
+        Scene = 39,
+
+        // time synchronization
+        Ping = 43,
+        Pong = 44,
+
+        Highest = 47
+    }
+
+    public static partial class ClientScene
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use NetworkIdentity.spawned[netId] instead.")]
+        public static GameObject FindLocalObject(uint netId)
+        {
+            if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
+            {
+                return identity.gameObject;
+            }
+            return null;
+        }
+    }
+
+    public static partial class MessagePacker
+    {
+        // pack message before sending
+        // -> pass writer instead of byte[] so we can reuse it
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use Pack<T> instead")]
+        public static byte[] PackMessage(int msgType, MessageBase msg)
+        {
+            // reset cached writer length and position
+            packWriter.SetLength(0);
+
+            // write message type
+            packWriter.Write((short)msgType);
+
+            // serialize message into writer
+            msg.Serialize(packWriter);
+
+            // return byte[]
+            return packWriter.ToArray();
+        }
+    }
+
+    public partial class NetworkClient
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use NetworkClient directly. Singleton isn't needed anymore, all functions are static now. For example: NetworkClient.Send(message) instead of NetworkClient.singleton.Send(message).")]
+        public static NetworkClient singleton = new NetworkClient();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use NetworkClient directly instead. There is always exactly one client.")]
+        public static List<NetworkClient> allClients => new List<NetworkClient> { singleton };
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use SendMessage<T> instead with no message id instead")]
+        public static bool Send(short msgType, MessageBase msg)
+        {
+            if (connection != null)
+            {
+                if (connectState != ConnectState.Connected)
+                {
+                    Debug.LogError("NetworkClient Send when not connected to a server");
+                    return false;
+                }
+                return connection.Send(msgType, msg);
+            }
+            Debug.LogError("NetworkClient Send with no connection");
+            return false;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use NetworkTime.rtt instead")]
+        public static float GetRTT()
+        {
+            return (float)NetworkTime.rtt;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use RegisterHandler<T> instead")]
+        public static void RegisterHandler(int msgType, NetworkMessageDelegate handler)
+        {
+            if (handlers.ContainsKey(msgType))
+            {
+                if (LogFilter.Debug) Debug.Log("NetworkClient.RegisterHandler replacing " + handler.ToString() + " - " + msgType);
+            }
+            handlers[msgType] = handler;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use RegisterHandler<T> instead")]
+        public static void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
+        {
+            RegisterHandler((int)msgType, handler);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use UnregisterHandler<T> instead")]
+        public static void UnregisterHandler(int msgType)
+        {
+            handlers.Remove(msgType);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use UnregisterHandler<T> instead")]
+        public static void UnregisterHandler(MsgType msgType)
+        {
+            UnregisterHandler((int)msgType);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Call NetworkClient.Shutdown() instead. There is only one client.")]
+        public static void ShutdownAll()
+        {
+            Shutdown();
+        }
+    }
+
+    public partial class NetworkConnection
+    {
+        // this is always true for regular connections, false for local
+        // connections because it's set in the constructor and never reset.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("isConnected will be removed because it's pointless. A NetworkConnection is always connected.")]
+        public bool isConnected { get; protected set; }
+
+        // this is always 0 for regular connections, -1 for local
+        // connections because it's set in the constructor and never reset.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("hostId will be removed because it's not needed ever since we removed LLAPI as default. It's always 0 for regular connections and -1 for local connections. Use connection.GetType() == typeof(NetworkConnection) to check if it's a regular or local connection.")]
+        public int hostId = -1;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("use Send<T> instead")]
+        public virtual bool Send(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        {
+            // pack message and send
+            byte[] message = MessagePacker.PackMessage(msgType, msg);
+            return SendBytes(message, channelId);
+        }
+    }
+
+    public partial class NetworkManager
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use NetworkClient directly, it will be made static soon. For example, use NetworkClient.Send(message) instead of NetworkManager.client.Send(message)")]
+        public NetworkClient client => NetworkClient.singleton;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use NetworkClient.isConnected instead")]
+        public bool IsClientConnected()
+        {
+            return NetworkClient.isConnected;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
+        public virtual void OnServerAddPlayer(NetworkConnection conn, NetworkMessage extraMessage)
+        {
+            OnServerAddPlayer(conn, null);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
+        public virtual void OnServerAddPlayer(NetworkConnection conn)
+        {
+            OnServerAddPlayer(conn, null);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use OnStartClient() instead of OnStartClient(NetworkClient client). All NetworkClient functions are static now, so you can use NetworkClient.Send(message) instead of client.Send(message) directly now.")]
+        public virtual void OnStartClient(NetworkClient client) { }
+    }
+
+    public static partial class NetworkServer
+    {
+        // this is like SendToReady - but it doesn't check the ready flag on the connection.
+        // this is used for ObjectDestroy messages.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("use SendToObservers<T> instead")]
+        static bool SendToObservers(NetworkIdentity identity, short msgType, MessageBase msg)
+        {
+            if (LogFilter.Debug) Debug.Log("Server.SendToObservers id:" + msgType);
+
+            if (identity != null && identity.observers != null)
+            {
+                // pack message into byte[] once
+                byte[] bytes = MessagePacker.PackMessage((ushort)msgType, msg);
+
+                // send to all observers
+                bool result = true;
+                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                {
+                    result &= kvp.Value.SendBytes(bytes);
+                }
+                return result;
+            }
+            return false;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use SendToAll<T> instead")]
+        public static bool SendToAll(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        {
+            if (LogFilter.Debug) Debug.Log("Server.SendToAll id:" + msgType);
+
+            // pack message into byte[] once
+            byte[] bytes = MessagePacker.PackMessage((ushort)msgType, msg);
+
+            // send to all
+            bool result = true;
+            foreach (KeyValuePair<int, NetworkConnection> kvp in connections)
+            {
+                result &= kvp.Value.SendBytes(bytes, channelId);
+            }
+            return result;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use SendToReady<T> instead")]
+        public static bool SendToReady(NetworkIdentity identity, short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
+        {
+            if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + msgType);
+
+            if (identity != null && identity.observers != null)
+            {
+                // pack message into byte[] once
+                byte[] bytes = MessagePacker.PackMessage((ushort)msgType, msg);
+
+                // send to all ready observers
+                bool result = true;
+                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                {
+                    if (kvp.Value.isReady)
+                    {
+                        result &= kvp.Value.SendBytes(bytes, channelId);
+                    }
+                }
+                return result;
+            }
+            return false;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use RegisterHandler<T> instead")]
+        public static void RegisterHandler(int msgType, NetworkMessageDelegate handler)
+        {
+            if (handlers.ContainsKey(msgType))
+            {
+                if (LogFilter.Debug) Debug.Log("NetworkServer.RegisterHandler replacing " + msgType);
+            }
+            handlers[msgType] = handler;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use RegisterHandler<T> instead")]
+        public static void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
+        {
+            RegisterHandler((int)msgType, handler);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use UnregisterHandler<T> instead")]
+        public static void UnregisterHandler(int msgType)
+        {
+            handlers.Remove(msgType);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use UnregisterHandler<T> instead")]
+        public static void UnregisterHandler(MsgType msgType)
+        {
+            UnregisterHandler((int)msgType);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use SendToClient<T> instead")]
+        public static void SendToClient(int connectionId, int msgType, MessageBase msg)
+        {
+            if (connections.TryGetValue(connectionId, out NetworkConnection conn))
+            {
+                conn.Send(msgType, msg);
+                return;
+            }
+            Debug.LogError("Failed to send message to connection ID '" + connectionId + ", not found in connection list");
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use SendToClientOfPlayer<T> instead")]
+        public static void SendToClientOfPlayer(NetworkIdentity identity, int msgType, MessageBase msg)
+        {
+            if (identity != null)
+            {
+                identity.connectionToClient.Send(msgType, msg);
+            }
+            else
+            {
+                Debug.LogError("SendToClientOfPlayer: player has no NetworkIdentity: " + identity.name);
+            }
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use NetworkIdentity.spawned[netId] instead.")]
+        public static GameObject FindLocalObject(uint netId)
+        {
+            if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
+            {
+                return identity.gameObject;
+            }
+            return null;
+        }
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use NetworkBehaviour.syncInterval field instead. Can be modified in the Inspector too.")]
+    [AttributeUsage(AttributeTargets.Class)]
+    public class NetworkSettingsAttribute : Attribute
+    {
+        public float sendInterval = 0.1f;
+    }
+
+    public abstract partial class Transport
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use ServerGetClientAddress(int connectionId) instead")]
+        public virtual bool GetConnectionInfo(int connectionId, out string address)
+        {
+            address = ServerGetClientAddress(connectionId);
+            return true;
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/Obsolete.cs
+++ b/Assets/Mirror/Runtime/Obsolete.cs
@@ -61,7 +61,7 @@ namespace Mirror
     public static partial class ClientScene
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Use NetworkIdentity.spawned[netId] instead.")]
+        [Obsolete("Use NetworkIdentity.spawned.TryGetValue() instead. See code in this method for example.")]
         public static GameObject FindLocalObject(uint netId)
         {
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))

--- a/Assets/Mirror/Runtime/Obsolete.cs
+++ b/Assets/Mirror/Runtime/Obsolete.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 /// the project.
 /// 
 /// In many cases the methods here are written to directly call their replacements
-/// so you likley can copy that code to your own project to clear the obsolete warnings.
+/// so you likely can copy that code to your own project to clear the obsolete warnings.
 /// 
 /// Those wishing to submit a PR that would obsolete something in a core class must move
 /// the obsoleted property or method to this file with appropriate comments and include

--- a/Assets/Mirror/Runtime/Obsolete.cs
+++ b/Assets/Mirror/Runtime/Obsolete.cs
@@ -206,20 +206,6 @@ namespace Mirror
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
-        public virtual void OnServerAddPlayer(NetworkConnection conn, NetworkMessage extraMessage)
-        {
-            OnServerAddPlayer(conn, null);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
-        public virtual void OnServerAddPlayer(NetworkConnection conn)
-        {
-            OnServerAddPlayer(conn, null);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use OnStartClient() instead of OnStartClient(NetworkClient client). All NetworkClient functions are static now, so you can use NetworkClient.Send(message) instead of client.Send(message) directly now.")]
         public virtual void OnStartClient(NetworkClient client) { }
     }

--- a/Assets/Mirror/Runtime/Obsolete.cs.meta
+++ b/Assets/Mirror/Runtime/Obsolete.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47440b8e8725b8543920eed6e4d01b1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -13,7 +13,7 @@ namespace Mirror
     [Serializable] public class UnityEventIntByteArray : UnityEvent<int, byte[]> {}
     [Serializable] public class UnityEventIntException : UnityEvent<int, Exception> {}
 
-    public abstract class Transport : MonoBehaviour
+    public abstract partial class Transport : MonoBehaviour
     {
         // static Transport which receives all network events
         // this is usually set by NetworkManager, but doesn't have to be.
@@ -49,13 +49,6 @@ namespace Mirror
         public abstract void ServerStart();
         public abstract bool ServerSend(int connectionId, int channelId, byte[] data);
         public abstract bool ServerDisconnect(int connectionId);
-
-        [Obsolete("Use ServerGetClientAddress(int connectionId) instead")]
-        public virtual bool GetConnectionInfo(int connectionId, out string address)
-        {
-            address = ServerGetClientAddress(connectionId);
-            return true;
-        }
 
         public abstract string ServerGetClientAddress(int connectionId);
         public abstract void ServerStop();

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -20,44 +20,6 @@ namespace Mirror
         SyncEvent
     }
 
-    // built-in system network messages
-    // original HLAPI uses short, so let's keep short to not break packet header etc.
-    // => use .ToString() to get the field name from the field value
-    // => we specify the short values so it's easier to look up opcodes when debugging packets
-    [Obsolete("Use Send<T>  with no message id instead")]
-    public enum MsgType : short
-    {
-        // internal system messages - cannot be replaced by user code
-        ObjectDestroy = 1,
-        Rpc = 2,
-        Owner = 4,
-        Command = 5,
-        SyncEvent = 7,
-        UpdateVars = 8,
-        SpawnPrefab = 3,
-        SpawnSceneObject = 10,
-        SpawnStarted = 11,
-        SpawnFinished = 12,
-        ObjectHide = 13,
-        LocalClientAuthority = 15,
-
-        // public system messages - can be replaced by user code
-        Connect = 32,
-        Disconnect = 33,
-        Error = 34,
-        Ready = 35,
-        NotReady = 36,
-        AddPlayer = 37,
-        RemovePlayer = 38,
-        Scene = 39,
-
-        // time synchronization
-        Ping = 43,
-        Pong = 44,
-
-        Highest = 47
-    }
-
     public enum Version
     {
         Current = 1


### PR DESCRIPTION
Moved all obsoleted methods and properties to a single file and made partial classes where needed.

This is a compromise between those that want all the Obsoletes ripped out of the code completely days or a few weeks after they were put in for the sake of "de-cluttering", making them utterly pointless to do at all, and those that believe they should be kept through the end of the year to support a painless transition for UNet users and 3rd party asset devs that are slowly assessing the level of effort to be compatible with Mirror. Growing the user base and having broad support of asset devs is critically important to the long-term success of Mirror, in my view.