### PR TITLE
fix: remove scene id warning

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -180,7 +180,7 @@ namespace Mirror
 
         // persistent scene id <sceneHash/32,sceneId/32>
         // (see AssignSceneID comments)
-        [SerializeField] ulong m_SceneId;
+        public ulong m_SceneId;
 
         // keep track of all sceneIds to detect scene duplicates
         static readonly Dictionary<ulong, NetworkIdentity> sceneIds = new Dictionary<ulong, NetworkIdentity>();


### PR DESCRIPTION
To get rid of this annoying warning
```
Assets\Mirror\Runtime\NetworkIdentity.cs(183,32): warning CS0649: Field 'NetworkIdentity.m_SceneId' is never assigned to, and will always have its default value 0
```