### PR TITLE
feat: Component-based Authentication - via abstract

### DIFF
--- a/Assets/Mirror/Examples/Tanks/Scenes/Scene.unity
+++ b/Assets/Mirror/Examples/Tanks/Scenes/Scene.unity
@@ -451,6 +451,7 @@ MonoBehaviour:
   transport: {fileID: 1282001521}
   networkAddress: localhost
   maxConnections: 4
+  authenticator: {fileID: 0}
   playerPrefab: {fileID: 1916082411674582, guid: 6f43bf5488a7443d19ab2a83c6b91f35,
     type: 3}
   autoCreatePlayer: 1
@@ -477,7 +478,7 @@ MonoBehaviour:
   OnClientDataReceived:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mirror.UnityEventByteArray, Mirror, Version=0.0.0.0, Culture=neutral,
+    m_TypeName: Mirror.UnityEventArraySegment, Mirror, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
   OnClientError:
     m_PersistentCalls:
@@ -496,7 +497,7 @@ MonoBehaviour:
   OnServerDataReceived:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Mirror.UnityEventIntByteArray, Mirror, Version=0.0.0.0, Culture=neutral,
+    m_TypeName: Mirror.UnityEventIntArraySegment, Mirror, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
   OnServerError:
     m_PersistentCalls:
@@ -509,6 +510,8 @@ MonoBehaviour:
     m_TypeName: Mirror.UnityEventInt, Mirror, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   port: 7777
   NoDelay: 1
+  serverMaxMessageSize: 16384
+  clientMaxMessageSize: 16384
 --- !u!1 &1458789072
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -49,7 +49,7 @@ namespace Mirror
         ///
         /// Make sure to call OnServerAuthenticated.Invoke() after a successful authentication!
         /// </summary>
-        /// <param name="conn">Connection from client.</param>
+        /// <param name="conn">Connection from server.</param>
         public abstract void OnServerAuthenticate(NetworkConnection conn);
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -1,0 +1,83 @@
+using System;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Mirror
+{
+    /// <summary>
+    /// Unity Event for the NetworkConnection
+    /// </summary>
+    [Serializable] public class UnityEventNetworkConnection : UnityEvent<NetworkConnection> { }
+
+    /// <summary>
+    /// Base class for implementing component-based authentication during the Connect phase
+    /// </summary>
+    [AddComponentMenu("Network/NetworkAuthenticator")]
+    [HelpURL("https://mirror-networking.com/xmldocs/articles/Concepts/Authentication.html")]
+    public class NetworkAuthenticator : MonoBehaviour
+    {
+        [Header("Event Listeners (optional)")]
+
+        /// <summary>
+        /// Notify subscribers on the server when a client is authenticated
+        /// </summary>
+        [Tooltip("Mirror has an internal subscriber to this event. You can add your own here.")]
+        public UnityEventNetworkConnection OnServerAuthenticated = new UnityEventNetworkConnection();
+
+        /// <summary>
+        /// Notify subscribers on the client when the client is authenticated
+        /// </summary>
+        [Tooltip("Mirror has an internal subscriber to this event. You can add your own here.")]
+        public UnityEventNetworkConnection OnClientAuthenticated = new UnityEventNetworkConnection();
+
+        /// <summary>
+        /// Called on server from StartServer to initialize the Authenticator
+        /// <para>Server message handlers should be registered in this method.</para>
+        /// </summary>
+        public virtual void OnStartServer() { }
+
+        /// <summary>
+        /// Called on client from StartClient to initialize the Authenticator
+        /// <para>Client message handlers should be registered in this method.</para>
+        /// </summary>
+        public virtual void OnStartClient() { }
+
+        // This will get more code in the near future
+        internal void OnServerAuthenticateInternal(NetworkConnection conn)
+        {
+            OnServerAuthenticate(conn);
+        }
+
+        /// <summary>
+        /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate
+        /// </summary>
+        /// <param name="conn">Connection from client.</param>
+        public virtual void OnServerAuthenticate(NetworkConnection conn)
+        {
+            // setting NetworkConnection.isAuthenticated = true is Required
+            conn.isAuthenticated = true;
+
+            // invoking the event is Required
+            OnServerAuthenticated.Invoke(conn);
+        }
+
+        // This will get more code in the near future
+        internal void OnClientAuthenticateInternal(NetworkConnection conn)
+        {
+            OnClientAuthenticate(conn);
+        }
+
+        /// <summary>
+        /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
+        /// </summary>
+        /// <param name="conn">Connection from client.</param>
+        public virtual void OnClientAuthenticate(NetworkConnection conn)
+        {
+            // setting NetworkConnection.isAuthenticated = true is Required
+            conn.isAuthenticated = true;
+
+            // invoking the event is Required
+            OnClientAuthenticated.Invoke(conn);
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -59,5 +59,19 @@ namespace Mirror
         /// </summary>
         /// <param name="conn">Connection from client.</param>
         public abstract void OnClientAuthenticate(NetworkConnection conn);
+
+        void OnValidate()
+        {
+#if UNITY_EDITOR
+            // automatically assign NetworkManager field if we add this to
+            // NetworkManager
+            NetworkManager manager = GetComponent<NetworkManager>();
+            if (manager != null && manager.authenticator == null)
+            {
+                manager.authenticator = this;
+                UnityEditor.Undo.RecordObject(gameObject, "Assigned NetworkManager authenticator");
+            }
+        }
+#endif
     }
 }

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -14,18 +14,20 @@ namespace Mirror
     /// </summary>
     [AddComponentMenu("Network/NetworkAuthenticator")]
     [HelpURL("https://mirror-networking.com/xmldocs/articles/Concepts/Authentication.html")]
-    public class NetworkAuthenticator : MonoBehaviour
+    public abstract class NetworkAuthenticator : MonoBehaviour
     {
         [Header("Event Listeners (optional)")]
 
         /// <summary>
-        /// Notify subscribers on the server when a client is authenticated
+        /// Notify subscribers on the server when a client is authenticated.
+        /// Call this from OnServerAuthenticate when successfully authenticated.
         /// </summary>
         [Tooltip("Mirror has an internal subscriber to this event. You can add your own here.")]
         public UnityEventNetworkConnection OnServerAuthenticated = new UnityEventNetworkConnection();
 
         /// <summary>
         /// Notify subscribers on the client when the client is authenticated
+        /// Call this from OnServerAuthenticate when successfully authenticated.
         /// </summary>
         [Tooltip("Mirror has an internal subscriber to this event. You can add your own here.")]
         public UnityEventNetworkConnection OnClientAuthenticated = new UnityEventNetworkConnection();
@@ -42,42 +44,20 @@ namespace Mirror
         /// </summary>
         public virtual void OnStartClient() { }
 
-        // This will get more code in the near future
-        internal void OnServerAuthenticateInternal(NetworkConnection conn)
-        {
-            OnServerAuthenticate(conn);
-        }
-
         /// <summary>
-        /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate
+        /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate.
+        ///
+        /// Make sure to call OnServerAuthenticated.Invoke() after a successful authentication!
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public virtual void OnServerAuthenticate(NetworkConnection conn)
-        {
-            // setting NetworkConnection.isAuthenticated = true is Required
-            conn.isAuthenticated = true;
-
-            // invoking the event is Required
-            OnServerAuthenticated.Invoke(conn);
-        }
-
-        // This will get more code in the near future
-        internal void OnClientAuthenticateInternal(NetworkConnection conn)
-        {
-            OnClientAuthenticate(conn);
-        }
+        public abstract void OnServerAuthenticate(NetworkConnection conn);
 
         /// <summary>
         /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
+        ///
+        /// Make sure to call OnClientAuthenticated.Invoke() after a successful authentication!
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public virtual void OnClientAuthenticate(NetworkConnection conn)
-        {
-            // setting NetworkConnection.isAuthenticated = true is Required
-            conn.isAuthenticated = true;
-
-            // invoking the event is Required
-            OnClientAuthenticated.Invoke(conn);
-        }
+        public abstract void OnClientAuthenticate(NetworkConnection conn);
     }
 }

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -45,7 +45,7 @@ namespace Mirror
         public virtual void OnStartClient() { }
 
         /// <summary>
