### PR TITLE
feat: Custom readers and writers

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -78,7 +78,7 @@ namespace Mirror.Weaver
 
             if (parameterType.Resolve().FullName != Weaver.NetworkReaderType.FullName)
             {
-                Weaver.Error($"Reader {md.FullName} must receive a NetworkReader");
+                Weaver.Error($"Reader {md.FullName} must be static and take one NetworkReader as parameter.");
                 return;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -86,11 +86,11 @@ namespace Mirror.Weaver
             }
         }
 
-        private static void RegisterCustomReader(MethodDefinition md)
+        static void RegisterCustomReader(MethodDefinition md)
         {
             if (md.Parameters.Count != 1)
             {
-                Weaver.Error($"Reader {md.FullName} must receive a NetworkReader");
+                Weaver.Error($"Reader {md.FullName} must have exactly one NetworkReader parameter and no others");
                 return;
             }
 
@@ -110,7 +110,7 @@ namespace Mirror.Weaver
                     returnType.ReturnType.FullName,
                     prevReader.FullName,
                     md.FullName
-                    ));
+                ));
                 return;
             }
             readFuncs[returnType.ReturnType.FullName] = md;

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -59,10 +59,7 @@ namespace Mirror.Weaver
         {
             foreach (TypeDefinition td in currentAssembly.MainModule.Types)
             {
-                if (td.IsClass && td.BaseType.CanBeResolved())
-                {
-                    RegisterCustomReaders(td);
-                }
+                RegisterCustomReaders(td);
             }
         }
 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -70,7 +70,7 @@ namespace Mirror.Weaver
             {
                 if (md.Parameters.Count != 0)
                 {
-                    Weaver.Error($"Reader {md.FullName} must have exactly one NetworkReader parameter and no others");
+                    Weaver.Error($"Reader {md.FullName} must be static and take one NetworkReader as parameter.");
                     return;
                 }
                 parameterType = md.DeclaringType;

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -106,8 +106,6 @@ namespace Mirror.Weaver
         public static TypeReference TargetRpcType;
         public static TypeReference SyncEventType;
         public static TypeReference SyncObjectType;
-        public static TypeReference ReaderType;
-        public static TypeReference WriterType;
         public static MethodReference InitSyncObjectReference;
 
         // system types
@@ -252,8 +250,6 @@ namespace Mirror.Weaver
             TargetRpcType = NetAssembly.MainModule.GetType("Mirror.TargetRpcAttribute");
             SyncEventType = NetAssembly.MainModule.GetType("Mirror.SyncEventAttribute");
             SyncObjectType = NetAssembly.MainModule.GetType("Mirror.SyncObject");
-            ReaderType = NetAssembly.MainModule.GetType("Mirror.NetworkReaderAttribute");
-            WriterType = NetAssembly.MainModule.GetType("Mirror.NetworkWriterAttribute");
         }
 
         static void SetupCorLib()
@@ -553,8 +549,8 @@ namespace Mirror.Weaver
             using (CurrentAssembly = AssemblyDefinition.ReadAssembly(assName, readParams))
             {
                 SetupTargetTypes();
-                Readers.Init(CurrentAssembly);
-                Writers.Init(CurrentAssembly);
+                Readers.Init(NetAssembly, CurrentAssembly);
+                Writers.Init(NetAssembly, CurrentAssembly);
 
                 ModuleDefinition moduleDefinition = CurrentAssembly.MainModule;
                 Console.WriteLine("Script Module: {0}", moduleDefinition.Name);

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -106,6 +106,7 @@ namespace Mirror.Weaver
         public static TypeReference TargetRpcType;
         public static TypeReference SyncEventType;
         public static TypeReference SyncObjectType;
+        public static TypeReference ReaderType;
         public static MethodReference InitSyncObjectReference;
 
         // system types
@@ -250,6 +251,7 @@ namespace Mirror.Weaver
             TargetRpcType = NetAssembly.MainModule.GetType("Mirror.TargetRpcAttribute");
             SyncEventType = NetAssembly.MainModule.GetType("Mirror.SyncEventAttribute");
             SyncObjectType = NetAssembly.MainModule.GetType("Mirror.SyncObject");
+            ReaderType = NetAssembly.MainModule.GetType("Mirror.ReaderAttribute");
         }
 
         static void SetupCorLib()

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -252,8 +252,8 @@ namespace Mirror.Weaver
             TargetRpcType = NetAssembly.MainModule.GetType("Mirror.TargetRpcAttribute");
             SyncEventType = NetAssembly.MainModule.GetType("Mirror.SyncEventAttribute");
             SyncObjectType = NetAssembly.MainModule.GetType("Mirror.SyncObject");
