### PR TITLE
Add LocalClient.cs Dummy for Asset Store

### DIFF
--- a/Assets/Mirror/Runtime/LocalClient.cs
+++ b/Assets/Mirror/Runtime/LocalClient.cs
@@ -1,0 +1,5 @@
+// This file was removed in Mirror 1.7
+// The prupose of this file is to get the old file overwritten
+// when users update from the asset store to prevent a flood of errors
+// from having the old file still in the project as a straggler.
+// This file will be dropped from the Assert Store 1.8 package in May 2019


### PR DESCRIPTION
This file should ship with 1.7 to the Asset Store, and can be removed when 1.8 is ready to publish to the store in a May 2019.

This should avoid causing this mess for users:

![image](https://user-images.githubusercontent.com/9826063/55647685-4b403000-57ac-11e9-849f-15086df5ffc7.png)

![image](https://user-images.githubusercontent.com/9826063/55647714-5f842d00-57ac-11e9-9551-5dfba59c2c75.png)
