### PR TITLE
Set a deprecation date

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -322,7 +322,7 @@ namespace Mirror
             NetworkIdentity.spawned.Clear();
         }
 
-        [Obsolete("Use NetworkIdentity.spawned[netId] instead.")]
+        [Obsolete("Use NetworkIdentity.spawned[netId] instead.  Will be removed on 04/30/2019")]
         public static GameObject FindLocalObject(uint netId)
         {
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -29,7 +29,7 @@ namespace Mirror
 
         // pack message before sending
         // -> pass writer instead of byte[] so we can reuse it
-        [Obsolete("Use Pack<T> instead")]
+        [Obsolete("Use Pack<T> instead. Will be removed on 04/30/2019")]
         public static byte[] PackMessage(int msgType, MessageBase msg)
         {
             // reset cached writer length and position

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -15,10 +15,10 @@ namespace Mirror
     // TODO make fully static after removing obsoleted singleton!
     public class NetworkClient
     {
-        [Obsolete("Use NetworkClient directly. Singleton isn't needed anymore, all functions are static now. For example: NetworkClient.Send(message) instead of NetworkClient.singleton.Send(message).")]
+        [Obsolete("Use NetworkClient directly. Singleton isn't needed anymore, all functions are static now. For example: NetworkClient.Send(message) instead of NetworkClient.singleton.Send(message).  Will be removed on 04/30/2019")]
         public static NetworkClient singleton = new NetworkClient();
 
-        [Obsolete("Use NetworkClient directly instead. There is always exactly one client.")]
+        [Obsolete("Use NetworkClient directly instead. There is always exactly one client.  Will be removed on 04/30/2019")]
         public static List<NetworkClient> allClients => new List<NetworkClient>{singleton};
 
         public static readonly Dictionary<int, NetworkMessageDelegate> handlers = new Dictionary<int, NetworkMessageDelegate>();
@@ -187,7 +187,7 @@ namespace Mirror
             Transport.activeTransport.OnClientError.RemoveListener(OnError);
         }
 
-        [Obsolete("Use SendMessage<T> instead with no message id instead")]
+        [Obsolete("Use SendMessage<T> instead with no message id instead. Will be removed on 04/30/2019")]
         public static bool Send(short msgType, MessageBase msg)
         {
             if (connection != null)
@@ -326,7 +326,7 @@ namespace Mirror
             RegisterHandler<SyncEventMessage>(ClientScene.OnSyncEventMessage);
         }
 
-        [Obsolete("Use RegisterHandler<T> instead")]
+        [Obsolete("Use RegisterHandler<T> instead. Will be removed on 04/30/2019")]
         public static void RegisterHandler(int msgType, NetworkMessageDelegate handler)
         {
             if (handlers.ContainsKey(msgType))
@@ -336,7 +336,7 @@ namespace Mirror
             handlers[msgType] = handler;
         }
 
-        [Obsolete("Use RegisterHandler<T> instead")]
+        [Obsolete("Use RegisterHandler<T> instead. Will be removed on 04/30/2019")]
         public static void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
         {
             RegisterHandler((int)msgType, handler);
@@ -355,13 +355,13 @@ namespace Mirror
             };
         }
 
-        [Obsolete("Use UnregisterHandler<T> instead")]
+        [Obsolete("Use UnregisterHandler<T> instead. Will be removed on 04/30/2019")]
         public static void UnregisterHandler(int msgType)
         {
             handlers.Remove(msgType);
         }
 
-        [Obsolete("Use UnregisterHandler<T> instead")]
+        [Obsolete("Use UnregisterHandler<T> instead. Will be removed on 04/30/2019")]
         public static void UnregisterHandler(MsgType msgType)
         {
             UnregisterHandler((int)msgType);
@@ -380,7 +380,7 @@ namespace Mirror
             active = false;
         }
 
-        [Obsolete("Call NetworkClient.Shutdown() instead. There is only one client.")]
+        [Obsolete("Call NetworkClient.Shutdown() instead. There is only one client. ")]
         public static void ShutdownAll()
         {
             Shutdown();

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -115,7 +115,7 @@ namespace Mirror
             m_MessageHandlers.Remove(msgType);
         }
 
-        [Obsolete("use Send<T> instead")]
+        [Obsolete("Use Send<T> instead. Will be removed on 04/30/2019")]
         public virtual bool Send(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             // pack message and send

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -61,7 +61,7 @@ namespace Mirror
         public static string networkSceneName = "";
         [NonSerialized]
         public bool isNetworkActive;
-        [Obsolete("Use NetworkClient directly, it will be made static soon. For example, use NetworkClient.Send(message) instead of NetworkManager.client.Send(message)")]
+        [Obsolete("Use NetworkClient directly, it will be made static soon. For example, use NetworkClient.Send(message) instead of NetworkManager.client.Send(message). Will be removed on 04/30/2019")]
         public NetworkClient client => NetworkClient.singleton;
         static int s_StartPositionIndex;
 
@@ -527,7 +527,7 @@ namespace Mirror
             startPositions.Remove(start);
         }
 
-        [Obsolete("Use NetworkClient.isConnected instead")]
+        [Obsolete("Use NetworkClient.isConnected instead. Will be removed on 04/30/2019")]
         public bool IsClientConnected()
         {
             return NetworkClient.isConnected;
@@ -781,7 +781,7 @@ namespace Mirror
 
         public virtual void OnStartHost() {}
         public virtual void OnStartServer() {}
-        [Obsolete("Use OnStartClient() instead of OnStartClient(NetworkClient client). All NetworkClient functions are static now, so you can use NetworkClient.Send(message) instead of client.Send(message) directly now.")]
+        [Obsolete("Use OnStartClient() instead of OnStartClient(NetworkClient client). All NetworkClient functions are static now, so you can use NetworkClient.Send(message) instead of client.Send(message) directly now. Will be removed on 04/30/2019")]
         public virtual void OnStartClient(NetworkClient client) {}
         public virtual void OnStartClient()
         {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -162,7 +162,7 @@ namespace Mirror
 
         // this is like SendToReady - but it doesn't check the ready flag on the connection.
         // this is used for ObjectDestroy messages.
-        [Obsolete("use SendToObservers<T> instead")]
+        [Obsolete("use SendToObservers<T> instead. Will be removed on 04/30/2019")]
         static bool SendToObservers(NetworkIdentity identity, short msgType, MessageBase msg)
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToObservers id:" + msgType);
@@ -204,7 +204,7 @@ namespace Mirror
             return false;
         }
 
-        [Obsolete("Use SendToAll<T> instead")]
+        [Obsolete("Use SendToAll<T> instead. Will be removed on 04/30/2019")]
         public static bool SendToAll(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToAll id:" + msgType);
@@ -236,7 +236,7 @@ namespace Mirror
             return result;
         }
 
-        [Obsolete("Use SendToReady<T> instead")]
+        [Obsolete("Use SendToReady<T> instead. Will be removed on 04/30/2019")]
         public static bool SendToReady(NetworkIdentity identity, short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + msgType);
@@ -469,7 +469,7 @@ namespace Mirror
             }
         }
 
