### PR TITLE
Internalize OnServerAddPlayer Safety Checks 

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -359,7 +359,7 @@ namespace Mirror
             NetworkServer.RegisterHandler<ConnectMessage>(OnServerConnectInternal);
             NetworkServer.RegisterHandler<DisconnectMessage>(OnServerDisconnectInternal);
             NetworkServer.RegisterHandler<ReadyMessage>(OnServerReadyMessageInternal);
-            NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayer);
+            NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerInternal);
             NetworkServer.RegisterHandler<RemovePlayerMessage>(OnServerRemovePlayerMessageInternal);
             NetworkServer.RegisterHandler<ErrorMessage>(OnServerErrorInternal);
         }
@@ -770,6 +770,31 @@ namespace Mirror
             OnServerReady(conn);
         }
 
+        void OnServerAddPlayerInternal(NetworkConnection conn, AddPlayerMessage extraMessage)
+        {
+            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerAddPlayer");
+
+            if (playerPrefab == null)
+            {
+                Debug.LogError("The PlayerPrefab is empty on the NetworkManager. Please setup a PlayerPrefab object.");
+                return;
+            }
+
+            if (playerPrefab.GetComponent<NetworkIdentity>() == null)
+            {
+                Debug.LogError("The PlayerPrefab does not have a NetworkIdentity. Please add a NetworkIdentity to the player prefab.");
+                return;
+            }
+
+            if (conn.playerController != null)
+            {
+                Debug.LogError("There is already a player for this connections.");
+                return;
+            }
+
+            OnServerAddPlayer(conn, extraMessage);
+        }
+
         void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerRemovePlayerMessageInternal");
@@ -885,26 +910,6 @@ namespace Mirror
         /// <param name="extraMessage">An extra message object passed for the new player.</param>
         public virtual void OnServerAddPlayer(NetworkConnection conn, AddPlayerMessage extraMessage)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerAddPlayer");
-
-            if (playerPrefab == null)
-            {
-                Debug.LogError("The PlayerPrefab is empty on the NetworkManager. Please setup a PlayerPrefab object.");
-                return;
-            }
-
-            if (playerPrefab.GetComponent<NetworkIdentity>() == null)
-            {
-                Debug.LogError("The PlayerPrefab does not have a NetworkIdentity. Please add a NetworkIdentity to the player prefab.");
-                return;
-            }
-
-            if (conn.playerController != null)
-            {
-                Debug.LogError("There is already a player for this connections.");
-                return;
-            }
-
             Transform startPos = GetStartPosition();
             GameObject player = startPos != null
                 ? Instantiate(playerPrefab, startPos.position, startPos.rotation)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -774,13 +774,13 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerAddPlayer");
 
-            if (playerPrefab == null)
+            if (autoCreatePlayer && playerPrefab == null)
             {
                 Debug.LogError("The PlayerPrefab is empty on the NetworkManager. Please setup a PlayerPrefab object.");
                 return;
             }
 
-            if (playerPrefab.GetComponent<NetworkIdentity>() == null)
+            if (autoCreatePlayer && playerPrefab.GetComponent<NetworkIdentity>() == null)
             {
                 Debug.LogError("The PlayerPrefab does not have a NetworkIdentity. Please add a NetworkIdentity to the player prefab.");
                 return;


### PR DESCRIPTION
Functionally the same, but moves safety checks to an internal method that is registered as the handler and calls the virtual method.

From reviewing user code samples, my observation is that when OnServerAddPlayer is overridden, devs often don't call the base method (for good reasons) and never include these safety checks in their override, and IMHO they shouldn't have to.  Virtual methods should be empty or as tiny as possible so that overrides don't have to copy a bunch of code.