### PR TITLE
NetworkIdentity.RebuildObservers: change "Observer is not ready for: warning to debug log, because it would constantly be spammed if a connection disconnects and we keep the player in the game for a while before disconnecting. E.g. if NetworkManager.OnServerDestroy delays the disconnect to avoid a player from fleeing combat.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -853,7 +853,7 @@ namespace Mirror
 
                 if (!conn.isReady)
                 {
-                    Debug.LogWarning("Observer is not ready for " + gameObject + " " + conn);
+                    if (LogFilter.Debug) Debug.Log("Observer is not ready for " + gameObject + " " + conn);
                     continue;
                 }
 


### PR DESCRIPTION
NetworkIdentity.RebuildObservers: change "Observer is not ready for: warning to debug log, because it would constantly be spammed if a connection disconnects and we keep the player in the game for a while before disconnecting. E.g. if NetworkManager.OnServerDestroy delays the disconnect to avoid a player from fleeing combat.