### PR TITLE
Updated Pong 2

### DIFF
--- a/Assets/Mirror/Examples/Pong/Prefabs/Ball.prefab
+++ b/Assets/Mirror/Examples/Pong/Prefabs/Ball.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1080679924113744}
-  m_IsPrefabParent: 1
 --- !u!1 &1080679924113744
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4700925592147096}
   - component: {fileID: 212107498293566416}
@@ -34,9 +24,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4700925592147096
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1080679924113744}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3, y: 0, z: 0}
@@ -45,97 +36,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &50354248948880112
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1080679924113744}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 0.0001
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
---- !u!61 &61279514624852186
-BoxCollider2D:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1080679924113744}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 6200000, guid: 97a3e4cddb8635c4eba1265f44d106bf, type: 2}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!114 &114121325390084138
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1080679924113744}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncInterval: 0.1
-  compressRotation: 1
---- !u!114 &114290021321007948
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1080679924113744}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SceneId: 0
-  m_ServerOnly: 0
-  m_LocalPlayerAuthority: 0
-  m_AssetId: 5f7a7f34494ed40268eff49dbf9168bf
---- !u!114 &114692463781779748
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1080679924113744}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 38b5c2f743cd8034a8beeebf277c92c1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncInterval: 0.1
-  speed: 30
 --- !u!212 &212107498293566416
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1080679924113744}
   m_Enabled: 1
   m_CastShadows: 0
@@ -144,6 +50,8 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -175,3 +83,95 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &61279514624852186
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080679924113744}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 6200000, guid: 97a3e4cddb8635c4eba1265f44d106bf, type: 2}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &50354248948880112
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080679924113744}
+  m_BodyType: 0
+  m_Simulated: 0
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 0.0001
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!114 &114290021321007948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080679924113744}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serverOnly: 0
+  localPlayerAuthority: 0
+  m_AssetId: 5f7a7f34494ed40268eff49dbf9168bf
+  m_SceneId: 0
+--- !u!114 &114692463781779748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080679924113744}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 38b5c2f743cd8034a8beeebf277c92c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncInterval: 0.1
+  speed: 30
+--- !u!114 &114121325390084138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080679924113744}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncInterval: 0
+  compressRotation: 1

--- a/Assets/Mirror/Examples/Pong/Prefabs/Ball.prefab
+++ b/Assets/Mirror/Examples/Pong/Prefabs/Ball.prefab
@@ -161,6 +161,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncInterval: 0.1
   speed: 30
+  rigidbody2d: {fileID: 50354248948880112}
 --- !u!114 &114121325390084138
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/Pong/Prefabs/Racket.prefab
+++ b/Assets/Mirror/Examples/Pong/Prefabs/Racket.prefab
@@ -143,8 +143,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_ServerOnly: 0
-  m_LocalPlayerAuthority: 1
+  serverOnly: 0
+  localPlayerAuthority: 1
   m_AssetId: b1651eaf8c7564a1c86031dfbb8a7b28
   m_SceneId: 0
 --- !u!114 &114626868563338794
@@ -173,5 +173,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncInterval: 0.1
+  syncInterval: 0
   compressRotation: 1

--- a/Assets/Mirror/Examples/Pong/Prefabs/Racket.prefab
+++ b/Assets/Mirror/Examples/Pong/Prefabs/Racket.prefab
@@ -161,6 +161,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncInterval: 0.1
   speed: 1500
+  rigidbody2d: {fileID: 50389918509199184}
 --- !u!114 &114398896143473162
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/Pong/Scenes/Scene.unity
+++ b/Assets/Mirror/Examples/Pong/Scenes/Scene.unity
@@ -908,7 +908,7 @@ MonoBehaviour:
   OnClientDataReceived:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mirror.UnityEventArraySegment, Mirror, Version=0.0.0.0, Culture=neutral,
+    m_TypeName: Mirror.UnityEventByteArray, Mirror, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
   OnClientError:
     m_PersistentCalls:
