### PR TITLE
feat: custom reader and writer for user types

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -98,6 +98,11 @@ namespace Mirror.Weaver
             {
                 return GetReadFunc(td.GetEnumUnderlyingType(), recursionCount);
             }
+            else if (GetCustomReader(td, out MethodReference customReaderFunc))
+            {
+                readFuncs[variable.FullName] = customReaderFunc;
+                return customReaderFunc;
+            }
             else
             {
                 newReaderFunc = GenerateStructReadFunction(variable, recursionCount);
@@ -110,6 +115,41 @@ namespace Mirror.Weaver
             }
             RegisterReadFunc(variable.FullName, newReaderFunc);
             return newReaderFunc;
+        }
+
+        private static bool GetCustomReader(TypeDefinition td, out MethodReference newReaderFunc)
+        {
+            newReaderFunc = default;
+
+            foreach (MethodDefinition md in td.Methods)
+            {
+
+                if (md.IsStatic && 
+                    md.Name == "OnDeserialize")
+                {
+
+                    if (md.Parameters.Count != 1)
+                    {
+                        Weaver.Error($"{md.FullName} should be static and receive only a NetworkReader");
+                        return false;
+                    }
+
+                    if (md.Parameters[0].ParameterType.FullName != Weaver.NetworkReaderDef.FullName)
+                    {
+                        Weaver.Error($"{md.FullName} should be static and receive only a NetworkReader");
+                        return false;
+                    }
+                    if (md.ReturnType.Resolve() != td)
+                    {
+                        Weaver.Error($"{md.FullName} should be static and return ${td.FullName}");
+                        return false;
+                    }
+
+                    newReaderFunc = Weaver.CurrentAssembly.MainModule.ImportReference(md);
+                    return true;
+                }
+            }
+            return false;
         }
 
         static void RegisterReadFunc(string name, MethodDefinition newReaderFunc)

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -117,15 +117,14 @@ namespace Mirror.Weaver
             return newReaderFunc;
         }
 
