### PR TITLE
feat: custom readers and writers

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -1,0 +1,65 @@
+using System;
+using Mono.CecilX;
+using UnityEditor.Compilation;
+
+namespace Mirror.Weaver
+{
+
+    public static class ReaderWriterProcessor
+    {
+
+        // find all readers and writers and register them
+        public static void ProcessReadersAndWriters(AssemblyDefinition CurrentAssembly)
+        {
+            Readers.Init(CurrentAssembly);
+            Writers.Init(CurrentAssembly);
+
+            foreach (Assembly unityAsm in CompilationPipeline.GetAssemblies())
+            {
+                if (unityAsm.name != CurrentAssembly.Name.Name)
+                {
+                    try
+                    {
+                        using (DefaultAssemblyResolver asmResolver = new DefaultAssemblyResolver())
+                        using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(unityAsm.outputPath, new ReaderParameters { ReadWrite = false, ReadSymbols = true, AssemblyResolver = asmResolver }))
+                        {
+                            ProcessAssemblyAttributes(CurrentAssembly, assembly);
+                        }
+                    }
+                    catch
+                    {
+                        // some assemblies cannot be loaded,  it is ok
+                    }
+                }
+            }
+
+            ProcessAssemblyAttributes(CurrentAssembly, CurrentAssembly);
+        }
+
+        private static void ProcessAssemblyAttributes(AssemblyDefinition CurrentAssembly, AssemblyDefinition assembly)
+        {
+            foreach (CustomAttribute attribute in assembly.CustomAttributes)
+            {
+                if (attribute.AttributeType.FullName == "Mirror.ReaderWriterAttribute")
+                {
+                    LoadReaderWriter(CurrentAssembly, attribute);
+                }
+            }
+        }
+
+        private static void LoadReaderWriter(AssemblyDefinition CurrentAssembly, CustomAttribute attribute)
+        {
+            TypeReference typeClass = (TypeReference)attribute.ConstructorArguments[0].Value;
+            TypeReference readerClass = (TypeReference)attribute.ConstructorArguments[1].Value;
+            string readerMethod = (string)attribute.ConstructorArguments[2].Value;
+            TypeReference writerClass = (TypeReference)attribute.ConstructorArguments[3].Value;
+            string writerMethod = (string)attribute.ConstructorArguments[4].Value;
+
+            Readers.Register(typeClass, Resolvers.ResolveMethod(readerClass, CurrentAssembly, readerMethod));
+            Writers.Register(typeClass, Resolvers.ResolveMethod(writerClass, CurrentAssembly, writerMethod));
+
+        }
+
+    }
+
+}

