### PR TITLE
Obsoleted IsHeadless()

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -87,7 +87,13 @@ namespace Mirror
         }
 
         // headless mode detection
-        public static bool IsHeadless => SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null;
+        public static bool isHeadless => SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null;
+
+        [Obsolete("This is a static property now...use `isHeadless` instead of `IsHeadless()`.  This method will be removed by summer 2019.")]
+        public static bool IsHeadless()
+        {
+            return isHeadless;
+        }
 
         void InitializeSingleton()
         {
@@ -129,7 +135,7 @@ namespace Mirror
             // some transports might not be ready until Start.
             //
             // (tick rate is applied in StartServer!)
-            if (IsHeadless && startOnHeadless)
+            if (isHeadless && startOnHeadless)
             {
                 StartServer();
             }
@@ -232,7 +238,7 @@ namespace Mirror
             // * if not in Editor (it doesn't work in the Editor)
             // * if not in Host mode
 #if !UNITY_EDITOR
-            if (!NetworkClient.active && IsHeadless)
+            if (!NetworkClient.active && isHeadless)
             {
                 Application.targetFrameRate = serverTickRate;
                 Debug.Log("Server Tick Rate set to: " + Application.targetFrameRate + " Hz.");


### PR DESCRIPTION
IsHeadless() was just added in Feb. 2019, so I wouldn't expect wide usage so quickly, but since there have been 3 asset store publishes since then, it should be obsoleted for a bit.

Also made `isHeadless` camelCase now that it's a property, which made obsoleting it possible.