### PR TITLE
Spawn objects in local space instead of world space

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -336,9 +336,11 @@ namespace Mirror
             {
                 identity.gameObject.SetActive(true);
             }
+            
+            // apply local values for VR support
             identity.transform.localPosition = position;
             identity.transform.localRotation = rotation;
-            identity.transform.localScale = scale;
+            identity.transform.localScale = scale;            
             if (payload != null && payload.Length > 0)
             {
                 NetworkReader payloadReader = new NetworkReader(payload);

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -336,8 +336,8 @@ namespace Mirror
             {
                 identity.gameObject.SetActive(true);
             }
-            identity.transform.position = position;
-            identity.transform.rotation = rotation;
+            identity.transform.localPosition = position;
+            identity.transform.localRotation = rotation;
             identity.transform.localScale = scale;
             if (payload != null && payload.Length > 0)
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -844,8 +844,8 @@ namespace Mirror
                     netId = identity.netId,
                     owner = conn?.playerController == identity,
                     assetId = identity.assetId,
-                    position = identity.transform.position,
-                    rotation = identity.transform.rotation,
+                    position = identity.transform.localPosition,
+                    rotation = identity.transform.localRotation,
                     scale = identity.transform.localScale,
 
                     // serialize all components with initialState = true
@@ -871,8 +871,8 @@ namespace Mirror
                     netId = identity.netId,
                     owner = conn?.playerController == identity,
                     sceneId = identity.sceneId,
-                    position = identity.transform.position,
-                    rotation = identity.transform.rotation,
+                    position = identity.transform.localPosition,
+                    rotation = identity.transform.localRotation,
                     scale = identity.transform.localScale,
 
                     // include synch data

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -844,6 +844,7 @@ namespace Mirror
                     netId = identity.netId,
                     owner = conn?.playerController == identity,
                     assetId = identity.assetId,
+                    // use local values for VR support
                     position = identity.transform.localPosition,
                     rotation = identity.transform.localRotation,
                     scale = identity.transform.localScale,
@@ -871,6 +872,7 @@ namespace Mirror
                     netId = identity.netId,
                     owner = conn?.playerController == identity,
                     sceneId = identity.sceneId,
+                    // use local values for VR support
                     position = identity.transform.localPosition,
                     rotation = identity.transform.localRotation,
                     scale = identity.transform.localScale,


### PR DESCRIPTION
Allow games where world origin is different for each players (Augmented reality for example) to spawn objects at the right position in the scene.

With PR #779 this should make Mirror a good solution for multiplayer projects running on Hololens, ARCore, ARkit devices. 