-            ReaderType = NetAssembly.MainModule.GetType("Mirror.ReaderAttribute");
-            WriterType = NetAssembly.MainModule.GetType("Mirror.WriterAttribute");
+            ReaderType = NetAssembly.MainModule.GetType("Mirror.NetworkReaderAttribute");
+            WriterType = NetAssembly.MainModule.GetType("Mirror.NetworkWriterAttribute");
         }
 
         static void SetupCorLib()

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -107,6 +107,7 @@ namespace Mirror.Weaver
         public static TypeReference SyncEventType;
         public static TypeReference SyncObjectType;
         public static TypeReference ReaderType;
+        public static TypeReference WriterType;
         public static MethodReference InitSyncObjectReference;
 
         // system types
@@ -252,6 +253,7 @@ namespace Mirror.Weaver
             SyncEventType = NetAssembly.MainModule.GetType("Mirror.SyncEventAttribute");
             SyncObjectType = NetAssembly.MainModule.GetType("Mirror.SyncObject");
             ReaderType = NetAssembly.MainModule.GetType("Mirror.ReaderAttribute");
+            WriterType = NetAssembly.MainModule.GetType("Mirror.WriterAttribute");
         }
 
         static void SetupCorLib()

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -86,7 +86,7 @@ namespace Mirror.Weaver
 
             if (writerParameterType.Resolve().FullName != Weaver.NetworkWriterType.FullName)
             {
-                Weaver.Error($"Writer {md.FullName} must have a NetworkWriter as the first parameter");
+                Weaver.Error($"Writer {md.FullName} must be static and have a NetworkWriter as its first parameter, and your type as the second parameter.");
                 return;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -61,10 +61,7 @@ namespace Mirror.Weaver
         {
             foreach (TypeDefinition td in currentAssembly.MainModule.Types)
             {
-                if (td.IsClass && td.BaseType.CanBeResolved())
-                {
-                    RegisterCustomWriters(td);
-                }
+                RegisterCustomWriters(td);
             }
         }
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -13,55 +13,26 @@ namespace Mirror.Weaver
 
         static Dictionary<string, MethodReference> writeFuncs;
         static Dictionary<string, MethodReference> customWriters;
+        static AssemblyDefinition currentAssembly;
 
-        public static void Init(AssemblyDefinition CurrentAssembly)
+
+        public static void Init(AssemblyDefinition mirrorAssembly, AssemblyDefinition currentAssembly)
         {
-            TypeReference networkWriterType = Weaver.NetworkWriterType;
+            Writers.currentAssembly = currentAssembly;
 
-            writeFuncs = new Dictionary<string, MethodReference>
-            {
-                { Weaver.singleType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.singleType) },
-                { Weaver.doubleType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.doubleType) },
-                { Weaver.boolType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.boolType) },
-                { Weaver.stringType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.stringType) },
-                { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedInt64") },
-                { Weaver.uint64Type.FullName, Weaver.NetworkWriterWritePackedUInt64 },
-                { Weaver.int32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedInt32") },
-                { Weaver.uint32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedUInt32") },
-                { Weaver.int16Type.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.int16Type) },
-                { Weaver.uint16Type.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.uint16Type) },
-                { Weaver.byteType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.byteType) },
-                { Weaver.sbyteType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.sbyteType) },
-                { Weaver.charType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.charType) },
-                { Weaver.decimalType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.decimalType) },
-                { Weaver.vector2Type.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.vector2Type) },
-                { Weaver.vector3Type.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.vector3Type) },
-                { Weaver.vector4Type.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.vector4Type) },
-                { Weaver.vector2IntType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.vector2IntType) },
-                { Weaver.vector3IntType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.vector3IntType) },
-                { Weaver.colorType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.colorType) },
-                { Weaver.color32Type.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.color32Type) },
-                { Weaver.quaternionType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.quaternionType) },
-                { Weaver.rectType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.rectType) },
-                { Weaver.planeType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.planeType) },
-                { Weaver.rayType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.rayType) },
-                { Weaver.matrixType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.matrixType) },
-                { Weaver.guidType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.guidType) },
-                { Weaver.gameObjectType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.gameObjectType) },
-                { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.NetworkIdentityType) },
-                { Weaver.transformType.FullName, Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "Write", Weaver.transformType) },
-                { "System.Byte[]", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSize", "System.Byte[]") }
-            };
-
+            writeFuncs = new Dictionary<string, MethodReference>();
             customWriters = new Dictionary<string, MethodReference>();
