### PR TITLE
fix: invalid scene id in 2019.1

### DIFF
--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -78,9 +78,6 @@ namespace Mirror
                             }
                         }
                     }
-                    // throwing an exception would only show it for one object
-                    // because this function would return afterwards.
-                    else Debug.LogError("Scene " + identity.gameObject.scene.path + " needs to be opened and resaved, because the scene object " + identity.name + " has no valid sceneId yet.");
                 }
             }
         }

--- a/Assets/Mirror/Editor/Weaver/Mirror.Weaver.asmdef.meta
+++ b/Assets/Mirror/Editor/Weaver/Mirror.Weaver.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5710c1f859f1945b6bc9b33cff6b43fc
+guid: 1d0b9d21c3ff546a4aa32399dfd33474
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
This post processor is finding objects that are not in the scene and failing the build in 2019.1

To reproduce,  merge #832 , open the tanks example and try to build 