### PR TITLE
fix: don't convert null arrays to empty array

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -152,16 +152,16 @@ namespace Mirror.Weaver
             ILProcessor worker = readerFunc.Body.GetILProcessor();
 
             worker.Append(worker.Create(OpCodes.Ldarg_0));
-            worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkReadUInt16));
+            worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkReaderReadPackedInt32));
             worker.Append(worker.Create(OpCodes.Stloc_0));
+
             worker.Append(worker.Create(OpCodes.Ldloc_0));
-
-            Instruction labelEmptyArray = worker.Create(OpCodes.Nop);
-            worker.Append(worker.Create(OpCodes.Brtrue, labelEmptyArray));
-
-            // return empty array
             worker.Append(worker.Create(OpCodes.Ldc_I4_0));
-            worker.Append(worker.Create(OpCodes.Newarr, variable.GetElementType()));
+            Instruction labelEmptyArray = worker.Create(OpCodes.Nop);
+            worker.Append(worker.Create(OpCodes.Bge, labelEmptyArray));
+
+            // return null
+            worker.Append(worker.Create(OpCodes.Ldnull));
             worker.Append(worker.Create(OpCodes.Ret));
 
             // create the actual array

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -151,40 +151,48 @@ namespace Mirror.Weaver
 
             ILProcessor worker = readerFunc.Body.GetILProcessor();
 
+            // int length = reader.ReadPackedInt32();
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkReaderReadPackedInt32));
             worker.Append(worker.Create(OpCodes.Stloc_0));
 
+            // if (length < 0) {
+            //    return null
+            // }
             worker.Append(worker.Create(OpCodes.Ldloc_0));
             worker.Append(worker.Create(OpCodes.Ldc_I4_0));
             Instruction labelEmptyArray = worker.Create(OpCodes.Nop);
             worker.Append(worker.Create(OpCodes.Bge, labelEmptyArray));
-
             // return null
             worker.Append(worker.Create(OpCodes.Ldnull));
             worker.Append(worker.Create(OpCodes.Ret));
-
-            // create the actual array
             worker.Append(labelEmptyArray);
+
+
+            // T value = new T[length];
             worker.Append(worker.Create(OpCodes.Ldloc_0));
             worker.Append(worker.Create(OpCodes.Newarr, variable.GetElementType()));
             worker.Append(worker.Create(OpCodes.Stloc_1));
+
+
+            // for (int i=0; i< length ; i++) {
             worker.Append(worker.Create(OpCodes.Ldc_I4_0));
             worker.Append(worker.Create(OpCodes.Stloc_2));
-
-            // loop start
             Instruction labelHead = worker.Create(OpCodes.Nop);
             worker.Append(worker.Create(OpCodes.Br, labelHead));
 
             // loop body
             Instruction labelBody = worker.Create(OpCodes.Nop);
             worker.Append(labelBody);
+            // value[i] = reader.ReadT();
             worker.Append(worker.Create(OpCodes.Ldloc_1));
             worker.Append(worker.Create(OpCodes.Ldloc_2));
             worker.Append(worker.Create(OpCodes.Ldelema, variable.GetElementType()));
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Call, elementReadFunc));
             worker.Append(worker.Create(OpCodes.Stobj, variable.GetElementType()));
+
+
             worker.Append(worker.Create(OpCodes.Ldloc_2));
             worker.Append(worker.Create(OpCodes.Ldc_I4_1));
             worker.Append(worker.Create(OpCodes.Add));
@@ -196,6 +204,7 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldloc_0));
             worker.Append(worker.Create(OpCodes.Blt, labelBody));
 
+            // return value;
             worker.Append(worker.Create(OpCodes.Ldloc_1));
             worker.Append(worker.Create(OpCodes.Ret));
             return readerFunc;

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -87,9 +87,11 @@ namespace Mirror.Weaver
         public static MethodReference NetworkServerGetLocalClientActive;
         public static MethodReference NetworkClientGetActive;
         public static MethodReference getBehaviourIsServer;
+        public static MethodReference NetworkReaderReadPackedInt32;
         public static MethodReference NetworkReaderReadPackedUInt32;
-        public static MethodReference NetworkReaderReadPackedUInt64;
         public static MethodReference NetworkWriterWritePackedUInt64;
+        public static MethodReference NetworkWriterWritePackedInt32;
+        public static MethodReference NetworkReaderReadPackedUInt64;
 
         public static MethodReference NetworkReadUInt16;
         public static MethodReference NetworkWriteUInt16;
@@ -309,10 +311,13 @@ namespace Mirror.Weaver
 
             NetworkWriterWriteInt16 = Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", int16Type);
 
+            NetworkReaderReadPackedInt32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedInt32");
             NetworkReaderReadPackedUInt32 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt32");
             NetworkReaderReadPackedUInt64 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadPackedUInt64");
 
+            NetworkWriterWritePackedInt32 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedInt32");
             NetworkWriterWritePackedUInt64 = Resolvers.ResolveMethod(NetworkWriterType, CurrentAssembly, "WritePackedUInt64");
+
 
             NetworkReadUInt16 = Resolvers.ResolveMethod(NetworkReaderType, CurrentAssembly, "ReadUInt16");
             NetworkWriteUInt16 = Resolvers.ResolveMethodWithArg(NetworkWriterType, CurrentAssembly, "Write", uint16Type);

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -220,7 +220,12 @@ namespace Mirror.Weaver
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
 
-            // null check
+            // generates:
+            // if (value == null)
+            // {
+            //     writer.WritePackedInt32(-1);
+            //     return;
+            // }
             Instruction labelNull = worker.Create(OpCodes.Nop);
             worker.Append(worker.Create(OpCodes.Ldarg_1));
             worker.Append(worker.Create(OpCodes.Brtrue, labelNull));
