### PR TITLE
Don't increment counter in constructor

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -36,11 +36,6 @@ namespace Mirror.Websocket
             client.NoDelay = NoDelay;
             server.NoDelay = NoDelay;
 
-            // HLAPI's local connection uses hard coded connectionId '0', so we
-            // need to make sure that external connections always start at '1'
-            // by simple eating the first one before the server starts
-            Server.NextConnectionId();
-
             Debug.Log("Websocket transport initialized!");
         }
 


### PR DESCRIPTION
This same change was done in TelepathyTransport.  The counter is incremented when the first client connects so it doesn't need to be done here.  With this change, first client gets ID 1 instead of 2.