### PR TITLE
fix: Add channelId to NetworkClient.Send Method

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -195,7 +195,7 @@ namespace Mirror
             return false;
         }
 
-        public static bool Send<T>(T message) where T : IMessageBase
+        public static bool Send<T>(T message, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             if (connection != null)
             {
@@ -204,7 +204,7 @@ namespace Mirror
                     Debug.LogError("NetworkClient Send when not connected to a server");
                     return false;
                 }
-                return connection.Send(message);
+                return connection.Send(message, channelId);
             }
             Debug.LogError("NetworkClient Send with no connection");
             return false;


### PR DESCRIPTION
This is to achieve parity with NetworkConnection:

```cs
public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T: IMessageBase
{
    // pack message and send
    byte[] message = MessagePacker.Pack(msg);
    return SendBytes(message, channelId);
}
```