-            RegisterCustomWriters(CurrentAssembly);
+            RegisterCustomWriters(mirrorAssembly);
+       
+            customWriters = new Dictionary<string, MethodReference>();
+            RegisterCustomWriters(currentAssembly);
         }
 
         static void RegisterCustomWriters(AssemblyDefinition currentAssembly)
         {
             foreach (TypeDefinition td in currentAssembly.MainModule.Types)
             {
-                RegisterCustomWriters(td);
+                RegisterCustomWriters(td.Resolve());
             }
         }
 
@@ -71,7 +42,7 @@ namespace Mirror.Weaver
             {
                 foreach (CustomAttribute ca in md.CustomAttributes)
                 {
-                    if (ca.AttributeType.FullName == Weaver.WriterType.FullName)
+                    if (ca.AttributeType.FullName == "Mirror.NetworkWriterAttribute")
                     {
                         RegisterCustomWriter(md);
                         break;
@@ -87,35 +58,50 @@ namespace Mirror.Weaver
 
         static void RegisterCustomWriter(MethodDefinition md)
         {
-            if (md.Parameters.Count != 2)
+            TypeReference writerParameterType;
+            TypeReference dataParameterType;
+
+            if (md.IsStatic)
             {
-                Weaver.Error($"Writer {md.FullName} must receive a NetworkWriter and your parameter");
-                return;
+                if (md.Parameters.Count != 2)
+                {
+                    Weaver.Error($"Writer {md.FullName} must receive a NetworkWriter and your parameter");
+                    return;
+                }
+
+                writerParameterType = md.Parameters[0].ParameterType;
+                dataParameterType = md.Parameters[1].ParameterType;
+            }
+            else
+            {
+                if (md.Parameters.Count != 1)
+                {
+                    Weaver.Error($"Writer {md.FullName} must receive a NetworkWriter and your parameter");
+                    return;
+                }
+
+                writerParameterType = md.DeclaringType;
+                dataParameterType = md.Parameters[0].ParameterType;
             }
 
-            ParameterDefinition writerParameter = md.Parameters[0];
-
-            if (writerParameter.ParameterType.Resolve().FullName != Weaver.NetworkWriterType.FullName)
+            if (writerParameterType.Resolve().FullName != Weaver.NetworkWriterType.FullName)
             {
                 Weaver.Error($"Writer {md.FullName} must have a NetworkWriter as the first parameter");
                 return;
             }
 
-            ParameterDefinition dataParameter = md.Parameters[1];
-
-            TypeReference parameterType = dataParameter.ParameterType;
-
-            if (customWriters.TryGetValue(parameterType.FullName, out MethodReference prevWriter))
+            if (customWriters.TryGetValue(dataParameterType.FullName, out MethodReference prevWriter))
             {
                 Weaver.Error(string.Format("Multiple writers found for {0}: {1} and {2} ",
-                    parameterType.FullName,
+                    dataParameterType.FullName,
                     prevWriter.FullName,
                     md.FullName
                 ));
                 return;
             }
-            writeFuncs[parameterType.FullName] = md;
-            customWriters[parameterType.FullName] = md;
+            MethodReference methodReference = currentAssembly.MainModule.ImportReference(md);
+            writeFuncs[dataParameterType.FullName] = methodReference;
+            customWriters[dataParameterType.FullName] = methodReference;
         }
 
         public static MethodReference GetWriteFunc(TypeReference variable, int recursionCount = 0)

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -76,7 +76,7 @@ namespace Mirror.Weaver
             {
                 if (md.Parameters.Count != 1)
                 {
-                    Weaver.Error($"Writer {md.FullName} must receive a NetworkWriter and your parameter");
+                    Weaver.Error($"Writer {md.FullName} must be static and have a NetworkWriter as its first parameter, and your type as the second parameter.");
                     return;
                 }
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -88,7 +88,7 @@ namespace Mirror.Weaver
             }
         }
 
-        private static void RegisterCustomWriter(MethodDefinition md)
+        static void RegisterCustomWriter(MethodDefinition md)
         {
             if (md.Parameters.Count != 2)
             {
@@ -100,7 +100,7 @@ namespace Mirror.Weaver
 
             if (writerParameter.ParameterType.Resolve().FullName != Weaver.NetworkWriterType.FullName)
             {
-                Weaver.Error($"Writer {md.FullName} must receive a NetworkWriter");
+                Weaver.Error($"Writer {md.FullName} must have a NetworkWriter as the first parameter");
                 return;
             }
 
@@ -114,7 +114,7 @@ namespace Mirror.Weaver
                     parameterType.FullName,
                     prevWriter.FullName,
                     md.FullName
-                    ));
+                ));
                 return;
             }
             writeFuncs[parameterType.FullName] = md;

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -55,4 +55,10 @@ namespace Mirror
 
     // For Scene property Drawer
     public class SceneAttribute : PropertyAttribute {}
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class WriterAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class ReaderAttribute : Attribute { }
 }

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -57,8 +57,8 @@ namespace Mirror
     public class SceneAttribute : PropertyAttribute {}
 
     [AttributeUsage(AttributeTargets.Method)]
