### PR TITLE
fix: ArraySegment<byte> work in Messages

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -56,7 +56,7 @@ namespace Mirror.Weaver
                 if (field.IsStatic || field.IsPrivate || field.IsSpecialName)
                     continue;
 
-                if (field.FieldType.Resolve().HasGenericParameters)
+                if (field.FieldType.Resolve().HasGenericParameters && field.FieldType.FullName != "System.ArraySegment`1<System.Byte>")
                 {
                     Weaver.Error($"{field} cannot have generic type {field.FieldType}.  Consider creating a class that derives the generic type");
                     return;

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -192,7 +192,7 @@ namespace Mirror
             netId = reader.ReadPackedUInt32();
             componentIndex = (int)reader.ReadPackedUInt32();
             functionHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
-            payload = reader.ReadBytesAndSizeSegment();
+            payload = reader.ReadBoolean() ? reader.ReadBytesSegment((int)reader.ReadPackedUInt32()) : default;
         }
 
         public override void Serialize(NetworkWriter writer)
@@ -232,7 +232,7 @@ namespace Mirror
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
             scale = reader.ReadVector3();
-            payload = reader.ReadBytesAndSizeSegment();
+            payload = reader.ReadBoolean() ? reader.ReadBytesSegment((int)reader.ReadPackedUInt32()) : default;
         }
 
         public override void Serialize(NetworkWriter writer)
@@ -267,7 +267,7 @@ namespace Mirror
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
             scale = reader.ReadVector3();
-            payload = reader.ReadBytesAndSizeSegment();
+            payload = reader.ReadBoolean() ? reader.ReadBytesSegment((int)reader.ReadPackedUInt32()) : default;
         }
 
         public override void Serialize(NetworkWriter writer)
@@ -344,7 +344,7 @@ namespace Mirror
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
-            payload = reader.ReadBytesAndSizeSegment();
+            payload = reader.ReadBoolean() ? reader.ReadBytesSegment((int)reader.ReadPackedUInt32()) : default;
         }
 
         public override void Serialize(NetworkWriter writer)

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -192,7 +192,7 @@ namespace Mirror
             netId = reader.ReadPackedUInt32();
             componentIndex = (int)reader.ReadPackedUInt32();
             functionHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
-            payload = reader.ReadBoolean() ? reader.ReadBytesSegment((int)reader.ReadPackedUInt32()) : default;
+            payload = reader.ReadBytesAndSizeSegment();
         }
 
         public override void Serialize(NetworkWriter writer)
@@ -232,7 +232,7 @@ namespace Mirror
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
             scale = reader.ReadVector3();
-            payload = reader.ReadBoolean() ? reader.ReadBytesSegment((int)reader.ReadPackedUInt32()) : default;
+            payload = reader.ReadBytesAndSizeSegment();
         }
 
         public override void Serialize(NetworkWriter writer)
@@ -267,7 +267,7 @@ namespace Mirror
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
             scale = reader.ReadVector3();
-            payload = reader.ReadBoolean() ? reader.ReadBytesSegment((int)reader.ReadPackedUInt32()) : default;
+            payload = reader.ReadBytesAndSizeSegment();
         }
 
         public override void Serialize(NetworkWriter writer)
@@ -344,7 +344,7 @@ namespace Mirror
         public override void Deserialize(NetworkReader reader)
         {
             netId = reader.ReadPackedUInt32();
-            payload = reader.ReadBoolean() ? reader.ReadBytesSegment((int)reader.ReadPackedUInt32()) : default;
+            payload = reader.ReadBytesAndSizeSegment();
         }
 
         public override void Serialize(NetworkWriter writer)

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -195,8 +195,7 @@ namespace Mirror
 
         public ArraySegment<byte> ReadBytesAndSizeSegment()
         {
-            byte[] bytes = ReadBytesAndSize();
-            return bytes == null ? default : new ArraySegment<byte>(bytes);
+            return ReadBoolean() ? ReadBytesSegment((int)ReadPackedUInt32()) : default;
         }
 
         // zigzag decoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -195,11 +195,8 @@ namespace Mirror
 
         public ArraySegment<byte> ReadBytesAndSizeSegment()
         {
-            if (ReadBoolean())
-            {
-                return ReadBytesSegment((int)ReadPackedUInt32());
-            }
-            return default;
+            byte[] bytes = ReadBytesAndSize();
+            return bytes == null ? default : new ArraySegment<byte>(bytes);
         }
 
         // zigzag decoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba

