### PR TITLE
fix(websocket): Remove both queues and asynchronous send functionality

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/IPingPongManager.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/IPingPongManager.cs
@@ -19,6 +19,6 @@ namespace Ninja.WebSockets
         /// </summary>
         /// <param name="payload">The payload (must be 125 bytes of less)</param>
         /// <param name="cancellation">The cancellation token</param>
-        Task SendPing(ArraySegment<byte> payload, CancellationToken cancellation);
+        void SendPing(ArraySegment<byte> payload, CancellationToken cancellation);
     }
 }

--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketImplementation.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketImplementation.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -519,7 +520,14 @@ namespace Ninja.WebSockets.Internal
         void WriteStreamToNetwork(MemoryStream stream, CancellationToken cancellationToken)
         {
             ArraySegment<byte> buffer = GetBuffer(stream);
-            _stream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            try
+            {
+                _stream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            }
+            catch(SocketException ex)
+            {
+                // do nothing, socket has been shut down
+            }
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/PingPongManager.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/PingPongManager.cs
@@ -82,9 +82,9 @@ namespace Ninja.WebSockets
         /// </summary>
         /// <param name="payload">The payload (must be 125 bytes of less)</param>
         /// <param name="cancellation">The cancellation token</param>
-        public async Task SendPing(ArraySegment<byte> payload, CancellationToken cancellation)
+        public void SendPing(ArraySegment<byte> payload, CancellationToken cancellation)
         {
-            await _webSocket.SendPingAsync(payload, cancellation);
+            _webSocket.SendPingAsync(payload, cancellation);
         }
 
         protected virtual void OnPong(PongEventArgs e)
@@ -118,7 +118,7 @@ namespace Ninja.WebSockets
                     {
                         _pingSentTicks = _stopwatch.Elapsed.Ticks;
                         ArraySegment<byte> buffer = new ArraySegment<byte>(BitConverter.GetBytes(_pingSentTicks));
-                        await SendPing(buffer, _cancellationToken);
+                        SendPing(buffer, _cancellationToken);
                     }
                 }
             }


### PR DESCRIPTION
The queues implemented in #839 worked fine in my game, but they severely degraded the performance of a game using much more network than mine (see GIF captured from queue version below).

![thelastwebsocketglitch](https://i.imgur.com/72s66bp.gif)

This removes both the queues and the asynchronous send functionality, meaning you can write to the SslStream without getting a nested call exception. I have tested it with a new example scene of mine (separate PR coming for that eventually) that tests SyncVars, SyncObjects, Commands and RPCs. It appears to work fine over SSL. It has also been tested in the same game from the GIF above (without SSL) and does not have any obvious issues.