-    public class WriterAttribute : Attribute { }
+    public class WriterAttribute : Attribute {}
 
     [AttributeUsage(AttributeTargets.Method)]
-    public class ReaderAttribute : Attribute { }
+    public class ReaderAttribute : Attribute {}
 }

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -57,8 +57,8 @@ namespace Mirror
     public class SceneAttribute : PropertyAttribute {}
 
     [AttributeUsage(AttributeTargets.Method)]
-    public class WriterAttribute : Attribute {}
+    public class NetworkWriterAttribute : Attribute {}
 
     [AttributeUsage(AttributeTargets.Method)]
-    public class ReaderAttribute : Attribute {}
+    public class NetworkReaderAttribute : Attribute {}
 }

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -27,23 +27,23 @@ namespace Mirror
         public int Position { get { return (int)reader.BaseStream.Position; }  set { reader.BaseStream.Position = value; } }
         public int Length => (int)reader.BaseStream.Length;
 
-        public byte ReadByte() => reader.ReadByte();
-        public sbyte ReadSByte() => reader.ReadSByte();
-        public char ReadChar() => reader.ReadChar();
-        public bool ReadBoolean() => reader.ReadBoolean();
-        public short ReadInt16() => reader.ReadInt16();
-        public ushort ReadUInt16() => reader.ReadUInt16();
+        [NetworkReader] public byte ReadByte() => reader.ReadByte();
+        [NetworkReader] public sbyte ReadSByte() => reader.ReadSByte();
+        [NetworkReader] public char ReadChar() => reader.ReadChar();
+        [NetworkReader] public bool ReadBoolean() => reader.ReadBoolean();
+        [NetworkReader] public short ReadInt16() => reader.ReadInt16();
+        [NetworkReader] public ushort ReadUInt16() => reader.ReadUInt16();
         public int ReadInt32() => reader.ReadInt32();
         public uint ReadUInt32() => reader.ReadUInt32();
         public long ReadInt64() => reader.ReadInt64();
         public ulong ReadUInt64() => reader.ReadUInt64();
-        public decimal ReadDecimal() => reader.ReadDecimal();
-        public float ReadSingle() => reader.ReadSingle();
-        public double ReadDouble() => reader.ReadDouble();
+        [NetworkReader] public decimal ReadDecimal() => reader.ReadDecimal();
+        [NetworkReader] public float ReadSingle() => reader.ReadSingle();
+        [NetworkReader] public double ReadDouble() => reader.ReadDouble();
 
         // note: this will throw an ArgumentException if an invalid utf8 string is sent
         // null support, see NetworkWriter
