### PR TITLE
Add more test cases to string read/write.

### DIFF
--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -84,6 +84,18 @@ namespace Mirror.Tests
                 "🆄🅽🅸🅲🅾🅳🅴 🆃🅴🆂🆃",
                 "ⓤⓝⓘⓒⓞⓓⓔ ⓣⓔⓢⓣ",
                 "̶̝̳̥͈͖̝͌̈͛̽͊̏̚͠",
+                // test control codes
+                "\r\n", "\n", "\r", "\t",
+                "\\", "\"", "\'",
+                "\u0000\u0001\u0002\u0003",
+                "\u0004\u0005\u0006\u0007",
+                "\u0008\u0009\u000A\u000B",
+                "\u000C\u000D\u000E\u000F",
+                // test invalid bytes as characters
+                "\u00C0\u00C1\u00F5\u00F6",
+                "\u00F7\u00F8\u00F9\u00FA",
+                "\u00FB\u00FC\u00FD\u00FE",
+                "\u00FF",
             };
             foreach (string weird in weirdUnicode)
             {


### PR DESCRIPTION
Note: the invalid byte tests pass, this is not a read-corruption test but a write-corruption test. (they are expected to pass.)