### PR TITLE
fix:Fix Round Robin Start Positions

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -715,9 +715,9 @@ namespace Mirror
             }
         }
 
-        public virtual void OnServerError(NetworkConnection conn, int errorCode) { }
+        public virtual void OnServerError(NetworkConnection conn, int errorCode) {}
 
-        public virtual void OnServerSceneChanged(string sceneName) { }
+        public virtual void OnServerSceneChanged(string sceneName) {}
         #endregion
 
         #region Client System Callbacks
@@ -739,13 +739,13 @@ namespace Mirror
             StopClient();
         }
 
-        public virtual void OnClientError(NetworkConnection conn, int errorCode) { }
+        public virtual void OnClientError(NetworkConnection conn, int errorCode) {}
 
-        public virtual void OnClientNotReady(NetworkConnection conn) { }
+        public virtual void OnClientNotReady(NetworkConnection conn) {}
 
         // Called from ClientChangeScene immediately before SceneManager.LoadSceneAsync is executed
         // This allows client to do work / cleanup / prep before the scene changes.
-        public virtual void OnClientChangeScene(string newSceneName) { }
+        public virtual void OnClientChangeScene(string newSceneName) {}
 
         public virtual void OnClientSceneChanged(NetworkConnection conn)
         {
@@ -769,10 +769,10 @@ namespace Mirror
         // their functionality, users would need override all the versions. Instead these callbacks are invoked
         // from all versions, so users only need to implement this one case.
 
-        public virtual void OnStartHost() { }
-        public virtual void OnStartServer() { }
+        public virtual void OnStartHost() {}
+        public virtual void OnStartServer() {}
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Use OnStartClient() instead of OnStartClient(NetworkClient client). All NetworkClient functions are static now, so you can use NetworkClient.Send(message) instead of client.Send(message) directly now.")]
-        public virtual void OnStartClient(NetworkClient client) { }
+        public virtual void OnStartClient(NetworkClient client) {}
         public virtual void OnStartClient()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -780,9 +780,9 @@ namespace Mirror
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
-        public virtual void OnStopServer() { }
-        public virtual void OnStopClient() { }
-        public virtual void OnStopHost() { }
+        public virtual void OnStopServer() {}
+        public virtual void OnStopClient() {}
+        public virtual void OnStopHost() {}
         #endregion
     }
 }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -639,7 +639,7 @@ namespace Mirror
         #endregion
 
         #region Server System Callbacks
-        public virtual void OnServerConnect(NetworkConnection conn) { }
+        public virtual void OnServerConnect(NetworkConnection conn) {}
 
         public virtual void OnServerDisconnect(NetworkConnection conn)
         {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -693,9 +693,7 @@ namespace Mirror
             startPositions.RemoveAll(t => t == null);
 
             if (playerSpawnMethod == PlayerSpawnMethod.Random && startPositions.Count > 0)
-            {
                 return startPositions[UnityEngine.Random.Range(0, startPositions.Count)];
-            }
 
             if (playerSpawnMethod == PlayerSpawnMethod.RoundRobin && startPositions.Count > 0)
             {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -507,7 +507,7 @@ namespace Mirror
         {
             startPositions.Clear();
             startPositionIndex = 0;
-            foreach (NetworkStartPosition networkStartPosition in FindObjectsOfType<NetworkStartPosition>().OrderBy(m => m.transform.GetSiblingIndex()).ToArray())
+            foreach (NetworkStartPosition networkStartPosition in FindObjectsOfType<NetworkStartPosition>().OrderBy(m => m.transform.GetSiblingIndex()))
                 startPositions.Add(networkStartPosition.transform);
         }
 

--- a/Assets/Mirror/Runtime/NetworkStartPosition.cs
+++ b/Assets/Mirror/Runtime/NetworkStartPosition.cs
@@ -7,10 +7,8 @@ namespace Mirror
     [HelpURL("https://vis2k.github.io/Mirror/Components/NetworkStartPosition")]
     public class NetworkStartPosition : MonoBehaviour
     {
-        public void Awake()
-        {
-            NetworkManager.RegisterStartPosition(transform);
-        }
+        // NetworkManager.RebuildStartPositions() will collect all objects
+        // in the scene with this component in depth-first hierarchy order
 
         public void OnDestroy()
         {


### PR DESCRIPTION
Fix for #724 by having Network Manager collect the Network Start Position objects from the scene using 
`FindObjectsOfType<NetworkStartPosition>().OrderBy(m => m.transform.GetSiblingIndex())`
in a new method, `RebuildStartPositions`, which returns a depth-first hierarchical order.

`RebuildStartPositions` is called at the end of `ServerStart` and `ServerChangeScene`.

The static method `RegisterStartPosition` remains so user code still works for manual adding.