### PR TITLE
Mirror Network Profiler

### DIFF
--- a/Assets/Mirror/Editor/NetworkProfilerWindow.cs
+++ b/Assets/Mirror/Editor/NetworkProfilerWindow.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace Mirror
+{
+    public class NetworkProfilerWindow : EditorWindow
+    {
+        public int activeConfigIndex;
+        private GUIStyle headerStyle;
+        private Vector2 leftScrollPosition;
+        private Vector2 rightScrollPosition;
+
+        private const int ChannelColumnWidth = 100;
+        private const int MessageColumnWidth = 100;
+
+        private List<NetworkProfileTick> ticks = new List<NetworkProfileTick>();
+        private NetworkProfileTick selectedTick;
+        
+
+        public GUIStyle columnHeaderStyle { get; private set; }
+
+        public void OnEnable()
+        {
+            NetworkProfiler.TickRecorded += this.OnTickRecorded;
+        }        
+
+        public void OnDisable()
+        {
+            NetworkProfiler.TickRecorded -= this.OnTickRecorded;
+        }
+
+        public void OnGUI()
+        {
+            if (this.headerStyle == null)
+            {
+                this.headerStyle = new GUIStyle(GUI.skin.label) { alignment = TextAnchor.MiddleLeft, fontStyle = FontStyle.Bold, fontSize = 14 };
+            }
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.BeginVertical(GUILayout.Width(250));
+
+            NetworkProfiler.IsRecording = GUILayout.Toggle(NetworkProfiler.IsRecording, "Record", "Button");
+            EditorGUILayout.Space();
+
+            this.leftScrollPosition = EditorGUILayout.BeginScrollView(this.leftScrollPosition);
+
+            for (int x = this.ticks.Count - 1; x > -1; x--)
+            {
+                NetworkProfileTick t = this.ticks[x];
+                if (GUILayout.Button($"{t.Time} - {t.TotalMessages} Messages ")) { this.Show(t); };
+            }
+            
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
+
+            // Tick Inspector Window
+            EditorGUILayout.BeginVertical();
+            this.rightScrollPosition = EditorGUILayout.BeginScrollView(this.rightScrollPosition);
+            if (this.selectedTick != null)
+            {
+                EditorGUILayout.LabelField($"Time : {this.selectedTick.Time}", this.headerStyle);
+
+                EditorGUILayout.Space();
+
+                EditorGUILayout.LabelField("Channels", this.headerStyle);
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Channel", GUILayout.Width(ChannelColumnWidth));
+                GUILayout.Label("Bytes In", GUILayout.Width(ChannelColumnWidth));
+                GUILayout.Label("Bytes Out", GUILayout.Width(ChannelColumnWidth));
+                GUILayout.EndHorizontal();
+                foreach (NetworkProfileChannel c in this.selectedTick.Channels)
+                {
+                    GUILayout.BeginHorizontal();
+                    GUILayout.Label(c.Id.ToString(), GUILayout.Width(ChannelColumnWidth));
+                    GUILayout.Label(c.BytesIncoming.ToString(), GUILayout.Width(ChannelColumnWidth));
+                    GUILayout.Label(c.BytesOutgoing.ToString(), GUILayout.Width(ChannelColumnWidth));
+                    GUILayout.EndHorizontal();
+                }
+
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Messages", this.headerStyle);
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Direction", GUILayout.Width(75));
+                GUILayout.Label("Count", GUILayout.Width(75));
+                GUILayout.Label("Type", GUILayout.Width(MessageColumnWidth * 4));
+                GUILayout.Label("Name", GUILayout.Width(MessageColumnWidth * 4));
+                GUILayout.EndHorizontal();
+                foreach (NetworkProfileMessage m in this.selectedTick.Messages)
+                {
+                    GUILayout.BeginHorizontal();
+                    GUILayout.Label(m.Direction.ToString(), GUILayout.Width(75));
+                    GUILayout.Label(m.Count.ToString(), GUILayout.Width(75));
+                    GUILayout.Label(m.Type.ToString(), GUILayout.Width(MessageColumnWidth * 4));
+                    GUILayout.Label(m.Name.ToString(), GUILayout.Width(MessageColumnWidth * 4));
+                    GUILayout.EndHorizontal();
+                }
+
+                EditorGUILayout.Space();
+                
+            }
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.EndHorizontal();
+            this.Repaint();
+        }
+
+        [MenuItem("Window/Analysis/Mirror Network Profiler", false, 0)]
+        public static void ShowWindow()
+        {
+            EditorWindow.GetWindow<NetworkProfilerWindow>("Mirror Network Profiler");
+        }
+
+        public void Show(NetworkProfileTick tick)
+        {
+            this.selectedTick = tick;
+        }
+
+        private void OnTickRecorded(NetworkProfileTick obj)
+        {
+            this.ticks.Add(obj);
+
+            if (this.ticks.Count > 300)
+            {
+                this.ticks.RemoveAt(0);
+            }
+        }
+
+        public static void DrawUILine(Color color, int thickness = 2, int padding = 10)
+        {
+            Rect r = EditorGUILayout.GetControlRect(GUILayout.Height(padding + thickness));
+            r.height = thickness;
+            r.y += padding / 2;
+            r.x -= 2;
+            r.width += 6;
+            EditorGUI.DrawRect(r, color);
+        }
+    }
+}

