### PR TITLE
feat: SceneMessage Additive & Physics flags

### DIFF
--- a/Assets/Mirror/Components/NetworkLobbyManager.cs
+++ b/Assets/Mirror/Components/NetworkLobbyManager.cs
@@ -373,7 +373,7 @@ namespace Mirror
             }
         }
 
-        public override void OnClientChangeScene(string newSceneName)
+        public override void OnClientChangeScene(string newSceneName, LoadSceneMode sceneMode)
         {
             if (LogFilter.Debug) Debug.LogFormat("OnClientChangeScene from {0} to {1}", SceneManager.GetActiveScene().name, newSceneName);
 

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -158,20 +158,17 @@ namespace Mirror
     {
         public string sceneName;
         public LoadSceneMode sceneMode; // Single = 0, Additive = 1
-        public LocalPhysicsMode physicsMode; // None = 0, Physics3D = 1, Physics2D = 2
 
         public override void Deserialize(NetworkReader reader)
         {
             sceneName = reader.ReadString();
             sceneMode = (LoadSceneMode)reader.ReadByte();
-            physicsMode = (LocalPhysicsMode)reader.ReadByte();
         }
 
         public override void Serialize(NetworkWriter writer)
         {
             writer.Write(sceneName);
             writer.Write((byte)sceneMode);
-            writer.Write((byte)physicsMode);
         }
     }
     #endregion

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -157,7 +157,7 @@ namespace Mirror
     public class SceneMessage : MessageBase
     {
         public string sceneName;
-        public LoadSceneMode sceneMode; // Single = 0, Additive = 1
+        public LoadSceneMode sceneMode = LoadSceneMode.Single;
 
         public override void Deserialize(NetworkReader reader)
         {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -445,7 +445,7 @@ namespace Mirror
                 SceneManager.LoadSceneAsync(newSceneName, new LoadSceneParameters(sceneMode, physicsMode));
 
                 // Do not include physicsMode in SceneMessage to clients.
-                // Clients will only have one instance of the additve scene
+                // Clients will only have one instance of the additive scene
                 // and the physics needs to be merged with their main scene.
                 SceneMessage msg = new SceneMessage()
                 {
@@ -465,7 +465,6 @@ namespace Mirror
             }
         }
 
-        //internal void ClientChangeScene(string newSceneName, bool forceReload, LoadSceneMode sceneMode)
         internal void ClientChangeScene(string newSceneName, LoadSceneMode sceneMode)
         {
             if (string.IsNullOrEmpty(newSceneName))


### PR DESCRIPTION
This PR fully implements additive and physics scene control options through SceneMessage and client side handling.  I'll submit documentation and an example separately after this is merged.

This PR also fixes bug #870 .

**Note**:  There is one small breaking change in this PR.  NetworkManager:L791 the signature of a virtual method is unavoidably changed.   OnClientChangeScene is not well documented and is a recent addition (UNet didn't have it).  There may be a few people using it (two have indicated so in Discord).  Making the old version obsolete makes more of a mess than breaking it here.

`public virtual void OnClientChangeScene(string newSceneName, LoadSceneMode sceneMode) {}`

With this enhancement, Mirror will now have built-in support for server-side instanced sub-scenes.  That means that within a main scene, the server can host dozens of simultaneous "match" scenes, isolated by physics so they don't interfere with each other or the main scene, simply by loading the same sub-scene multiple times and moving the server-side players into an instance to play together.  On the client side, the sub-scene is only additive loaded once, and only the clients that are in the same instance on the server can see / interact / collide with each other.