### PR TITLE
Add float binary compatibility tests to NetworkWriter

### DIFF
--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -354,7 +354,8 @@ namespace Mirror.Tests
                 writer.Write(input);
                 NetworkReader reader = new NetworkReader(writer.ToArray());
                 Ray output = reader.ReadRay();
-                Assert.That(output, Is.EqualTo(input));
+                Assert.That((output.direction - input.direction).magnitude, Is.LessThan(1e-6f));
+                Assert.That(output.origin, Is.EqualTo(input.origin));
             }
         }
 
@@ -749,6 +750,63 @@ namespace Mirror.Tests
                 decimal readDecimal = reader.ReadDecimal();
                 Assert.That(readDecimal, Is.EqualTo(weird));
             }
+        }
+
+        [Test]
+        public void TestFloatBinaryCompatibility()
+        {
+            float[] weirdFloats = new float[]{
+                ((float) Math.PI) / 3.0f,
+                ((float) Math.E) / 3.0f
+            };
+            byte[] expected = new byte[]{
+                146, 10,134, 63,
+                197,245,103, 63,
+            };
+            NetworkWriter writer = new NetworkWriter();
+            foreach (float weird in weirdFloats)
+            {
+                writer.Write(weird);
+            }
+            Assert.That(writer.ToArray(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TestDoubleBinaryCompatibility()
+        {
+            double[] weirdDoubles = new double[]{
+                Math.PI / 3.0d,
+                Math.E / 3.0d
+            };
+            byte[] expected = new byte[]{
+                101,115, 45, 56, 82,193,240, 63,
+                140,116,112,185,184,254,236, 63,
+            };
+            NetworkWriter writer = new NetworkWriter();
+            foreach (double weird in weirdDoubles)
+            {
+                writer.Write(weird);
+            }
+            Assert.That(writer.ToArray(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TestDecimalBinaryCompatibility()
+        {
+            decimal[] weirdDecimals = new decimal[]{
+                ((decimal) Math.PI) / 3.0m,
+                ((decimal) Math.E) / 3.0m
+            };
+            byte[] expected = new byte[]{
+                171,234,132, 10, 91, 94,177,  3, 18, 55,214, 33,  0,  0, 28,  0,
+                240,109,194,164,104, 82,  0,  0,  0,  0,  0,  0,  0,  0, 14,  0,
+            };
+            NetworkWriter writer = new NetworkWriter();
+            foreach (decimal weird in weirdDecimals)
+            {
+                writer.Write(weird);
+            }
+            Assert.That(writer.ToArray(), Is.EqualTo(expected));
         }
 
         [Test]


### PR DESCRIPTION
Also added tolerance threshold to Ray normal test since that test was being rickety.