### PR TITLE
fix: error with missing assemblies

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -3,6 +3,7 @@ using Mono.CecilX;
 using UnityEditor.Compilation;
 using System.Linq;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Mirror.Weaver
 {
@@ -26,7 +27,7 @@ namespace Mirror.Weaver
                             ProcessAssemblyClasses(CurrentAssembly, assembly);
                         }
                     }
-                    catch(FileNotFoundException ex)
+                    catch(FileNotFoundException)
                     {
                         // During first import,  this gets called before some assemblies
                         // are built,  just skip them

--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -18,10 +18,18 @@ namespace Mirror.Weaver
             {
                 if (unityAsm.name != CurrentAssembly.Name.Name)
                 {
-                    using (DefaultAssemblyResolver asmResolver = new DefaultAssemblyResolver())
-                    using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(unityAsm.outputPath, new ReaderParameters { ReadWrite = false, ReadSymbols = true, AssemblyResolver = asmResolver }))
+                    try
                     {
-                        ProcessAssemblyClasses(CurrentAssembly, assembly);
+                        using (DefaultAssemblyResolver asmResolver = new DefaultAssemblyResolver())
+                        using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(unityAsm.outputPath, new ReaderParameters { ReadWrite = false, ReadSymbols = true, AssemblyResolver = asmResolver }))
+                        {
+                            ProcessAssemblyClasses(CurrentAssembly, assembly);
+                        }
+                    }
+                    catch(FileNotFoundException ex)
+                    {
+                        // During first import,  this gets called before some assemblies
+                        // are built,  just skip them
                     }
                 }
             }


### PR DESCRIPTION
During first import,  the weaver will be called before all assemblies
are built.  No need to look for custom readers and writers if the assemblies
are not built.

fixes #1051