-        public string ReadString() => ReadBoolean() ? reader.ReadString() : null;
+        [NetworkReader] public string ReadString() => ReadBoolean() ? reader.ReadString() : null;
 
         public byte[] ReadBytes(int count)
         {
@@ -54,9 +54,11 @@ namespace Mirror
 
         // Use checked() to force it to throw OverflowException if data is invalid
         // null support, see NetworkWriter
-        public byte[] ReadBytesAndSize() => ReadBoolean() ? ReadBytes(checked((int)ReadPackedUInt32())) : null;
+        [NetworkReader] public byte[] ReadBytesAndSize() => 
+            ReadBoolean() ? ReadBytes(checked((int)ReadPackedUInt32())) : null;
 
         // zigzag decoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba
+        [NetworkReader]
         public int ReadPackedInt32()
         {
             uint data = ReadPackedUInt32();
@@ -66,15 +68,17 @@ namespace Mirror
         // http://sqlite.org/src4/doc/trunk/www/varint.wiki
         // NOTE: big endian.
         // Use checked() to force it to throw OverflowException if data is invalid
-        public uint ReadPackedUInt32() => checked((uint)ReadPackedUInt64());
+        [NetworkReader] public uint ReadPackedUInt32() => checked((uint)ReadPackedUInt64());
 
         // zigzag decoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba
+        [NetworkReader]
         public long ReadPackedInt64()
         {
             ulong data = ReadPackedUInt64();
             return ((long)(data >> 1)) ^ -((long)data & 1);
         }
 
+        [NetworkReader]
         public ulong ReadPackedUInt64()
         {
             byte a0 = ReadByte();
@@ -134,18 +138,19 @@ namespace Mirror
             throw new IndexOutOfRangeException("ReadPackedUInt64() failure: " + a0);
         }
 
-        public Vector2 ReadVector2() => new Vector2(ReadSingle(), ReadSingle());
-        public Vector3 ReadVector3() => new Vector3(ReadSingle(), ReadSingle(), ReadSingle());
-        public Vector4 ReadVector4() => new Vector4(ReadSingle(), ReadSingle(), ReadSingle(), ReadSingle());
-        public Vector2Int ReadVector2Int() => new Vector2Int(ReadPackedInt32(), ReadPackedInt32());
-        public Vector3Int ReadVector3Int() => new Vector3Int(ReadPackedInt32(), ReadPackedInt32(), ReadPackedInt32());
-        public Color ReadColor() => new Color(ReadSingle(), ReadSingle(), ReadSingle(), ReadSingle());
-        public Color32 ReadColor32() => new Color32(ReadByte(), ReadByte(), ReadByte(), ReadByte());
-        public Quaternion ReadQuaternion() => new Quaternion(ReadSingle(), ReadSingle(), ReadSingle(), ReadSingle());
-        public Rect ReadRect() => new Rect(ReadSingle(), ReadSingle(), ReadSingle(), ReadSingle());
-        public Plane ReadPlane() => new Plane(ReadVector3(), ReadSingle());
-        public Ray ReadRay() => new Ray(ReadVector3(), ReadVector3());
+        [NetworkReader] public Vector2 ReadVector2() => new Vector2(ReadSingle(), ReadSingle());
+        [NetworkReader] public Vector3 ReadVector3() => new Vector3(ReadSingle(), ReadSingle(), ReadSingle());
+        [NetworkReader] public Vector4 ReadVector4() => new Vector4(ReadSingle(), ReadSingle(), ReadSingle(), ReadSingle());
+        [NetworkReader] public Vector2Int ReadVector2Int() => new Vector2Int(ReadPackedInt32(), ReadPackedInt32());
+        [NetworkReader] public Vector3Int ReadVector3Int() => new Vector3Int(ReadPackedInt32(), ReadPackedInt32(), ReadPackedInt32());
+        [NetworkReader] public Color ReadColor() => new Color(ReadSingle(), ReadSingle(), ReadSingle(), ReadSingle());
+        [NetworkReader] public Color32 ReadColor32() => new Color32(ReadByte(), ReadByte(), ReadByte(), ReadByte());
+        [NetworkReader] public Quaternion ReadQuaternion() => new Quaternion(ReadSingle(), ReadSingle(), ReadSingle(), ReadSingle());
+        [NetworkReader] public Rect ReadRect() => new Rect(ReadSingle(), ReadSingle(), ReadSingle(), ReadSingle());
+        [NetworkReader] public Plane ReadPlane() => new Plane(ReadVector3(), ReadSingle());
+        [NetworkReader] public Ray ReadRay() => new Ray(ReadVector3(), ReadVector3());
 
+        [NetworkReader]
         public Matrix4x4 ReadMatrix4x4()
         {
             return new Matrix4x4
@@ -169,10 +174,11 @@ namespace Mirror
             };
         }
 
-        public Guid ReadGuid() => new Guid(ReadBytes(16));
-        public Transform ReadTransform() => ReadNetworkIdentity()?.transform;
-        public GameObject ReadGameObject() => ReadNetworkIdentity()?.gameObject;
+        [NetworkReader] public Guid ReadGuid() => new Guid(ReadBytes(16));
+        [NetworkReader] public Transform ReadTransform() => ReadNetworkIdentity()?.transform;
+        [NetworkReader] public GameObject ReadGameObject() => ReadNetworkIdentity()?.gameObject;
 
+        [NetworkReader]
         public NetworkIdentity ReadNetworkIdentity()
         {
             uint netId = ReadPackedUInt32();

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -38,20 +38,21 @@ namespace Mirror
             ((MemoryStream)writer.BaseStream).SetLength(value);
         }
 
-        public void Write(byte value) => writer.Write(value);
-        public void Write(sbyte value) => writer.Write(value);
-        public void Write(char value) => writer.Write(value);
-        public void Write(bool value) => writer.Write(value);
-        public void Write(short value) => writer.Write(value);
-        public void Write(ushort value) => writer.Write(value);
+        [NetworkWriter] public void Write(byte value) => writer.Write(value);
+        [NetworkWriter] public void Write(sbyte value) => writer.Write(value);
+        [NetworkWriter] public void Write(char value) => writer.Write(value);
+        [NetworkWriter] public void Write(bool value) => writer.Write(value);
+        [NetworkWriter] public void Write(short value) => writer.Write(value);
+        [NetworkWriter] public void Write(ushort value) => writer.Write(value);
         public void Write(int value) => writer.Write(value);
         public void Write(uint value) => writer.Write(value);
         public void Write(long value) => writer.Write(value);
         public void Write(ulong value) => writer.Write(value);
-        public void Write(float value) => writer.Write(value);
-        public void Write(double value) => writer.Write(value);
-        public void Write(decimal value) => writer.Write(value);
+        [NetworkWriter] public void Write(float value) => writer.Write(value);
+        [NetworkWriter] public void Write(double value) => writer.Write(value);
+        [NetworkWriter] public void Write(decimal value) => writer.Write(value);
 
+        [NetworkWriter]
         public void Write(string value)
         {
             // BinaryWriter doesn't support null strings, so let's write an extra boolean for that
@@ -95,6 +96,7 @@ namespace Mirror
 
         // Weaver needs a write function with just one byte[] parameter
         // (we don't name it .Write(byte[]) because it's really a WriteBytesAndSize since we write size / null info too)
+        [NetworkWriter]
         public void WriteBytesAndSize(byte[] buffer)
         {
             // buffer might be null, so we can't use .Length in that case
@@ -102,6 +104,7 @@ namespace Mirror
         }
 
         // zigzag encoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba
+        [NetworkWriter]
         public void WritePackedInt32(int i)
         {
             uint zigzagged = (uint)((i >> 31) ^ (i << 1));
@@ -109,6 +112,7 @@ namespace Mirror
         }
 
         // http://sqlite.org/src4/doc/trunk/www/varint.wiki
+        [NetworkWriter]
         public void WritePackedUInt32(uint value)
         {
             // for 32 bit values WritePackedUInt64 writes the
@@ -117,12 +121,14 @@ namespace Mirror
         }
 
         // zigzag encoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba
+        [NetworkWriter]
         public void WritePackedInt64(long i)
         {
             ulong zigzagged = (ulong)((i >> 63) ^ (i << 1));
             WritePackedUInt64(zigzagged);
         }
 
+        [NetworkWriter]
         public void WritePackedUInt64(ulong value)
         {
             if (value <= 240)
@@ -208,12 +214,14 @@ namespace Mirror
             }
         }
 
+        [NetworkWriter]
         public void Write(Vector2 value)
         {
             Write(value.x);
             Write(value.y);
         }
 
+        [NetworkWriter]
         public void Write(Vector3 value)
         {
             Write(value.x);
@@ -221,6 +229,7 @@ namespace Mirror
             Write(value.z);
         }
 
+        [NetworkWriter]
         public void Write(Vector4 value)
         {
             Write(value.x);
@@ -229,12 +238,14 @@ namespace Mirror
             Write(value.w);
         }
 
+        [NetworkWriter]
         public void Write(Vector2Int value)
         {
             WritePackedInt32(value.x);
             WritePackedInt32(value.y);
         }
 
+        [NetworkWriter]
         public void Write(Vector3Int value)
         {
             WritePackedInt32(value.x);
@@ -242,6 +253,7 @@ namespace Mirror
             WritePackedInt32(value.z);
         }
 
+        [NetworkWriter]
         public void Write(Color value)
         {
             Write(value.r);
@@ -250,6 +262,7 @@ namespace Mirror
             Write(value.a);
         }
 
+        [NetworkWriter]
         public void Write(Color32 value)
         {
             Write(value.r);
@@ -258,6 +271,7 @@ namespace Mirror
             Write(value.a);
         }
 
+        [NetworkWriter]
         public void Write(Quaternion value)
         {
             Write(value.x);
@@ -266,6 +280,7 @@ namespace Mirror
             Write(value.w);
         }
 
+        [NetworkWriter]
         public void Write(Rect value)
         {
             Write(value.xMin);
@@ -274,18 +289,21 @@ namespace Mirror
             Write(value.height);
         }
 
+        [NetworkWriter]
         public void Write(Plane value)
         {
             Write(value.normal);
             Write(value.distance);
         }
 
+        [NetworkWriter]
         public void Write(Ray value)
         {
             Write(value.direction);
             Write(value.origin);
         }
 
+        [NetworkWriter]
         public void Write(Matrix4x4 value)
         {
             Write(value.m00);
@@ -306,11 +324,13 @@ namespace Mirror
             Write(value.m33);
         }
 
+        [NetworkWriter]
         public void Write(Guid value)
         {
             writer.Write(value.ToByteArray());
         }
 
+        [NetworkWriter]
         public void Write(NetworkIdentity value)
         {
             if (value == null)
@@ -321,6 +341,7 @@ namespace Mirror
             WritePackedUInt32(value.netId);
         }
 
+        [NetworkWriter]
         public void Write(Transform value)
         {
             if (value == null || value.gameObject == null)
@@ -340,6 +361,7 @@ namespace Mirror
             }
         }
 
