### PR TITLE
Synchronize scale with NetworkTransformBase

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -35,6 +35,7 @@ namespace Mirror
         // server
         Vector3 lastPosition;
         Quaternion lastRotation;
+        private Vector3 lastScale;
 
         // client
         public class DataPoint
@@ -43,6 +44,7 @@ namespace Mirror
             // use local position/rotation for VR support
             public Vector3 localPosition;
             public Quaternion localRotation;
+            public Vector3 localScale;
             public float movementSpeed;
         }
         // interpolation start and goal
@@ -56,7 +58,7 @@ namespace Mirror
         protected abstract Transform targetComponent { get; }
 
         // serialization is needed by OnSerialize and by manual sending from authority
-        static void SerializeIntoWriter(NetworkWriter writer, Vector3 position, Quaternion rotation, Compression compressRotation)
+        static void SerializeIntoWriter(NetworkWriter writer, Vector3 position, Quaternion rotation, Compression compressRotation, Vector3 scale)
         {
             // serialize position
             writer.WriteVector3(position);
@@ -86,12 +88,15 @@ namespace Mirror
                 // write 2 byte, 5 bits for each float
                 writer.WriteUInt16(FloatBytePacker.PackThreeFloatsIntoUShort(euler.x, euler.y, euler.z, 0, 360));
             }
+
+            // serialize scale
+            writer.WriteVector3(scale);
         }
 
         public override bool OnSerialize(NetworkWriter writer, bool initialState)
         {
-            // use local position/rotation for VR support
-            SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation);
+            // use local position/rotation/scale for VR support
+            SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation, targetComponent.transform.localScale);
             return true;
         }
 
@@ -141,6 +146,8 @@ namespace Mirror
                 temp.localRotation = Quaternion.Euler(xyz[0], xyz[1], xyz[2]);
             }
 
+            temp.localScale = reader.ReadVector3();
+
             temp.timeStamp = Time.time;
 
             // movement speed: based on how far it moved since last time
@@ -158,6 +165,7 @@ namespace Mirror
                     // local position/rotation for VR support
                     localPosition = targetComponent.transform.localPosition,
                     localRotation = targetComponent.transform.localRotation,
+                    localScale = targetComponent.transform.localScale,
                     movementSpeed = temp.movementSpeed
                 };
             }
@@ -205,6 +213,7 @@ namespace Mirror
                 {
                     start.localPosition = targetComponent.transform.localPosition;
                     start.localRotation = targetComponent.transform.localRotation;
+                    start.localScale = targetComponent.transform.localScale;
                 }
             }
 
@@ -229,7 +238,7 @@ namespace Mirror
             // server-only mode does no interpolation to save computations,
             // but let's set the position directly
             if (isServer && !isClient)
-                ApplyPositionAndRotation(goal.localPosition, goal.localRotation);
+                ApplyPositionRotationScale(goal.localPosition, goal.localRotation, goal.localScale);
 
             // set dirty so that OnSerialize broadcasts it
             SetDirtyBit(1UL);
@@ -279,6 +288,16 @@ namespace Mirror
             return defaultRotation;
         }
 
+        static Vector3 InterpolateScale(DataPoint start, DataPoint goal, Vector3 currentScale)
+        {
+            if (start != null)
+            {
+                float t = CurrentInterpolationFactor(start, goal);
+                return Vector3.Lerp(start.localScale, goal.localScale, t);
+            }
+            return currentScale;
+        }
+
         // teleport / lag / stuck detection
         // -> checking distance is not enough since there could be just a tiny
         //    fence between us and the goal
@@ -295,29 +314,31 @@ namespace Mirror
         }
 
         // moved since last time we checked it?
