### PR TITLE
perf: Implement zigzag algorithm so negatives pack efficiently

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -229,7 +229,7 @@ namespace Mirror
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
                     int newIntValue = animator.GetInteger(par.nameHash);
-                    writer.WritePackedUInt32((uint)newIntValue);
+                    writer.WritePackedInt32(newIntValue);
                 }
                 else if (par.type == AnimatorControllerParameterType.Float)
                 {
@@ -256,7 +256,7 @@ namespace Mirror
                 AnimatorControllerParameter par = parameters[i];
                 if (par.type == AnimatorControllerParameterType.Int)
                 {
-                    int newIntValue = (int)reader.ReadPackedUInt32();
+                    int newIntValue = reader.ReadPackedInt32();
                     animator.SetInteger(par.nameHash, newIntValue);
                 }
                 else if (par.type == AnimatorControllerParameterType.Float)

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -372,7 +372,7 @@ namespace Mirror.Weaver
             serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
             serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
             serWorker.Append(serWorker.Create(OpCodes.Call, Weaver.NetworkBehaviourDirtyBitsReference));
-            serWorker.Append(serWorker.Create(OpCodes.Callvirt, Weaver.NetworkWriterWritePacked64));
+            serWorker.Append(serWorker.Create(OpCodes.Callvirt, Weaver.NetworkWriterWritePackedUInt64));
 
             // generate a writer call for any dirty variable in this class
 
@@ -572,7 +572,7 @@ namespace Mirror.Weaver
 
             // get dirty bits
             serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
-            serWorker.Append(serWorker.Create(OpCodes.Callvirt, Weaver.NetworkReaderReadPacked64));
+            serWorker.Append(serWorker.Create(OpCodes.Callvirt, Weaver.NetworkReaderReadPackedUInt64));
             serWorker.Append(serWorker.Create(OpCodes.Stloc_0));
 
             // conditionally read each syncvar

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -462,7 +462,7 @@ namespace Mirror.Weaver
 
                 // read id and store in a local variable
                 serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
-                serWorker.Append(serWorker.Create(OpCodes.Call, Weaver.NetworkReaderReadPacked32));
+                serWorker.Append(serWorker.Create(OpCodes.Call, Weaver.NetworkReaderReadPackedUInt32));
                 serWorker.Append(serWorker.Create(OpCodes.Stloc, tmpValue));
 
                 if (foundMethod != null)

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -101,10 +101,12 @@ namespace Mirror.Weaver
         public static MethodReference NetworkServerGetLocalClientActive;
         public static MethodReference NetworkClientGetActive;
         public static MethodReference UBehaviourIsServer;
-        public static MethodReference NetworkReaderReadPacked32;
+        public static MethodReference NetworkReaderReadPackedUInt32;
+        public static MethodReference NetworkReaderReadPackedInt32;
         public static MethodReference NetworkReaderReadPacked64;
         public static MethodReference NetworkReaderReadByte;
-        public static MethodReference NetworkWriterWritePacked32;
+        public static MethodReference NetworkWriterWritePackedUInt32;
+        public static MethodReference NetworkWriterWritePackedInt32;
         public static MethodReference NetworkWriterWritePacked64;
 
         public static MethodReference NetworkReadUInt16;
@@ -1101,11 +1103,13 @@ namespace Mirror.Weaver
             NetworkWriterWriteInt32 = Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", int32Type);
             NetworkWriterWriteInt16 = Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", int16Type);
 
-            NetworkReaderReadPacked32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt32");
+            NetworkReaderReadPackedUInt32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt32");
+            NetworkReaderReadPackedInt32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedInt32");
             NetworkReaderReadPacked64 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt64");
             NetworkReaderReadByte = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadByte");
 
-            NetworkWriterWritePacked32 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedUInt32");
+            NetworkWriterWritePackedUInt32 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedUInt32");
+            NetworkWriterWritePackedInt32 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedInt32");
             NetworkWriterWritePacked64 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedUInt64");
 
             NetworkReadUInt16 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadUInt16");
@@ -1182,8 +1186,8 @@ namespace Mirror.Weaver
                 { stringType.FullName, Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadString") },
                 { int64Type.FullName, NetworkReaderReadPacked64 },
                 { uint64Type.FullName, NetworkReaderReadPacked64 },
-                { int32Type.FullName, NetworkReaderReadPacked32 },
-                { uint32Type.FullName, NetworkReaderReadPacked32 },
+                { int32Type.FullName, NetworkReaderReadPackedInt32 },
+                { uint32Type.FullName, NetworkReaderReadPackedUInt32 },
                 { int16Type.FullName, Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadInt16") },
                 { uint16Type.FullName, Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadUInt16") },
                 { byteType.FullName, Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadByte") },
@@ -1220,8 +1224,8 @@ namespace Mirror.Weaver
                 { stringType.FullName, Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", stringType) },
                 { int64Type.FullName, NetworkWriterWritePacked64 },
                 { uint64Type.FullName, NetworkWriterWritePacked64 },
-                { int32Type.FullName, NetworkWriterWritePacked32 },
-                { uint32Type.FullName, NetworkWriterWritePacked32 },
+                { int32Type.FullName, NetworkWriterWritePackedInt32 },
+                { uint32Type.FullName, NetworkWriterWritePackedUInt32 },
                 { int16Type.FullName, Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", int16Type) },
                 { uint16Type.FullName, Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", uint16Type) },
                 { byteType.FullName, Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", byteType) },

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -103,11 +103,13 @@ namespace Mirror.Weaver
         public static MethodReference UBehaviourIsServer;
         public static MethodReference NetworkReaderReadPackedUInt32;
         public static MethodReference NetworkReaderReadPackedInt32;
-        public static MethodReference NetworkReaderReadPacked64;
+        public static MethodReference NetworkReaderReadPackedUInt64;
+        public static MethodReference NetworkReaderReadPackedInt64;
         public static MethodReference NetworkReaderReadByte;
         public static MethodReference NetworkWriterWritePackedUInt32;
         public static MethodReference NetworkWriterWritePackedInt32;
-        public static MethodReference NetworkWriterWritePacked64;
+        public static MethodReference NetworkWriterWritePackedUInt64;
+        public static MethodReference NetworkWriterWritePackedInt64;
 
         public static MethodReference NetworkReadUInt16;
         public static MethodReference NetworkWriteUInt16;
@@ -1105,12 +1107,14 @@ namespace Mirror.Weaver
 
             NetworkReaderReadPackedUInt32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt32");
             NetworkReaderReadPackedInt32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedInt32");
-            NetworkReaderReadPacked64 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt64");
+            NetworkReaderReadPackedUInt64 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt64");
+            NetworkReaderReadPackedInt64 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedInt64");
             NetworkReaderReadByte = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadByte");
 
             NetworkWriterWritePackedUInt32 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedUInt32");
             NetworkWriterWritePackedInt32 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedInt32");
-            NetworkWriterWritePacked64 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedUInt64");
+            NetworkWriterWritePackedUInt64 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedUInt64");
+            NetworkWriterWritePackedInt64 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedInt64");
 
             NetworkReadUInt16 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadUInt16");
             NetworkWriteUInt16 = Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", uint16Type);
@@ -1184,8 +1188,8 @@ namespace Mirror.Weaver
                 { doubleType.FullName, Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadDouble") },
                 { boolType.FullName, Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadBoolean") },
                 { stringType.FullName, Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadString") },
-                { int64Type.FullName, NetworkReaderReadPacked64 },
-                { uint64Type.FullName, NetworkReaderReadPacked64 },
+                { int64Type.FullName, NetworkReaderReadPackedInt64 },
+                { uint64Type.FullName, NetworkReaderReadPackedUInt64 },
                 { int32Type.FullName, NetworkReaderReadPackedInt32 },
                 { uint32Type.FullName, NetworkReaderReadPackedUInt32 },
                 { int16Type.FullName, Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadInt16") },
@@ -1222,8 +1226,8 @@ namespace Mirror.Weaver
                 { doubleType.FullName, Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", doubleType) },
                 { boolType.FullName, Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", boolType) },
                 { stringType.FullName, Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", stringType) },
-                { int64Type.FullName, NetworkWriterWritePacked64 },
-                { uint64Type.FullName, NetworkWriterWritePacked64 },
+                { int64Type.FullName, NetworkWriterWritePackedInt64 },
+                { uint64Type.FullName, NetworkWriterWritePackedUInt64 },
                 { int32Type.FullName, NetworkWriterWritePackedInt32 },
                 { uint32Type.FullName, NetworkWriterWritePackedUInt32 },
                 { int16Type.FullName, Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", int16Type) },

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -99,12 +99,12 @@ namespace Mirror
 
         public override void Deserialize(NetworkReader reader)
         {
-            value = (int)reader.ReadPackedUInt32();
+            value = reader.ReadPackedInt32();
         }
 
         public override void Serialize(NetworkWriter writer)
         {
-            writer.WritePackedUInt32((uint)value);
+            writer.WritePackedInt32(value);
         }
     }
 

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -76,6 +76,13 @@ namespace Mirror
             return (uint)value;
         }
 
+        // zigzag decoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba
+        public long ReadPackedInt64()
+        {
+            ulong data = ReadPackedUInt64();
+            return ((long)(data >> 1)) ^ -((long)data & 1);
+        }
+
         public ulong ReadPackedUInt64()
         {
             byte a0 = ReadByte();

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -57,6 +57,13 @@ namespace Mirror
             return null;
         }
 
+        // zigzag decoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba
+        public int ReadPackedInt32()
+        {
+            uint data = ReadPackedUInt32();
+            return (int)((data >> 1) ^ -(data & 1));
+        }
+
         // http://sqlite.org/src4/doc/trunk/www/varint.wiki
         // NOTE: big endian.
         public uint ReadPackedUInt32()
@@ -145,12 +152,12 @@ namespace Mirror
 
         public Vector2Int ReadVector2Int()
         {
-            return new Vector2Int((int)ReadPackedUInt32(), (int)ReadPackedUInt32());
+            return new Vector2Int(ReadPackedInt32(), ReadPackedInt32());
         }
 
         public Vector3Int ReadVector3Int()
         {
-            return new Vector3Int((int)ReadPackedUInt32(), (int)ReadPackedUInt32(), (int)ReadPackedUInt32());
+            return new Vector3Int(ReadPackedInt32(), ReadPackedInt32(), ReadPackedInt32());
         }
 
         public Color ReadColor()

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -115,6 +115,13 @@ namespace Mirror
             WritePackedUInt64(value);
         }
 
+        // zigzag encoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba
+        public void WritePackedInt64(long i)
+        {
+            ulong zigzagged = (ulong)((i >> 63) ^ (i << 1));
+            WritePackedUInt64(zigzagged);
+        }
+
         public void WritePackedUInt64(ulong value)
         {
             if (value <= 240)

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -100,6 +100,13 @@ namespace Mirror
             WriteBytesAndSize(buffer, 0, buffer != null ? buffer.Length : 0);
         }
 
+        // zigzag encoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba
+        public void WritePackedInt32(int i)
+        {
+            uint zigzagged = (uint)((i >> 31) ^ (i << 1));
+            WritePackedUInt32(zigzagged);
+        }
+
         // http://sqlite.org/src4/doc/trunk/www/varint.wiki
         public void WritePackedUInt32(uint value)
         {
@@ -216,15 +223,15 @@ namespace Mirror
 
         public void Write(Vector2Int value)
         {
-            WritePackedUInt32((uint)value.x);
-            WritePackedUInt32((uint)value.y);
+            WritePackedInt32(value.x);
+            WritePackedInt32(value.y);
         }
 
         public void Write(Vector3Int value)
         {
-            WritePackedUInt32((uint)value.x);
-            WritePackedUInt32((uint)value.y);
-            WritePackedUInt32((uint)value.z);
+            WritePackedInt32(value.x);
+            WritePackedInt32(value.y);
+            WritePackedInt32(value.z);
         }
 
         public void Write(Color value)

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -19,8 +19,8 @@ namespace Mirror
 
     public class SyncListInt : SyncList<int>
     {
-        protected override void SerializeItem(NetworkWriter writer, int item) => writer.WritePackedUInt32((uint)item);
-        protected override int DeserializeItem(NetworkReader reader) => (int)reader.ReadPackedUInt32();
+        protected override void SerializeItem(NetworkWriter writer, int item) => writer.WritePackedInt32(item);
+        protected override int DeserializeItem(NetworkReader reader) => reader.ReadPackedInt32();
     }
 
     public class SyncListUInt : SyncList<uint>

--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -146,6 +146,58 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestPackedInt64()
+        {
+            NetworkWriter writer = new NetworkWriter();
+            writer.WritePackedInt64(0);
+            writer.WritePackedInt64(234);
+            writer.WritePackedInt64(2284);
+            writer.WritePackedInt64(67821);
+            writer.WritePackedInt64(16777210);
+            writer.WritePackedInt64(16777219);
+            writer.WritePackedInt64(4294967295);
+            writer.WritePackedInt64(1099511627775);
+            writer.WritePackedInt64(281474976710655);
+            writer.WritePackedInt64(72057594037927935);
+            writer.WritePackedInt64(long.MaxValue);
+            writer.WritePackedInt64(-1);
+            writer.WritePackedInt64(-234);
+            writer.WritePackedInt64(-2284);
+            writer.WritePackedInt64(-67821);
+            writer.WritePackedInt64(-16777210);
+            writer.WritePackedInt64(-16777219);
+            writer.WritePackedInt64(-4294967295);
+            writer.WritePackedInt64(-1099511627775);
+            writer.WritePackedInt64(-281474976710655);
+            writer.WritePackedInt64(-72057594037927935);
+            writer.WritePackedInt64(long.MinValue);
+
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(0));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(234));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(2284));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(67821));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(16777210));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(16777219));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(4294967295));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(1099511627775));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(281474976710655));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(72057594037927935));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(long.MaxValue));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-1));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-234));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-2284));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-67821));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-16777210));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-16777219));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-4294967295));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-1099511627775));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-281474976710655));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(-72057594037927935));
+            Assert.That(reader.ReadPackedInt64(), Is.EqualTo(long.MinValue));
+        }
+
+        [Test]
         public void TestGuid()
         {
             Guid originalGuid = new Guid("0123456789abcdef9876543210fedcba");

--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -80,6 +80,42 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestPackedInt32()
+        {
+            NetworkWriter writer = new NetworkWriter();
+            writer.WritePackedInt32(0);
+            writer.WritePackedInt32(234);
+            writer.WritePackedInt32(2284);
+            writer.WritePackedInt32(67821);
+            writer.WritePackedInt32(16777210);
+            writer.WritePackedInt32(16777219);
+            writer.WritePackedInt32(int.MaxValue);
+            writer.WritePackedInt32(-1);
+            writer.WritePackedInt32(-234);
+            writer.WritePackedInt32(-2284);
+            writer.WritePackedInt32(-67821);
+            writer.WritePackedInt32(-16777210);
+            writer.WritePackedInt32(-16777219);
+            writer.WritePackedInt32(int.MinValue);
+
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(0));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(234));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(2284));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(67821));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(16777210));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(16777219));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(int.MaxValue));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(-1));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(-234));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(-2284));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(-67821));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(-16777210));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(-16777219));
+            Assert.That(reader.ReadPackedInt32(), Is.EqualTo(int.MinValue));
+        }
+
+        [Test]
         public void TestPackedUInt64()
         {
             NetworkWriter writer = new NetworkWriter();


### PR DESCRIPTION
This implements standard zigzag algorithm.

Previously, it took 5 bytes to serialize -1.   With this PR, small negatives take only 1 byte.

Zigzag is well known and well documented algorithm described here:
https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba

Maps negative values to positive values while going back and forth 
(0 = 0, -1 = 1, 1 = 2, -2 = 3, 2 = 4, -3 = 5, 3 = 6 ...)
