### PR TITLE
fix: Added WriteBytesAndSize tests, and fixed the function to be pedantic.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -74,23 +74,16 @@ namespace Mirror
         // (like an inventory with different items etc.)
         public void WriteBytesAndSize(byte[] buffer, int offset, int count)
         {
+            uint length = checked((uint)count);
             // null is supported because [SyncVar]s might be structs with null byte[] arrays
             // (writing a size=0 empty array is not the same, the server and client would be out of sync)
             // (using size=-1 for null would limit max size to 32kb instead of 64kb)
-            if (buffer == null)
+            writer.Write(buffer != null); // notNull?
+            if (buffer != null)
             {
-                writer.Write(false); // notNull?
-                return;
+                WritePackedUInt32(length);
+                writer.Write(buffer, offset, count);
             }
-            if (count < 0)
-            {
-                Debug.LogError("NetworkWriter WriteBytesAndSize: size " + count + " cannot be negative");
-                return;
-            }
-
-            writer.Write(true); // notNull?
-            WritePackedUInt32((uint)count);
-            writer.Write(buffer, offset, count);
         }
 
         // Weaver needs a write function with just one byte[] parameter

--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -70,6 +70,16 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestWritingNegativeBytesAndSizeFailure()
+        {
+            NetworkWriter writer = new NetworkWriter();
+            Assert.Throws<OverflowException>(() => writer.WriteBytesAndSize(new byte[0], 0, -1));
+            Assert.That(writer.Position, Is.EqualTo(0));
+            Assert.Throws<OverflowException>(() => writer.WriteBytesAndSize(null, 0, -1));
+            Assert.That(writer.Position, Is.EqualTo(0));
+        }
+
+        [Test]
         public void TestReadingTooMuch()
         {
             void EnsureThrows(Action<NetworkReader> read, byte[] data = null)


### PR DESCRIPTION
There were several problems with WriteBytesAndSize, all are covered by this test:
1. negative count check happened *after* Write(isNull), which meant that you could provide a negative count argument which should be rejected, and have it still write a boolean out, modifying Position.
2. negative count check didnt throw any exception, only logged an error.

All tests pass.