### PR TITLE
feat: Added toggle between local and world coordinates

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -203,9 +203,14 @@ namespace Mirror
                 // position if we aren't too far away
                 if (Vector3.Distance(targetComponent.transform.position, start.position) < oldDistance + newDistance)
                 {
-                    start.position = useLocalCoordinates ? targetComponent.transform.localPosition : targetComponent.transform.position;
-                    start.rotation = useLocalCoordinates ? targetComponent.transform.localRotation : targetComponent.transform.rotation;
-                }
+                    if(useLocalCoordinates){
+                        start.position = targetComponent.transform.localPosition;
+                        start.rotation = targetComponent.transform.localRotation;
+                    } else {
+                        start.position = targetComponent.transform.position;
+                        start.rotation = targetComponent.transform.rotation;
+                    }
+               }
             }
 
             // set new destination in any case. new data is best data.

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -342,7 +342,6 @@ namespace Mirror
                     targetComponent.transform.rotation = rotation;
                 }
             }
-
         }
 
         void Update()
@@ -369,8 +368,14 @@ namespace Mirror
                         {
                             // serialize
                             NetworkWriter writer = new NetworkWriter();
-                            SerializeIntoWriter(writer, targetComponent.transform.position, targetComponent.transform.rotation, compressRotation);
-
+                            if(useLocalCoordinates)
+                            {
+                                SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation);
+                            }
+                            else
+                            {
+                                SerializeIntoWriter(writer, targetComponent.transform.position, targetComponent.transform.rotation, compressRotation);
+                            }
                             // send to server
                             CmdClientToServerSync(writer.ToArray());
                         }

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -32,7 +32,7 @@ namespace Mirror
         [SerializeField] Compression compressRotation = Compression.Much;
         public enum Compression { None, Much, Lots , NoRotation }; // easily understandable and funny
 
-        [SerializeField] bool useLocalCoordinates; // Default behavior of UNET NetworkTransformChild = true. AR devs need local positions on everything, so expose bool in inspector for all NetworkTransforms
+        public bool useLocalCoordinates; // Default behavior of UNET NetworkTransformChild = true. AR devs need local positions on everything, so expose bool in inspector for all NetworkTransforms
 
         // server
         Vector3 lastPosition;

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -313,9 +313,6 @@ namespace Mirror
         // set position carefully depending on the target component
         void ApplyPositionAndRotation(Vector3 position, Quaternion rotation)
         {
-
-
-
             if (useLocalCoordinates)
             {
                 targetComponent.transform.localPosition = position;

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -91,11 +91,13 @@ namespace Mirror
 
         public override bool OnSerialize(NetworkWriter writer, bool initialState)
         {
-        if(useLocalCoordinates){
-                    SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation);
-        } else {
-                    SerializeIntoWriter(writer, targetComponent.transform.position, targetComponent.transform.rotation, compressRotation);
-        }
+            if(useLocalCoordinates){
+                SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation);
+            }
+            else
+            {
+                SerializeIntoWriter(writer, targetComponent.transform.position, targetComponent.transform.rotation, compressRotation);
+            }
             return true;
         }
 
@@ -206,7 +208,9 @@ namespace Mirror
                     if(useLocalCoordinates){
                         start.position = targetComponent.transform.localPosition;
                         start.rotation = targetComponent.transform.localRotation;
-                    } else {
+                    }
+                    else
+                    {
                         start.position = targetComponent.transform.position;
                         start.rotation = targetComponent.transform.rotation;
                     }
@@ -329,7 +333,9 @@ namespace Mirror
                 {
                     targetComponent.transform.localRotation = rotation;
                 }
-            } else {
+            }
+            else
+            {
                 targetComponent.transform.position = position;
                 if (Compression.NoRotation != compressRotation)
                 {

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -91,7 +91,11 @@ namespace Mirror
 
         public override bool OnSerialize(NetworkWriter writer, bool initialState)
         {
-            SerializeIntoWriter(writer, useLocalCoordinates ? targetComponent.transform.localPosition : targetComponent.transform.position, useLocalCoordinates ? targetComponent.transform.localRotation : targetComponent.transform.rotation, compressRotation);
+        if(useLocalCoordinates){
+                    SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation);
+        } else {
+                    SerializeIntoWriter(writer, targetComponent.transform.position, targetComponent.transform.rotation, compressRotation);
+        }
             return true;
         }
 


### PR DESCRIPTION
In UNET, NetworkChildTransform defaults to localPosition, while in Mirror it's .position. For any situation where local and world position don't line up (for example, when calibrating an AR scene) this breaks everything.
Added a boolean toggle and a ternary operator to minimize code rewrite. By adding a bool, users can decide whether to cast to local or world coordinates on any NetworkTransform descendant, including NetworkTransform and NetworkTransformChild.