### PR TITLE
feat: Show compile time error if overriding unused OnServerAddPlayer

### DIFF
--- a/Assets/Mirror/Components/NetworkLobbyManager.cs
+++ b/Assets/Mirror/Components/NetworkLobbyManager.cs
@@ -195,12 +195,6 @@ namespace Mirror
             OnLobbyServerDisconnect(conn);
         }
 
-        [System.Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
-        public override void OnServerAddPlayer(NetworkConnection conn)
-        {
-            OnServerAddPlayer(conn, null);
-        }
-
         public override void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)
         {
             if (SceneManager.GetActiveScene().name != LobbyScene) return;

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -662,18 +662,6 @@ namespace Mirror
             NetworkServer.SetClientReady(conn);
         }
 
-        [Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
-        public virtual void OnServerAddPlayer(NetworkConnection conn, NetworkMessage extraMessage)
-        {
-            OnServerAddPlayer(conn, null);
-        }
-
-        [Obsolete("Use OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage) instead")]
-        public virtual void OnServerAddPlayer(NetworkConnection conn)
-        {
-            OnServerAddPlayer(conn, null);
-        }
-
         public virtual void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerAddPlayer");


### PR DESCRIPTION
Any person that overrides these methods has a broken game.  These methods are never called anywhere.

The user gets a warning because they are overriding an obsolete method,  which might get ignored if they have lots of other warnings.   They would run their game and their game would not work at all.  No errors.

By removing these methods, users that override these methods will get a compile time error instead.  So they can catch this error at compile time instead of at runtime.