### PR TITLE
Expose methods for profiler

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -227,8 +227,14 @@ namespace Mirror
             return null;
         }
 
-        // spawn handlers and prefabs
-        static bool GetPrefab(Guid assetId, out GameObject prefab)
+        /// <summary>
+        /// Find the registered prefab for this asset id.
+        /// Useful for debuggers
+        /// </summary>
+        /// <param name="assetId">asset id of the prefab</param>
+        /// <param name="prefab">the prefab gameobject</param>
+        /// <returns>true if prefab was registered</returns>
+        public static bool GetPrefab(Guid assetId, out GameObject prefab)
         {
             prefab = null;
             return assetId != Guid.Empty &&

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -438,6 +438,22 @@ namespace Mirror
             }
             return false;
         }
+
+        /// <summary>
+        /// Gets the handler function for a given hash
+        /// Can be used by profilers and debuggers
+        /// </summary>
+        /// <param name="cmdHash">rpc function hash</param>
+        /// <returns>The function delegate that will handle the command</returns>
+        public CmdDelegate GetRpcHandler(int cmdHash)
+        {
+            if (cmdHandlerDelegates.TryGetValue(cmdHash, out Invoker invoker))
+            {
+                return invoker.invokeFunction;
+            }
+            return null;
+        }
+
         #endregion
 
         #region Helpers

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -188,6 +188,8 @@ namespace Mirror
         // keep track of all sceneIds to detect scene duplicates
         static readonly Dictionary<ulong, NetworkIdentity> sceneIds = new Dictionary<ulong, NetworkIdentity>();
 
+        public NetworkIdentity GetSceneIdenity(ulong id) => sceneIds[id];
+
         // used when adding players
         internal void SetClientOwner(NetworkConnection conn)
         {


### PR DESCRIPTION
These methods are needed by the profiler to display useful information about the messages