### PR TITLE
fix: Potential DOS attack on server by sending packed ulongs when packed uints are expected.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -71,6 +71,9 @@ namespace Mirror
             ulong value = ReadPackedUInt64();
             if (value > uint.MaxValue)
             {
+                // show warning, but don't throw an exception to avoid DOS attack where
+                // an attacker might send a packed UInt64 where a packed UInt32 was
+                // expected (https://github.com/vis2k/Mirror/pull/730/)
                 Debug.LogWarning("ReadPackedUInt32() failure, value too large: " + value);
             }
             return (uint)value;

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -71,7 +71,7 @@ namespace Mirror
             ulong value = ReadPackedUInt64();
             if (value > uint.MaxValue)
             {
-                throw new IndexOutOfRangeException("ReadPackedUInt32() failure, value too large");
+                Debug.LogWarning("ReadPackedUInt32() failure, value too large: " + value);
             }
             return (uint)value;
         }

--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -80,6 +80,22 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestPackedUInt32Failure()
+        {
+            Assert.DoesNotThrow(() => {
+                NetworkWriter writer = new NetworkWriter();
+                writer.WritePackedUInt64(1099511627775);
+                writer.WritePackedUInt64(281474976710655);
+                writer.WritePackedUInt64(72057594037927935);
+
+                NetworkReader reader = new NetworkReader(writer.ToArray());
+                reader.ReadPackedUInt32();
+                reader.ReadPackedUInt32();
+                reader.ReadPackedUInt32();
+            });
+        }
+
+        [Test]
         public void TestPackedInt32()
         {
             NetworkWriter writer = new NetworkWriter();
@@ -113,6 +129,22 @@ namespace Mirror.Tests
             Assert.That(reader.ReadPackedInt32(), Is.EqualTo(-16777210));
             Assert.That(reader.ReadPackedInt32(), Is.EqualTo(-16777219));
             Assert.That(reader.ReadPackedInt32(), Is.EqualTo(int.MinValue));
+        }
+
+        [Test]
+        public void TestPackedInt32Failure()
+        {
+            Assert.DoesNotThrow(() => {
+                NetworkWriter writer = new NetworkWriter();
+                writer.WritePackedInt64(1099511627775);
+                writer.WritePackedInt64(281474976710655);
+                writer.WritePackedInt64(72057594037927935);
+
+                NetworkReader reader = new NetworkReader(writer.ToArray());
+                reader.ReadPackedInt32();
+                reader.ReadPackedInt32();
+                reader.ReadPackedInt32();
+            });
         }
 
         [Test]


### PR DESCRIPTION
Note: PackedUInt64 does not have this issue because there is no case for which the initial byte defines an invalid long.