### PR TITLE
fix: #791 corrected assembly paths passed to weaver

### DIFF
--- a/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
+++ b/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
@@ -134,7 +134,7 @@ namespace Mirror.Weaver
             if (Program.Process(unityEngineCoreModuleDLL, mirrorRuntimeDll, null, new[] { assemblyPath }, dependencyPaths.ToArray(), HandleWarning, HandleError))
             {
                 WeaveFailed = false;
-                //Debug.Log("Weaving succeeded for: " + assemblyPath);
+                Debug.Log("Weaving succeeded for: " + assemblyPath);
             }
             else
             {

--- a/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
+++ b/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
-using DotNetAssembly = System.Reflection.Assembly;
 using UnityAssembly = UnityEditor.Compilation.Assembly;
 
 namespace Mirror.Weaver
@@ -68,38 +66,6 @@ namespace Mirror.Weaver
             return "";
         }
 
-        // get all dependency directories
-        static HashSet<string> GetDependencyDirectories(AssemblyName[] dependencies)
-        {
-            // Since this assembly is already loaded in the domain this is a
-            // no-op and returns the already loaded assembly
-            return new HashSet<string>(
-                dependencies.Select(dependency => Path.GetDirectoryName(DotNetAssembly.Load(dependency).Location))
-            );
-        }
-
-        // get all non-dynamic assembly directories
-        static HashSet<string> GetNonDynamicAssemblyDirectories(DotNetAssembly[] assemblies)
-        {
-            HashSet<string> paths = new HashSet<string>();
-
-            foreach (DotNetAssembly assembly in assemblies)
-            {
-                if (!assembly.IsDynamic)
-                {
-                    // need to check if file exists to avoid potential
-                    // FileNotFoundException in Assembly.Load
-                    string assemblyName = assembly.GetName().Name;
-                    if (File.Exists(assemblyName))
-                    {
-                        paths.Add(Path.GetDirectoryName(DotNetAssembly.Load(assemblyName).Location));
-                    }
-                }
-            }
-
-            return paths;
-        }
-
         static bool CompilerMessagesContainError(CompilerMessage[] messages)
         {
             return messages.Any(msg => msg.type == CompilerMessageType.Error);
@@ -151,62 +117,24 @@ namespace Mirror.Weaver
                 return;
             }
 
-            // find all assemblies and the currently compiling assembly
-            DotNetAssembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            DotNetAssembly targetAssembly = assemblies.FirstOrDefault(asm => asm.GetName().Name == Path.GetFileNameWithoutExtension(assemblyPath));
-
-            // prepare variables
+            // build directory list for later asm/symbol resolving using CompilationPipeline refs
             HashSet<string> dependencyPaths = new HashSet<string>();
-
-            // found this assembly in assemblies?
-            if (targetAssembly != null)
-            {
-                // get all dependencies for the target assembly
-                AssemblyName[] dependencies = targetAssembly.GetReferencedAssemblies();
-
-                // does the target assembly depend on Mirror at all?
-                // otherwise there is nothing to weave anyway.
-                bool usesMirror = dependencies.Any(dependency => dependency.Name == MirrorRuntimeAssemblyName);
-                if (!usesMirror)
-                {
-                    return;
-                }
-
-                // get all the directories
-                dependencyPaths = GetDependencyDirectories(dependencies);
-            }
-            else
-            {
-                // Target assembly not found in current domain, trying to load it to check references
-                // will lead to trouble in the build pipeline, so lets assume it should go to weaver.
-                // Add all assemblies in current domain to dependency list since there could be a
-                // dependency lurking there (there might be generated assemblies so ignore file not found exceptions).
-                // (can happen in runtime test framework on editor platform and when doing full library reimport)
-                dependencyPaths = GetNonDynamicAssemblyDirectories(assemblies);
-            }
-
-            // add compiled refs from CompilationPipeline
+            dependencyPaths.Add(Path.GetDirectoryName(assemblyPath));
             foreach (UnityAssembly unityAsm in _cachedAssemblies)
             {
                 if (unityAsm.outputPath != assemblyPath) continue;
 
                 foreach (string unityAsmRef in unityAsm.compiledAssemblyReferences)
                 {
-                    // including NetStandard dependencies causes a stack overflow
-                    // in the Weaver: https://github.com/vis2k/Mirror/issues/791
-                    // root issue: https://github.com/jbevain/cecil/issues/573
-                    if (!unityAsmRef.Contains("NetStandard"))
-                        dependencyPaths.Add(Path.GetDirectoryName(unityAsmRef));
+                    dependencyPaths.Add(Path.GetDirectoryName(unityAsmRef));
                 }
             }
-
-            //if (UnityLogEnabled) Debug.Log("Weaving: " + assemblyPath); // uncomment to easily observe weave targets
-
+             
             // passing null in the outputDirectory param will do an in-place update of the assembly
             if (Program.Process(unityEngineCoreModuleDLL, mirrorRuntimeDll, null, new[] { assemblyPath }, dependencyPaths.ToArray(), HandleWarning, HandleError))
             {
                 WeaveFailed = false;
-                Debug.Log("Weaving succeeded for: " + assemblyPath);
+                //Debug.Log("Weaving succeeded for: " + assemblyPath);
             }
             else
             {


### PR DESCRIPTION
Loading the assembly to read its refs was causing you to see the JIT compiler shim for netstandard.dll. It only exports types and has no definitions. This is what caused the stack overflow as mono bounced back and forth between two assemblies (mscorlib shim and netstandard shim) both of which exported but did not define the types from mscorlib.

Should be resolved with this, although some errors do pop up when doing the re-import trick. They are from the unity upgrade tool that uses cecil and is likely unhappy about symbols not matching the assembly. Everything still weaves and the errors do not recur. Why this triggers on an import project and not otherwise, I do not know.