+        [NetworkWriter]
         public void Write(GameObject value)
         {
             if (value == null)

--- a/Assets/Mirror/Tests/CustomWriterTest.cs
+++ b/Assets/Mirror/Tests/CustomWriterTest.cs
@@ -47,7 +47,7 @@ namespace Mirror.Tests
 
             MyMessage unpacked = MessagePacker.Unpack<MyMessage>(data);
 
-            Assert.That(unpacked.myobj.name, Is.EqualTo("Hello World"), "Show be able to use user provider reader/writer");
+            Assert.That(unpacked.myobj.name, Is.EqualTo("Hello World"), "Should be able to use user provider reader/writer");
         }
     }
 }

--- a/Assets/Mirror/Tests/CustomWriterTest.cs
+++ b/Assets/Mirror/Tests/CustomWriterTest.cs
@@ -7,13 +7,13 @@ namespace Mirror.Tests
     {
         public class MyClass
         {
-            public string name {get; set; }
+            public string Name { get; set; }
         }
 
         [Writer]
         public static void WriteMyClass(NetworkWriter networkWriter, MyClass obj)
         {
-            networkWriter.Write(obj.name);
+            networkWriter.Write(obj.Name);
         }
 
         [Reader]
@@ -21,7 +21,7 @@ namespace Mirror.Tests
         {
             return new MyClass()
             {
-                name = reader.ReadString()
+                Name = reader.ReadString()
             };
         }
 
@@ -35,7 +35,7 @@ namespace Mirror.Tests
         {
             MyClass obj = new MyClass()
             {
-                name = "Hello World"
+                Name = "Hello World"
             };
 
             MyMessage message = new MyMessage()
@@ -47,7 +47,7 @@ namespace Mirror.Tests
 
             MyMessage unpacked = MessagePacker.Unpack<MyMessage>(data);
 
-            Assert.That(unpacked.myobj.name, Is.EqualTo("Hello World"), "Should be able to use user provider reader/writer");
+            Assert.That(unpacked.myobj.Name, Is.EqualTo("Hello World"), "Should be able to use user provider reader/writer");
         }
     }
 }