-        /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate.
+        /// Called on server from OnServerAuthenticateInternal when a server needs to authenticate.
         ///
         /// Make sure to call OnServerAuthenticated.Invoke() after a successful authentication!
         /// </summary>

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs.meta
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 407fc95d4a8257f448799f26cdde0c2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -33,6 +33,17 @@ namespace Mirror
         public int connectionId = -1;
 
         /// <summary>
+        /// Flag that indicates the client has been authenticated.
+        /// </summary>
+        public bool isAuthenticated;
+
+        /// <summary>
+        /// General purpose object to hold authentication data, character selection, tokens, etc.
+        /// associated with the connection for reference after Authentication completes.
+        /// </summary>
+        public object authenticationData;
+
+        /// <summary>
         /// Flag that tells if the connection has been marked as "ready" by a client calling ClientScene.Ready().
         /// <para>This property is read-only. It is set by the system on the client when ClientScene.Ready() is called, and set by the system on the server when a ready message is received from a client.</para>
         /// <para>A client that is ready is sent spawned objects by the server and updates to the state of spawned objects. A client that is not ready is not sent spawned objects.</para>


### PR DESCRIPTION
**abstract NetworkAuthenticator based on #1057** 
* inherit from NetworkAuthenticator to make your own
* simply call OnServerAuthenticated.Invoke() and Mirror handles the successful auth. This way we can still control what we do upon successful auth, and auth components never have to worry.
* users don't have to worry about how to properly auth someone. just invoke the event.
* existing projects won't be touched
* simple projects remain simple. no empty component added
* it's easier to use than #1057 . there is only one way to do it. inherit and add component. nothing to remove etc.
* inspector assigned events persist after OnStopServer because we only remove exactly those, not all listeners

basically, KISS - keep it simple and stupid.

**TODO**
* update docs

NetworkManager still works without authenticator:
![image](https://user-images.githubusercontent.com/16416509/64925415-82e9e400-d7f0-11e9-9594-d71d073cacf1.png)


Example:
![image](https://user-images.githubusercontent.com/16416509/64925413-76fe2200-d7f0-11e9-8339-9ca4af0fa8b6.png)

```csharp
using System.Collections;
using System.Collections.Generic;
using UnityEngine;
using Mirror;

public class ExampleAuthenticator : NetworkAuthenticator
{
    /// <summary>
    /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate
    /// </summary>
    /// <param name="conn">Connection from client.</param>
    public override void OnServerAuthenticate(NetworkConnection conn)
    {
        OnServerAuthenticated.Invoke(conn);
    }

    /// <summary>
    /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
    /// </summary>
    /// <param name="conn">Connection from client.</param>
    public override void OnClientAuthenticate(NetworkConnection conn)
    {
        OnServerAuthenticated.Invoke(conn);
    }
}
```
