### PR TITLE
Add Mirror.Components AsmDef

### DIFF
--- a/Assets/Mirror/Components/Mirror.Components.asmdef
+++ b/Assets/Mirror/Components/Mirror.Components.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "MirrorComponents",
+    "name": "Mirror.Components",
     "references": [
         "Mirror"
     ],

--- a/Assets/Mirror/Components/Mirror.Components.asmdef
+++ b/Assets/Mirror/Components/Mirror.Components.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "MirrorComponents",
+    "references": [
+        "Mirror"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/Mirror/Components/Mirror.Components.asmdef.meta
+++ b/Assets/Mirror/Components/Mirror.Components.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 52586e1eedfbc4743ae38471bf6a7153
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is part of the solution to #632 and Visual Studio not being able to hit breakpoints when debugging.  The other part the users have to do, and that's cover all their code with one or more AsmDef's that references both Mirror and Mirror.Components.

They can probably just create one in the project root (directly under Assets) that will suffice.

![image](https://user-images.githubusercontent.com/9826063/55268779-8d74e900-5263-11e9-847e-f6260535c123.png)