-        [Obsolete("Use RegisterHandler<T> instead")]
+        [Obsolete("Use RegisterHandler<T> instead. Will be removed on 04/30/2019")]
         public static void RegisterHandler(int msgType, NetworkMessageDelegate handler)
         {
             if (handlers.ContainsKey(msgType))
@@ -479,7 +479,7 @@ namespace Mirror
             handlers[msgType] = handler;
         }
 
-        [Obsolete("Use RegisterHandler<T> instead")]
+        [Obsolete("Use RegisterHandler<T> instead. Will be removed on 04/30/2019")]
         public static void RegisterHandler(MsgType msgType, NetworkMessageDelegate handler)
         {
             RegisterHandler((int)msgType, handler);
@@ -499,13 +499,13 @@ namespace Mirror
             };
         }
 
-        [Obsolete("Use UnregisterHandler<T> instead")]
+        [Obsolete("Use UnregisterHandler<T> instead. Will be removed on 04/30/2019")]
         public static void UnregisterHandler(int msgType)
         {
             handlers.Remove(msgType);
         }
 
-        [Obsolete("Use UnregisterHandler<T> instead")]
+        [Obsolete("Use UnregisterHandler<T> instead. Will be removed on 04/30/2019")]
         public static void UnregisterHandler(MsgType msgType)
         {
             UnregisterHandler((int)msgType);
@@ -522,7 +522,7 @@ namespace Mirror
             handlers.Clear();
         }
 
-        [Obsolete("Use SendToClient<T> instead")]
+        [Obsolete("Use SendToClient<T> instead. Will be removed on 04/30/2019")]
         public static void SendToClient(int connectionId, int msgType, MessageBase msg)
         {
             if (connections.TryGetValue(connectionId, out NetworkConnection conn))
@@ -545,7 +545,7 @@ namespace Mirror
         }
 
 
-        [Obsolete("Use SendToClientOfPlayer<T> instead")]
+        [Obsolete("Use SendToClientOfPlayer<T> instead. Will be removed on 04/30/2019")]
         public static void SendToClientOfPlayer(NetworkIdentity identity, int msgType, MessageBase msg)
         {
             if (identity != null)
@@ -1166,7 +1166,7 @@ namespace Mirror
             }
         }
 
-        [Obsolete("Use NetworkIdentity.spawned[netId] instead.")]
+        [Obsolete("Use NetworkIdentity.spawned[netId] instead. Will be removed on 04/30/2019")]
         public static GameObject FindLocalObject(uint netId)
         {
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -43,7 +43,7 @@ namespace Mirror
     // in Unity 2019.1.
     //
     // TODO rename back to SyncListStruct after 2019.1!
-    [Obsolete("Use SyncList<MyStruct> instead")]
+    [Obsolete("Use SyncList<MyStruct> instead. Will be removed on 04/30/2019")]
     public class SyncListSTRUCT<T> : SyncList<T> where T : struct
     {
         public T GetItem(int i) => base[i];

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -50,7 +50,7 @@ namespace Mirror
         public abstract bool ServerSend(int connectionId, int channelId, byte[] data);
         public abstract bool ServerDisconnect(int connectionId);
 
-        [Obsolete("Use ServerGetClientAddress(int connectionId) instead")]
+        [Obsolete("Use ServerGetClientAddress(int connectionId) instead. Will be removed on 04/30/2019")]
         public virtual bool GetConnectionInfo(int connectionId, out string address)
         {
             address = ServerGetClientAddress(connectionId);

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -24,7 +24,7 @@ namespace Mirror
     // original HLAPI uses short, so let's keep short to not break packet header etc.
     // => use .ToString() to get the field name from the field value
     // => we specify the short values so it's easier to look up opcodes when debugging packets
-    [Obsolete("Use Send<T>  with no message id instead")]
+    [Obsolete("Use Send<T>  with no message id instead. Will be removed on 04/30/2019")]
     public enum MsgType : short
     {
         // internal system messages - cannot be replaced by user code


### PR DESCRIPTION
Warn users about when some of the obsolete methods will be deprecated.

Most of these methods have been deprecated for an entire month,  so we can just set a date for getting rid of the dead weight.