### PR TITLE
Simplify GetStartPosition

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -691,24 +691,17 @@ namespace Mirror
             // first remove any dead transforms
             startPositions.RemoveAll(t => t == null);
 
-            if (playerSpawnMethod == PlayerSpawnMethod.Random && startPositions.Count > 0)
-            {
-                // try to spawn at a random start location
-                int index = UnityEngine.Random.Range(0, startPositions.Count);
-                return startPositions[index];
-            }
-            if (playerSpawnMethod == PlayerSpawnMethod.RoundRobin && startPositions.Count > 0)
-            {
-                if (startPositionIndex >= startPositions.Count)
-                {
-                    startPositionIndex = 0;
-                }
+			if (startPositions.Count == 0)
+				return null;
 
-                Transform startPos = startPositions[startPositionIndex];
-                startPositionIndex += 1;
-                return startPos;
-            }
-            return null;
+			// In the unlikely event we've actually had 2,147,483,647 clients join....
+			if (startPositionIndex == int.MaxValue)
+				startPositionIndex = 0;
+
+			if (playerSpawnMethod == PlayerSpawnMethod.Random)
+				return startPositions[UnityEngine.Random.Range(0, startPositions.Count)];
+			else
+				return startPositions[startPositionIndex++ % startPositions.Count];
         }
 
         public virtual void OnServerRemovePlayer(NetworkConnection conn, NetworkIdentity player)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -686,23 +686,23 @@ namespace Mirror
             NetworkServer.AddPlayerForConnection(conn, player);
         }
 
-        public Transform GetStartPosition()
-        {
-            // first remove any dead transforms
-            startPositions.RemoveAll(t => t == null);
+		public Transform GetStartPosition()
+		{
+			// first remove any dead transforms
+			startPositions.RemoveAll(t => t == null);
 
 			if (startPositions.Count == 0)
 				return null;
 
-			// In the unlikely event we've actually had 2,147,483,647 clients join....
-			if (startPositionIndex == int.MaxValue)
-				startPositionIndex = 0;
-
 			if (playerSpawnMethod == PlayerSpawnMethod.Random)
 				return startPositions[UnityEngine.Random.Range(0, startPositions.Count)];
 			else
-				return startPositions[startPositionIndex++ % startPositions.Count];
-        }
+			{
+				Transform startPosition = startPositions[startPositionIndex];
+				startPositionIndex = (startPositionIndex + 1) % startPositions.Count;
+				return startPosition;
+			}
+		}
 
         public virtual void OnServerRemovePlayer(NetworkConnection conn, NetworkIdentity player)
         {


### PR DESCRIPTION
- Early out if startPositions.Count = 0
- Reduces the normal returns to single LOC each
- Only resets startPositionIndex if it reaches int.MaxValue
- Uses modulo and increment-after against count to pick round robin index
- Eliminates unnecessary last return that could never be reached