### PR TITLE
Put all RoomPlayer's in DDOL

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -321,20 +321,6 @@ namespace Mirror
                     }
                 }
             }
-            else
-            {
-                if (dontDestroyOnLoad)
-                {
-                    foreach (NetworkRoomPlayer roomPlayer in roomSlots)
-                    {
-                        if (roomPlayer != null)
-                        {
-                            roomPlayer.transform.SetParent(null);
-                            DontDestroyOnLoad(roomPlayer);
-                        }
-                    }
-                }
-            }
 
             base.ServerChangeScene(sceneName);
         }
@@ -459,32 +445,6 @@ namespace Mirror
                 // This let's it be destroyed when client changes to the Offline scene.
                 SceneManager.MoveGameObjectToScene(gameObject, SceneManager.GetActiveScene());
             }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="newSceneName"></param>
-        public override void OnClientChangeScene(string newSceneName)
-        {
-            if (LogFilter.Debug) Debug.LogFormat("OnClientChangeScene from {0} to {1}", SceneManager.GetActiveScene().name, newSceneName);
-
-            if (SceneManager.GetActiveScene().name == RoomScene && newSceneName == GameplayScene && dontDestroyOnLoad && NetworkClient.isConnected)
-            {
-                if (NetworkClient.connection != null && NetworkClient.connection.playerController != null)
-                {
-                    GameObject roomPlayer = NetworkClient.connection.playerController.gameObject;
-                    if (roomPlayer != null)
-                    {
-                        roomPlayer.transform.SetParent(null);
-                        DontDestroyOnLoad(roomPlayer);
-                    }
-                    else
-                        Debug.LogWarningFormat("OnClientChangeScene: roomPlayer is null");
-                }
-            }
-            else
-               if (LogFilter.Debug) Debug.LogFormat("OnClientChangeScene {0} {1}", dontDestroyOnLoad, NetworkClient.isConnected);
         }
 
         /// <summary>

--- a/Assets/Mirror/Components/NetworkRoomPlayer.cs
+++ b/Assets/Mirror/Components/NetworkRoomPlayer.cs
@@ -38,8 +38,17 @@ namespace Mirror
         /// </summary>
         public void Start()
         {
-            if (NetworkManager.singleton as NetworkRoomManager)
+            NetworkRoomManager room = NetworkManager.singleton as NetworkRoomManager;
+            if (room != null)
+            {
+                // NetworkRoomPlayer object must be set to DontDestroyOnLoad along with NetworkRoomManager
+                // in server and all clients, otherwise it will be respawned in the game scene which would 
+                // have undesireable effects.
+                if (room.dontDestroyOnLoad)
+                    DontDestroyOnLoad(gameObject);
+
                 OnClientEnterRoom();
+            }
             else
                 Debug.LogError("RoomPlayer could not find a NetworkRoomManager. The RoomPlayer requires a NetworkRoomManager object to function. Make sure that there is one in the scene.");
         }
@@ -49,7 +58,7 @@ namespace Mirror
         #region Commands
 
         [Command]
-        public void CmdChangeReadyState(bool readyState)
+        void CmdChangeReadyState(bool readyState)
         {
             readyToBegin = readyState;
             NetworkRoomManager room = NetworkManager.singleton as NetworkRoomManager;

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomPlayerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomPlayerExt.cs
@@ -11,20 +11,6 @@ namespace Mirror.Examples.NetworkRoom
             if (LogFilter.Debug) Debug.LogFormat("OnStartClient {0}", SceneManager.GetActiveScene().name);
 
             base.OnStartClient();
-            NetworkRoomManager room = NetworkManager.singleton as NetworkRoomManager;
-
-            /*
-                This demonstrates how to set the parent of the RoomPlayerPrefab to an arbitrary scene object
-                A similar technique would be used if a full canvas layout UI existed and we wanted to show
-                something more visual for each player in that layout, such as a name, avatar, etc.
-
-                Note: RoomPlayer prefab will be marked DontDestroyOnLoad and carried forward to the game scene.
-                      Because of this, NetworkRoomManager must automatically set the parent to null
-                      in ServerChangeScene and OnClientChangeScene.
-            */
-
-            if (room != null && SceneManager.GetActiveScene().name == room.RoomScene)
-                gameObject.transform.SetParent(GameObject.Find("Players").transform);
         }
 
         public override void OnClientEnterRoom()


### PR DESCRIPTION
This is a cleanup / simplification.  Since Room players will respawn in the game scene after scene change, that's problematic, so now they're all in DontDestroyOnLoad at Start on both Server and Client to make modifying / extending the system easier.