--- a/Assets/Mirror/Editor/NetworkProfilerWindow.cs.meta
+++ b/Assets/Mirror/Editor/NetworkProfilerWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a090c2f7eb0f55941be54dad139bc759
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -72,6 +72,10 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.LogWarning("ClientScene.InternalAddPlayer");
 
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(AddPlayerMessage), identity.gameObject.name, 1);
+#endif
+
             // NOTE: It can be "normal" when changing scenes for the player to be destroyed and recreated.
             // But, the player structures are not cleaned up, we'll just replace the old player
             localPlayer = identity;
@@ -148,6 +152,9 @@ namespace Mirror
             if (readyConnection.playerController != null)
             {
                 readyConnection.Send(new RemovePlayerMessage());
+#if MIRROR_PROFILING
+                NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(RemovePlayerMessage), readyConnection.playerController.gameObject.name, 1);
+#endif
 
                 Object.Destroy(readyConnection.playerController.gameObject);
 
@@ -174,7 +181,9 @@ namespace Mirror
             }
 
             if (LogFilter.Debug) Debug.Log("ClientScene.Ready() called with connection [" + conn + "]");
-
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Outgoing, typeof(ReadyMessage), null, 1);
+#endif
             if (conn != null)
             {
                 conn.Send(new ReadyMessage());
@@ -543,6 +552,9 @@ namespace Mirror
                 // this object already exists (was in the scene)
                 localObject.Reset();
                 ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId);
+#if MIRROR_PROFILING
+                NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(SpawnSceneObjectMessage), localObject.gameObject.name, 1);
+#endif
                 return;
             }
 
@@ -562,6 +574,9 @@ namespace Mirror
             }
 
             if (LogFilter.Debug) Debug.Log("Client spawn for [netId:" + msg.netId + "] [sceneId:" + msg.sceneId + "] obj:" + spawnedId.gameObject.name);
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(SpawnSceneObjectMessage), spawnedId.gameObject.name, 1);
+#endif
             spawnedId.Reset();
             spawnedId.pendingOwner = msg.owner;
             ApplySpawnPayload(spawnedId, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId);
@@ -570,7 +585,9 @@ namespace Mirror
         internal static void OnObjectSpawnStarted(NetworkConnection _, ObjectSpawnStartedMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("SpawnStarted");
-
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(ObjectSpawnStartedMessage), null, 1);
+#endif
             PrepareToSpawnSceneObjects();
             isSpawnFinished = false;
         }
@@ -578,6 +595,7 @@ namespace Mirror
         internal static void OnObjectSpawnFinished(NetworkConnection _, ObjectSpawnFinishedMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("SpawnFinished");
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(ObjectSpawnFinishedMessage), null, 1);
 
             // paul: Initialize the objects in the same order as they were initialized
             // in the server.   This is important if spawned objects
@@ -609,6 +627,8 @@ namespace Mirror
 
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity localObject) && localObject != null)
             {
+                NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(ObjectDestroyMessage), netId.ToString(), 1);
+
                 localObject.OnNetworkDestroy();
 
                 if (!InvokeUnSpawnHandler(localObject.assetId, localObject.gameObject))