@@ -927,7 +927,7 @@ MonoBehaviour:
   OnServerDataReceived:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mirror.UnityEventIntArraySegment, Mirror, Version=0.0.0.0, Culture=neutral,
+    m_TypeName: Mirror.UnityEventIntByteArray, Mirror, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
   OnServerError:
     m_PersistentCalls:
@@ -940,5 +940,3 @@ MonoBehaviour:
     m_TypeName: Mirror.UnityEventInt, Mirror, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   port: 7777
   NoDelay: 1
-  serverMaxMessageSize: 16384
-  clientMaxMessageSize: 16384

--- a/Assets/Mirror/Examples/Pong/Scenes/Scene.unity
+++ b/Assets/Mirror/Examples/Pong/Scenes/Scene.unity
@@ -888,8 +888,6 @@ MonoBehaviour:
   - {fileID: 1080679924113744, guid: 5f7a7f34494ed40268eff49dbf9168bf, type: 3}
   leftRacketSpawn: {fileID: 473997961}
   rightRacketSpawn: {fileID: 1397990096}
-  ballPrefab: {fileID: 1080679924113744, guid: 5f7a7f34494ed40268eff49dbf9168bf, type: 3}
-  ball: {fileID: 0}
 --- !u!114 &1886246553
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -910,7 +908,7 @@ MonoBehaviour:
   OnClientDataReceived:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mirror.UnityEventByteArray, Mirror, Version=0.0.0.0, Culture=neutral,
+    m_TypeName: Mirror.UnityEventArraySegment, Mirror, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
   OnClientError:
     m_PersistentCalls:
@@ -929,7 +927,7 @@ MonoBehaviour:
   OnServerDataReceived:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mirror.UnityEventIntByteArray, Mirror, Version=0.0.0.0, Culture=neutral,
+    m_TypeName: Mirror.UnityEventIntArraySegment, Mirror, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
   OnServerError:
     m_PersistentCalls:
@@ -942,3 +940,5 @@ MonoBehaviour:
     m_TypeName: Mirror.UnityEventInt, Mirror, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   port: 7777
   NoDelay: 1
+  serverMaxMessageSize: 16384
+  clientMaxMessageSize: 16384

--- a/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
@@ -5,19 +5,17 @@ namespace Mirror.Examples.Pong
     public class Ball : NetworkBehaviour
     {
         public float speed = 30;
-
-        Rigidbody2D rb;
+        public Rigidbody2D rigidbody2d;
 
         public override void OnStartServer()
         {
             base.OnStartServer();
 
-            rb = GetComponent<Rigidbody2D>();
-
             // only simulate ball physics on server
-            rb.simulated = true;
+            rigidbody2d.simulated = true;
 
-            rb.velocity = Vector2.right * speed;
+            // Serve the ball from left player
+            rigidbody2d.velocity = Vector2.right * speed;
         }
 
         float HitFactor(Vector2 ballPos, Vector2 racketPos, float racketHeight)
@@ -55,7 +53,7 @@ namespace Mirror.Examples.Pong
                 Vector2 dir = new Vector2(x, y).normalized;
 
                 // Set Velocity with dir * speed
-                rb.velocity = dir * speed;
+                rigidbody2d.velocity = dir * speed;
             }
         }
     }

--- a/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
@@ -6,12 +6,18 @@ namespace Mirror.Examples.Pong
     {
         public float speed = 30;
 
-        public void Start()
+        Rigidbody2D rb;
+
+        public override void OnStartServer()
         {
+            base.OnStartServer();
+
+            rb = GetComponent<Rigidbody2D>();
+
             // only simulate ball physics on server
-            GetComponent<Rigidbody2D>().simulated = isServer;
-            if (isServer)
-                GetComponent<Rigidbody2D>().velocity = Vector2.right * speed;
+            rb.simulated = true;
+
+            rb.velocity = Vector2.right * speed;
         }
 
         float HitFactor(Vector2 ballPos, Vector2 racketPos, float racketHeight)
@@ -49,7 +55,7 @@ namespace Mirror.Examples.Pong
                 Vector2 dir = new Vector2(x, y).normalized;
 
                 // Set Velocity with dir * speed
-                GetComponent<Rigidbody2D>().velocity = dir * speed;
+                rb.velocity = dir * speed;
             }
         }
     }

