### PR TITLE
Avoid memory leak from cloned materials

### DIFF
--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/PlayerController.cs
@@ -21,12 +21,22 @@ namespace Mirror.Examples.Additive
         [SyncVar(hook = nameof(SetColor))]
         public Color playerColor = Color.black;
 
-        void SetColor(Color color)
-        {
-            GetComponent<Renderer>().material.color = color;
-        }
+		// Unity makes a clone of the material when GetComponent<Renderer>().material is used
+		// Cache it here and Destroy it in OnDestroy to prevent a memory leak
+		Material materialClone;
 
-        Camera mainCam;
+		void SetColor(Color color)
+		{
+			if (materialClone == null) materialClone = GetComponent<Renderer>().material;
+			materialClone.color = color;
+		}
+
+		private void OnDestroy()
+		{
+			Destroy(materialClone);
+		}
+
+		Camera mainCam;
 
         public override void OnStartLocalPlayer()
         {

--- a/Assets/Mirror/Examples/Lobby/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/Lobby/Scripts/PlayerController.cs
@@ -18,9 +18,6 @@ namespace Mirror.Examples.NetworkLobby
         [SyncVar]
         public uint score;
 
-        [SyncVar(hook = nameof(SetColor))]
-        public Color playerColor = Color.black;
-
         public override void OnStartLocalPlayer()
         {
             base.OnStartLocalPlayer();
@@ -31,12 +28,25 @@ namespace Mirror.Examples.NetworkLobby
             Camera.main.enabled = false;
         }
 
-        void SetColor(Color color)
-        {
-            GetComponent<Renderer>().material.color = color;
-        }
+        [SyncVar(hook = nameof(SetColor))]
+        public Color playerColor = Color.black;
 
-        float horizontal = 0f;
+		// Unity makes a clone of the material when GetComponent<Renderer>().material is used
+		// Cache it here and Destroy it in OnDestroy to prevent a memory leak
+		Material materialClone;
+
+		void SetColor(Color color)
+		{
+			if (materialClone == null) materialClone = GetComponent<Renderer>().material;
+			materialClone.color = color;
+		}
+
+		private void OnDestroy()
+		{
+			Destroy(materialClone);
+		}
+
+		float horizontal = 0f;
         float vertical = 0f;
         float turn = 0f;
 

--- a/Assets/Mirror/Examples/Lobby/Scripts/Reward.cs
+++ b/Assets/Mirror/Examples/Lobby/Scripts/Reward.cs
@@ -7,12 +7,22 @@ namespace Mirror.Examples.NetworkLobby
         [SyncVar(hook = nameof(SetColor))]
         public Color prizeColor = Color.black;
 
-        void SetColor(Color color)
-        {
-            GetComponent<Renderer>().material.color = color;
-        }
+		// Unity makes a clone of the material when GetComponent<Renderer>().material is used
+		// Cache it here and Destroy it in OnDestroy to prevent a memory leak
+		Material materialClone;
 
-        public bool available = true;
+		void SetColor(Color color)
+		{
+			if (materialClone == null) materialClone = GetComponent<Renderer>().material;
+			materialClone.color = color;
+		}
+
+		private void OnDestroy()
+		{
+			Destroy(materialClone);
+		}
+
+		public bool available = true;
         public Spawner spawner;
         uint points;
 


### PR DESCRIPTION
Only the Additive and Lobby examples are changed for their SyncVar's - no testing with uMMORPG needed.