### PR TITLE
fix: fix #1073 sync components with different intervals

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -22,7 +22,7 @@ namespace Mirror
     [AddComponentMenu("")]
     public class NetworkBehaviour : MonoBehaviour
     {
-        float lastSyncTime;
+        internal float lastSyncTime;
 
         // hidden because NetworkBehaviourInspector shows it only if has OnSerialize.
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -563,6 +563,10 @@ namespace Mirror
         /// </summary>
         public void ClearAllDirtyBits()
         {
+            // do not clear sync bits object is not dirty
+            if (!IsDirty())
+                return;
+
             lastSyncTime = Time.time;
             syncVarDirtyBits = 0L;
 

--- a/Assets/Mirror/Tests/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/SyncVarTest.cs
@@ -52,6 +52,32 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestSyncInterval()
+        {
+
+            GameObject gameObject = new GameObject();
+
+            MockPlayer player = gameObject.AddComponent<MockPlayer>();
+            player.lastSyncTime = Time.time;
+            // synchronize immediatelly
+            player.syncInterval = 1f;
+
+            player.guild = new MockPlayer.Guild
+            {
+                name = "Back street boys"
+            };
+
+            Assert.That(player.IsDirty(), Is.False, "Sync interval not met,  so not dirty yet");
+
+            // clear bits shoudl do nothing since the object is not dirty
+            player.ClearAllDirtyBits();
+
+            // lets reduce the syncinterval
+            player.syncInterval = 0f;
+            Assert.That(player.IsDirty(), Is.True, "Sync interval met,  should synchronize");
+        }
+
+        [Test]
         public void TestSynchronizingObjects()
         {
             // set up a "server" object


### PR DESCRIPTION
First commit is a unit test that reproduces the issue
second commit fixes #1073.   If a component is not synchronize, don't clear the dirty bits and syncTime,  it may be that its sync interval has not expired.