### PR TITLE
Minor "Scene needs to be resaved" wording change.

### DIFF
--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -80,7 +80,7 @@ namespace Mirror
                     }
                     // throwing an exception would only show it for one object
                     // because this function would return afterwards.
-                    else Debug.LogError("Scene " + identity.gameObject.scene.path + " needs to be opened and resaved, because the scene object " + identity.name + " has no valid sceneId yet.");
+                    else Debug.LogError("The scene '" + identity.gameObject.scene.path + "' needs to be opened and resaved, because the scene object '" + identity.name + "' has no valid sceneId yet. If you continue to see this, try making sure that your project Build Settings doesn't contain any deleted/ghost scenes. Failing that, please open a bug report and tell us how you got this error.");
                 }
             }
         }


### PR DESCRIPTION
This PR just simply rewords the error message that appears when a scene needs to be saved because a scene object doesn't have a network ID.

This might be a pointless PR but it points out a possible issue or two and then says "if you can't solve it, it may be a bug, report it". Better to give some pointers that might help newcomers what could be going on (some users had ghost/deleted scenes that bowled them over in their Build Settings) than having to point out such a simple fix in the Discord.