### PR TITLE
ASMDEF for Examples

### DIFF
--- a/Assets/Mirror/Components/Mirror.Components.asmdef
+++ b/Assets/Mirror/Components/Mirror.Components.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Mirror.Components",
+    "references": [
+        "Mirror"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/Mirror/Components/Mirror.Components.asmdef.meta
+++ b/Assets/Mirror/Components/Mirror.Components.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 72872094b21c16e48b631b2224833d49
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Editor/Mirror.Editor.asmdef
+++ b/Assets/Mirror/Editor/Mirror.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Mirror.Editor",
+    "references": [
+        "Mirror"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/Mirror/Editor/Mirror.Editor.asmdef.meta
+++ b/Assets/Mirror/Editor/Mirror.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c7c33eb5480dd24c9e29a8250c1a775
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Examples/AdditiveScenes/README.md
+++ b/Assets/Mirror/Examples/AdditiveScenes/README.md
@@ -7,6 +7,8 @@ In Build Settings, remove all scenes and add all of the scenes from the Examples
 - MainScene
 - SubScene
 
+Open the MainScene and add the SubScene to the Network Gameobject's AdditiveNetworkManager subScenes list
+
 File -> Build and Run
 
 Start up to 3 built instances:  These will all be client players.

--- a/Assets/Mirror/Examples/AdditiveScenes/README.md
+++ b/Assets/Mirror/Examples/AdditiveScenes/README.md
@@ -7,8 +7,6 @@ In Build Settings, remove all scenes and add all of the scenes from the Examples
 - MainScene
 - SubScene
 
-Open the MainScene and add the SubScene to the Network Gameobject's AdditiveNetworkManager subScenes list
-
 File -> Build and Run
 
 Start up to 3 built instances:  These will all be client players.

--- a/Assets/Mirror/Examples/Mirror.Examples.asmdef
+++ b/Assets/Mirror/Examples/Mirror.Examples.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "Mirror.Examples",
+    "references": [
+        "Mirror",
+        "Mirror.Components"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/Mirror/Examples/Mirror.Examples.asmdef.meta
+++ b/Assets/Mirror/Examples/Mirror.Examples.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fecf25954bb196642ab50657689761d6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Mirror is not fully ASMDEF capable (Example scripts can't be referenced from other assemblies). This adds three additional ASMDEFs to make that work.