### PR TITLE
perf: ping messages should be value types

### DIFF
--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -356,27 +356,40 @@ namespace Mirror
 
     // A client sends this message to the server
     // to calculate RTT and synchronize time
-    class NetworkPingMessage : DoubleMessage
+    struct NetworkPingMessage : IMessageBase
     {
-        public NetworkPingMessage() {}
+        public double clientTime;
 
-        public NetworkPingMessage(double value) : base(value) {}
+        public NetworkPingMessage(double value)
+        {
+            clientTime = value;
+        }
+
+        public void Deserialize(NetworkReader reader)
+        {
+            clientTime = reader.ReadDouble();
+        }
+
+        public void Serialize(NetworkWriter writer)
+        {
+            writer.Write(clientTime);
+        }        
     }
 
     // The server responds with this message
     // The client can use this to calculate RTT and sync time
-    class NetworkPongMessage : MessageBase
+    struct NetworkPongMessage : IMessageBase
     {
         public double clientTime;
         public double serverTime;
 
-        public override void Deserialize(NetworkReader reader)
+        public void Deserialize(NetworkReader reader)
         {
             clientTime = reader.ReadDouble();
             serverTime = reader.ReadDouble();
         }
 
-        public override void Serialize(NetworkWriter writer)
+        public void Serialize(NetworkWriter writer)
         {
             writer.Write(clientTime);
             writer.Write(serverTime);

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -64,7 +64,7 @@ namespace Mirror
 
             NetworkPongMessage pongMsg = new NetworkPongMessage
             {
-                clientTime = msg.value,
+                clientTime = msg.clientTime,
                 serverTime = LocalTime()
             };
 


### PR DESCRIPTION
I would like to do this for all messages,  let's start with a simple one.

Messages should be value types,  this avoids unnecessary allocations and avoid NPE

It gets rid of this small allocation per message

<img width="694" alt="Screen Shot 2019-07-29 at 7 13 21 AM" src="https://user-images.githubusercontent.com/466007/62048458-8e4a6700-b1d2-11e9-980b-3779a42ade60.png">
