### PR TITLE
Fix round robin bug

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -729,6 +729,7 @@ namespace Mirror
 			}
 			else
 			{
+                startPositionIndex = startPositionIndex % startPositions.Count;
 				Transform startPosition = startPositions[startPositionIndex];
 				startPositionIndex = (startPositionIndex + 1) % startPositions.Count;
 				return startPosition;


### PR DESCRIPTION
If a level in the game has more start positions than another, its possible to get in a state where the index is higher than what the level supports.  This extra check puts it within range.