--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -11,8 +11,8 @@ namespace Mirror.Weaver
         // find all readers and writers and register them
         public static void ProcessReadersAndWriters(AssemblyDefinition CurrentAssembly)
         {
-            Readers.Init(CurrentAssembly);
-            Writers.Init(CurrentAssembly);
+            Readers.Init();
+            Writers.Init();
 
             foreach (Assembly unityAsm in CompilationPipeline.GetAssemblies())
             {

--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs.meta
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3263602f0a374ecd8d08588b1fc2f76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadInt16") },
                 { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadUInt16") },
                 { Weaver.byteType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadByte") },
                 { Weaver.sbyteType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadSByte") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.sbyteType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadSByte") },
                 { Weaver.charType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadChar") },
                 { Weaver.decimalType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadDecimal") },
                 { Weaver.vector2Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector2") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.transformType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadTransform") },
                 { "System.Byte[]", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSize") },
                 { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSizeSegment") }
             };

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector3IntType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector3Int") },
                 { Weaver.colorType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadColor") },
                 { Weaver.color32Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadColor32") },
                 { Weaver.quaternionType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadQuaternion") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadString") },
                 { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPackedInt64") },
                 { Weaver.uint64Type.FullName, Weaver.NetworkReaderReadPackedUInt64 },
                 { Weaver.uint32Type.FullName, Weaver.NetworkReaderReadPackedUInt32 },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.color32Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadColor32") },
                 { Weaver.quaternionType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadQuaternion") },
                 { Weaver.rectType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadRect") },
                 { Weaver.planeType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPlane") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadUInt16") },
                 { Weaver.byteType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadByte") },
                 { Weaver.sbyteType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadSByte") },
                 { Weaver.charType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadChar") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.uint64Type.FullName, Weaver.NetworkReaderReadPackedUInt64 },
                 { Weaver.uint32Type.FullName, Weaver.NetworkReaderReadPackedUInt32 },
                 { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadInt16") },
                 { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadUInt16") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadNetworkIdentity") },
                 { Weaver.transformType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadTransform") },
                 { "System.Byte[]", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSize") },
                 { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSizeSegment") }

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.rayType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadRay") },
                 { Weaver.matrixType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadMatrix4x4") },
                 { Weaver.guidType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadGuid") },
                 { Weaver.gameObjectType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadGameObject") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSizeSegment") }
             };
 
         }

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.singleType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadSingle") },
                 { Weaver.doubleType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadDouble") },
                 { Weaver.boolType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBoolean") },
                 { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadString") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.colorType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadColor") },
                 { Weaver.color32Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadColor32") },
                 { Weaver.quaternionType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadQuaternion") },
                 { Weaver.rectType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadRect") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.decimalType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadDecimal") },
                 { Weaver.vector2Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector2") },
                 { Weaver.vector3Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector3") },
                 { Weaver.vector4Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector4") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.byteType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadByte") },
                 { Weaver.sbyteType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadSByte") },
                 { Weaver.charType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadChar") },
                 { Weaver.decimalType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadDecimal") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -11,14 +11,9 @@ namespace Mirror.Weaver
         const int MaxRecursionCount = 128;
         static Dictionary<string, MethodReference> readFuncs;
 
-        public static void Init(AssemblyDefinition CurrentAssembly)
+        public static void Init()
         {
-            TypeReference networkReaderType = Weaver.NetworkReaderType;
-
-            readFuncs = new Dictionary<string, MethodReference>
-            {
-            };
-
+            readFuncs = new Dictionary<string, MethodReference>();
         }
 
         internal static void Register(TypeReference typeClass, MethodReference methodReference)

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.quaternionType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadQuaternion") },
                 { Weaver.rectType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadRect") },
                 { Weaver.planeType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPlane") },
                 { Weaver.rayType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadRay") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.rectType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadRect") },
                 { Weaver.planeType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPlane") },
                 { Weaver.rayType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadRay") },
                 { Weaver.matrixType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadMatrix4x4") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.charType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadChar") },
                 { Weaver.decimalType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadDecimal") },
                 { Weaver.vector2Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector2") },
                 { Weaver.vector3Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector3") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -50,8 +50,13 @@ namespace Mirror.Weaver
                 { "System.Byte[]", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSize") },
                 { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSizeSegment") }
             };
+
         }
 
+        internal static void Register(TypeReference typeClass, MethodReference methodReference)
+        {
+            readFuncs[typeClass.FullName] = methodReference;
+        }
 
         public static MethodReference GetReadFunc(TypeReference variable, int recursionCount = 0)
         {

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector4Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector4") },
                 { Weaver.vector2IntType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector2Int") },
                 { Weaver.vector3IntType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector3Int") },
                 { Weaver.colorType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadColor") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -23,7 +23,6 @@ namespace Mirror.Weaver
                 { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadString") },
                 { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPackedInt64") },
                 { Weaver.uint64Type.FullName, Weaver.NetworkReaderReadPackedUInt64 },
-                { Weaver.int32Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPackedInt32") },
                 { Weaver.uint32Type.FullName, Weaver.NetworkReaderReadPackedUInt32 },
                 { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadInt16") },
                 { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadUInt16") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.uint32Type.FullName, Weaver.NetworkReaderReadPackedUInt32 },
                 { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadInt16") },
                 { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadUInt16") },
                 { Weaver.byteType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadByte") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.matrixType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadMatrix4x4") },
                 { Weaver.guidType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadGuid") },
                 { Weaver.gameObjectType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadGameObject") },
                 { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadNetworkIdentity") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector2IntType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector2Int") },
                 { Weaver.vector3IntType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector3Int") },
                 { Weaver.colorType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadColor") },
                 { Weaver.color32Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadColor32") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPackedInt64") },
                 { Weaver.uint64Type.FullName, Weaver.NetworkReaderReadPackedUInt64 },
                 { Weaver.uint32Type.FullName, Weaver.NetworkReaderReadPackedUInt32 },
                 { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadInt16") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.gameObjectType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadGameObject") },
                 { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadNetworkIdentity") },
                 { Weaver.transformType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadTransform") },
                 { "System.Byte[]", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSize") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector2Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector2") },
                 { Weaver.vector3Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector3") },
                 { Weaver.vector4Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector4") },
                 { Weaver.vector2IntType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector2Int") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { "System.Byte[]", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSize") },
                 { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBytesAndSizeSegment") }
             };
 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.guidType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadGuid") },
                 { Weaver.gameObjectType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadGameObject") },
                 { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadNetworkIdentity") },
                 { Weaver.transformType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadTransform") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.doubleType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadDouble") },
                 { Weaver.boolType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBoolean") },
                 { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadString") },
                 { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPackedInt64") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.planeType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPlane") },
                 { Weaver.rayType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadRay") },
                 { Weaver.matrixType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadMatrix4x4") },
                 { Weaver.guidType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadGuid") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector3Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector3") },
                 { Weaver.vector4Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector4") },
                 { Weaver.vector2IntType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector2Int") },
                 { Weaver.vector3IntType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadVector3Int") },

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -17,7 +17,6 @@ namespace Mirror.Weaver
 
             readFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.boolType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadBoolean") },
                 { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadString") },
                 { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkReaderType, CurrentAssembly, "ReadPackedInt64") },
                 { Weaver.uint64Type.FullName, Weaver.NetworkReaderReadPackedUInt64 },

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -560,8 +560,8 @@ namespace Mirror.Weaver
                 }
 
                 SetupTargetTypes();
-                Readers.Init(CurrentAssembly);
-                Writers.Init(CurrentAssembly);
+
+                ReaderWriterProcessor.ProcessReadersAndWriters(CurrentAssembly);
 
                 ModuleDefinition moduleDefinition = CurrentAssembly.MainModule;
                 Console.WriteLine("Script Module: {0}", moduleDefinition.Name);

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference vector2IntType;
         public static TypeReference vector3IntType;
         public static TypeReference colorType;
         public static TypeReference color32Type;
@@ -220,7 +219,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            vector2IntType = UnityAssembly.MainModule.GetType("UnityEngine.Vector2Int");
             vector3IntType = UnityAssembly.MainModule.GetType("UnityEngine.Vector3Int");
             colorType = UnityAssembly.MainModule.GetType("UnityEngine.Color");
             color32Type = UnityAssembly.MainModule.GetType("UnityEngine.Color32");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference vector4Type;
         public static TypeReference vector2IntType;
         public static TypeReference vector3IntType;
         public static TypeReference colorType;
@@ -221,7 +220,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            vector4Type = UnityAssembly.MainModule.GetType("UnityEngine.Vector4");
             vector2IntType = UnityAssembly.MainModule.GetType("UnityEngine.Vector2Int");
             vector3IntType = UnityAssembly.MainModule.GetType("UnityEngine.Vector3Int");
             colorType = UnityAssembly.MainModule.GetType("UnityEngine.Color");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference vector3IntType;
         public static TypeReference colorType;
         public static TypeReference color32Type;
         public static TypeReference quaternionType;
@@ -219,7 +218,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            vector3IntType = UnityAssembly.MainModule.GetType("UnityEngine.Vector3Int");
             colorType = UnityAssembly.MainModule.GetType("UnityEngine.Color");
             color32Type = UnityAssembly.MainModule.GetType("UnityEngine.Color32");
             quaternionType = UnityAssembly.MainModule.GetType("UnityEngine.Quaternion");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -111,7 +111,6 @@ namespace Mirror.Weaver
         public static TypeReference voidType;
         public static TypeReference singleType;
         public static TypeReference doubleType;
-        public static TypeReference decimalType;
         public static TypeReference boolType;
         public static TypeReference stringType;
         public static TypeReference int64Type;
@@ -279,7 +278,6 @@ namespace Mirror.Weaver
             voidType = ImportCorLibType("System.Void");
             singleType = ImportCorLibType("System.Single");
             doubleType = ImportCorLibType("System.Double");
-            decimalType = ImportCorLibType("System.Decimal");
             boolType = ImportCorLibType("System.Boolean");
             stringType = ImportCorLibType("System.String");
             int64Type = ImportCorLibType("System.Int64");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference vector3Type;
         public static TypeReference vector4Type;
         public static TypeReference vector2IntType;
         public static TypeReference vector3IntType;
@@ -222,7 +221,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            vector3Type = UnityAssembly.MainModule.GetType("UnityEngine.Vector3");
             vector4Type = UnityAssembly.MainModule.GetType("UnityEngine.Vector4");
             vector2IntType = UnityAssembly.MainModule.GetType("UnityEngine.Vector2Int");
             vector3IntType = UnityAssembly.MainModule.GetType("UnityEngine.Vector3Int");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference vector2Type;
         public static TypeReference vector3Type;
         public static TypeReference vector4Type;
         public static TypeReference vector2IntType;
@@ -223,7 +222,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            vector2Type = UnityAssembly.MainModule.GetType("UnityEngine.Vector2");
             vector3Type = UnityAssembly.MainModule.GetType("UnityEngine.Vector3");
             vector4Type = UnityAssembly.MainModule.GetType("UnityEngine.Vector4");
             vector2IntType = UnityAssembly.MainModule.GetType("UnityEngine.Vector2Int");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference quaternionType;
         public static TypeReference rectType;
         public static TypeReference rayType;
         public static TypeReference planeType;
@@ -216,7 +215,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            quaternionType = UnityAssembly.MainModule.GetType("UnityEngine.Quaternion");
             rectType = UnityAssembly.MainModule.GetType("UnityEngine.Rect");
             planeType = UnityAssembly.MainModule.GetType("UnityEngine.Plane");
             rayType = UnityAssembly.MainModule.GetType("UnityEngine.Ray");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference rayType;
         public static TypeReference matrixType;
         public static TypeReference guidType;
         public static TypeReference typeType;
@@ -213,7 +212,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            rayType = UnityAssembly.MainModule.GetType("UnityEngine.Ray");
             matrixType = UnityAssembly.MainModule.GetType("UnityEngine.Matrix4x4");
             gameObjectType = UnityAssembly.MainModule.GetType("UnityEngine.GameObject");
             transformType = UnityAssembly.MainModule.GetType("UnityEngine.Transform");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference guidType;
         public static TypeReference typeType;
         public static TypeReference gameObjectType;
         public static TypeReference transformType;
@@ -269,7 +268,6 @@ namespace Mirror.Weaver
             valueTypeType = ImportCorLibType("System.ValueType");
             typeType = ImportCorLibType("System.Type");
             IEnumeratorType = ImportCorLibType("System.Collections.IEnumerator");
-            guidType = ImportCorLibType("System.Guid");
 
             ArraySegmentType = ImportCorLibType("System.ArraySegment`1");
             ArraySegmentArrayReference = Resolvers.ResolveProperty(ArraySegmentType, CurrentAssembly, "Array");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference rectType;
         public static TypeReference rayType;
         public static TypeReference planeType;
         public static TypeReference matrixType;
@@ -215,7 +214,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            rectType = UnityAssembly.MainModule.GetType("UnityEngine.Rect");
             planeType = UnityAssembly.MainModule.GetType("UnityEngine.Plane");
             rayType = UnityAssembly.MainModule.GetType("UnityEngine.Ray");
             matrixType = UnityAssembly.MainModule.GetType("UnityEngine.Matrix4x4");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -125,7 +125,6 @@ namespace Mirror.Weaver
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
         public static TypeReference rayType;
-        public static TypeReference planeType;
         public static TypeReference matrixType;
         public static TypeReference guidType;
         public static TypeReference typeType;
@@ -214,7 +213,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            planeType = UnityAssembly.MainModule.GetType("UnityEngine.Plane");
             rayType = UnityAssembly.MainModule.GetType("UnityEngine.Ray");
             matrixType = UnityAssembly.MainModule.GetType("UnityEngine.Matrix4x4");
             gameObjectType = UnityAssembly.MainModule.GetType("UnityEngine.GameObject");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference matrixType;
         public static TypeReference guidType;
         public static TypeReference typeType;
         public static TypeReference gameObjectType;
@@ -212,7 +211,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            matrixType = UnityAssembly.MainModule.GetType("UnityEngine.Matrix4x4");
             gameObjectType = UnityAssembly.MainModule.GetType("UnityEngine.GameObject");
             transformType = UnityAssembly.MainModule.GetType("UnityEngine.Transform");
             unityObjectType = UnityAssembly.MainModule.GetType("UnityEngine.Object");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference color32Type;
         public static TypeReference quaternionType;
         public static TypeReference rectType;
         public static TypeReference rayType;
@@ -217,7 +216,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            color32Type = UnityAssembly.MainModule.GetType("UnityEngine.Color32");
             quaternionType = UnityAssembly.MainModule.GetType("UnityEngine.Quaternion");
             rectType = UnityAssembly.MainModule.GetType("UnityEngine.Rect");
             planeType = UnityAssembly.MainModule.GetType("UnityEngine.Plane");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -124,7 +124,6 @@ namespace Mirror.Weaver
         public static TypeReference charType;
         public static TypeReference objectType;
         public static TypeReference valueTypeType;
-        public static TypeReference colorType;
         public static TypeReference color32Type;
         public static TypeReference quaternionType;
         public static TypeReference rectType;
@@ -218,7 +217,6 @@ namespace Mirror.Weaver
 
         static void SetupUnityTypes()
         {
-            colorType = UnityAssembly.MainModule.GetType("UnityEngine.Color");
             color32Type = UnityAssembly.MainModule.GetType("UnityEngine.Color32");
             quaternionType = UnityAssembly.MainModule.GetType("UnityEngine.Quaternion");
             rectType = UnityAssembly.MainModule.GetType("UnityEngine.Rect");

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -126,7 +126,6 @@ namespace Mirror.Weaver
         public static TypeReference valueTypeType;
         public static TypeReference typeType;
         public static TypeReference gameObjectType;
-        public static TypeReference transformType;
         public static TypeReference unityObjectType;
         public static MethodReference gameObjectInequality;
 
@@ -211,7 +210,6 @@ namespace Mirror.Weaver
         static void SetupUnityTypes()
         {
             gameObjectType = UnityAssembly.MainModule.GetType("UnityEngine.GameObject");
-            transformType = UnityAssembly.MainModule.GetType("UnityEngine.Transform");
             unityObjectType = UnityAssembly.MainModule.GetType("UnityEngine.Object");
 
             NetworkClientType = NetAssembly.MainModule.GetType("Mirror.NetworkClient");
@@ -300,7 +298,6 @@ namespace Mirror.Weaver
             CmdDelegateReference = NetAssembly.MainModule.GetType("Mirror.NetworkBehaviour/CmdDelegate");
             CmdDelegateConstructor = Resolvers.ResolveMethod(CmdDelegateReference, CurrentAssembly, ".ctor");
             CurrentAssembly.MainModule.ImportReference(gameObjectType);
-            CurrentAssembly.MainModule.ImportReference(transformType);
 
             TypeReference networkIdentityTmp = NetAssembly.MainModule.GetType("Mirror.NetworkIdentity");
             NetworkIdentityType = CurrentAssembly.MainModule.ImportReference(networkIdentityTmp);

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.gameObjectType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteGameObject") },
                 { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteNetworkIdentity") },
                 { Weaver.transformType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteTransform") },
                 { "System.Byte[]", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSize", "System.Byte[]") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector4Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector4") },
                 { Weaver.vector2IntType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector2Int") },
                 { Weaver.vector3IntType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector3Int") },
                 { Weaver.colorType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteColor") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.singleType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteSingle") },
                 { Weaver.doubleType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteDouble") },
                 { Weaver.boolType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteBoolean") },
                 { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteString") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.quaternionType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteQuaternion") },
                 { Weaver.rectType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteRect") },
                 { Weaver.planeType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePlane") },
                 { Weaver.rayType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteRay") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteNetworkIdentity") },
                 { Weaver.transformType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteTransform") },
                 { "System.Byte[]", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSize", "System.Byte[]") },
                 { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSizeSegment", "System.ArraySegment`1<System.Byte>") }

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.doubleType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteDouble") },
                 { Weaver.boolType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteBoolean") },
                 { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteString") },
                 { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedInt64") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteString") },
                 { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedInt64") },
                 { Weaver.uint64Type.FullName, Weaver.NetworkWriterWritePackedUInt64 },
                 { Weaver.uint32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedUInt32") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.sbyteType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteSByte") },
                 { Weaver.charType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteChar") },
                 { Weaver.decimalType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteDecimal") },
                 { Weaver.vector2Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector2") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.rayType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteRay") },
                 { Weaver.matrixType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteMatrix4x4") },
                 { Weaver.guidType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteGuid") },
                 { Weaver.gameObjectType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteGameObject") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { "System.Byte[]", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSize", "System.Byte[]") },
                 { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSizeSegment", "System.ArraySegment`1<System.Byte>") }
             };
         }

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector3IntType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector3Int") },
                 { Weaver.colorType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteColor") },
                 { Weaver.color32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteColor32") },
                 { Weaver.quaternionType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteQuaternion") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector2Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector2") },
                 { Weaver.vector3Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector3") },
                 { Weaver.vector4Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector4") },
                 { Weaver.vector2IntType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector2Int") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.guidType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteGuid") },
                 { Weaver.gameObjectType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteGameObject") },
                 { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteNetworkIdentity") },
                 { Weaver.transformType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteTransform") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -53,6 +53,11 @@ namespace Mirror.Weaver
             };
         }
 
+        internal static void Register(TypeReference typeClass, MethodReference methodReference)
+        {
+            writeFuncs[typeClass.FullName] = methodReference;
+        }
+
         public static MethodReference GetWriteFunc(TypeReference variable, int recursionCount = 0)
         {
             if (writeFuncs.TryGetValue(variable.FullName, out MethodReference foundFunc))

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteInt16") },
                 { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteUInt16") },
                 { Weaver.byteType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteByte") },
                 { Weaver.sbyteType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteSByte") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector2IntType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector2Int") },
                 { Weaver.vector3IntType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector3Int") },
                 { Weaver.colorType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteColor") },
                 { Weaver.color32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteColor32") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.matrixType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteMatrix4x4") },
                 { Weaver.guidType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteGuid") },
                 { Weaver.gameObjectType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteGameObject") },
                 { Weaver.NetworkIdentityType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteNetworkIdentity") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedInt64") },
                 { Weaver.uint64Type.FullName, Weaver.NetworkWriterWritePackedUInt64 },
                 { Weaver.uint32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedUInt32") },
                 { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteInt16") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.color32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteColor32") },
                 { Weaver.quaternionType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteQuaternion") },
                 { Weaver.rectType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteRect") },
                 { Weaver.planeType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePlane") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.uint64Type.FullName, Weaver.NetworkWriterWritePackedUInt64 },
                 { Weaver.uint32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedUInt32") },
                 { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteInt16") },
                 { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteUInt16") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.byteType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteByte") },
                 { Weaver.sbyteType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteSByte") },
                 { Weaver.charType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteChar") },
                 { Weaver.decimalType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteDecimal") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.charType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteChar") },
                 { Weaver.decimalType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteDecimal") },
                 { Weaver.vector2Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector2") },
                 { Weaver.vector3Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector3") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSizeSegment", "System.ArraySegment`1<System.Byte>") }
             };
         }
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.vector3Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector3") },
                 { Weaver.vector4Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector4") },
                 { Weaver.vector2IntType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector2Int") },
                 { Weaver.vector3IntType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector3Int") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.transformType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteTransform") },
                 { "System.Byte[]", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSize", "System.Byte[]") },
                 { "System.ArraySegment`1<System.Byte>", Resolvers.ResolveMethodWithArg(networkWriterType, CurrentAssembly, "WriteBytesAndSizeSegment", "System.ArraySegment`1<System.Byte>") }
             };

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -12,13 +12,9 @@ namespace Mirror.Weaver
 
         static Dictionary<string, MethodReference> writeFuncs;
 
-        public static void Init(AssemblyDefinition CurrentAssembly)
+        public static void Init()
         {
-            TypeReference networkWriterType = Weaver.NetworkWriterType;
-
-            writeFuncs = new Dictionary<string, MethodReference>
-            {
-            };
+            writeFuncs = new Dictionary<string, MethodReference>();
         }
 
         internal static void Register(TypeReference typeClass, MethodReference methodReference)

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.decimalType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteDecimal") },
                 { Weaver.vector2Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector2") },
                 { Weaver.vector3Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector3") },
                 { Weaver.vector4Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteVector4") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.colorType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteColor") },
                 { Weaver.color32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteColor32") },
                 { Weaver.quaternionType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteQuaternion") },
                 { Weaver.rectType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteRect") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.boolType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteBoolean") },
                 { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteString") },
                 { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedInt64") },
                 { Weaver.uint64Type.FullName, Weaver.NetworkWriterWritePackedUInt64 },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.rectType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteRect") },
                 { Weaver.planeType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePlane") },
                 { Weaver.rayType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteRay") },
                 { Weaver.matrixType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteMatrix4x4") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.planeType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePlane") },
                 { Weaver.rayType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteRay") },
                 { Weaver.matrixType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteMatrix4x4") },
                 { Weaver.guidType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteGuid") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -24,7 +24,6 @@ namespace Mirror.Weaver
                 { Weaver.stringType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteString") },
                 { Weaver.int64Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedInt64") },
                 { Weaver.uint64Type.FullName, Weaver.NetworkWriterWritePackedUInt64 },
-                { Weaver.int32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedInt32") },
                 { Weaver.uint32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedUInt32") },
                 { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteInt16") },
                 { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteUInt16") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.uint32Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WritePackedUInt32") },
                 { Weaver.int16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteInt16") },
                 { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteUInt16") },
                 { Weaver.byteType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteByte") },

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
             writeFuncs = new Dictionary<string, MethodReference>
             {
-                { Weaver.uint16Type.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteUInt16") },
                 { Weaver.byteType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteByte") },
                 { Weaver.sbyteType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteSByte") },
                 { Weaver.charType.FullName, Resolvers.ResolveMethod(networkWriterType, CurrentAssembly, "WriteChar") },

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -194,6 +194,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteNetworkIdentity))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Transform),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadTransform),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteTransform))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -75,6 +75,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteSByte))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.Char),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadChar),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteChar))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -138,6 +138,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteColor32))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Quaternion),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadQuaternion),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteQuaternion))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -47,6 +47,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WritePackedUInt64))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.Int16),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadInt16),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteInt16))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -12,6 +12,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteSingle))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.Double),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadDouble),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteDouble))]
+
+[assembly: ReaderWriter(
     type: typeof(System.Int32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -96,6 +96,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteVector2))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Vector3),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadVector3),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteVector3))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -208,6 +208,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WritePackedUInt64))]
 
 [assembly: ReaderWriter(
+    type: typeof(byte[]),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadBytesAndSize),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteByteArray))]
+
+[assembly: ReaderWriter(
     type: typeof(System.Int32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -4,6 +4,12 @@ using Mirror;
 
 [assembly: InternalsVisibleTo("Mirror.Tests")]
 
+[assembly: ReaderWriter(
+    type: typeof(System.Single),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadSingle),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteSingle))]
 
 [assembly: ReaderWriter(
     type: typeof(System.Int32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -19,6 +19,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteDouble))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.Boolean),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadBoolean),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteBoolean))]
+
+[assembly: ReaderWriter(
     type: typeof(System.Int32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -47,6 +47,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WritePackedUInt64))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.UInt32),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadPackedUInt32),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WritePackedUInt64))]
+
+[assembly: ReaderWriter(
     type: typeof(System.Int32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -166,6 +166,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteRay))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Matrix4x4),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadMatrix4x4),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteMatrix4x4))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -187,6 +187,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteGameObject))]
 
 [assembly: ReaderWriter(
+    type: typeof(Mirror.NetworkIdentity),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadNetworkIdentity),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteNetworkIdentity))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -61,6 +61,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteUInt16))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.Byte),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadByte),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteByte))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -110,6 +110,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteVector4))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Vector2Int),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadVector2Int),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteVector2Int))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -1,3 +1,13 @@
 ﻿using System.Runtime.CompilerServices;
+using Mirror;
+
 
 [assembly: InternalsVisibleTo("Mirror.Tests")]
+
+
+[assembly: ReaderWriter(
+    type: typeof(System.Int32),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadPackedInt32),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WritePackedInt32))]

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -145,6 +145,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteQuaternion))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Rect),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadRect),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteRect))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -117,6 +117,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteVector2Int))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Vector3Int),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadVector3Int),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteVector3Int))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -173,6 +173,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteMatrix4x4))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.Guid),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadGuid),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteGuid))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -103,6 +103,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteVector3))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Vector4),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadVector4),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteVector4))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -68,6 +68,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteByte))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.SByte),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadSByte),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteSByte))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -215,6 +215,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteByteArray))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.ArraySegment<byte>),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadBytesAndSizeSegment),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteBytesAndSizeSegment))]
+
+[assembly: ReaderWriter(
     type: typeof(System.Int32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -124,6 +124,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteVector3Int))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Color),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadColor),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteColor))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -26,6 +26,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteBoolean))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.String),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadString),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteString))]