@@ -230,18 +235,20 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkWriterWritePackedInt32));
             worker.Append(worker.Create(OpCodes.Ret));
 
-            // setup array length local variable
+            // generates:
+            // int length = value.Length;
             worker.Append(labelNull);
             worker.Append(worker.Create(OpCodes.Ldarg_1));
             worker.Append(worker.Create(OpCodes.Ldlen));
             worker.Append(worker.Create(OpCodes.Stloc_0));
 
-            //write length
+            // generates:
+            // writer.WritePackedInt32(length);
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Ldloc_0));
             worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkWriterWritePackedInt32));
 
-            // start loop
+            // for (int i=0; i< value.length; i++) {
             worker.Append(worker.Create(OpCodes.Ldc_I4_0));
             worker.Append(worker.Create(OpCodes.Stloc_1));
             Instruction labelHead = worker.Create(OpCodes.Nop);
@@ -250,6 +257,7 @@ namespace Mirror.Weaver
             // loop body
             Instruction labelBody = worker.Create(OpCodes.Nop);
             worker.Append(labelBody);
+            // writer.Write(value[i]);
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Ldarg_1));
             worker.Append(worker.Create(OpCodes.Ldloc_1));
@@ -257,12 +265,14 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldobj, variable.GetElementType()));
             worker.Append(worker.Create(OpCodes.Call, elementWriteFunc));
             worker.Append(worker.Create(OpCodes.Ldloc_1));
+
+
             worker.Append(worker.Create(OpCodes.Ldc_I4_1));
             worker.Append(worker.Create(OpCodes.Add));
-            worker.Append(worker.Create(OpCodes.Conv_U2));
             worker.Append(worker.Create(OpCodes.Stloc_1));
 
-            // loop while check
+
+            // end for loop
             worker.Append(labelHead);
             worker.Append(worker.Create(OpCodes.Ldloc_1));
             worker.Append(worker.Create(OpCodes.Ldarg_1));
@@ -270,6 +280,7 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Conv_I4));
             worker.Append(worker.Create(OpCodes.Blt, labelBody));
 
+            // return
             worker.Append(worker.Create(OpCodes.Ret));
             return writerFunc;
         }

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -220,7 +220,6 @@ namespace Mirror.Weaver
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
 
-            // generates:
             // if (value == null)
             // {
             //     writer.WritePackedInt32(-1);
@@ -235,14 +234,12 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkWriterWritePackedInt32));
             worker.Append(worker.Create(OpCodes.Ret));
 
-            // generates:
             // int length = value.Length;
             worker.Append(labelNull);
             worker.Append(worker.Create(OpCodes.Ldarg_1));
             worker.Append(worker.Create(OpCodes.Ldlen));
             worker.Append(worker.Create(OpCodes.Stloc_0));
 
-            // generates:
             // writer.WritePackedInt32(length);
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Ldloc_0));
@@ -264,9 +261,9 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldelema, variable.GetElementType()));
             worker.Append(worker.Create(OpCodes.Ldobj, variable.GetElementType()));
             worker.Append(worker.Create(OpCodes.Call, elementWriteFunc));
+
+
             worker.Append(worker.Create(OpCodes.Ldloc_1));
-
-
             worker.Append(worker.Create(OpCodes.Ldc_I4_1));
             worker.Append(worker.Create(OpCodes.Add));
             worker.Append(worker.Create(OpCodes.Stloc_1));

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -214,8 +214,8 @@ namespace Mirror.Weaver
             writerFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkWriterType)));
             writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(variable)));
 
-            writerFunc.Body.Variables.Add(new VariableDefinition(Weaver.uint16Type));
-            writerFunc.Body.Variables.Add(new VariableDefinition(Weaver.uint16Type));
+            writerFunc.Body.Variables.Add(new VariableDefinition(Weaver.int32Type));
+            writerFunc.Body.Variables.Add(new VariableDefinition(Weaver.int32Type));
             writerFunc.Body.InitLocals = true;
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
@@ -226,22 +226,20 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Brtrue, labelNull));
 
             worker.Append(worker.Create(OpCodes.Ldarg_0));
-            worker.Append(worker.Create(OpCodes.Ldc_I4_0));
-            worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkWriteUInt16));
+            worker.Append(worker.Create(OpCodes.Ldc_I4_M1));
+            worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkWriterWritePackedInt32));
             worker.Append(worker.Create(OpCodes.Ret));
 
             // setup array length local variable
             worker.Append(labelNull);
             worker.Append(worker.Create(OpCodes.Ldarg_1));
             worker.Append(worker.Create(OpCodes.Ldlen));
-            worker.Append(worker.Create(OpCodes.Conv_I4));
-            worker.Append(worker.Create(OpCodes.Conv_U2));
             worker.Append(worker.Create(OpCodes.Stloc_0));
 
             //write length
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkWriteUInt16));
+            worker.Append(worker.Create(OpCodes.Call, Weaver.NetworkWriterWritePackedInt32));
 
             // start loop
             worker.Append(worker.Create(OpCodes.Ldc_I4_0));


### PR DESCRIPTION
When you pass a null array,  don't convert it to empty array.  For example:

```cs
[Command]
public void CmdTest(int [] data, int [] data2,  int [] data3)
{
     // data should be null,    mirror was giving []
     // data2 should be []
     // data 3 should be [3]
}

public void OnClientStart()
{
    CmdTest(
        null,
        new int[] {},
        new int [] {3});
}
```