### PR TITLE
perf: reuse the network writer used for rpc parameters

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -107,7 +107,7 @@ namespace Mirror.Weaver
         public static void WriteCreateWriter(ILProcessor worker)
         {
             // create writer
-            worker.Append(worker.Create(OpCodes.Call, Weaver.GetArgWriterMethod));
+            worker.Append(worker.Create(OpCodes.Call, Weaver.WeaverRemoteArgWriterReference));
             worker.Append(worker.Create(OpCodes.Stloc_0));
         }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -108,7 +108,6 @@ namespace Mirror.Weaver
         {
             // create writer
             worker.Append(worker.Create(OpCodes.Call, Weaver.GetArgWriterMethod));
-            //worker.Append(worker.Create(OpCodes.Newobj, Weaver.NetworkWriterCtor));
             worker.Append(worker.Create(OpCodes.Stloc_0));
         }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -107,7 +107,8 @@ namespace Mirror.Weaver
         public static void WriteCreateWriter(ILProcessor worker)
         {
             // create writer
-            worker.Append(worker.Create(OpCodes.Newobj, Weaver.NetworkWriterCtor));
+            worker.Append(worker.Create(OpCodes.Call, Weaver.GetArgWriterMethod));
+            //worker.Append(worker.Create(OpCodes.Newobj, Weaver.NetworkWriterCtor));
             worker.Append(worker.Create(OpCodes.Stloc_0));
         }
 

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -57,7 +57,7 @@ namespace Mirror.Weaver
         public static TypeReference SyncDictionaryType;
 
         public static MethodReference NetworkBehaviourDirtyBitsReference;
-        public static MethodReference GetArgWriterMethod;
+        public static MethodReference WeaverRemoteArgWriterReference;
         public static TypeReference NetworkClientType;
         public static TypeReference NetworkServerType;
 
@@ -342,7 +342,7 @@ namespace Mirror.Weaver
             SyncDictionaryType = NetAssembly.MainModule.GetType("Mirror.SyncDictionary`2");
 
             NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "syncVarDirtyBits");
-            GetArgWriterMethod = Resolvers.ResolveMethod(NetworkBehaviourType, CurrentAssembly, "GetArgWriter");
+            WeaverRemoteArgWriterReference = Resolvers.ResolveMethod(NetworkBehaviourType, CurrentAssembly, "WeaverRemoteArgWriter");
 
             ComponentType = UnityAssembly.MainModule.GetType("UnityEngine.Component");
             ClientSceneType = NetAssembly.MainModule.GetType("Mirror.ClientScene");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -342,7 +342,7 @@ namespace Mirror.Weaver
             SyncDictionaryType = NetAssembly.MainModule.GetType("Mirror.SyncDictionary`2");
 
             NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "syncVarDirtyBits");
-            GetArgWriterMethod = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "GetArgWriter");
+            GetArgWriterMethod = Resolvers.ResolveMethod(NetworkBehaviourType, CurrentAssembly, "GetArgWriter");
 
             ComponentType = UnityAssembly.MainModule.GetType("UnityEngine.Component");
             ClientSceneType = NetAssembly.MainModule.GetType("Mirror.ClientScene");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -57,6 +57,7 @@ namespace Mirror.Weaver
         public static TypeReference SyncDictionaryType;
 
         public static MethodReference NetworkBehaviourDirtyBitsReference;
+        public static MethodReference GetArgWriterMethod;
         public static TypeReference NetworkClientType;
         public static TypeReference NetworkServerType;
 
@@ -341,6 +342,7 @@ namespace Mirror.Weaver
             SyncDictionaryType = NetAssembly.MainModule.GetType("Mirror.SyncDictionary`2");
 
             NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "syncVarDirtyBits");
+            GetArgWriterMethod = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "GetArgWriter");
 
             ComponentType = UnityAssembly.MainModule.GetType("UnityEngine.Component");
             ClientSceneType = NetAssembly.MainModule.GetType("Mirror.ClientScene");

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -74,12 +74,14 @@ namespace Mirror
             syncObjects.Add(syncObject);
         }
 
-        private static NetworkWriter argWriter;
-        protected static NetworkWriter GetArgWriter()
+        // this writer is used by the weaver to serialize remote method arguments
+        // it is declared here so that we can reuse it instead of allocating a new one
+        // in every call
+        private static readonly NetworkWriter weaverRemoteArgWriter = new NetworkWriter();
+        protected static NetworkWriter WeaverRemoteArgWriter()
         {
-            argWriter = argWriter ?? new NetworkWriter();
-            argWriter.SetLength(0);
-            return argWriter;
+            weaverRemoteArgWriter.SetLength(0);
+            return weaverRemoteArgWriter;
         }
 
         #region Commands

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -74,6 +74,14 @@ namespace Mirror
             syncObjects.Add(syncObject);
         }
 
+        private static NetworkWriter argWriter;
+        protected static NetworkWriter GetArgWriter()
+        {
+            argWriter = argWriter ?? new NetworkWriter();
+            argWriter.SetLength(0);
+            return argWriter;
+        }
+
         #region Commands
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void SendCommandInternal(Type invokeClass, string cmdName, NetworkWriter writer, int channelId)


### PR DESCRIPTION
Eliminates the NeworkWriter creation here:

<img width="836" alt="Screen Shot 2019-06-16 at 12 20 28 PM" src="https://user-images.githubusercontent.com/466007/59567301-8aeb8980-9031-11e9-9490-6a64c48ce54b.png">