@@ -637,14 +657,18 @@ namespace Mirror
         internal static void OnLocalClientObjectDestroy(NetworkConnection _, ObjectDestroyMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnLocalObjectObjDestroy netId:" + msg.netId);
-
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(ObjectDestroyMessage), msg.netId.ToString(), 1);
+#endif
             NetworkIdentity.spawned.Remove(msg.netId);
         }
 
         internal static void OnLocalClientObjectHide(NetworkConnection _, ObjectHideMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene::OnLocalObjectObjHide netId:" + msg.netId);
-
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(ObjectHideMessage), msg.netId.ToString(), 1);
+#endif
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 localObject.OnSetLocalVisibility(false);
@@ -711,6 +735,9 @@ namespace Mirror
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
+#if MIRROR_PROFILING
+                NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(ClientAuthorityMessage), identity.gameObject.name, 1);
+#endif
                 identity.HandleClientAuthority(msg.authority);
             }
         }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -323,6 +323,11 @@ namespace Mirror
         /// <param name="buffer">The data recieved.</param>
         public virtual void TransportReceive(ArraySegment<byte> buffer)
         {
+#if MIRROR_PROFILING
+            // -1 for now since we don't know the incoming segment channel
+            NetworkProfiler.RecordTraffic(NetworkDirection.Incoming, -1, buffer.Count);
+#endif
+
             // unpack message
             NetworkReader reader = new NetworkReader(buffer);
             if (MessagePacker.UnpackMessage(reader, out int msgType))
@@ -351,6 +356,9 @@ namespace Mirror
         /// <returns></returns>
         public virtual bool TransportSend(int channelId, byte[] bytes)
         {
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordTraffic(NetworkDirection.Outgoing, channelId, bytes.Length);
+#endif
             if (Transport.activeTransport.ClientConnected())
             {
                 return Transport.activeTransport.ClientSend(channelId, bytes);

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -720,6 +720,9 @@ namespace Mirror
                 if (initialState || comp.IsDirty())
                 {
                     if (LogFilter.Debug) Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState);
+#if MIRROR_PROFILING
+                    NetworkProfiler.RecordMessage(NetworkDirection.Outgoing, typeof(UpdateVarsMessage), $"{comp.GetType()} {name}", 1);
+#endif
 
                     // serialize into ownerWriter first
                     // (owner always gets everything!)
@@ -829,6 +832,9 @@ namespace Mirror
                 if ((dirtyComponentsMask & dirtyBit) != 0L)
                 {
                     OnDeserializeSafely(components[i], reader, initialState);
+#if MIRROR_PROFILING
+                    NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(UpdateVarsMessage), components[i].GetType().Name, 1);
+#endif
                 }
             }
         }
@@ -873,18 +879,27 @@ namespace Mirror
         internal void HandleSyncEvent(int componentIndex, int eventHash, NetworkReader reader)
         {
             HandleRemoteCall(componentIndex, eventHash, MirrorInvokeType.SyncEvent, reader);
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(SyncEventMessage), NetworkBehaviour.GetCmdHashEventName(eventHash), 1);
+#endif
         }
 
         // happens on server
         internal void HandleCommand(int componentIndex, int cmdHash, NetworkReader reader)
         {
             HandleRemoteCall(componentIndex, cmdHash, MirrorInvokeType.Command, reader);
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(CommandMessage), NetworkBehaviour.GetCmdHashCmdName(cmdHash), 1);
+#endif
         }
 
         // happens on client
         internal void HandleRPC(int componentIndex, int rpcHash, NetworkReader reader)
         {
             HandleRemoteCall(componentIndex, rpcHash, MirrorInvokeType.ClientRpc, reader);
+#if MIRROR_PROFILING
+            NetworkProfiler.RecordMessage(NetworkDirection.Incoming, typeof(RpcMessage), NetworkBehaviour.GetCmdHashRpcName(rpcHash), 1);
+#endif
         }
 
         internal void OnUpdateVars(NetworkReader reader, bool initialState)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -295,7 +295,9 @@ namespace Mirror
             NetworkClient.Update();
             UpdateScene();
 
+#if MIRROR_PROFILING
             NetworkProfiler.Tick(Time.time);
+#endif
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -294,6 +294,8 @@ namespace Mirror
             NetworkServer.Update();
             NetworkClient.Update();
             UpdateScene();
