### PR TITLE
fix: Don't increment counter in Awake

### DIFF
--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -44,11 +44,6 @@ namespace Mirror
             server.NoDelay = NoDelay;
             server.MaxMessageSize = serverMaxMessageSize;
 
-            // HLAPI's local connection uses hard coded connectionId '0', so we
-            // need to make sure that external connections always start at '1'
-            // by simple eating the first one before the server starts
-            Telepathy.Server.NextConnectionId();
-
             Debug.Log("TelepathyTransport initialized!");
         }
 


### PR DESCRIPTION
Doing it in Awake and also before assigning to clients skips connection ID 1.