-        private static bool GetCustomReader(TypeDefinition td, out MethodReference newReaderFunc)
+        static bool GetCustomReader(TypeDefinition td, out MethodReference newReaderFunc)
         {
             newReaderFunc = default;
 
             foreach (MethodDefinition md in td.Methods)
             {
 
-                if (md.IsStatic && 
-                    md.Name == "OnDeserialize")
+                if (md.IsStatic && md.Name == "OnDeserialize")
                 {
 
                     if (md.Parameters.Count != 1)

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -117,6 +117,21 @@ namespace Mirror.Weaver
             return newReaderFunc;
         }
 
+        /* 
+         * Finds OnDeserialize functions provided by the user, and uses them as readers
+         * For example:
+         * 
+         * class ScriptableQuest 
+         * {
+         *     public static Dictionary<int, ScriptableQuest> quests = new Dictionary<int, ScriptableQuest>();
+         * 
+         *     public static ScriptableQuest OnDeserialize(NetworkReader reader) 
+         *     {
+         *        int id = reader.ReadInt32();
+         *        return quests[id];
+         *     }
+         * }        
+         */
         static bool GetCustomReader(TypeDefinition td, out MethodReference newReaderFunc)
         {
             newReaderFunc = default;
@@ -333,3 +348,4 @@ namespace Mirror.Weaver
     }
 
 }
+ 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -123,10 +123,8 @@ namespace Mirror.Weaver
 
             foreach (MethodDefinition md in td.Methods)
             {
-
                 if (md.IsStatic && md.Name == "OnDeserialize")
                 {
-
                     if (md.Parameters.Count != 1)
                     {
                         Weaver.Error($"{md.FullName} should be static and receive only a NetworkReader");

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -92,6 +92,11 @@ namespace Mirror.Weaver
             {
                 return GetWriteFunc(variable.Resolve().GetEnumUnderlyingType(), recursionCount);
             }
+            else if (GetCustomWriter(variable.Resolve(), out MethodReference customWriterFunc))
+            {
+                writeFuncs[variable.FullName] = customWriterFunc;
+                return customWriterFunc;
+            }
             else
             {
                 newWriterFunc = GenerateStructWriterFunction(variable, recursionCount);
@@ -104,6 +109,48 @@ namespace Mirror.Weaver
 
             RegisterWriteFunc(variable.FullName, newWriterFunc);
             return newWriterFunc;
+        }
+
+        static bool GetCustomWriter(TypeDefinition td, out MethodReference newWriterFunc)
+        {
+            newWriterFunc = default;
+
+            foreach (MethodDefinition md in td.Methods)
+            {
+
+                if (md.IsStatic &&
+                    md.Name == "OnSerialize")
+                {
+
+                    if (md.Parameters.Count != 2)
+                    {
+                        Weaver.Error($"{md.FullName} should be static and receive NetworkWriter and ${td.FullName}");
+                        return false;
+                    }
+
+                    if (md.Parameters[0].ParameterType.FullName != Weaver.NetworkWriterDef.FullName)
+                    {
+                        Weaver.Error($"{md.FullName} should be static and receive NetworkWriter and ${td.FullName}");
+                        return false;
+                    }
+
+                    if (md.Parameters[1].ParameterType.FullName != td.FullName)
+                    {
+                        Weaver.Error($"{md.FullName} should be static and receive NetworkWriter and ${td.FullName}");
+                        return false;
+                    }
+
+                    if (md.ReturnType.Resolve().FullName != Weaver.voidType.FullName)
+                    {
+                        Weaver.Error($"{md.FullName} should be void static");
+                        return false;
+                    }
+
+                    newWriterFunc = Weaver.CurrentAssembly.MainModule.ImportReference(md);
+                    return true;
+                }
+            }
+            return false;
         }
 
         static void RegisterWriteFunc(string name, MethodDefinition newWriterFunc)

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -117,10 +117,8 @@ namespace Mirror.Weaver
 
             foreach (MethodDefinition md in td.Methods)
             {
-
                 if (md.IsStatic && md.Name == "OnSerialize")
                 {
-
                     if (md.Parameters.Count != 2)
                     {
                         Weaver.Error($"{md.FullName} should be static and receive NetworkWriter and ${td.FullName}");

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -118,8 +118,7 @@ namespace Mirror.Weaver
             foreach (MethodDefinition md in td.Methods)
             {
 
-                if (md.IsStatic &&
-                    md.Name == "OnSerialize")
+                if (md.IsStatic && md.Name == "OnSerialize")
                 {
 
                     if (md.Parameters.Count != 2)

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -111,6 +111,20 @@ namespace Mirror.Weaver
             return newWriterFunc;
         }
 
+        /* 
+         * Finds OnSerialize functions provided by the user, and uses them as readers
+         * For example:
+         * 
+         * class ScriptableQuest 
+         * {
+         *     public int Id { get; set; }
+         * 
+         *     public static void OnSerialize(NetworkWriter writer, ScripableQuest quest) 
+         *     {
+         *        writer.Write(quest.Id);
+         *     }
+         * }        
+         */
         static bool GetCustomWriter(TypeDefinition td, out MethodReference newWriterFunc)
         {
             newWriterFunc = default;


### PR DESCRIPTION
This is an alternative to #784 

In this implementation,  you add an "OnSerialize/OnDeserialize"  to your custom types.  

Suppose you want to serialize this class:

```cs
public struct Quest
{
    public ScriptableQuest scriptableQuest;

    public int progress;
    public bool completed;
    ...
}
```

You can add a `OnSerialize` and `OnDeserialize` method in the `ScritpableQuest` class:

```cs
class ScriptableQuest 
{
    ...

    public static void OnSerialize(NetworkWriter writer, ScriptableQuest scriptableQuest) {
         writer.Write(scriptableQuest.Name.GetStableHashCode());
    }

    public static ScriptableQuest OnDeserialize(NetworkReader reader) {
        int hash = reader.ReadInt32();
        return ScriptableQuest.dict[hash];
    }
}
```

There are pros and cons with #784 
## Pros ##
* Much simpler code.  Mirror simply looks for `OnSerialize` and `OnDeserialize` methods in every type
* Much faster weaving.  Mirror does not need to scan assemblies
* Works across assemblies <- this is a show stopper for #784 

## Cons ##
* Cannot define readers and writers for System.* types
* Cannot override Mirror readers and writers
* Cannot add to NetworkBehaviors,  because they have a `OnSerialize` and `OnDeserialize` that are not compatible.

It is enough to solve the serialization issues in ummorpg and Cubica.