+
+            NetworkProfiler.Tick(Time.time);
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkProfiler.cs
+++ b/Assets/Mirror/Runtime/NetworkProfiler.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mirror
+{
+    /// <summary>
+    /// The direction of network traffic
+    /// </summary>
+    public enum NetworkDirection
+    {
+        /// <summary>
+        /// Data/Message is coming from a remote host
+        /// </summary>
+        Incoming = 0,
+
+        /// <summary>
+        /// Data/Message going to a remote host
+        /// </summary>
+        Outgoing = 1
+    }
+
+    /// <summary>
+    /// Stores data related to a channel
+    /// </summary>
+    public class NetworkProfileChannel
+    {
+        /// <summary>
+        /// The channel id
+        /// </summary>
+        public int Id;
+
+        /// <summary>
+        /// The number of bytes outgoing
+        /// </summary>
+        public int BytesOutgoing;
+
+        /// <summary>
+        /// The number of bytes incoming
+        /// </summary>
+        public int BytesIncoming;
+    }
+
+    /// <summary>
+    /// Stores a network tick
+    /// </summary>
+    public class NetworkProfileTick
+    {
+        /// <summary>
+        /// The Time.time at the moment tick collection ended
+        /// </summary>
+        public float Time;
+
+        /// <summary>
+        /// The total number of messages captured during this tick
+        /// </summary>
+        public int TotalMessages;
+
+        /// <summary>
+        /// The summary of messages captured during the tick
+        /// </summary>
+        public List<NetworkProfileMessage> Messages = new List<NetworkProfileMessage>();
+
+        /// <summary>
+        /// The channels that sent or received data during the tick
+        /// </summary>
+        public List<NetworkProfileChannel> Channels = new List<NetworkProfileChannel>();
+
+        /// <summary>
+        /// Records the message to the current tick
+        /// </summary>
+        /// <param name="direction">The direction of the message</param>
+        /// <param name="messageType">The message type</param>
+        /// <param name="entryName">The name of the entry, generally represents the target of the message</param>
+        /// <param name="count">The number of these messages sent</param>
+        public void RecordMessage(NetworkDirection direction, Type messageType, string entryName, int count)
+        {
+            this.TotalMessages += count;
+
+            foreach (NetworkProfileMessage m in this.Messages)
+            {
+                if (m.Direction == direction && messageType == m.Type && entryName == m.Name)
+                {
+                    m.Count += count;
+                    return;
+                }
+            }
+
+            this.Messages.Add(new NetworkProfileMessage()
+            {
+                Type = messageType,
+                Direction = direction,
+                Name = entryName,
+                Count = count
+            });
+        }
+    }
+
+    /// <summary>
+    /// Stores a network profile message
+    /// </summary>
+    public class NetworkProfileMessage
+    {
+        public NetworkDirection Direction;
+        public Type Type;
+        public string Name;
+        public int Count;
+    }
+
+    /// <summary>
+    /// Profiler used to profiling Mirror Low Level and High Level Activities
+    /// </summary>
+    public class NetworkProfiler
+    {
+        /// <summary>
+        /// Set to true if profiler should record and fire an event on each server tick
+        /// Defaults to false
+        /// </summary>
+        public static bool IsRecording { get; set; } = false;
+
+        /// <summary>
+        /// Event that is fired at the end of every server tick
+        /// </summary>
+        public static event Action<NetworkProfileTick> TickRecorded;
+
+        private static NetworkProfileTick CurrentTick = new NetworkProfileTick();
+
+        /// <summary>
+        /// Records a message
+        /// </summary>
+        /// <param name="direction"></param>
+        /// <param name="messageType"></param>
+        /// <param name="entryName"></param>
+        /// <param name="count"></param>
+        public static void RecordMessage(NetworkDirection direction, Type messageType, string entryName, int count)
+        {
+            if (NetworkProfiler.IsRecording)
+            {
+                NetworkProfiler.CurrentTick.RecordMessage(direction, messageType, entryName, count);
+            }
+        }
+
+        /// <summary>
+        /// Completes the collection of this frame and marks the frame tick
+        /// </summary>
+        /// <param name="newTime"></param>
+        public static void Tick(float newTime)
+        {
+#if !MIRROR_PROFILING
+            throw new InvalidOperationException("Network Profiling Ticks will return nothing without setting the MIRROR_PROFILING define");
+#endif
+
+            if (NetworkProfiler.IsRecording)
+            {
+                NetworkProfiler.CurrentTick.Time = newTime;
+                NetworkProfiler.TickRecorded?.Invoke(NetworkProfiler.CurrentTick);
+                NetworkProfiler.CurrentTick = new NetworkProfileTick();
+            }
+        }
+
+        /// <summary>
+        /// Records transport traffic
+        /// </summary>
+        /// <param name="direction"></param>
+        /// <param name="channelId"></param>
+        /// <param name="numBytes"></param>
+        public static void RecordTraffic(NetworkDirection direction, int channelId, int numBytes)
+        {
+            if (NetworkProfiler.IsRecording)
+            {
+                foreach (NetworkProfileChannel c in NetworkProfiler.CurrentTick.Channels)
+                {
+                    if (c.Id == channelId)
+                    {
+                        if (direction == NetworkDirection.Incoming)
+                        {
+                            c.BytesIncoming += numBytes;
+                        }
+                        else
+                        {
+                            c.BytesOutgoing += numBytes;
+                        }
+                        return;
+                    }
+                }
+
+                NetworkProfiler.CurrentTick.Channels.Add(new NetworkProfileChannel
+                {
+                    Id = channelId,
+                    BytesIncoming = direction == NetworkDirection.Incoming ? numBytes : 0,
+                    BytesOutgoing = direction == NetworkDirection.Outgoing ? numBytes : 0,
+                });
+            }
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/NetworkProfiler.cs.meta
+++ b/Assets/Mirror/Runtime/NetworkProfiler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb842af19bf94bc4e83b08a766963df9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is a Work in Progress PR to show the approach to adding a Network Profiler to Unity to get feedback on the approach.  To enable, add `MIRROR_PROFILING` to your build defines.

**Example of Profiler**
![a5tjmSUfje](https://user-images.githubusercontent.com/22383358/64901805-54360700-d652-11e9-98e4-3e9f6fd96bce.gif)
