### PR TITLE
feat: component based SyncToOwner, fixes #39

### DIFF
--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -177,12 +177,18 @@ namespace Mirror
                 NetworkBehaviour networkBehaviour = target as NetworkBehaviour;
                 if (networkBehaviour != null)
                 {
+                    // syncMode
+                    serializedObject.FindProperty("syncMode").enumValueIndex = (int)(SyncMode)
+                        EditorGUILayout.EnumPopup("Network Sync Mode", networkBehaviour.syncMode);
+
                     // syncInterval
                     // [0,2] should be enough. anything >2s is too laggy anyway.
                     serializedObject.FindProperty("syncInterval").floatValue = EditorGUILayout.Slider(
                         new GUIContent("Network Sync Interval",
                                        "Time in seconds until next change is synchronized to the client. '0' means send immediately if changed. '0.5' means only send changes every 500ms.\n(This is for state synchronization like SyncVars, SyncLists, OnSerialize. Not for Cmds, Rpcs, etc.)"),
                         networkBehaviour.syncInterval, 0, 2);
+
+                    // apply
                     serializedObject.ApplyModifiedProperties();
                 }
             }

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -170,13 +170,14 @@ namespace Mirror
                 }
             }
 
-            // only show SyncInterval if we have an OnSerialize function.
-            // No need to show it if the class only has Cmds/Rpcs and no sync.
+            // does it sync anything? then show extra properties
+            // (no need to show it if the class only has Cmds/Rpcs and no sync)
             if (syncsAnything)
             {
                 NetworkBehaviour networkBehaviour = target as NetworkBehaviour;
                 if (networkBehaviour != null)
                 {
+                    // syncInterval
                     // [0,2] should be enough. anything >2s is too laggy anyway.
                     serializedObject.FindProperty("syncInterval").floatValue = EditorGUILayout.Slider(
                         new GUIContent("Network Sync Interval",

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -258,7 +258,7 @@ namespace Mirror
                 payload = writer.ToArraySegment() // segment to avoid reader allocations
             };
 
-            NetworkServer.SendToReady(netIdentity, message, channelId);
+            NetworkServer.SendToReady(netIdentity, message, true, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -332,7 +332,7 @@ namespace Mirror
                 payload = writer.ToArraySegment() // segment to avoid reader allocations
             };
 
-            NetworkServer.SendToReady(netIdentity,message, channelId);
+            NetworkServer.SendToReady(netIdentity, message, true, channelId);
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -258,7 +258,7 @@ namespace Mirror
                 payload = writer.ToArraySegment() // segment to avoid reader allocations
             };
 
-            NetworkServer.SendToReady(netIdentity, message, true, channelId);
+            NetworkServer.SendToReady(netIdentity, message, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -332,7 +332,7 @@ namespace Mirror
                 payload = writer.ToArraySegment() // segment to avoid reader allocations
             };
 
-            NetworkServer.SendToReady(netIdentity, message, true, channelId);
+            NetworkServer.SendToReady(netIdentity, message, channelId);
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -8,7 +8,7 @@ namespace Mirror
     /// <summary>
     /// Sync to everyone, or only to owner.
     /// </summary>
-    public enum SyncMode { Everyone, Owner }
+    public enum SyncMode { Observers, Owner }
 
     /// <summary>
     /// Base class which should be inherited by scripts which contain networking functionality.
@@ -28,7 +28,7 @@ namespace Mirror
         /// <summary>
         /// sync mode for OnSerialize
         /// </summary>
-        [HideInInspector] public SyncMode syncMode = SyncMode.Everyone;
+        [HideInInspector] public SyncMode syncMode = SyncMode.Observers;
 
         // hidden because NetworkBehaviourInspector shows it only if has OnSerialize.
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -6,6 +6,11 @@ using UnityEngine;
 namespace Mirror
 {
     /// <summary>
+    /// Sync to everyone, or only to owner.
+    /// </summary>
+    public enum SyncMode { Everyone, Owner }
+
+    /// <summary>
     /// Base class which should be inherited by scripts which contain networking functionality.
     /// </summary>
     /// <remarks>
@@ -18,6 +23,12 @@ namespace Mirror
     public class NetworkBehaviour : MonoBehaviour
     {
         float lastSyncTime;
+
+        // hidden because NetworkBehaviourInspector shows it only if has OnSerialize.
+        /// <summary>
+        /// sync mode for OnSerialize
+        /// </summary>
+        [HideInInspector] public SyncMode syncMode = SyncMode.Everyone;
 
         // hidden because NetworkBehaviourInspector shows it only if has OnSerialize.
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -770,7 +770,7 @@ namespace Mirror
                 NetworkBehaviour comp = components[i];
                 if (comp.syncMode == SyncMode.Observers)
                 {
-                    mask |= (ulong)(1L << i);
+                    mask |= 1UL << i;
                 }
             }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -185,9 +185,6 @@ namespace Mirror
         // keep track of all sceneIds to detect scene duplicates
         static readonly Dictionary<ulong, NetworkIdentity> sceneIds = new Dictionary<ulong, NetworkIdentity>();
 
-        // SyncMode.Observers components mask
-        ulong syncModeObserversMask;
-
         // used when adding players
         internal void SetClientOwner(NetworkConnection conn)
         {
@@ -286,8 +283,6 @@ namespace Mirror
                 }
             }
 
-            // build SyncMode.Observers mask once
-            syncModeObserversMask = GetSyncModeObserversMask();
         }
 
         void OnValidate()
@@ -694,6 +689,17 @@ namespace Mirror
 
             if (dirtyComponentsMask == 0L)
                 return false;
+
+            // calculate syncMode mask at runtime. this allows users to change
+            // component.syncMode while the game is running, which can be a huge
+            // advantage over syncvar-based sync modes. e.g. if a player decides
+            // to share or not share his inventory, or to go invisible, etc.
+            //
+            // (this also lets the TestSynchronizingObjects test pass because
+            //  otherwise if we were to cache it in Awake, then we would call
+            //  GetComponents<NetworkBehaviour> before all the test behaviours
+            //  were added)
+            ulong syncModeObserversMask = GetSyncModeObserversMask();
 
             // write regular dirty mask for owner,
             // writer 'dirty mask & syncMode==Everyone' for everyone else

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -763,7 +763,7 @@ namespace Mirror
         internal ulong GetSyncModeObserversMask()
         {
             // loop through all components
-            ulong mask = 0L;
+            ulong mask = 0UL;
             NetworkBehaviour[] components = NetworkBehaviours;
             for (int i = 0; i < NetworkBehaviours.Length; ++i)
             {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1199,8 +1199,9 @@ namespace Mirror
                     varsMessage.netId = netId;
 
                     // send ownerWriter to owner
-                    // (only if ready because we use SendToReady below too)
-                    // (connectionToClient is null for local player in host mode)
+                    // (only if there is a connection (e.g. if not a monster),
+                    //  and if connection is ready because we use SendToReady
+                    //  below too)
                     varsMessage.payload = ownerWriter.ToArraySegment();
                     if (connectionToClient != null && connectionToClient.isReady)
                         NetworkServer.SendToClientOfPlayer(this, varsMessage);

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -758,7 +758,7 @@ namespace Mirror
             // loop through all components
             ulong mask = 0L;
             NetworkBehaviour[] components = NetworkBehaviours;
-            for (int i = 0; i < components.Length; ++i)
+            for (int i = 0; i < NetworkBehaviours.Length; ++i)
             {
                 NetworkBehaviour comp = components[i];
                 if (comp.syncMode == SyncMode.Observers)

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -282,7 +282,6 @@ namespace Mirror
                     sceneIds[sceneId] = this;
                 }
             }
-
         }
 
         void OnValidate()

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -727,7 +727,8 @@ namespace Mirror
                     if (comp.syncMode == SyncMode.Observers)
                     {
                         ArraySegment<byte> segment = ownerWriter.ToArraySegment();
-                        observersWriter.WriteBytes(segment.Array, startPosition, ownerWriter.Position);
+                        int length = ownerWriter.Position - startPosition;
+                        observersWriter.WriteBytes(segment.Array, startPosition, length);
                     }
                 }
             }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -724,7 +724,7 @@ namespace Mirror
                     //    with the user's OnSerialize timing code etc.
                     // => so we just copy the result without touching
                     //    OnSerialize again
