### PR TITLE
SkipAuthority flag on NetworkIdentity to send CMDS over objects that …

### DIFF
--- a/Assets/Mirror/Editor/NetworkIdentityEditor.cs
+++ b/Assets/Mirror/Editor/NetworkIdentityEditor.cs
@@ -10,10 +10,13 @@ namespace Mirror
     {
         SerializedProperty serverOnlyProperty;
         SerializedProperty localPlayerAuthorityProperty;
+		SerializedProperty skipAuthorityProperty;
 
         readonly GUIContent serverOnlyLabel = new GUIContent("Server Only", "True if the object should only exist on the server.");
         readonly GUIContent localPlayerAuthorityLabel = new GUIContent("Local Player Authority", "True if this object will be controlled by a player on a client.");
-        readonly GUIContent spawnLabel = new GUIContent("Spawn Object", "This causes an unspawned server object to be spawned on clients");
+        readonly GUIContent skipAuthorityLabel = new GUIContent("Skip Authority", "This causes clients to send cmds over an object without authority");
+		readonly GUIContent spawnLabel = new GUIContent("Spawn Object", "This causes an unspawned server object to be spawned on clients");
+
 
         NetworkIdentity networkIdentity;
         bool initialized;
@@ -30,6 +33,7 @@ namespace Mirror
 
             serverOnlyProperty = serializedObject.FindProperty("serverOnly");
             localPlayerAuthorityProperty = serializedObject.FindProperty("localPlayerAuthority");
+			skipAuthorityProperty = serializedObject.FindProperty("skipAuthority");
         }
 
         public override void OnInspectorGUI()
@@ -58,6 +62,8 @@ namespace Mirror
                 EditorGUILayout.PropertyField(serverOnlyProperty, serverOnlyLabel);
                 EditorGUILayout.PropertyField(localPlayerAuthorityProperty, localPlayerAuthorityLabel);
             }
+			
+			EditorGUILayout.PropertyField(skipAuthorityProperty, skipAuthorityLabel);
 
             serializedObject.ApplyModifiedProperties();
 

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -22,6 +22,7 @@ namespace Mirror
         public bool isServerOnly => isServer && !isClient;
         public bool isClientOnly => isClient && !isServer;
         public bool hasAuthority => netIdentity.hasAuthority;
+		public bool skipAuthority => netIdentity.skipAuthority;
         public uint netId => netIdentity.netId;
         public NetworkConnection connectionToServer => netIdentity.connectionToServer;
         public NetworkConnection connectionToClient => netIdentity.connectionToClient;
@@ -87,7 +88,7 @@ namespace Mirror
                 return;
             }
             // local players can always send commands, regardless of authority, other objects must have authority.
-            if (!(isLocalPlayer || hasAuthority))
+            if (!(isLocalPlayer || hasAuthority || skipAuthority))
             {
                 Debug.LogWarning("Trying to send command for object without authority.");
                 return;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -38,6 +38,7 @@ namespace Mirror
         }
         public bool isLocalPlayer { get; private set; }
         public bool hasAuthority { get; private set; }
+		public bool skipAuthority { get; private set; }
 
         // <connectionId, NetworkConnection>
         // null until OnStartServer was called. this is necessary for SendTo...

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -605,7 +605,7 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("Adding new playerGameObject object netId: " + identity.netId + " asset ID " + identity.assetId);
 
             FinishPlayerForConnection(identity, player);
-            if (identity.localPlayerAuthority)
+            if (identity.localPlayerAuthority || identity.skipAuthority)
             {
                 identity.SetClientOwner(conn);
             }
@@ -792,7 +792,7 @@ namespace Mirror
             // Commands can be for player objects, OR other objects with client-authority
             // -> so if this connection's controller has a different netId then
             //    only allow the command if clientAuthorityOwner
-            if (conn.playerController != null && conn.playerController.netId != identity.netId)
+            if (conn.playerController != null && conn.playerController.netId != identity.netId && !identity.skipAuthority)
             {
                 if (identity.clientAuthorityOwner != conn)
                 {


### PR DESCRIPTION
…don't need to have authority.

References issue #873.

For my current project I can guarantee that people aren't hacking. So when they click on a certain object I want that action to be executed immediately instead of having to navigate to that object on the server to execute the correct command.