### PR TITLE
Use NetworkIdentity.spawned to avoid resetting assets, resources, and unspawned objects.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -418,7 +418,7 @@ namespace Mirror
 
         void CleanupNetworkIdentities()
         {
-            foreach (NetworkIdentity identity in Resources.FindObjectsOfTypeAll<NetworkIdentity>())
+            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
             {
                 identity.MarkForReset();
             }


### PR DESCRIPTION
Please test this in your projects. It works in Pong and in Tanks just fine.