### PR TITLE
fix(NetworkManager) : properly load scene on clients using new load parameters

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -442,7 +442,7 @@ namespace Mirror
 
         void ClientChangeScene(string newSceneName, bool forceReload)
         {
-            ClientChangeScene(networkSceneName, forceReload, LoadSceneMode.Single, LocalPhysicsMode.None);
+            ClientChangeScene(newSceneName, forceReload, LoadSceneMode.Single, LocalPhysicsMode.None);
         }
 
         internal void ClientChangeScene(string newSceneName, bool forceReload, LoadSceneMode sceneMode, LocalPhysicsMode physicsMode)
@@ -651,13 +651,9 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientSceneInternal");
 
-            string newSceneName = msg.sceneName;
-            LoadSceneMode newSceneMode = msg.sceneMode;
-            LocalPhysicsMode newScenePhysicsMode = msg.physicsMode;
-
             if (NetworkClient.isConnected && !NetworkServer.active)
             {
-                ClientChangeScene(newSceneName, true, newSceneMode, newScenePhysicsMode);
+                ClientChangeScene(msg.sceneName, true, msg.sceneMode, msg.physicsMode);
             }
         }
         #endregion

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -442,7 +442,7 @@ namespace Mirror
 
         void ClientChangeScene(string newSceneName, bool forceReload)
         {
-            ClientChangeScene(networkSceneName, forceReload, LoadSceneMode.Single, LocalPhysicsMode.None);
+            ClientChangeScene(newSceneName, forceReload, LoadSceneMode.Single, LocalPhysicsMode.None);
         }
 
         internal void ClientChangeScene(string newSceneName, bool forceReload, LoadSceneMode sceneMode, LocalPhysicsMode physicsMode)
@@ -652,10 +652,12 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientSceneInternal");
 
             string newSceneName = msg.sceneName;
+            LoadSceneMode newSceneMode = msg.sceneMode;
+            LocalPhysicsMode newScenePhysicsMode = msg.physicsMode;
 
             if (NetworkClient.isConnected && !NetworkServer.active)
             {
-                ClientChangeScene(newSceneName, true);
+                ClientChangeScene(newSceneName, true, newSceneMode, newScenePhysicsMode);
             }
         }
         #endregion

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -442,7 +442,7 @@ namespace Mirror
 
         void ClientChangeScene(string newSceneName, bool forceReload)
         {
-            ClientChangeScene(newSceneName, forceReload, LoadSceneMode.Single, LocalPhysicsMode.None);
+            ClientChangeScene(networkSceneName, forceReload, LoadSceneMode.Single, LocalPhysicsMode.None);
         }
 
         internal void ClientChangeScene(string newSceneName, bool forceReload, LoadSceneMode sceneMode, LocalPhysicsMode physicsMode)


### PR DESCRIPTION
Include fix from PR #866.

ClientChangeScene did not use new parameters available for loading scene. 

Scenes would always be loaded in LoadSceneMode.single & LocalPhysicsMode.None on clients.