-        bool HasMovedOrRotated()
+        bool HasEitherMovedRotatedScaled()
         {
-            // moved or rotated?
-            // local position/rotation for VR support
+            // moved or rotated or scaled?
+            // local position/rotation/scale for VR support
             bool moved = lastPosition != targetComponent.transform.localPosition;
             bool rotated = lastRotation != targetComponent.transform.localRotation;
+            bool scaled = lastScale != targetComponent.transform.localScale;
 
             // save last for next frame to compare
             // (only if change was detected. otherwise slow moving objects might
             //  never sync because of C#'s float comparison tolerance. see also:
             //  https://github.com/vis2k/Mirror/pull/428)
-            bool change = moved || rotated;
+            bool change = moved || rotated || scaled;
             if (change)
             {
                 // local position/rotation for VR support
                 lastPosition = targetComponent.transform.localPosition;
                 lastRotation = targetComponent.transform.localRotation;
+                lastScale = targetComponent.transform.localScale;
             }
             return change;
         }
 
         // set position carefully depending on the target component
-        void ApplyPositionAndRotation(Vector3 position, Quaternion rotation)
+        void ApplyPositionRotationScale(Vector3 position, Quaternion rotation, Vector3 scale)
         {
             // local position/rotation for VR support
             targetComponent.transform.localPosition = position;
@@ -325,6 +346,7 @@ namespace Mirror
             {
                 targetComponent.transform.localRotation = rotation;
             }
+            targetComponent.transform.localScale = scale;
         }
 
         void Update()
@@ -334,7 +356,7 @@ namespace Mirror
             {
                 // just use OnSerialize via SetDirtyBit only sync when position
                 // changed. set dirty bits 0 or 1
-                SetDirtyBit(HasMovedOrRotated() ? 1UL : 0UL);
+                SetDirtyBit(HasEitherMovedRotatedScaled() ? 1UL : 0UL);
             }
 
             // no 'else if' since host mode would be both
@@ -347,12 +369,12 @@ namespace Mirror
                     // check only each 'syncInterval'
                     if (Time.time - lastClientSendTime >= syncInterval)
                     {
-                        if (HasMovedOrRotated())
+                        if (HasEitherMovedRotatedScaled())
                         {
                             // serialize
                             // local position/rotation for VR support
                             NetworkWriter writer = new NetworkWriter();
-                            SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation);
+                            SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation, targetComponent.transform.localScale);
 
                             // send to server
                             CmdClientToServerSync(writer.ToArray());
@@ -373,13 +395,14 @@ namespace Mirror
                         if (NeedsTeleport())
                         {
                             // local position/rotation for VR support
-                            ApplyPositionAndRotation(goal.localPosition, goal.localRotation);
+                            ApplyPositionRotationScale(goal.localPosition, goal.localRotation, goal.localScale);
                         }
                         else
                         {
                             // local position/rotation for VR support
-                            ApplyPositionAndRotation(InterpolatePosition(start, goal, targetComponent.transform.localPosition),
-                                                     InterpolateRotation(start, goal, targetComponent.transform.localRotation));
+                            ApplyPositionRotationScale(InterpolatePosition(start, goal, targetComponent.transform.localPosition),
+                                                     InterpolateRotation(start, goal, targetComponent.transform.localRotation),
+                                                     InterpolateScale(start, goal, targetComponent.transform.localScale));
                         }
                     }
                 }

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -401,8 +401,8 @@ namespace Mirror
                         {
                             // local position/rotation for VR support
                             ApplyPositionRotationScale(InterpolatePosition(start, goal, targetComponent.transform.localPosition),
-                                                     InterpolateRotation(start, goal, targetComponent.transform.localRotation),
-                                                     InterpolateScale(start, goal, targetComponent.transform.localScale));
+                                                       InterpolateRotation(start, goal, targetComponent.transform.localRotation),
+                                                       InterpolateScale(start, goal, targetComponent.transform.localScale));
                         }
                     }
                 }


### PR DESCRIPTION
Closes #999 

Previously only position and rotation were synchronizedin NetworkTransformBase, with this commit scale is synchronized similarly to position.

I played with it a little and it seems to work as expected. (Created an empty project and changed the scale on a NetworkTransform-ed object manually and through a script as well and it synced correctly)

Please let me know if I should do something differently, or write some tests, or whatever else.