### PR TITLE
feat: sync to owner,  fixes #39

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -299,7 +299,7 @@ namespace Mirror
         /// <param name="writer"></param>
         /// <param name="forceAll"></param>
         /// <returns></returns>
-        public override bool OnSerialize(NetworkWriter writer, bool forceAll)
+        public override bool OnSerialize(NetworkWriter writer, bool forceAll, bool owner)
         {
             if (forceAll)
             {

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -93,7 +93,7 @@ namespace Mirror
             writer.WriteVector3(scale);
         }
 
-        public override bool OnSerialize(NetworkWriter writer, bool initialState)
+        public override bool OnSerialize(NetworkWriter writer, bool initialState, bool owner)
         {
             // use local position/rotation/scale for VR support
             SerializeIntoWriter(writer, targetComponent.transform.localPosition, targetComponent.transform.localRotation, compressRotation, targetComponent.transform.localScale);

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -356,6 +356,7 @@ namespace Mirror.Weaver
 
             serialize.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkWriterType)));
             serialize.Parameters.Add(new ParameterDefinition("forceAll", ParameterAttributes.None, Weaver.boolType));
+            serialize.Parameters.Add(new ParameterDefinition("owner", ParameterAttributes.None, Weaver.boolType));
             ILProcessor serWorker = serialize.Body.GetILProcessor();
 
             serialize.Body.InitLocals = true;
@@ -370,6 +371,7 @@ namespace Mirror.Weaver
                 serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
                 serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
                 serWorker.Append(serWorker.Create(OpCodes.Ldarg_2)); // forceAll
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_3)); // owner
                 serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
                 serWorker.Append(serWorker.Create(OpCodes.Stloc_0)); // set dirtyLocal to result of base.OnSerialize()
             }

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -242,6 +242,7 @@ namespace Mirror.Weaver
             // the mapping of dirtybits to sync-vars is implicit in the order of the fields here. this order is recorded in m_replacementProperties.
             // start assigning syncvars at the place the base class stopped, if any
             int dirtyBitCounter = Weaver.GetSyncVarStart(td.BaseType.FullName);
+            ulong ownerBitMask = Weaver.GetOwnerSyncVarMask(td.BaseType.FullName);
 
             syncVarNetIds.Clear();
 
@@ -311,6 +312,11 @@ namespace Mirror.Weaver
 
                         syncVars.Add(fd);
 
+                        if (Weaver.isOwnerOnly(ca))
+                        {
+                            ownerBitMask |= (1ul << dirtyBitCounter);
+                        }
+
                         ProcessSyncVar(td, fd, syncVarNetIds, 1L << dirtyBitCounter);
                         dirtyBitCounter += 1;
                         numSyncVars += 1;
@@ -343,6 +349,7 @@ namespace Mirror.Weaver
             }
 
             Weaver.SetNumSyncVars(td.FullName, numSyncVars);
+            Weaver.SetOwnerSyncVarMask(td.FullName, ownerBitMask);
         }
     }
 }

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -363,7 +363,7 @@ namespace Mirror.Weaver
             SyncSetType = NetAssembly.MainModule.GetType("Mirror.SyncSet`1");
             SyncDictionaryType = NetAssembly.MainModule.GetType("Mirror.SyncDictionary`2");
 
-            NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "syncVarDirtyBits");
+            NetworkBehaviourDirtyBitsReference = Resolvers.ResolveMethod(NetworkBehaviourType, CurrentAssembly, "GetDirtySyncVarMask");
             TypeDefinition NetworkWriterPoolType = NetAssembly.MainModule.GetType("Mirror.NetworkWriterPool");
             GetPooledWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, CurrentAssembly, "GetWriter");
             RecycleWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, CurrentAssembly, "Recycle");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -29,6 +29,9 @@ namespace Mirror.Weaver
 
         // amount of SyncVars per class. dict<className, amount>
         public Dictionary<string, int> numSyncVars = new Dictionary<string, int>();
+
+        // owner only bits per class
+        public Dictionary<string, ulong> ownerSyncVarMask = new Dictionary<string, ulong>();
     }
 
     class Weaver
@@ -189,6 +192,18 @@ namespace Mirror.Weaver
         public static void SetNumSyncVars(string className, int num)
         {
             WeaveLists.numSyncVars[className] = num;
+        }
+
+        public static ulong GetOwnerSyncVarMask(string className)
+        {
+            return WeaveLists.ownerSyncVarMask.ContainsKey(className)
+                   ? WeaveLists.ownerSyncVarMask[className]
+                   : 0;
+        }
+
+        public static void SetOwnerSyncVarMask(string className, ulong num)
+        {
+            WeaveLists.ownerSyncVarMask[className] = num;
         }
 
         internal static void ConfirmGeneratedCodeClass()
