### PR TITLE
Logging Improvements

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -444,9 +444,14 @@ namespace Mirror
             if (spawnedId == null)
             {
                 Debug.LogError("Spawn scene object not found for " + msg.sceneId.ToString("X") + " SpawnableObjects.Count=" + spawnableObjects.Count);
+
                 // dump the whole spawnable objects dict for easier debugging
-                foreach (KeyValuePair<ulong, NetworkIdentity> kvp in spawnableObjects)
-                    Debug.Log("Spawnable: SceneId=" + kvp.Key + " name=" + kvp.Value.name);
+                if (LogFilter.Debug)
+                {
+                    foreach (KeyValuePair<ulong, NetworkIdentity> kvp in spawnableObjects)
+                        Debug.Log("Spawnable: SceneId=" + kvp.Key + " name=" + kvp.Value.name);
+                }
+                
                 return;
             }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -419,7 +419,7 @@ namespace Mirror
                 }
             }
 
-            if (LogFilter.Debug) Debug.Log("OnStartServer " + this + " GUID:" + netId);
+            if (LogFilter.Debug) Debug.Log("OnStartServer " + this + " NetId:" + netId + " SceneId:" + sceneId);
 
             // add to spawned (note: the original EnableIsServer isn't needed
             // because we already set m_isServer=true above)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -549,7 +549,7 @@ namespace Mirror
             {
                 if (identity.gameObject.activeSelf) //TODO this is different // try with far away ones in ummorpg!
                 {
-                    if (LogFilter.Debug) Debug.Log("Sending spawn message for current server objects name='" + identity.name + "' netId=" + identity.netId);
+                    if (LogFilter.Debug) Debug.Log("Sending spawn message for current server objects name='" + identity.name + "' netId=" + identity.netId + " sceneId=" + identity.sceneId);
 
                     bool visible = identity.OnCheckObserver(conn);
                     if (visible)


### PR DESCRIPTION
Added one logging improvement to prevent the entire spawnable dictionary from being dumped during a mismatch.

Added SceneID logging to help diagnose issues with SceneID spawning