### PR TITLE
fix: SceneId was not set to 0 for prefab variants (#976)

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -361,6 +361,8 @@ namespace Mirror
                 m_SceneId = 0; // force 0 for prefabs
                 AssignAssetID(gameObject);
             }
+            // check prefabstage BEFORE SceneObjectWithPrefabParent
+            // (fixes https://github.com/vis2k/Mirror/issues/976)
             else if (PrefabStageUtility.GetCurrentPrefabStage() != null)
             {
                 m_SceneId = 0; // force 0 for prefabs

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -361,16 +361,16 @@ namespace Mirror
                 m_SceneId = 0; // force 0 for prefabs
                 AssignAssetID(gameObject);
             }
-            else if (ThisIsASceneObjectWithPrefabParent(out GameObject prefab))
-            {
-                AssignSceneID();
-                AssignAssetID(prefab);
-            }
             else if (PrefabStageUtility.GetCurrentPrefabStage() != null)
             {
                 m_SceneId = 0; // force 0 for prefabs
                 string path = PrefabStageUtility.GetCurrentPrefabStage().prefabAssetPath;
                 AssignAssetID(path);
+            }
+            else if (ThisIsASceneObjectWithPrefabParent(out GameObject prefab))
+            {
+                AssignSceneID();
+                AssignAssetID(prefab);
             }
             else
             {


### PR DESCRIPTION
This PR fixes sceneIDs not being set to 0 in prefab variants (#976).

It seems that prefab variants that are loaded in the prefab stage are considered instances of the base prefab. ThisIsASceneObjectWithPrefabParent() returns true and a new sceneId is assigned when opening the prefab variant. Because of this, the next check, where the NetworkIdentity would detect being loaded in a prefab stage, is not executed. Swapping the order of the two checks fixes this.

Per the instructions of @MrGadget1024, I tested this fix with the AdaptiveLoading and Lobby examples and didn't see any issues.