### PR TITLE
fix(websocket): Remove send queues and temporarily disable SSL

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketImplementation.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketImplementation.cs
@@ -58,10 +58,6 @@ namespace Ninja.WebSockets.Internal
         const int MAX_PING_PONG_PAYLOAD_LEN = 125;
         WebSocketCloseStatus? _closeStatus;
         string _closeStatusDescription;
-        bool sendingMessage = false;
-        Queue<ArraySegment<byte>> messagesToSend = new Queue<ArraySegment<byte>>();
-        Queue<ArraySegment<byte>> pongMessagesToSend = new Queue<ArraySegment<byte>>();
-        Queue<ArraySegment<byte>> pingMessagesToSend = new Queue<ArraySegment<byte>>();
 
         public event EventHandler<PongEventArgs> Pong;
 
@@ -223,24 +219,6 @@ namespace Ninja.WebSockets.Internal
         /// <param name="cancellationToken">the cancellation token</param>
         public override async Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
         {
-            // workaround for: https://forum.unity.com/threads/unity-2017-1-tls-1-2-still-not-working-with-net-4-6.487415/
-            // In SslStream, only one SendAsync can be going at a time
-            // if Send is called multiple time, only the first one calls SendAsync,
-            // the other ones queue up the message
-            messagesToSend.Enqueue(buffer);
-            if (!sendingMessage)
-            {
-                sendingMessage = true;
-                while (messagesToSend.Count > 0)
-                {
-                    await SendAsyncInternal(messagesToSend.Dequeue(), messageType, endOfMessage, cancellationToken);
-                }
-                sendingMessage = false;
-            }
-        }
-
-        private async Task SendAsyncInternal(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
-        {
             using (MemoryStream stream = _recycledStreamFactory())
             {
                 WebSocketOpCode opCode = GetOppCode(messageType);
@@ -282,20 +260,6 @@ namespace Ninja.WebSockets.Internal
                 throw new InvalidOperationException($"Cannot send Ping: Max ping message size {MAX_PING_PONG_PAYLOAD_LEN} exceeded: {payload.Count}");
             }
 
-            pingMessagesToSend.Enqueue(payload);
-            if (!sendingMessage)
-            {
-                sendingMessage = true;
-                while (pingMessagesToSend.Count > 0)
-                {
-                    await SendPingAsyncInternal(pingMessagesToSend.Dequeue(), cancellationToken);
-                }
-                sendingMessage = false;
-            }
-        }
-
-        async Task SendPingAsyncInternal(ArraySegment<byte> payload, CancellationToken cancellationToken)
-        {
             if (_state == WebSocketState.Open)
             {
                 using (MemoryStream stream = _recycledStreamFactory())
@@ -448,34 +412,20 @@ namespace Ninja.WebSockets.Internal
 
             try
             {
-                pongMessagesToSend.Enqueue(payload);
-                if (!sendingMessage)
+                if (_state == WebSocketState.Open)
                 {
-                    sendingMessage = true;
-                    while (pongMessagesToSend.Count > 0)
+                    using (MemoryStream stream = _recycledStreamFactory())
                     {
-                        await SendPongAsyncInternal(pongMessagesToSend.Dequeue(), cancellationToken);
+                        WebSocketFrameWriter.Write(WebSocketOpCode.Pong, payload, stream, true, _isClient);
+                        Events.Log.SendingFrame(_guid, WebSocketOpCode.Pong, true, payload.Count, false);
+                        await WriteStreamToNetwork(stream, cancellationToken);
                     }
-                    sendingMessage = false;
                 }
             }
             catch (Exception ex)
             {
                 await CloseOutputAutoTimeoutAsync(WebSocketCloseStatus.EndpointUnavailable, "Unable to send Pong response", ex);
                 throw;
-            }
-        }
-
-        async Task SendPongAsyncInternal(ArraySegment<byte> payload, CancellationToken cancellationToken)
-        {
-            if (_state == WebSocketState.Open)
-            {
-                using (MemoryStream stream = _recycledStreamFactory())
-                {
-                    WebSocketFrameWriter.Write(WebSocketOpCode.Pong, payload, stream, true, _isClient);
-                    Events.Log.SendingFrame(_guid, WebSocketOpCode.Pong, true, payload.Count, false);
-                    await WriteStreamToNetwork(stream, cancellationToken);
-                }
             }
         }
 

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -14,12 +14,6 @@ namespace Mirror.Websocket
         [Tooltip("Nagle Algorithm can be disabled by enabling NoDelay")]
         public bool NoDelay = true;
 
-        public bool Secure = false;
-
-        public string CertificatePath;
-
-        public string CertificatePassword;
-
         public WebsocketTransport()
         {
             // dispatch the events from the server
@@ -57,14 +51,7 @@ namespace Mirror.Websocket
 
         public override void ClientConnect(string host)
         {
-            if (Secure)
-            {
-                client.Connect(new Uri($"wss://{host}:{port}"));
-            }
-            else
-            {
-                client.Connect(new Uri($"ws://{host}:{port}"));
-            }
+            client.Connect(new Uri($"ws://{host}:{port}"));
         }
 
         public override bool ClientSend(int channelId, byte[] data) { client.Send(data); return true; }
@@ -76,18 +63,6 @@ namespace Mirror.Websocket
 
         public override void ServerStart()
         {
-
-            if (Secure)
-            {
-                server._secure = Secure;
-                server._sslConfig = new Server.SslConfiguration
-                {
-                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(Application.dataPath + CertificatePath, CertificatePassword),
-                    ClientCertificateRequired = false,
-                    CheckCertificateRevocation = false,
-                    EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default
-                };
-            }
             server.Listen(port);
         }
 


### PR DESCRIPTION
This removes the queues implemented in #839 for the reasons described in #874.

It also temporarily removes SSL functionality. It never properly worked in Mirror. After 30-120 seconds all standalone clients or servers will experience the `nested call` issue, which is gamebreaking. The send queues were introduced to fix this and did not work. [According to Unity themselves, asynchronous interleaved write to an SslStream is not possible in Unity.](https://forum.unity.com/threads/unity-2017-1-tls-1-2-still-not-working-with-net-4-6.487415/#post-3561106) There is a possible workaround technique actively being investigated by me and Paul that will come in a separate PR to re-enable SSL.

Testing strategy: this patch has been tested in 3-4 production games and also with 2 Mirror examples, for about a week and a half now. It restores totally solid standalone WebSockets networking in Mirror.