### PR TITLE
perf: eliminate small allocation on remote calls

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -55,14 +55,17 @@ namespace Mirror
         {
             get
             {
-                int index = Array.FindIndex(netIdentity.NetworkBehaviours, component => component == this);
-                if (index < 0)
+                for (int i = 0; i < netIdentity.NetworkBehaviours.Length; i++)
                 {
-                    // this should never happen
-                    Debug.LogError("Could not find component in GameObject. You should not add/remove components in networked objects dynamically", this);
+                    NetworkBehaviour component = netIdentity.NetworkBehaviours[i];
+                    if (component == this)
+                        return i;
                 }
 
-                return index;
+                // this should never happen
+                Debug.LogError("Could not find component in GameObject. You should not add/remove components in networked objects dynamically", this);
+
+                return -1;
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -55,6 +55,7 @@ namespace Mirror
         {
             get
             {
+                // note: FindIndex causes allocations, we search manually instead
                 for (int i = 0; i < netIdentity.NetworkBehaviours.Length; i++)
                 {
                     NetworkBehaviour component = netIdentity.NetworkBehaviours[i];


### PR DESCRIPTION
Eliminate this allocation that happens in every remote method call:

<img width="808" alt="Screen Shot 2019-06-16 at 11 10 12 AM" src="https://user-images.githubusercontent.com/466007/59566589-d26d1800-9027-11e9-9115-37533840ea56.png">
