### PR TITLE
perf: avoid allocation with message structs

### DIFF
--- a/Assets/Mirror/Runtime/NetworkMessage.cs
+++ b/Assets/Mirror/Runtime/NetworkMessage.cs
@@ -8,12 +8,8 @@ namespace Mirror
 
         public TMsg ReadMessage<TMsg>() where TMsg : IMessageBase, new()
         {
-            TMsg msg = default;
+            TMsg msg = typeof(TMsg).IsValueType ? default(TMsg) : new TMsg();
 
-            if (!typeof(TMsg).IsValueType)
-            {
-                msg = new TMsg();
-            }
             msg.Deserialize(reader);
             return msg;
         }

--- a/Assets/Mirror/Runtime/NetworkMessage.cs
+++ b/Assets/Mirror/Runtime/NetworkMessage.cs
@@ -8,7 +8,12 @@ namespace Mirror
 
         public TMsg ReadMessage<TMsg>() where TMsg : IMessageBase, new()
         {
-            TMsg msg = new TMsg();
+            TMsg msg = default;
+
+            if (!typeof(TMsg).IsValueType)
+            {
+                msg = new TMsg();
+            }
             msg.Deserialize(reader);
             return msg;
         }

--- a/Assets/Mirror/Runtime/NetworkMessage.cs
+++ b/Assets/Mirror/Runtime/NetworkMessage.cs
@@ -8,8 +8,11 @@ namespace Mirror
 
         public TMsg ReadMessage<TMsg>() where TMsg : IMessageBase, new()
         {
+            // Normally I would just do:
+            // TMsg msg = new TMsg();
+            // but mono calls an expensive method Activator.CreateInstance
+            // For value types this is unnecesary,  just use the default value
             TMsg msg = typeof(TMsg).IsValueType ? default(TMsg) : new TMsg();
-
             msg.Deserialize(reader);
             return msg;
         }


### PR DESCRIPTION
Avoid creating messages in the stack if messages are structs.
When combined with #987 ,  it gets rid of this:

<img width="678" alt="Screen Shot 2019-07-29 at 7 29 41 AM" src="https://user-images.githubusercontent.com/466007/62048820-6b6c8280-b1d3-11e9-83ad-210992b82d00.png">