@@ -387,6 +402,18 @@ namespace Mirror.Weaver
 
             SyncObjectType = CurrentAssembly.MainModule.ImportReference(SyncObjectType);
             InitSyncObjectReference = Resolvers.ResolveMethod(NetworkBehaviourType, CurrentAssembly, "InitSyncObject");
+        }
+
+        internal static bool isOwnerOnly(CustomAttribute ca)
+        {
+            foreach (var field in ca.Fields)
+            {
+                if (field.Name == "ownerOnly")
+                {
+                    return field.Argument.Value.Equals(true);
+                }
+            }
+            return false;
         }
 
         public static bool IsNetworkBehaviour(TypeDefinition td)

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -15,6 +15,7 @@ namespace Mirror
     public class SyncVarAttribute : Attribute
     {
         public string hook;
+        public bool ownerOnly;
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -79,6 +79,10 @@ namespace Mirror
         /// </summary>
         public NetworkConnection connectionToClient => netIdentity.connectionToClient;
 
+        // overriden by the weaver
+        // to tell which sync vars are owner only
+        protected internal virtual ulong getSyncVarOwnerMask() => 0;
+
         protected ulong syncVarDirtyBits { get; private set; }
         private ulong syncVarHookGuard;
 

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -584,11 +584,14 @@ namespace Mirror
             return false;
         }
 
-        internal bool IsDirty()
+        internal bool IsDirty(bool owner)
         {
             if (Time.time - lastSyncTime >= syncInterval)
             {
-                return syncVarDirtyBits != 0L || AnySyncObjectDirty();
+                // if owner,  take into account all bits
+                // if not owner,  do not take into account owner only variables
+                ulong dirtyBits = owner ? syncVarDirtyBits : (syncVarDirtyBits & ~getSyncVarOwnerMask());
+                return dirtyBits != 0L || AnySyncObjectDirty();
             }
             return false;
         }

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -596,6 +596,14 @@ namespace Mirror
             return false;
         }
 
+        // Determines which variables are dirty, but take into account
+        // if we are synchronizing to an owner and if this is the initial message
+        protected internal ulong GetDirtySyncVarMask(bool initial, bool owner)
+        {
+            ulong dirty = initial ? ~0ul : syncVarDirtyBits;
+            return owner ? dirty : (dirty & ~getSyncVarOwnerMask());
+        }
+
         /// <summary>
         /// Virtual function to override to send custom serialization data. The corresponding function to send serialization data is OnDeserialize().
         /// </summary>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -607,7 +607,7 @@ namespace Mirror
         /// <param name="writer">Writer to use to write to the stream.</param>
         /// <param name="initialState">If this is being called to send initial state.</param>
         /// <returns>True if data was written.</returns>
