### PR TITLE
Renamed networkBehaviours to networkBehavioursCache to reduce confusion

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -22,7 +22,7 @@ namespace Mirror
         [SerializeField] bool m_ServerOnly;
         [SerializeField] bool m_LocalPlayerAuthority;
         bool m_IsServer;
-        NetworkBehaviour[] networkBehaviours;
+        NetworkBehaviour[] networkBehavioursCache;
 
         // member used to mark a identity for future reset
         // check MarkForReset for more information.
@@ -53,7 +53,7 @@ namespace Mirror
         // all spawned NetworkIdentities by netId. needed on server and client.
         public static readonly Dictionary<uint, NetworkIdentity> spawned = new Dictionary<uint, NetworkIdentity>();
 
-        public NetworkBehaviour[] NetworkBehaviours => networkBehaviours = networkBehaviours ?? GetComponents<NetworkBehaviour>();
+        public NetworkBehaviour[] NetworkBehaviours => networkBehavioursCache = networkBehavioursCache ?? GetComponents<NetworkBehaviour>();
 
         // the AssetId trick:
         // - ideally we would have a serialized 'Guid m_AssetId' but Unity can't
@@ -447,7 +447,7 @@ namespace Mirror
 
         void OnStartAuthority()
         {
-            if (networkBehaviours == null)
+            if (networkBehavioursCache == null)
             {
                 Debug.LogError("Network object " + name + " not initialized properly. Do you have more than one NetworkIdentity in the same object? Did you forget to spawn this object with NetworkServer?", this);
                 return;
@@ -561,19 +561,19 @@ namespace Mirror
             // reset cached writer length and position
             onSerializeWriter.SetLength(0);
 
-            if (networkBehaviours.Length > 64)
+            if (networkBehavioursCache.Length > 64)
             {
                 Debug.LogError("Only 64 NetworkBehaviour components are allowed for NetworkIdentity: " + name + " because of the dirtyComponentMask");
                 return null;
             }
-            ulong dirtyComponentsMask = GetDirtyMask(networkBehaviours, initialState);
+            ulong dirtyComponentsMask = GetDirtyMask(networkBehavioursCache, initialState);
 
             if (dirtyComponentsMask == 0L)
                 return null;
 
             onSerializeWriter.WritePackedUInt64(dirtyComponentsMask); // WritePacked64 so we don't write full 8 bytes if we don't have to
 
-            foreach (NetworkBehaviour comp in networkBehaviours)
+            foreach (NetworkBehaviour comp in networkBehavioursCache)
             {
                 // is this component dirty?
                 // -> always serialize if initialState so all components are included in spawn packet
@@ -680,9 +680,9 @@ namespace Mirror
             }
 
             // find the right component to invoke the function on
-            if (0 <= componentIndex && componentIndex < networkBehaviours.Length)
+            if (0 <= componentIndex && componentIndex < networkBehavioursCache.Length)
             {
-                NetworkBehaviour invokeComponent = networkBehaviours[componentIndex];
+                NetworkBehaviour invokeComponent = networkBehavioursCache[componentIndex];
                 if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader))
                 {
                     Debug.LogError("Found no receiver for incoming " + invokeType + " [" + functionHash + "] on " + gameObject + ",  the server and client should have the same NetworkBehaviour instances [netId=" + netId + "].");
@@ -730,7 +730,7 @@ namespace Mirror
                 hasAuthority = true;
             }
 
-            foreach (NetworkBehaviour comp in networkBehaviours)
+            foreach (NetworkBehaviour comp in networkBehavioursCache)
             {
                 comp.OnStartLocalPlayer();
 
@@ -743,9 +743,9 @@ namespace Mirror
 
         internal void OnNetworkDestroy()
         {
-            for (int i = 0; networkBehaviours != null && i < networkBehaviours.Length; i++)
+            for (int i = 0; networkBehavioursCache != null && i < networkBehavioursCache.Length; i++)
             {
-                NetworkBehaviour comp = networkBehaviours[i];
+                NetworkBehaviour comp = networkBehavioursCache[i];
                 comp.OnNetworkDestroy();
             }
             m_IsServer = false;
@@ -985,7 +985,7 @@ namespace Mirror
             isLocalPlayer = false;
             connectionToServer = null;
             connectionToClient = null;
-            networkBehaviours = null;
+            networkBehavioursCache = null;
 
             ClearObservers();
             clientAuthorityOwner = null;


### PR DESCRIPTION
No functionality changes. Figuring out when we should use cache and when we shouldnt is for another PR. This is just to make the name less confusing, because before the two names were identical except for capitalization of the first letter.