### PR TITLE
fix: Respect Player Prefab Position & Rotation

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -681,7 +681,7 @@ namespace Mirror
             Transform startPos = GetStartPosition();
             GameObject player = startPos != null
                 ? Instantiate(playerPrefab, startPos.position, startPos.rotation)
-                : Instantiate(playerPrefab, Vector3.zero, Quaternion.identity);
+                : Instantiate(playerPrefab);
 
             NetworkServer.AddPlayerForConnection(conn, player);
         }


### PR DESCRIPTION
I don't understand why we're forcing position and rotation to be 0,0,0 when a prefab's stored values can be used.
Capsules in particular need to be positioned at least Y>=1 to not fall through a floor that's at Y=0.
We shouldn't need to use a NetworkStartPosition or code an override to get the prefab to spawn where we defined in the prefab.