### PR TITLE
Remove conditional accesses on unity objects

### DIFF
--- a/Assets/Mirror/Components/NetworkLobbyManager.cs
+++ b/Assets/Mirror/Components/NetworkLobbyManager.cs
@@ -84,11 +84,14 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("NetworkLobbyManager OnServerReady");
             base.OnServerReady(conn);
 
-            GameObject lobbyPlayer = conn?.playerController?.gameObject;
+            if (conn != null && conn.playerController != null)
+            {
+                GameObject lobbyPlayer = conn.playerController.gameObject;
 
-            // if null or not a lobby player, dont replace it
-            if (lobbyPlayer?.GetComponent<NetworkLobbyPlayer>() != null)
-                SceneLoadedForPlayer(conn, lobbyPlayer);
+                // if null or not a lobby player, dont replace it
+                if (lobbyPlayer != null && lobbyPlayer.GetComponent<NetworkLobbyPlayer>() != null)
+                    SceneLoadedForPlayer(conn, lobbyPlayer);
+            }
         }
 
         void SceneLoadedForPlayer(NetworkConnection conn, GameObject lobbyPlayer)
@@ -142,14 +145,20 @@ namespace Mirror
         {
             OnLobbyClientEnter();
             foreach (NetworkLobbyPlayer player in lobbySlots)
-                player?.OnClientEnterLobby();
+                if (player != null)
+                {
+                    player.OnClientEnterLobby();
+                }
         }
 
         void CallOnClientExitLobby()
         {
             OnLobbyClientExit();
             foreach (NetworkLobbyPlayer player in lobbySlots)
-                player?.OnClientExitLobby();
+                if (player != null)
+                {
+                    player.OnClientExitLobby();
+                }
         }
 
         #region server handlers
@@ -370,14 +379,17 @@ namespace Mirror
 
             if (SceneManager.GetActiveScene().name == LobbyScene && newSceneName == GameplayScene && dontDestroyOnLoad && NetworkClient.isConnected)
             {
-                GameObject lobbyPlayer = NetworkClient.connection?.playerController?.gameObject;
-                if (lobbyPlayer != null)
+                if (NetworkClient.connection != null && NetworkClient.connection.playerController != null)
                 {
-                    lobbyPlayer.transform.SetParent(null);
-                    DontDestroyOnLoad(lobbyPlayer);
+                    GameObject lobbyPlayer = NetworkClient.connection.playerController.gameObject;
+                    if (lobbyPlayer != null)
+                    {
+                        lobbyPlayer.transform.SetParent(null);
+                        DontDestroyOnLoad(lobbyPlayer);
+                    }
+                    else
+                        Debug.LogWarningFormat("OnClientChangeScene: lobbyPlayer is null");
                 }
-                else
-                    Debug.LogWarningFormat("OnClientChangeScene: lobbyPlayer is null");
             }
             else
                if (LogFilter.Debug) Debug.LogFormat("OnClientChangeScene {0} {1}", dontDestroyOnLoad, NetworkClient.isConnected);

--- a/Assets/Mirror/Components/NetworkLobbyPlayer.cs
+++ b/Assets/Mirror/Components/NetworkLobbyPlayer.cs
@@ -38,7 +38,10 @@ namespace Mirror
         {
             ReadyToBegin = ReadyState;
             NetworkLobbyManager lobby = NetworkManager.singleton as NetworkLobbyManager;
-            lobby?.ReadyStatusChanged();
+            if (lobby != null)
+            {
+                lobby.ReadyStatusChanged();
+            }
         }
 
         #endregion

--- a/Assets/Mirror/Examples/Lobby/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/Lobby/Scripts/PlayerController.cs
@@ -31,22 +31,22 @@ namespace Mirror.Examples.NetworkLobby
         [SyncVar(hook = nameof(SetColor))]
         public Color playerColor = Color.black;
 
-		// Unity makes a clone of the material when GetComponent<Renderer>().material is used
-		// Cache it here and Destroy it in OnDestroy to prevent a memory leak
-		Material materialClone;
+        // Unity makes a clone of the material when GetComponent<Renderer>().material is used
+        // Cache it here and Destroy it in OnDestroy to prevent a memory leak
+        Material materialClone;
 
-		void SetColor(Color color)
-		{
-			if (materialClone == null) materialClone = GetComponent<Renderer>().material;
-			materialClone.color = color;
-		}
+        void SetColor(Color color)
+        {
+            if (materialClone == null) materialClone = GetComponent<Renderer>().material;
+            materialClone.color = color;
+        }
 
-		private void OnDestroy()
-		{
-			Destroy(materialClone);
-		}
+        private void OnDestroy()
+        {
+            Destroy(materialClone);
+        }
 
-		float horizontal = 0f;
+        float horizontal = 0f;
         float vertical = 0f;
         float turn = 0f;
 
@@ -110,7 +110,10 @@ namespace Mirror.Examples.NetworkLobby
         public void CmdClaimPrize(GameObject hitObject)
         {
             // Null check is required, otherwise close timing of multiple claims could throw a null ref.
-            hitObject?.GetComponent<Reward>().ClaimPrize(gameObject);
+            if (hitObject != null)
+            {
+                hitObject.GetComponent<Reward>().ClaimPrize(gameObject);
+            }
         }
 
         void OnGUI()

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -614,7 +614,10 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("ClientScene.OnOwnerMessage - connectionId=" + readyConnection.connectionId + " netId: " + netId);
 
             // is there already an owner that is a different object??
-            readyConnection.playerController?.SetNotLocalPlayer();
+            if (readyConnection.playerController != null)
+            {
+                readyConnection.playerController.SetNotLocalPlayer();
+            }
 
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity localObject) && localObject != null)
             {


### PR DESCRIPTION
?? and something? don't work with unitys objects, use == null instead.
Tested with Pong Example, due to the nature of changes, it shouldn't cause any issues.