### PR TITLE
SetClientReady() spawns observers if no player

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -674,7 +674,11 @@ namespace Mirror
                 // this is now allowed (was not for a while)
                 if (LogFilter.Debug) Debug.Log("Ready with no player object");
             }
-            NetworkServer.SetClientReady(conn);
+
+            // Spawn observers if no player.
+            // Otherwise, do it when add player.
+            bool spawnObservers = (playerPrefab == null);
+            NetworkServer.SetClientReady(conn, spawnObservers);
         }
 
         public virtual void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -588,14 +588,7 @@ namespace Mirror
             identity.connectionToClient = conn;
 
             // set ready if not set yet
-            SetClientReady(conn);
-
-            // add connection to observers AFTER the playerController was set.
-            // by definition, there is nothing to observe if there is no player
-            // controller.
-            //
-            // IMPORTANT: do this in AddPlayerForConnection & ReplacePlayerForConnection!
-            SpawnObserversForConnection(conn);
+            SetClientReady(conn, true);
 
             if (SetupLocalPlayerForConnection(conn, identity))
             {
@@ -683,8 +676,6 @@ namespace Mirror
             // add connection to observers AFTER the playerController was set.
             // by definition, there is nothing to observe if there is no player
             // controller.
-            //
-            // IMPORTANT: do this in AddPlayerForConnection & ReplacePlayerForConnection!
             SpawnObserversForConnection(conn);
 
             if (LogFilter.Debug) Debug.Log("NetworkServer ReplacePlayer setup local");
@@ -715,12 +706,17 @@ namespace Mirror
             return true;
         }
 
-        public static void SetClientReady(NetworkConnection conn)
+        public static void SetClientReady(NetworkConnection conn, bool spawnObservers)
         {
             if (LogFilter.Debug) Debug.Log("SetClientReadyInternal for conn:" + conn.connectionId);
 
             // set ready
             conn.isReady = true;
+
+            if (spawnObservers)
+            {
+                SpawnObserversForConnection(conn);
+            }
         }
 
         internal static void ShowForConnection(NetworkIdentity identity, NetworkConnection conn)
@@ -763,7 +759,7 @@ namespace Mirror
         static void OnClientReadyMessage(NetworkConnection conn, ReadyMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("Default handler for ready message from " + conn);
-            SetClientReady(conn);
+            SetClientReady(conn, true);
         }
 
         // default remove player handler


### PR DESCRIPTION
With #609, SpawnObserversForConnection() is now called in AddPlayerForConnection().
But there can be a case that no player.
- clients just watch the server local play
- just synchronize parameters like non-game applications

So if no player, SetClientReady() calls SpawnObserversForConnection().