### PR TITLE
Remove redundant code

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -459,7 +459,6 @@ namespace Mirror
             // objects spawned as part of initial state are started on a second pass
             if (isSpawnFinished)
             {
-                identity.isClient = true;
                 identity.OnStartClient();
                 CheckForOwner(identity);
             }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -541,7 +541,6 @@ namespace Mirror
             if (NetworkClient.active && NetworkServer.localClientActive)
             {
                 // there will be no spawn message, so start the client here too
-                isClient = true;
                 OnStartClient();
             }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -207,7 +207,6 @@ namespace Mirror
                 {
                     if (LogFilter.Debug) Debug.Log("ActivateClientScene " + identity.netId + " " + identity);
 
-                    identity.isClient = true;
                     identity.OnStartClient();
                 }
             }


### PR DESCRIPTION
NetworkIdentity.OnStartClient(); sets isClient = true so there's no need to set it right before calling it in these three places.