### PR TITLE
perf: remove syncvar boxing

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -423,8 +423,7 @@ namespace Mirror
         protected void SetSyncVar<T>(T value, ref T fieldValue, ulong dirtyBit)
         {
             // newly initialized or changed value?
-            if ((value == null && fieldValue != null) ||
-                (value != null && !value.Equals(fieldValue)))
+            if (!EqualityComparer<T>.Default.Equals(value, fieldValue))
             {
                 if (LogFilter.Debug) Debug.Log("SetSyncVar " + GetType().Name + " bit [" + dirtyBit + "] " + fieldValue + "->" + value);
                 SetDirtyBit(dirtyBit);


### PR DESCRIPTION
On the "death by 1000 cuts" theme,   here is a fix for a small boxing that happens every time you set a value in a syncvar