### PR TITLE
Remove SyncListStructProcessor Dummy [MERGE AFTER MAY 2019]

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncListStructProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncListStructProcessor.cs
@@ -1,5 +1,0 @@
-// This file was removed in Mirror 3.4.9
-// The purpose of this file is to get the old file overwritten
-// when users update from the asset store to prevent a flood of errors
-// from having the old file still in the project as a straggler.
-// This file will be dropped from the Asset Store package in May 2019


### PR DESCRIPTION
Created this PR so we don't forget to remove the dummy file **after** publishing to the store May 2019