### PR TITLE
Foundation for Authentication

### DIFF
--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -171,6 +171,21 @@ namespace Mirror
         }
     }
 
+    public struct AuthenticationMessage : IMessageBase
+    {
+        public byte[] value;
+
+        public void Deserialize(NetworkReader reader)
+        {
+            value = reader.ReadBytesAndSize();
+        }
+
+        public void Serialize(NetworkWriter writer)
+        {
+            writer.WriteBytesAndSize(value);
+        }
+    }
+
     public struct RemovePlayerMessage : IMessageBase
     {
         public void Deserialize(NetworkReader reader) { }

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -171,7 +171,22 @@ namespace Mirror
         }
     }
 
-    public struct AuthenticationMessage : IMessageBase
+    public struct AuthRequestMessage : IMessageBase
+    {
+        public byte[] value;
+
+        public void Deserialize(NetworkReader reader)
+        {
+            value = reader.ReadBytesAndSize();
+        }
+
+        public void Serialize(NetworkWriter writer)
+        {
+            writer.WriteBytesAndSize(value);
+        }
+    }
+
+    public struct AuthResponseMessage : IMessageBase
     {
         public byte[] value;
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -183,6 +183,11 @@ namespace Mirror
             else Debug.LogError("Skipped Connect message handling because connection is null.");
         }
 
+        static void OnAuthResponseMessage(NetworkConnection conn, AuthResponseMessage msg)
+        {
+            if (connection != null) connection.isAuthenticated = true;
+        }
+
         /// <summary>
         /// Disconnect from server.
         /// <para>The disconnect message will be invoked.</para>
@@ -369,6 +374,7 @@ namespace Mirror
                 RegisterHandler<ObjectSpawnFinishedMessage>(ClientScene.OnObjectSpawnFinished);
                 RegisterHandler<UpdateVarsMessage>(ClientScene.OnUpdateVarsMessage);
             }
+            RegisterHandler<AuthResponseMessage>(OnAuthResponseMessage);
             RegisterHandler<ClientAuthorityMessage>(ClientScene.OnClientAuthority);
             RegisterHandler<RpcMessage>(ClientScene.OnRPCMessage);
             RegisterHandler<SyncEventMessage>(ClientScene.OnSyncEventMessage);

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -33,6 +33,11 @@ namespace Mirror
         public int connectionId = -1;
 
         /// <summary>
+        /// Flag that indicates the connection has been authenticated
+        /// </summary>
+        public bool isAuthenticated;
+
+        /// <summary>
         /// Flag that tells if the connection has been marked as "ready" by a client calling ClientScene.Ready().
         /// <para>This property is read-only. It is set by the system on the client when ClientScene.Ready() is called, and set by the system on the server when a ready message is received from a client.</para>
         /// <para>A client that is ready is sent spawned objects by the server and updates to the state of spawned objects. A client that is not ready is not sent spawned objects.</para>

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -785,7 +785,7 @@ namespace Mirror
 
             if (conn.playerController != null)
             {
-                Debug.LogError("There is already a player for this connections.");
+                Debug.LogError("There is already a player for this connection.");
                 return;
             }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -111,6 +111,7 @@ namespace Mirror
 
         internal static void RegisterMessageHandlers()
         {
+            RegisterHandler<AuthenticationMessage>(OnAuthenticationMessage);
             RegisterHandler<ReadyMessage>(OnClientReadyMessage);
             RegisterHandler<CommandMessage>(OnCommandMessage);
             RegisterHandler<RemovePlayerMessage>(OnRemovePlayerMessage);
@@ -947,6 +948,11 @@ namespace Mirror
 
                 conn.Send(new NotReadyMessage());
             }
+        }
+
+        static void OnAuthenticationMessage(NetworkConnection conn, AuthenticationMessage msg)
+        {
+            conn.isAuthenticated = true;
         }
 
         // default ready handler.

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -111,7 +111,7 @@ namespace Mirror
 
         internal static void RegisterMessageHandlers()
         {
-            RegisterHandler<AuthenticationMessage>(OnAuthenticationMessage);
+            RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage);
             RegisterHandler<ReadyMessage>(OnClientReadyMessage);
             RegisterHandler<CommandMessage>(OnCommandMessage);
             RegisterHandler<RemovePlayerMessage>(OnRemovePlayerMessage);
@@ -950,7 +950,7 @@ namespace Mirror
             }
         }
 
-        static void OnAuthenticationMessage(NetworkConnection conn, AuthenticationMessage msg)
+        static void OnAuthRequestMessage(NetworkConnection conn, AuthRequestMessage msg)
         {
             conn.isAuthenticated = true;
         }


### PR DESCRIPTION
This does nothing other than lay a foundation for Authentication implementation in PR's that will come after.

Ultimately I want to make it possible to process an Authentication message very early in the connection sequence, before the server sends any scene message or anything else.

Currently, the earliest point where users can intervene in the process is in Network Manager's `OnServerConnect`, which is called from this:
```cs
void OnServerConnectInternal(NetworkConnection conn, ConnectMessage connectMsg)
{
    if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerConnectInternal");

    if (networkSceneName != "" && networkSceneName != offlineScene)
    {
        SceneMessage msg = new SceneMessage() { sceneName = networkSceneName };
        conn.Send(msg);
    }

    OnServerConnect(conn);
}
```
This is really too late, even if `OnServerConnect` was called before the Scene message, or this method was made public virtual.  There needs to be an Authentication process before all this.