--- a/Assets/Mirror/Tests/CustomWriterTest.cs
+++ b/Assets/Mirror/Tests/CustomWriterTest.cs
@@ -10,13 +10,13 @@ namespace Mirror.Tests
             public string Name { get; set; }
         }
 
-        [Writer]
+        [NetworkWriter]
         public static void WriteMyClass(NetworkWriter networkWriter, MyClass obj)
         {
             networkWriter.Write(obj.Name);
         }
 
-        [Reader]
+        [NetworkReader]
         public static MyClass ReadMyClass(NetworkReader reader)
         {
             return new MyClass()

--- a/Assets/Mirror/Tests/CustomWriterTest.cs
+++ b/Assets/Mirror/Tests/CustomWriterTest.cs
@@ -47,7 +47,7 @@ namespace Mirror.Tests
 
             MyMessage unpacked = MessagePacker.Unpack<MyMessage>(data);
 
-            Assert.That(unpacked.myobj.Name, Is.EqualTo("Hello World"), "Should be able to use user provider reader/writer");
+            Assert.That(unpacked.myobj.Name, Is.EqualTo("Hello World"), "Should be able to use user provided reader/writer");
         }
     }
 }

--- a/Assets/Mirror/Tests/CustomWriterTest.cs
+++ b/Assets/Mirror/Tests/CustomWriterTest.cs
@@ -1,0 +1,53 @@
+using System;
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    public class CustomWriterTest
+    {
+        public class MyClass
+        {
+            public string name {get; set; }
+        }
+
+        [Writer]
+        public static void WriteMyClass(NetworkWriter networkWriter, MyClass obj)
+        {
+            networkWriter.Write(obj.name);
+        }
+
+        [Reader]
+        public static MyClass ReadMyClass(NetworkReader reader)
+        {
+            return new MyClass()
+            {
+                name = reader.ReadString()
+            };
+        }
+
+        class MyMessage : MessageBase
+        {
+            public MyClass myobj;
+        }
+
+        [Test]
+        public void TestCustomWriter()
+        {
+            MyClass obj = new MyClass()
+            {
+                name = "Hello World"
+            };
+
+            MyMessage message = new MyMessage()
+            {
+                myobj = obj
+            };
+
+            byte[] data = MessagePacker.Pack(message);
+
+            MyMessage unpacked = MessagePacker.Unpack<MyMessage>(data);
+
+            Assert.That(unpacked.myobj.name, Is.EqualTo("Hello World"), "Show be able to use user provider reader/writer");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/CustomWriterTest.cs.meta
+++ b/Assets/Mirror/Tests/CustomWriterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7567506989ce54ab0910cea9787c39b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Same as #770 , but this version removes all the hardcoded readers and writers in the weaver and gets them from the NetworkReader and NetworkWriter instead using attributes.

This eliminates the need to modify the weaver every time we add a new type to NetworkReader and NetworkWriter.

To use it for your own classes,  declare a [NetworkReader] and [NetworkWriter] function to handle your type.  for example:

```cs
public partial struct Quest
{
    public ScriptableQuest scriptableQuest;

    public int progress;
    public bool completed;
    ...
}
```
And write a custom reader/writer:

```cs
[NetworkWriter]
public static void WriteQuest(NetworkWriter writer, ScriptableQuest scriptableQuest) {
     writer.Write(scriptableQuest.Name.GetStableHashCode());
}

[NetworkReader]
public static ScriptableQuest ReadQuest(NetworkReader reader) {
    int hash = reader.ReadInt32();
    return ScriptableQuest.dict[hash];
}
```

Another example,  say you want to be able to use Url:

```cs
[NetworkWriter]
public static void WriteUrl(NetworkWriter writer, Url url) {
     writer.Write(url.ToString());
}

[NetworkReader]
public static Url ReadUrl(NetworkReader reader) {
    string txt = reader.ReadString();
    return new Url(txt);
}
```

Now you can use Urls as syncvars,  inside synclists,  as parameters in rpc methods and in messages