### PR TITLE
perf: eliminate string concat during remote method calls

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -75,6 +75,16 @@ namespace Mirror
         }
 
         #region Commands
+
+        private static int GetMethodHash(Type invokeClass, string methodName)
+        {
+            unchecked
+            {
+                int hash = invokeClass.FullName.GetStableHashCode();
+                return hash * 503 + methodName.GetStableHashCode();
+            }
+        }
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void SendCommandInternal(Type invokeClass, string cmdName, NetworkWriter writer, int channelId)
         {
@@ -104,7 +114,7 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", cmdName), // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = GetMethodHash(invokeClass, cmdName), // type+func so Inventory.RpcUse != Equipment.RpcUse
                 payload = writer.ToArray()
             };
 
@@ -140,7 +150,7 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", rpcName), // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = GetMethodHash(invokeClass, rpcName), // type+func so Inventory.RpcUse != Equipment.RpcUse
                 payload = writer.ToArray()
             };
 
@@ -179,7 +189,7 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", rpcName), // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = GetMethodHash(invokeClass, rpcName), // type+func so Inventory.RpcUse != Equipment.RpcUse
                 payload = writer.ToArray()
             };
 
@@ -208,7 +218,7 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", eventName), // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = GetMethodHash(invokeClass, eventName), // type+func so Inventory.RpcUse != Equipment.RpcUse
                 payload = writer.ToArray()
             };
 
@@ -238,7 +248,7 @@ namespace Mirror
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected static void RegisterDelegate(Type invokeClass, string cmdName, MirrorInvokeType invokerType, CmdDelegate func)
         {
-            int cmdHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", cmdName); // type+func so Inventory.RpcUse != Equipment.RpcUse
+            int cmdHash = GetMethodHash(invokeClass, cmdName); // type+func so Inventory.RpcUse != Equipment.RpcUse
 
             if (cmdHandlerDelegates.ContainsKey(cmdHash))
             {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -78,6 +78,8 @@ namespace Mirror
 
         private static int GetMethodHash(Type invokeClass, string methodName)
         {
+            // (invokeClass + ":" + cmdName).GetStableHashCode() would cause allocations.
+            // so hash1 + hash2 is better.
             unchecked
             {
                 int hash = invokeClass.FullName.GetStableHashCode();

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -104,7 +104,7 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = (invokeClass + ":" + cmdName).GetStableHashCode(), // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", cmdName), // type+func so Inventory.RpcUse != Equipment.RpcUse
                 payload = writer.ToArray()
             };
 
@@ -140,7 +140,7 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = (invokeClass + ":" + rpcName).GetStableHashCode(), // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", rpcName), // type+func so Inventory.RpcUse != Equipment.RpcUse
                 payload = writer.ToArray()
             };
 
@@ -179,7 +179,7 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = (invokeClass + ":" + rpcName).GetStableHashCode(), // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", rpcName), // type+func so Inventory.RpcUse != Equipment.RpcUse
                 payload = writer.ToArray()
             };
 
@@ -208,7 +208,7 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = (invokeClass + ":" + eventName).GetStableHashCode(), // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", eventName), // type+func so Inventory.RpcUse != Equipment.RpcUse
                 payload = writer.ToArray()
             };
 
@@ -238,7 +238,7 @@ namespace Mirror
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected static void RegisterDelegate(Type invokeClass, string cmdName, MirrorInvokeType invokerType, CmdDelegate func)
         {
-            int cmdHash = (invokeClass + ":" + cmdName).GetStableHashCode(); // type+func so Inventory.RpcUse != Equipment.RpcUse
+            int cmdHash = StringHash.GetStableHashCode(invokeClass.FullName, ":", cmdName); // type+func so Inventory.RpcUse != Equipment.RpcUse
 
             if (cmdHandlerDelegates.ContainsKey(cmdHash))
             {

--- a/Assets/Mirror/Runtime/StringHash.cs
+++ b/Assets/Mirror/Runtime/StringHash.cs
@@ -16,15 +16,14 @@ namespace Mirror
         }
 
         // calculate a stable hash out of several strings
-        public static int GetStableHashCode(params string [] texts)
+        public static int GetStableHashCode(string txt1, string txt2, string txt3)
         {
             unchecked
             {
                 int hash = 23;
-                foreach (string txt in texts)
-                {
-                    hash = hash * 31 + GetStableHashCode(txt);
-                }
+                hash = hash * 31 + GetStableHashCode(txt1);
+                hash = hash * 31 + GetStableHashCode(txt2);
+                hash = hash * 31 + GetStableHashCode(txt3);
                 return hash;
             }
         }

--- a/Assets/Mirror/Runtime/StringHash.cs
+++ b/Assets/Mirror/Runtime/StringHash.cs
@@ -14,18 +14,5 @@ namespace Mirror
                 return hash;
             }
         }
-
-        // calculate a stable hash out of several strings
-        public static int GetStableHashCode(string txt1, string txt2, string txt3)
-        {
-            unchecked
-            {
-                int hash = 23;
-                hash = hash * 31 + GetStableHashCode(txt1);
-                hash = hash * 31 + GetStableHashCode(txt2);
-                hash = hash * 31 + GetStableHashCode(txt3);
-                return hash;
-            }
-        }
     }
 }

--- a/Assets/Mirror/Runtime/StringHash.cs
+++ b/Assets/Mirror/Runtime/StringHash.cs
@@ -14,5 +14,19 @@ namespace Mirror
                 return hash;
             }
         }
+
+        // calculate a stable hash out of several strings
+        public static int GetStableHashCode(params string [] texts)
+        {
+            unchecked
+            {
+                int hash = 23;
+                foreach (string txt in texts)
+                {
+                    hash = hash * 31 + GetStableHashCode(txt);
+                }
+                return hash;
+            }
+        }
     }
 }


### PR DESCRIPTION
Eliminates this allocation during all rpc calls:

<img width="811" alt="Screen Shot 2019-06-16 at 11 24 18 AM" src="https://user-images.githubusercontent.com/466007/59566737-cbdfa000-9029-11e9-9f1f-6f8ecb611a83.png">