--- a/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
@@ -8,7 +8,6 @@ public class NetworkManagerPong : NetworkManager
 {
     public Transform leftRacketSpawn;
     public Transform rightRacketSpawn;
-    public GameObject ballPrefab;
     GameObject ball;
 
     public override void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)
@@ -21,7 +20,7 @@ public class NetworkManagerPong : NetworkManager
         // spawn ball if two players
         if (numPlayers == 2)
         {
-            ball = Instantiate(ballPrefab);
+            ball = Instantiate(spawnPrefabs.Find(prefab => prefab.name == "Ball"));
             NetworkServer.Spawn(ball);
         }
     }

--- a/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
@@ -1,9 +1,9 @@
-// custom NetworkManager that simply assigns the correct racket positions when
-// spawning players. the built in RoundRobin spawn method wouldn't work after
-// someone reconnects (both players would be on the same side).
 using UnityEngine;
 using Mirror;
 
+// Custom NetworkManager that simply assigns the correct racket positions when
+// spawning players. The built in RoundRobin spawn method wouldn't work after
+// someone reconnects (both players would be on the same side).
 public class NetworkManagerPong : NetworkManager
 {
     public Transform leftRacketSpawn;

--- a/Assets/Mirror/Examples/Pong/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/Player.cs
@@ -6,15 +6,21 @@ namespace Mirror.Examples.Pong
     {
         public float speed = 30;
 
+        Rigidbody2D rb;
+
+        public override void OnStartClient()
+        {
+            base.OnStartClient();
+            rb = GetComponent<Rigidbody2D>();
+        }
+
         // need to use FixedUpdate for rigidbody
         void FixedUpdate()
         {
             // only let the local player control the racket.
             // don't control other player's rackets
-            if (!isLocalPlayer) return;
-
-            float vertical = Input.GetAxisRaw("Vertical");
-            GetComponent<Rigidbody2D>().velocity = new Vector2(0, vertical) * speed * Time.fixedDeltaTime;
+            if (isLocalPlayer)
+                rb.velocity = new Vector2(0, Input.GetAxisRaw("Vertical")) * speed * Time.fixedDeltaTime;
         }
     }
 }

--- a/Assets/Mirror/Examples/Pong/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/Player.cs
@@ -5,14 +5,7 @@ namespace Mirror.Examples.Pong
     public class Player : NetworkBehaviour
     {
         public float speed = 30;
-
-        Rigidbody2D rb;
-
-        public override void OnStartClient()
-        {
-            base.OnStartClient();
-            rb = GetComponent<Rigidbody2D>();
-        }
+        public Rigidbody2D rigidbody2d;
 
         // need to use FixedUpdate for rigidbody
         void FixedUpdate()
@@ -20,7 +13,7 @@ namespace Mirror.Examples.Pong
             // only let the local player control the racket.
             // don't control other player's rackets
             if (isLocalPlayer)
-                rb.velocity = new Vector2(0, Input.GetAxisRaw("Vertical")) * speed * Time.fixedDeltaTime;
+                rigidbody2d.velocity = new Vector2(0, Input.GetAxisRaw("Vertical")) * speed * Time.fixedDeltaTime;
         }
     }
 }


### PR DESCRIPTION
Individual Commits
- Set Sync Interval to zero for ball and racquet to make it smoother
- Turned off Simulated in Ball prefab and set true in OnStartServer
- Cached GetComponent<Rigidbody2D>() in OnStartServer and OnStartLocalPlayer instead of calling it repeatedly in FixedUpdate
- Used Find to get Ball prefab from Network Manager's Spawnable Prefabs list instead of having a separate field for spawning it