### PR TITLE
Don't call Ready if we're ready already

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -988,7 +988,7 @@ namespace Mirror
             if (!clientLoadedScene)
             {
                 // Ready/AddPlayer is usually triggered by a scene load completing. if no scene was loaded, then Ready/AddPlayer it here instead.
-                ClientScene.Ready(conn);
+                if (!ClientScene.ready) ClientScene.Ready(conn);
                 if (autoCreatePlayer)
                 {
                     ClientScene.AddPlayer();
@@ -1035,7 +1035,7 @@ namespace Mirror
         public virtual void OnClientSceneChanged(NetworkConnection conn)
         {
             // always become ready.
-            ClientScene.Ready(conn);
+            if (!ClientScene.ready) ClientScene.Ready(conn);
 
             if (autoCreatePlayer && ClientScene.localPlayer == null)
             {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -785,7 +785,7 @@ namespace Mirror
 
             if (conn.playerController != null)
             {
-                Debug.LogError("There is already a player for this connections.");
+                Debug.LogError("There is already a player for this connection.");
                 return;
             }
 


### PR DESCRIPTION
For reference, this is what's in `ClientScene.Ready()`
```cs
public static bool Ready(NetworkConnection conn)
{
    if (ready)
    {
        Debug.LogError("A connection has already been set as ready. There can only be one.");
        return false;
    }

    if (LogFilter.Debug) Debug.Log("ClientScene.Ready() called with connection [" + conn + "]");

    if (conn != null)
    {
        conn.Send(new ReadyMessage());
        ready = true;
        readyConnection = conn;
        readyConnection.isReady = true;
        return true;
    }
    Debug.LogError("Ready() called with invalid connection object: conn=null");
    return false;
}
```