--- a/Assets/Mirror/Tests/ArraySegmentWriterTest.cs
+++ b/Assets/Mirror/Tests/ArraySegmentWriterTest.cs
@@ -1,0 +1,70 @@
+using System;
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    [TestFixture]
+    public class ArraySegmentWriterTest
+    {
+        class ArrayMessage : MessageBase
+        {
+            public ArraySegment<byte> array;
+        }
+
+        [Test]
+        public void TestEmptyByteArray()
+        {
+            ArrayMessage message = new ArrayMessage
+            {
+                array = new ArraySegment<byte>(new byte[0])
+            };
+
+            byte[] data = MessagePacker.Pack(message);
+
+            ArrayMessage unpacked = MessagePacker.Unpack<ArrayMessage>(data);
+
+            Assert.IsNotNull(unpacked.array.Array);
+            Assert.That(unpacked.array.Array.Length, Is.EqualTo(0));
+            Assert.That(unpacked.array.Offset, Is.EqualTo(0));
+            Assert.That(unpacked.array.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestNullByteArray()
+        {
+            ArrayMessage message = new ArrayMessage
+            {
+                array = default
+            };
+
+            byte[] data = MessagePacker.Pack(message);
+
+            ArrayMessage unpacked = MessagePacker.Unpack<ArrayMessage>(data);
+
+            Assert.IsNull(unpacked.array.Array);
+            Assert.That(unpacked.array.Offset, Is.EqualTo(0));
+            Assert.That(unpacked.array.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestSegmentByteArray()
+        {
+            byte[] sourcedata = { 0, 1, 2, 3, 4, 5, 6 };
+
+            ArrayMessage message = new ArrayMessage
+            {
+                array = new ArraySegment<byte>(sourcedata, 3, 2)
+            };
+
+            byte[] data = MessagePacker.Pack(message);
+
+            ArrayMessage unpacked = MessagePacker.Unpack<ArrayMessage>(data);
+
+            Assert.IsNotNull(unpacked.array.Array);
+            Assert.That(unpacked.array.Array.Length, Is.EqualTo(2));
+            Assert.That(unpacked.array.Offset, Is.EqualTo(0));
+            Assert.That(unpacked.array.Count, Is.EqualTo(2));
+            Assert.That(unpacked.array, Is.EquivalentTo(new byte[] { 3, 4 }));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/ArraySegmentWriterTest.cs
+++ b/Assets/Mirror/Tests/ArraySegmentWriterTest.cs
@@ -24,8 +24,6 @@ namespace Mirror.Tests
             ArrayMessage unpacked = MessagePacker.Unpack<ArrayMessage>(data);
 
             Assert.IsNotNull(unpacked.array.Array);
-            Assert.That(unpacked.array.Array.Length, Is.EqualTo(0));
-            Assert.That(unpacked.array.Offset, Is.EqualTo(0));
             Assert.That(unpacked.array.Count, Is.EqualTo(0));
         }
 
@@ -61,8 +59,6 @@ namespace Mirror.Tests
             ArrayMessage unpacked = MessagePacker.Unpack<ArrayMessage>(data);
 
             Assert.IsNotNull(unpacked.array.Array);
-            Assert.That(unpacked.array.Array.Length, Is.EqualTo(2));
-            Assert.That(unpacked.array.Offset, Is.EqualTo(0));
             Assert.That(unpacked.array.Count, Is.EqualTo(2));
             Assert.That(unpacked.array, Is.EquivalentTo(new byte[] { 3, 4 }));
         }

--- a/Assets/Mirror/Tests/ArraySegmentWriterTest.cs.meta
+++ b/Assets/Mirror/Tests/ArraySegmentWriterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f4698aeeb4f71441a21cc368bd26377
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ReadBytesAndSizeSegment needs to create a new array in case users want to use the ArraySegment after we get rid of the buffer.