### PR TITLE
perf: Use 0 for null byte arrays

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -194,6 +194,9 @@ namespace Mirror
 
         public ArraySegment<byte> ReadBytesAndSizeSegment()
         {
+
+            // count = 0 means the array was null
+            // otherwise count - 1 is the length of the array
             uint count = ReadPackedUInt32();
             return count == 0 ? default : ReadBytesSegment(checked((int)(count - 1u)));
         }

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -186,16 +186,14 @@ namespace Mirror
         // null support, see NetworkWriter
         public byte[] ReadBytesAndSize()
         {
-            if (ReadBoolean())
-            {
-                return ReadBytes(checked((int)ReadPackedUInt32()));
-            }
-            return null;
+            uint count = ReadPackedUInt32();
+            return count == 0 ? null : ReadBytes(checked((int)(count - 1u)));
         }
 
         public ArraySegment<byte> ReadBytesAndSizeSegment()
         {
-            return ReadBoolean() ? ReadBytesSegment((int)ReadPackedUInt32()) : default;
+            uint count = ReadPackedUInt32();
+            return count == 0 ? default : ReadBytesSegment(checked((int)(count - 1u)));
         }
 
         // zigzag decoding https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -186,6 +186,8 @@ namespace Mirror
         // null support, see NetworkWriter
         public byte[] ReadBytesAndSize()
         {
+            // count = 0 means the array was null
+            // otherwise count -1 is the length of the array 
             uint count = ReadPackedUInt32();
             return count == 0 ? null : ReadBytes(checked((int)(count - 1u)));
         }

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -103,7 +103,7 @@ namespace Mirror
         public void WriteBytesAndSize(byte[] buffer, int offset, int count)
         {
             // null is supported because [SyncVar]s might be structs with null byte[] arrays
-            // (writing a size=0 empty array is not the same, the server and client would be out of sync)
+            // write 0 for null array, increment normal size by 1 to save bandwith
             // (using size=-1 for null would limit max size to 32kb instead of 64kb)
             if (buffer == null)
             {

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -102,16 +102,16 @@ namespace Mirror
         // (like an inventory with different items etc.)
         public void WriteBytesAndSize(byte[] buffer, int offset, int count)
         {
-            uint length = checked((uint)count);
             // null is supported because [SyncVar]s might be structs with null byte[] arrays
             // (writing a size=0 empty array is not the same, the server and client would be out of sync)
             // (using size=-1 for null would limit max size to 32kb instead of 64kb)
-            writer.Write(buffer != null); // notNull?
-            if (buffer != null)
+            if (buffer == null)
             {
-                WritePackedUInt32(length);
-                writer.Write(buffer, offset, count);
+                WritePackedUInt32(0u);// notNull?
+                return;
             }
+            WritePackedUInt32(checked((uint)count) + 1u);
+            writer.Write(buffer, offset, count);
         }
 
         // Weaver needs a write function with just one byte[] parameter

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -107,7 +107,7 @@ namespace Mirror
             // (using size=-1 for null would limit max size to 32kb instead of 64kb)
             if (buffer == null)
             {
-                WritePackedUInt32(0u);// notNull?
+                WritePackedUInt32(0u);
                 return;
             }
             WritePackedUInt32(checked((uint)count) + 1u);

--- a/Assets/Mirror/Tests/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/NetworkWriterTest.cs
@@ -159,7 +159,6 @@ namespace Mirror.Tests
         public void TestReadingLengthWrapAround()
         {
             NetworkWriter writer = new NetworkWriter();
-            writer.Write(true);
             // This is 1.5x int.MaxValue, in the negative range of int.
             writer.WritePackedUInt32(3221225472);
             NetworkReader reader = new NetworkReader(writer.ToArray());
@@ -189,8 +188,6 @@ namespace Mirror.Tests
         {
             NetworkWriter writer = new NetworkWriter();
             Assert.Throws<OverflowException>(() => writer.WriteBytesAndSize(new byte[0], 0, -1));
-            Assert.That(writer.Position, Is.EqualTo(0));
-            Assert.Throws<OverflowException>(() => writer.WriteBytesAndSize(null, 0, -1));
             Assert.That(writer.Position, Is.EqualTo(0));
         }
 


### PR DESCRIPTION
Breaks compatibility with older versions, saves 1 byte for non null arrays, doesn't make null arrays the same as empty ones.