-        public virtual bool OnSerialize(NetworkWriter writer, bool initialState)
+        public virtual bool OnSerialize(NetworkWriter writer, bool initialState, bool owner)
         {
             if (initialState)
             {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -643,7 +643,7 @@ namespace Mirror
         // -> OnDeserialize carefully extracts each data, then deserializes each component with separate readers
         //    -> it will be impossible to read too many or too few bytes in OnDeserialize
         //    -> we can properly track down errors
-        bool OnSerializeSafely(NetworkBehaviour comp, NetworkWriter writer, bool initialState)
+        bool OnSerializeSafely(NetworkBehaviour comp, NetworkWriter writer, bool initialState, bool owner)
         {
             // write placeholder length bytes
             // (jumping back later is WAY faster than allocating a temporary
@@ -656,7 +656,7 @@ namespace Mirror
             bool result = false;
             try
             {
-                result = comp.OnSerialize(writer, initialState);
+                result = comp.OnSerialize(writer, initialState, owner);
             }
             catch (Exception e)
             {
@@ -700,7 +700,7 @@ namespace Mirror
                 {
                     // serialize the data
                     if (LogFilter.Debug) Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState);
-                    OnSerializeSafely(comp, writer, initialState);
+                    OnSerializeSafely(comp, writer, initialState, owner);
                 }
             }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -677,7 +677,7 @@ namespace Mirror
 
         // serialize all components (or only dirty ones if not initial state)
         // -> returns true if something was written
-        internal bool OnSerializeAllSafely(bool initialState, NetworkWriter writer)
+        internal bool OnSerializeAllSafely(bool initialState, NetworkWriter writer, bool owner)
         {
             if (NetworkBehaviours.Length > 64)
             {
@@ -1144,7 +1144,7 @@ namespace Mirror
 
                 NetworkWriter writer = NetworkWriterPool.GetWriter();
                 // serialize all the dirty components and send (if any were dirty)
-                if (OnSerializeAllSafely(false, writer))
+                if (OnSerializeAllSafely(false, writer, true))
                 {
                     // populate cached UpdateVarsMessage and send
                     varsMessage.netId = netId;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -684,7 +684,7 @@ namespace Mirror
                 Debug.LogError("Only 64 NetworkBehaviour components are allowed for NetworkIdentity: " + name + " because of the dirtyComponentMask");
                 return false;
             }
-            ulong dirtyComponentsMask = GetDirtyMask(initialState);
+            ulong dirtyComponentsMask = GetDirtyMask(initialState, owner);
 
             if (dirtyComponentsMask == 0L)
                 return false;
@@ -707,7 +707,7 @@ namespace Mirror
             return true;
         }
 
-        internal ulong GetDirtyMask(bool initialState)
+        internal ulong GetDirtyMask(bool initialState, bool owner)
         {
             // loop through all components only once and then write dirty+payload into the writer afterwards
             ulong dirtyComponentsMask = 0L;
@@ -715,7 +715,7 @@ namespace Mirror
             for (int i = 0; i < components.Length; ++i)
             {
                 NetworkBehaviour comp = components[i];
-                if (initialState || comp.IsDirty(true))
+                if (initialState || comp.IsDirty(owner))
                 {
                     dirtyComponentsMask |= (ulong)(1L << i);
                 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1212,7 +1212,7 @@ namespace Mirror
                 // segment to avoid reader allocations.
                 // (never null because of our above check)
                 varsMessage.payload = writer.ToArraySegment();
-                NetworkServer.SendToReadyNonOwners(this, varsMessage);
+                NetworkServer.SendToReady(this, varsMessage, false);
 
                 updated = true;
             }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -696,7 +696,7 @@ namespace Mirror
                 // is this component dirty?
                 // -> always serialize if initialState so all components are included in spawn packet
                 // -> note: IsDirty() is false if the component isn't dirty or sendInterval isn't elapsed yet
-                if (initialState || comp.IsDirty())
+                if (initialState || comp.IsDirty(owner))
                 {
                     // serialize the data
                     if (LogFilter.Debug) Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState);
@@ -715,7 +715,7 @@ namespace Mirror
             for (int i = 0; i < components.Length; ++i)
             {
                 NetworkBehaviour comp = components[i];
-                if (initialState || comp.IsDirty())
+                if (initialState || comp.IsDirty(true))
                 {
                     dirtyComponentsMask |= (ulong)(1L << i);
                 }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -337,24 +337,7 @@ namespace Mirror
         /// <returns></returns>
         public static bool SendToReady<T>(NetworkIdentity identity,T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
-            if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + typeof(T));
-
-            if (identity != null && identity.observers != null)
-            {
-                // pack message into byte[] once
-                byte[] bytes = MessagePacker.Pack(msg);
-
-                bool result = true;
-                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
-                {
-                    if (kvp.Value.isReady)
-                    {
-                        result &= kvp.Value.SendBytes(bytes, channelId);
-                    }
-                }
-                return result;
-            }
-            return false;
+            return SendToReady(identity, msg, true, channelId);
         }
 
         /// <summary>
@@ -366,7 +349,7 @@ namespace Mirror
         /// <param name="msg">Message structure.</param>
         /// <param name="channelId">Transport channel to use</param>
         /// <returns></returns>
-        internal static bool SendToReadyNonOwners<T>(NetworkIdentity identity, T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
+        internal static bool SendToReady<T>(NetworkIdentity identity, T msg, bool sendToSelf, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + typeof(T));
 
@@ -378,6 +361,9 @@ namespace Mirror
                 bool result = true;
                 foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
                 {
+                    if (!sendToSelf && kvp.Value == identity.connectionToClient)
+                        continue;
+
                     if (kvp.Value.isReady && kvp.Value != identity.connectionToClient)
                     {
                         result &= kvp.Value.SendBytes(bytes, channelId);

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1016,10 +1016,11 @@ namespace Mirror
             // convert to ArraySegment to avoid reader allocations
             // (need to handle null case too)
             ArraySegment<byte> segment = default;
+            bool owner = conn?.playerController == identity;
 
             // serialize all components with initialState = true
             // (can be null if has none)
-            if (identity.OnSerializeAllSafely(true, writer))
+            if (identity.OnSerializeAllSafely(true, writer, owner))
             {
                 segment = writer.ToArraySegment();
             }
@@ -1030,7 +1031,7 @@ namespace Mirror
                 SpawnPrefabMessage msg = new SpawnPrefabMessage
                 {
                     netId = identity.netId,
-                    owner = conn?.playerController == identity,
+                    owner = owner,
                     assetId = identity.assetId,
                     // use local values for VR support
                     position = identity.transform.localPosition,
@@ -1056,7 +1057,7 @@ namespace Mirror
                 SpawnSceneObjectMessage msg = new SpawnSceneObjectMessage
                 {
                     netId = identity.netId,
-                    owner = conn?.playerController == identity,
+                    owner = owner,
                     sceneId = identity.sceneId,
                     // use local values for VR support
                     position = identity.transform.localPosition,

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -358,6 +358,36 @@ namespace Mirror
         }
 
         /// <summary>
+        /// Send a message structure with the given type number to only clients which are ready.
+        /// <para>See Networking.NetworkClient.Ready.</para>
+        /// </summary>
+        /// <typeparam name="T">Message type.</typeparam>
+        /// <param name="identity"></param>
+        /// <param name="msg">Message structure.</param>
+        /// <param name="channelId">Transport channel to use</param>
+        /// <returns></returns>
+        internal static bool SendToReadyNonOwners<T>(NetworkIdentity identity, T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
+        {
+            if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + typeof(T));
+
+            if (identity != null && identity.observers != null)
+            {
+                // pack message into byte[] once
+                byte[] bytes = MessagePacker.Pack(msg);
+
+                bool result = true;
+                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                {
+                    if (kvp.Value.isReady && kvp.Value != identity.connectionToClient)
+                    {
+                        result &= kvp.Value.SendBytes(bytes, channelId);
+                    }
+                }
+                return result;
+            }
+            return false;
+        }
+        /// <summary>
         /// Disconnect all currently connected clients, including the local connection.
         /// <para>This can only be called on the server. Clients will receive the Disconnect message.</para>
         /// </summary>

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -138,5 +138,22 @@ namespace Mirror.Tests
             Assert.That(identity.GetDirtyMask(false, false), Is.EqualTo(0b100), "first component is not dirty for observers");
 
         }
+
+        [Test]
+        public void TestDirtySyncVarMask()
+        {
+            GameObject gameObject1 = new GameObject();
+            NetworkIdentity identity = gameObject1.AddComponent<NetworkIdentity>();
+            MockPlayer player1 = gameObject1.AddComponent<MockPlayer>();
+
+            // owner bit
+            player1.health = 10;
+            player1.playerName = "Paul";
+
+            Assert.That(player1.GetDirtySyncVarMask(true, true), Is.EqualTo(~0UL), "All components are considered dirty on initialization");
+            Assert.That(player1.GetDirtySyncVarMask(true, false), Is.EqualTo(~0b0110ul), "owner only should not be considered dirty");
+            Assert.That(player1.GetDirtySyncVarMask(false, true), Is.EqualTo(0b1010ul), "Onwer can see both health and player name");
+            Assert.That(player1.GetDirtySyncVarMask(false, false), Is.EqualTo(0b1000ul), "Non Owner can only see player name");
+        }
     }
 }

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -75,7 +75,7 @@ namespace Mirror.Tests
 
             // serialize all the data as we would for the network
             NetworkWriter writer = new NetworkWriter();
-            identity1.OnSerializeAllSafely(true, writer);
+            identity1.OnSerializeAllSafely(true, writer, true);
 
             // set up a "client" object
             GameObject gameObject2 = new GameObject();

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -116,5 +116,27 @@ namespace Mirror.Tests
             Assert.That(player1.IsDirty(false), Is.False, "Object is not dirty from observer perspective");
             Assert.That(player1.IsDirty(true), Is.True, "Object is dirty from owner perspective");
         }
+
+        [Test]
+        public void TestDirtyComponentMask()
+        {
+            GameObject gameObject1 = new GameObject();
+            NetworkIdentity identity = gameObject1.AddComponent<NetworkIdentity>();
+            MockPlayer player1 = gameObject1.AddComponent<MockPlayer>();
+            player1.syncInterval = 0;
+            MockPlayer player2 = gameObject1.AddComponent<MockPlayer>();
+            player2.syncInterval = 0;
+            MockPlayer player3 = gameObject1.AddComponent<MockPlayer>();
+            player3.syncInterval = 0;
+
+            // owner bit
+            player1.health = 10;
+            player3.playerName = "Paul";
+
+            Assert.That(identity.GetDirtyMask(true, true), Is.EqualTo(0b111), "All components are considered dirty on initialization");
+            Assert.That(identity.GetDirtyMask(false, true), Is.EqualTo(0b101), "first and third component are dirty for owners");
+            Assert.That(identity.GetDirtyMask(false, false), Is.EqualTo(0b100), "first component is not dirty for observers");
+
+        }
     }
 }

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -42,7 +42,7 @@ namespace Mirror.Tests
             // synchronize immediatelly
             player.syncInterval = 0f;
 
-            Assert.That(player.IsDirty(), Is.False, "First time object should not be dirty");
+            Assert.That(player.IsDirty(false), Is.False, "First time object should not be dirty");
 
             MockPlayer.Guild myGuild = new MockPlayer.Guild
             {
@@ -51,13 +51,13 @@ namespace Mirror.Tests
 
             player.guild = myGuild;
 
-            Assert.That(player.IsDirty(), "Setting struct should mark object as dirty");
+            Assert.That(player.IsDirty(false), "Setting struct should mark object as dirty");
             player.ClearAllDirtyBits();
-            Assert.That(player.IsDirty(), Is.False, "ClearAllDirtyBits() should clear dirty flag");
+            Assert.That(player.IsDirty(false), Is.False, "ClearAllDirtyBits() should clear dirty flag");
 
             // clearing the guild should set dirty bit too
             player.guild = default;
-            Assert.That(player.IsDirty(), "Clearing struct should mark object as dirty");
+            Assert.That(player.IsDirty(false), "Clearing struct should mark object as dirty");
         }
 
         [Test]
@@ -98,6 +98,23 @@ namespace Mirror.Tests
             MockPlayer player1 = gameObject1.AddComponent<MockPlayer>();
 
             Assert.That(player1.getSyncVarOwnerMask(), Is.EqualTo(0b0110), "second and third variable are owner private");
+        }
+
+        [Test]
+        public void TestOwnerDirtyBits()
+        {
+            GameObject gameObject1 = new GameObject();
+            NetworkIdentity _ = gameObject1.AddComponent<NetworkIdentity>();
+            MockPlayer player1 = gameObject1.AddComponent<MockPlayer>();
+            player1.syncInterval = 0;
+
+            Assert.That(player1.IsDirty(false), Is.False, "Object is not dirty from observer perspective");
+            Assert.That(player1.IsDirty(true), Is.False, "Object is not dirty from owner perspective");
+
+            player1.health = 10;
+
+            Assert.That(player1.IsDirty(false), Is.False, "Object is not dirty from observer perspective");
+            Assert.That(player1.IsDirty(true), Is.True, "Object is dirty from owner perspective");
         }
     }
 }

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -16,6 +16,15 @@ namespace Mirror.Tests
         [SyncVar]
         public Guild guild;
 
+        [SyncVar(ownerOnly = true)]
+        public int health;
+
+        [SyncVar(ownerOnly = true)]
+        public int mana;
+
+        [SyncVar]
+        public string playerName;
+
     }
 
 
@@ -79,6 +88,16 @@ namespace Mirror.Tests
 
             // check that the syncvars got updated
             Assert.That(player2.guild.name, Is.EqualTo("Back street boys"), "Data should be synchronized");
+        }
+
+        [Test]
+        public void TestOwnerBits()
+        {
+            GameObject gameObject1 = new GameObject();
+            NetworkIdentity _ = gameObject1.AddComponent<NetworkIdentity>();
+            MockPlayer player1 = gameObject1.AddComponent<MockPlayer>();
+
+            Assert.That(player1.getSyncVarOwnerMask(), Is.EqualTo(0b0110), "second and third variable are owner private");
         }
     }
 }


### PR DESCRIPTION
Allow to restrict synchronizing a syncvar only with the owner.  For example:
```cs
public class Player 
{
     [SyncVar(owner = true)]
     public int health;

     [SyncVar(owner = true)]
     public SyncListItem inventory = new SyncListItem();

     [SyncVar]
     public string PlayerName;
}
```
