### PR TITLE
feat(NetworkManager): Allow the user to disable NetworkManager Server Tick Rate capping

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -21,10 +21,14 @@ namespace Mirror
 
         // configuration
         [FormerlySerializedAs("m_DontDestroyOnLoad")] public bool dontDestroyOnLoad = true;
-        [FormerlySerializedAs("m_RunInBackground")] public bool runInBackground = true;
-        public bool startOnHeadless = true;
+        [FormerlySerializedAs("m_RunInBackground")] public bool runInBackground = true;		
+        [Tooltip("Autostart Network Server on Headless mode builds?")]
+		public bool startOnHeadless = true;
+		[Tooltip("Enable this to allow NetworkManager to take control of the server/client tick rate. Disabling allows other scripts to control the tick rate instead.")]
+		public bool limitTickRate = true;
         [Tooltip("Server Update frequency, per second. Use around 60Hz for fast paced games like Counter-Strike to minimize latency. Use around 30Hz for games like WoW to minimize computations. Use around 1-10Hz for slow paced games like EVE.")]
         public int serverTickRate = 30;
+
         [FormerlySerializedAs("m_ShowDebugMessages")] public bool showDebugMessages;
 
         [Scene]
@@ -249,7 +253,8 @@ namespace Mirror
 #if !UNITY_EDITOR
             if (!NetworkClient.active)
             {
-                Application.targetFrameRate = serverTickRate;
+				// If the user wants the server tick rate limited, then take control here.
+                if(limitTickRate) Application.targetFrameRate = serverTickRate;
                 Debug.Log("Server Tick Rate set to: " + Application.targetFrameRate + " Hz.");
             }
 #endif


### PR DESCRIPTION
This is a very late response to a old issue ticket where some people where upset that there was no way to disable NetworkManager setting the server tick rate. Given how I've seen some people request this in the Discord, I think this is the most non-intrusive patch possible.

**What does this PR contain?**

Simply contains a new switch called "Limit Tick Rate" and patches a `Application.targetFrameRate` line. This allows people to turn off Mirror NetworkManager auto-setting frame rate. For example, you could have a server bootstrap scene that parses a configuration file in a startup scene before passing control over to Mirror in a game map scene.

I won't be surprised if there's some debate about this, but I say let's just merge it. The setting is set to enabled by default, so majority of our users will be fine and CPU usage won't dramatically spike after patching it. But for that small minority that want to be able to do funky things with their target frame rate, this should keep them happy. And that's what we all want, right? 😄 