### PR TITLE
No need to read symbols

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -22,7 +22,7 @@ namespace Mirror.Weaver
                     try
                     {
                         using (DefaultAssemblyResolver asmResolver = new DefaultAssemblyResolver())
-                        using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(unityAsm.outputPath, new ReaderParameters { ReadWrite = false, ReadSymbols = true, AssemblyResolver = asmResolver }))
+                        using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(unityAsm.outputPath, new ReaderParameters { ReadWrite = false, ReadSymbols = false, AssemblyResolver = asmResolver }))
                         {
                             ProcessAssemblyClasses(CurrentAssembly, assembly);
                         }


### PR DESCRIPTION
Should speed up build slightly.
If user has old symbols we don't care, so don't give an error.