### PR TITLE
fix: #696 detect .mystruct = new MyStruct() changes with syncvars

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
@@ -85,11 +85,11 @@ namespace Mirror.Weaver
                     }
                 }
 
-                int iCount = 0;
-                foreach (Instruction i in md.Body.Instructions)
+                for (int iCount= 0; iCount < md.Body.Instructions.Count;)
                 {
-                    ProcessInstruction(moduleDef, td, md, i, iCount);
-                    iCount += 1;
+                    Instruction instr = md.Body.Instructions[iCount];
+
+                    iCount += ProcessInstruction(moduleDef, td, md, instr, iCount);
                 }
             }
         }
@@ -175,33 +175,35 @@ namespace Mirror.Weaver
             }
         }
 
-        static void ProcessInstruction(ModuleDefinition moduleDef, TypeDefinition td, MethodDefinition md, Instruction i, int iCount)
+        static int ProcessInstruction(ModuleDefinition moduleDef, TypeDefinition td, MethodDefinition md, Instruction instr, int iCount)
         {
-            if (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            if (instr.OpCode == OpCodes.Call || instr.OpCode == OpCodes.Callvirt)
             {
-                if (i.Operand is MethodReference opMethod)
+                if (instr.Operand is MethodReference opMethod)
                 {
-                    ProcessInstructionMethod(moduleDef, td, md, i, opMethod, iCount);
+                    ProcessInstructionMethod(moduleDef, td, md, instr, opMethod, iCount);
                 }
             }
 
-            if (i.OpCode == OpCodes.Stfld)
+            if (instr.OpCode == OpCodes.Stfld)
             {
                 // this instruction sets the value of a field. cache the field reference.
-                if (i.Operand is FieldDefinition opField)
+                if (instr.Operand is FieldDefinition opField)
                 {
-                    ProcessInstructionSetterField(td, md, i, opField);
+                    ProcessInstructionSetterField(td, md, instr, opField);
                 }
             }
 
-            if (i.OpCode == OpCodes.Ldfld)
+            if (instr.OpCode == OpCodes.Ldfld)
             {
                 // this instruction gets the value of a field. cache the field reference.
-                if (i.Operand is FieldDefinition opField)
+                if (instr.Operand is FieldDefinition opField)
                 {
-                    ProcessInstructionGetterField(td, md, i, opField);
+                    ProcessInstructionGetterField(td, md, instr, opField);
                 }
             }
+
+            return 1;
         }
 
         static void ProcessInstructionMethod(ModuleDefinition moduleDef, TypeDefinition td, MethodDefinition md, Instruction instr, MethodReference opMethodRef, int iCount)

--- a/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
@@ -203,6 +203,60 @@ namespace Mirror.Weaver
                 }
             }
 
+            if (instr.OpCode == OpCodes.Ldflda)
+            {
+                // loading a field by reference,  watch out for initobj instruction
+                // see https://github.com/vis2k/Mirror/issues/696
+
+                if (instr.Operand is FieldDefinition opField)
+                {
+                    return ProcessInstructionLoadAddress(td, md, instr, opField, iCount);
+                }
+            }
+
+            return 1;
+        }
+
+        private static int ProcessInstructionLoadAddress(TypeDefinition td, MethodDefinition md, Instruction instr, FieldDefinition opField, int iCount)
+        {
+            // dont replace property call sites in constructors
+            if (md.Name == ".ctor")
+                return 1;
+
+            // does it set a field that we replaced?
+            if (Weaver.WeaveLists.replacementSetterProperties.TryGetValue(opField, out MethodDefinition replacement))
+            {
+                // we have a replacement for this property
+                // is the next instruction a initobj?
+                Instruction nextInstr = md.Body.Instructions[iCount + 1];
+
+
+                if (nextInstr.OpCode == OpCodes.Initobj)
+                {
+                    // we need to replace this code with:
+                    //     var tmp = new MyStruct();
+                    //     this.set_Networkxxxx(tmp);
+                    ILProcessor worker = md.Body.GetILProcessor();
+                    VariableDefinition tmpVariable = new VariableDefinition(opField.FieldType);
+                    md.Body.Variables.Add(tmpVariable);
+
+                    worker.InsertBefore(instr, worker.Create(OpCodes.Ldloca, tmpVariable));
+                    worker.InsertBefore(instr, worker.Create(OpCodes.Initobj, opField.FieldType));
+                    worker.InsertBefore(instr, worker.Create(OpCodes.Ldloc, tmpVariable));
+                    worker.InsertBefore(instr, worker.Create(OpCodes.Call, replacement));
+
+                    worker.Remove(instr);
+                    worker.Remove(nextInstr);
+                    return 4;
+
+                }
+                else
+                {
+                    UnityEngine.Debug.LogWarning("Unrecognized syncvar field assignment in method " + md.FullName + " for field " + opField.FullName);
+                }
+
+            }
+
             return 1;
         }
 

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -26,8 +26,6 @@ namespace Mirror.Tests
     public class SyncVarTest
     {
 
-
-
         [Test]
         public void TestSettingGuild()
         {
@@ -36,7 +34,7 @@ namespace Mirror.Tests
 
             MockPlayer player = gameObject.AddComponent<MockPlayer>();
 
-            Assert.That(!player.IsDirty());
+            Assert.That(player.IsDirty(), Is.False, "First time object should not be dirty");
 
             MockPlayer.Guild myGuild = new MockPlayer.Guild
             {
@@ -45,7 +43,13 @@ namespace Mirror.Tests
 
             player.guild = myGuild;
 
-            Assert.That(player.IsDirty());
+            Assert.That(player.IsDirty(), "Setting struct should mark object as dirty");
+            player.ClearAllDirtyBits();
+            Assert.That(player.IsDirty(), Is.False, "SetDirtyBit(0) should clear dirty flag");
+
+            // clearing the guild should set dirty bit too
+            player.guild = default;
+            Assert.That(player.IsDirty(), "Clearing struct should mark object as dirty");
         }
 
     }

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -45,7 +45,7 @@ namespace Mirror.Tests
 
             Assert.That(player.IsDirty(), "Setting struct should mark object as dirty");
             player.ClearAllDirtyBits();
-            Assert.That(player.IsDirty(), Is.False, "SetDirtyBit(0) should clear dirty flag");
+            Assert.That(player.IsDirty(), Is.False, "ClearAllDirtyBits() should clear dirty flag");
 
             // clearing the guild should set dirty bit too
             player.guild = default;

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -27,7 +27,7 @@ namespace Mirror.Tests
     {
 
         [Test]
-        public void TestSettingGuild()
+        public void TestSettingStruct()
         {
 
             GameObject gameObject = new GameObject();


### PR DESCRIPTION
fixes issue #696 

when you initialize a syncvar field with `.mystruct = new MyStruct()` or `.mystruct = default`  now the weaver will call the generated setter.  

Who knows how many people are affected by this bug and don't know it.   This bug goes all the way back to HLAPI