-                    if (comp.syncMode == SyncMode.Everyone)
+                    if (comp.syncMode == SyncMode.Observers)
                     {
                         ArraySegment<byte> segment = ownerWriter.ToArraySegment();
                         everyoneWriter.WriteBytes(segment.Array, startPosition, ownerWriter.Position);
@@ -761,7 +761,7 @@ namespace Mirror
             for (int i = 0; i < components.Length; ++i)
             {
                 NetworkBehaviour comp = components[i];
-                if (comp.syncMode == SyncMode.Everyone)
+                if (comp.syncMode == SyncMode.Observers)
                 {
                     mask |= (ulong)(1L << i);
                 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1200,8 +1200,9 @@ namespace Mirror
 
                     // send ownerWriter to owner
                     // (only if ready because we use SendToReady below too)
+                    // (connectionToClient is null for local player in host mode)
                     varsMessage.payload = ownerWriter.ToArraySegment();
-                    if (connectionToClient.isReady)
+                    if (connectionToClient != null && connectionToClient.isReady)
                         NetworkServer.SendToClientOfPlayer(this, varsMessage);
 
                     // send observersWriter to everyone but owner

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1070,9 +1070,6 @@ namespace Mirror
                 // conn is == null when spawning it for the local player
                 else
                 {
-                    // TODO do we need to send to owner and everyone here too?
-                    // TODO what exactly does this do?
-
                     // send ownerWriter to owner
                     msg.payload = ownerSegment;
                     SendToClientOfPlayer(identity, msg);
@@ -1109,9 +1106,6 @@ namespace Mirror
                 // conn is == null when spawning it for the local player
                 else
                 {
-                    // TODO do we need to send to owner and everyone here too?
-                    // TODO what exactly does this do?
-
                     // send ownerWriter to owner
                     msg.payload = ownerSegment;
                     SendToClientOfPlayer(identity, msg);

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1060,12 +1060,10 @@ namespace Mirror
                 // conn is != null when spawning it for a client
                 if (conn != null)
                 {
-                    // 'conn' owns this identity?
-                    if (identity.connectionToClient == conn)
-                        msg.payload = ownerSegment;
-                    // otherwise it's for someone else
-                    else
-                        msg.payload = observersSegment;
+                    // use owner segment if 'conn' owns this identity, otherwise
+                    // use observers segment
+                    bool isOwner = identity.connectionToClient == conn;
+                    msg.payload = isOwner ? ownerSegment : observersSegment;
 
                     conn.Send(msg);
                 }
@@ -1101,12 +1099,10 @@ namespace Mirror
                 // conn is != null when spawning it for a client
                 if (conn != null)
                 {
-                    // 'conn' owns this identity?
-                    if (identity.connectionToClient == conn)
-                        msg.payload = ownerSegment;
-                    // otherwise it's for someone else
-                    else
-                        msg.payload = observersSegment;
+                    // use owner segment if 'conn' owns this identity, otherwise
+                    // use observers segment
+                    bool isOwner = identity.connectionToClient == conn;
+                    msg.payload = isOwner ? ownerSegment : observersSegment;
 
                     conn.Send(msg);
                 }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -361,6 +361,20 @@ namespace Mirror
         }
 
         /// <summary>
+        /// Send a message structure with the given type number to only clients which are ready.
+        /// <para>See Networking.NetworkClient.Ready.</para>
+        /// </summary>
+        /// <typeparam name="T">Message type.</typeparam>
+        /// <param name="identity"></param>
+        /// <param name="msg">Message structure.</param>
+        /// <param name="channelId">Transport channel to use</param>
+        /// <returns></returns>
+        public static bool SendToReady<T>(NetworkIdentity identity, T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
+        {
+            return SendToReady(identity, msg, true, channelId);
+        }
+
+        /// <summary>
         /// Disconnect all currently connected clients, including the local connection.
         /// <para>This can only be called on the server. Clients will receive the Disconnect message.</para>
         /// </summary>

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -67,7 +67,7 @@ namespace Mirror.Tests
             // serialize all the data as we would for the network
             NetworkWriter ownerWriter = new NetworkWriter();
             NetworkWriter observersWriter = new NetworkWriter(); // not really used in this Test
-            identity1.OnSerializeAllSafely(true, ownerWriter, observersWriter);
+            identity1.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
 
             // set up a "client" object
             GameObject gameObject2 = new GameObject();

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -66,8 +66,8 @@ namespace Mirror.Tests
 
             // serialize all the data as we would for the network
             NetworkWriter ownerWriter = new NetworkWriter();
-            NetworkWriter everyoneWriter = new NetworkWriter(); // not really used in this Test
-            identity1.OnSerializeAllSafely(true, ownerWriter, everyoneWriter);
+            NetworkWriter observersWriter = new NetworkWriter(); // not really used in this Test
+            identity1.OnSerializeAllSafely(true, ownerWriter, observersWriter);
 
             // set up a "client" object
             GameObject gameObject2 = new GameObject();

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -81,5 +81,25 @@ namespace Mirror.Tests
             // check that the syncvars got updated
             Assert.That(player2.guild.name, Is.EqualTo("Back street boys"), "Data should be synchronized");
         }
+
+        [Test]
+        public void TestSyncModeObserversMask()
+        {
+            GameObject gameObject1 = new GameObject();
+            NetworkIdentity identity = gameObject1.AddComponent<NetworkIdentity>();
+            MockPlayer player1 = gameObject1.AddComponent<MockPlayer>();
+            player1.syncInterval = 0;
+            MockPlayer player2 = gameObject1.AddComponent<MockPlayer>();
+            player2.syncInterval = 0;
+            MockPlayer player3 = gameObject1.AddComponent<MockPlayer>();
+            player3.syncInterval = 0;
+
+            // sync mode
+            player1.syncMode = SyncMode.Observers;
+            player2.syncMode = SyncMode.Owner;
+            player3.syncMode = SyncMode.Observers;
+
+            Assert.That(identity.GetSyncModeObserversMask(), Is.EqualTo(0b101));
+        }
     }
 }

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -65,8 +65,9 @@ namespace Mirror.Tests
             player1.guild = myGuild;
 
             // serialize all the data as we would for the network
-            NetworkWriter writer = new NetworkWriter();
-            identity1.OnSerializeAllSafely(true, writer);
+            NetworkWriter ownerWriter = new NetworkWriter();
+            NetworkWriter everyoneWriter = new NetworkWriter(); // not really used in this Test
+            identity1.OnSerializeAllSafely(true, ownerWriter, everyoneWriter);
 
             // set up a "client" object
             GameObject gameObject2 = new GameObject();
@@ -74,7 +75,7 @@ namespace Mirror.Tests
             MockPlayer player2 = gameObject2.AddComponent<MockPlayer>();
 
             // apply all the data from the server object
-            NetworkReader reader = new NetworkReader(writer.ToArray());
+            NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
             identity2.OnDeserializeAllSafely(reader, true);
 
             // check that the syncvars got updated


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16416509/62893616-4c313180-bd4b-11e9-8e11-efa4c20aedfb.png)

+ no weaver magic
+ no breaking projects
+ OnSerialize/OnDeserialize is unchanged
+ OnSerialize is still only called once, not twice (not guaranteed to get same result when calling it twice, also not guaranteed to not break user's timing code if called twice)
+ no attributes/custom tags needed
+ no [SyncVar(owner=true)] SyncListInt magic
+ no dirtyBit magic
+ only a few more lines of code, a lot of it are comments
+ saves computations (only serialize each component once)
+ **Runtime SyncMode changes** supported to go invisible, etc. Previously there was no good way for a player to go truly stealth mode.
+ **Ease of use:** people could set their inventories to OWNER with just a mouse click