### PR TITLE
fix: #840 by allowing Mirror to respect the forceHidden flag

### DIFF
--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -65,8 +65,10 @@ namespace Mirror
         public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initial)
         {
             if (forceHidden)
-                return false;
-
+            {
+                // always return true when overwriting OnRebuildObservers so that
+                // Mirror knows not to use the built in rebuild method.
+                return true;             } 
             // find players within range
             switch (checkMethod)
             {

--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -64,11 +64,12 @@ namespace Mirror
 
         public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initial)
         {
+            // if force hidden then return without adding any observers.
             if (forceHidden)
-            {
                 // always return true when overwriting OnRebuildObservers so that
                 // Mirror knows not to use the built in rebuild method.
-                return true;             } 
+                return true;
+            
             // find players within range
             switch (checkMethod)
             {


### PR DESCRIPTION
fix: #840 by allowing Mirror to respect the forceHidden flag on NetworkProximityChecker.
This bug was introduced in ab44ac8 on 4/1/2019