+
+[assembly: ReaderWriter(
     type: typeof(System.Int32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -89,6 +89,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteDecimal))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Vector2),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadVector2),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteVector2))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -152,6 +152,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteRect))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Plane),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadPlane),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WritePlane))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -131,6 +131,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteColor))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Color32),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadColor32),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteColor32))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -54,6 +54,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteInt16))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.UInt16),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadUInt16),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteUInt16))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -33,6 +33,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteString))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.Int64),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadPackedInt64),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WritePackedInt64))]
+
+[assembly: ReaderWriter(
     type: typeof(System.Int32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -82,6 +82,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteChar))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.Decimal),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadDecimal),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteDecimal))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -180,6 +180,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WriteGuid))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.GameObject),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadGameObject),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteGameObject))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -40,6 +40,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WritePackedInt64))]
 
 [assembly: ReaderWriter(
+    type: typeof(System.UInt64),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadPackedUInt64),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WritePackedUInt64))]
+
+[assembly: ReaderWriter(
     type: typeof(System.Int32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedInt32),

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -159,6 +159,13 @@ using Mirror;
     writerMethod: nameof(NetworkWriter.WritePlane))]
 
 [assembly: ReaderWriter(
+    type: typeof(UnityEngine.Ray),
+    readerClass: typeof(NetworkReader),
+    readerMethod: nameof(NetworkReader.ReadRay),
+    writerClass: typeof(NetworkWriter),
+    writerMethod: nameof(NetworkWriter.WriteRay))]
+
+[assembly: ReaderWriter(
     type: typeof(System.UInt32),
     readerClass: typeof(NetworkReader),
     readerMethod: nameof(NetworkReader.ReadPackedUInt32),

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -55,4 +55,24 @@ namespace Mirror
 
     // For Scene property Drawer
     public class SceneAttribute : PropertyAttribute {}
+
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple=true)]
+    public class ReaderWriterAttribute : Attribute 
+    {
+
+        public ReaderWriterAttribute( Type type, Type readerClass, string readerMethod, Type writerClass, string writerMethod)
+        {
+            Type = type;
+            ReaderClass = readerClass;
+            ReaderMethod = readerMethod;
+            WriterClass = writerClass;
+            WriterMethod = writerMethod;
+        }
+        public Type Type { get; }
+        public Type ReaderClass { get; }
+        public string ReaderMethod { get; }
+        public Type WriterClass { get; }
+        public string WriterMethod { get; }
+    }
+
 }

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -230,6 +230,9 @@ namespace Mirror
             WriteBytesAndSize(buffer, 0, buffer != null ? buffer.Length : 0);
         }
 
+        // alias for WriteBytesAndSize to avoid overloaded method in the ReadWriter registration
+        public void WriteByteArray(byte[] buffer) => WriteBytesAndSize(buffer);
+
         public void WriteBytesAndSizeSegment(ArraySegment<byte> buffer)
         {
             WriteBytesAndSize(buffer.Array, buffer.Offset, buffer.Count);


### PR DESCRIPTION
With this pull request,  users can register a custom reader/writer and mirror would use it.   
To register a reader/writer,  the user adds an assembly attribute.  For example:

```cs

// register a reader and writer for Quests
[assembly: ReaderWriter( 
    typeof(Quest),  
    typeof(Quest),  
    nameof(Quest.ReadQuest),  
    typeof(Quest),  
    nameof(Quest.WriteQuest)]

class Quest 
{
          public static Quest ReadQuest(NetworkReader reader) 
          {
                Quest quest = new Quest();
                quest.xxx = reader.Readxxx();
                 ...
                return quest;
          }
          public static void WriteQuest(NetworkWriter writer,  Quest quest) 
          {
                 writer.Writexxx(quest.xxx);
                 ...
          }
}
```

As part of this pull request,  mirror itself has been refactored to use the attribute and remove all the hardcoded types in the weaver.

Should fix #1043 