### PR TITLE
feat: SyncDictionary can now be used for any IDictionary

### DIFF
--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -9,7 +9,7 @@ namespace Mirror
     {
         public delegate void SyncDictionaryChanged(Operation op, K key, V item);
 
-        readonly Dictionary<K, V> objects;
+        readonly IDictionary<K, V> objects;
 
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
@@ -61,6 +61,11 @@ namespace Mirror
         protected SyncDictionary(IEqualityComparer<K> eq)
         {
             objects = new Dictionary<K, V>(eq);
+        }
+
+        protected SyncDictionary(IDictionary<K,V> objects)
+        {
+            this.objects = objects;
         }
 
         void AddOperation(Operation op, K key, V item)


### PR DESCRIPTION
With this constructor,  now syncdictionaries can be used to create SortedLists, SortedDictionary, or any other IDictionary implementation.  For example:

```cs
class MySortedList : SyncDictionary<int, string> {
      public MySortedList() : base(new SortedList<int,string>()) {}
}
```

Or any other arbitrary IDictionary implementation.
