### PR TITLE
Avoid copying a HashSet.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -977,9 +977,14 @@ namespace Mirror
             {
                 if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
                 {
+                    // note: clear the owner before destroying, because DestroyObject
+                    // tries to remove this object from the authority owner and fails
+                    // because we are foreach'ing over that collection.
+                    identity.clientAuthorityOwner = null;
                     Destroy(identity.gameObject);
                 }
             }
+            conn.clientOwnedObjects.Clear();
 
             // note: conn.playerController might be null if
             // the player is still in a lobby and hasn't joined the world yet

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -970,11 +970,10 @@ namespace Mirror
             }
         }
 
+        // destroy the player and all their possessions
         public static void DestroyPlayerForConnection(NetworkConnection conn)
         {
-            // => destroy what we can destroy.
-            HashSet<uint> tmp = new HashSet<uint>(conn.clientOwnedObjects);
-            foreach (uint netId in tmp)
+            foreach (uint netId in conn.clientOwnedObjects)
             {
                 if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
                 {
@@ -982,6 +981,8 @@ namespace Mirror
                 }
             }
 
+            // note: conn.playerController might be null if
+            // the player is still in a lobby and hasn't joined the world yet
             if (conn.playerController != null)
             {
                 DestroyObject(conn.playerController, true);


### PR DESCRIPTION
This solves one of the 2 dumb allocations in Mirror that are not related to NetworkReader/NetworkWriter and messages. (The other one is related to NetworkProximityChecker).
Edit: to elaborate, this works in Pong, as opposed to just getting rid of the tmp.