### PR TITLE
fix: maintain Unity's copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Mirror was forked from Unity's UNET Networking, Copyright (c) 2015, Unity Technologies (https://bitbucket.org/Unity-Technologies/)
-Mirror fork modifications (c) vis2k & paul, 2019.
+Copyright (c) 2015, Unity Technologies
+Mirror modifications Copyright (c) 2019, vis2k & paul
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
IANAL but my understanding from the MIT license,  is that we cannot modify unity's copyright notice.

But we can add our own copyright notice.  

This should fix this issue