### PR TITLE
perf: Reduce enum bandwidth

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Mono.Cecil;
 
 namespace Mirror.Weaver
@@ -38,6 +39,16 @@ namespace Mirror.Weaver
                 }
             }
             return false;
+        }
+
+        public static TypeReference GetEnumUnderlyingType(this TypeDefinition td)
+        {
+            foreach (FieldDefinition field in td.Fields)
+            {
+                if (!field.IsStatic)
+                    return field.FieldType;
+            }
+            throw new ArgumentException($"Invalid enum {td.FullName}");
         }
 
         public static bool ImplementsInterface(this TypeDefinition td, TypeReference baseInterface)

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -96,7 +96,7 @@ namespace Mirror.Weaver
             }
             else if (td.IsEnum)
             {
-                return Weaver.NetworkReaderReadInt32;
+                return GetReadFunc(td.GetEnumUnderlyingType(), recursionCount);
             }
             else
             {

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -83,9 +83,6 @@ namespace Mirror.Weaver
         public static TypeReference CmdDelegateReference;
         public static MethodReference CmdDelegateConstructor;
 
-        public static MethodReference NetworkReaderReadInt32;
-
-        public static MethodReference NetworkWriterWriteInt32;
         public static MethodReference NetworkWriterWriteInt16;
 
         public static MethodReference NetworkServerGetActive;
@@ -307,9 +304,6 @@ namespace Mirror.Weaver
             NetworkServerGetLocalClientActive = Resolvers.ResolveMethod(NetworkServerType, CurrentAssembly, "get_localClientActive");
             NetworkClientGetActive = Resolvers.ResolveMethod(NetworkClientType, CurrentAssembly, "get_active");
 
-            NetworkReaderReadInt32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadInt32");
-
-            NetworkWriterWriteInt32 = Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", int32Type);
             NetworkWriterWriteInt16 = Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", int16Type);
 
             NetworkReaderReadPackedUInt32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt32");

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -90,7 +90,7 @@ namespace Mirror.Weaver
             }
             else if (variable.Resolve().IsEnum)
             {
-                return Weaver.NetworkWriterWriteInt32;
+                return GetWriteFunc(variable.Resolve().GetEnumUnderlyingType(), recursionCount);
             }
             else
             {


### PR DESCRIPTION
enums are serialized according to their size.
if enum extend byte,  they use 1 byte
if enum extend short, they use 2 bytes
if enum extend int,  they are varinted
if enum extend long, they are varinted

So on average,  most enums will take 1 byte.   Previously they always required 4 bytes