### PR TITLE
feat: transports can now send to multiple connections

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -13,6 +13,16 @@ namespace Mirror
             connectionId = 0;
         }
 
+        public override bool Send<T>(T msg, int channelId = 0)
+        {
+            // TODO this can be done by queueing the msg itsef
+            // instead of serializing and deserializing
+            byte[] packet = MessagePacker.Pack(msg);
+            NetworkClient.localClientPacketQueue.Enqueue(packet);
+            return true;
+        }
+
+        [Obsolete]
         internal override bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
         {
             NetworkClient.localClientPacketQueue.Enqueue(bytes);
@@ -30,6 +40,18 @@ namespace Mirror
             connectionId = 0;
         }
 
+        public override bool Send<T>(T msg, int channelId = Channels.DefaultReliable)
+        {
+
+            // handle the server's message directly
+            // TODO any way to do this without serializing the message?
+            byte[] data = MessagePacker.Pack(msg);
+            NetworkServer.localConnection.TransportReceive(new ArraySegment<byte>(data));
+            return true;
+        }
+
+
+        [Obsolete]
         internal override bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
         {
             if (bytes.Length == 0)

--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -42,14 +42,12 @@ namespace Mirror
 
         public override bool Send<T>(T msg, int channelId = Channels.DefaultReliable)
         {
-
             // handle the server's message directly
             // TODO any way to do this without serializing the message?
             byte[] data = MessagePacker.Pack(msg);
             NetworkServer.localConnection.TransportReceive(new ArraySegment<byte>(data));
             return true;
         }
-
 
         [Obsolete]
         internal override bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -25,6 +25,11 @@ namespace Mirror
             return typeof(T).FullName.GetStableHashCode() & 0xFFFF;
         }
 
+        public static int GetId(Type type)
+        {
+            return type.FullName.GetStableHashCode() & 0xFFFF;
+        }
+
         // pack message before sending
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Use Pack<T> instead")]
         public static byte[] PackMessage(int msgType, MessageBase msg)
@@ -54,7 +59,7 @@ namespace Mirror
             try
             {
                 // write message type
-                int msgType = GetId<T>();
+                int msgType = GetId(message.GetType());
                 writer.WriteUInt16((ushort)msgType);
 
                 // serialize message into writer

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -113,8 +113,7 @@ namespace Mirror
             // create server connection to local client
             ULocalConnectionToClient connectionToClient = new ULocalConnectionToClient();
             NetworkServer.SetLocalConnection(connectionToClient);
-
-            localClientPacketQueue.Enqueue(MessagePacker.Pack(new ConnectMessage()));
+            connectionToClient.Send(new ConnectMessage());
         }
 
         /// <summary>
@@ -197,7 +196,7 @@ namespace Mirror
             {
                 if (isConnected)
                 {
-                    localClientPacketQueue.Enqueue(MessagePacker.Pack(new DisconnectMessage()));
+                    NetworkServer.localConnection.Send(new DisconnectMessage());
                 }
                 NetworkServer.RemoveLocalConnection();
             }
@@ -274,6 +273,8 @@ namespace Mirror
                 while (localClientPacketQueue.Count > 0)
                 {
                     byte[] packet = localClientPacketQueue.Dequeue();
+                    // TODO avoid serializing and deserializng the message
+                    // just pass it as is
                     OnDataReceived(new ArraySegment<byte>(packet));
                 }
             }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -240,7 +240,6 @@ namespace Mirror
         /// <returns></returns>
         public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
-            // pack message and send
             if (Transport.activeTransport.ClientConnected())
             {
                 return Transport.activeTransport.ClientSend(channelId, msg);

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -61,6 +61,9 @@ namespace Mirror
         /// </summary>
         public float lastMessageTime;
 
+        // recipient list used to send to transport
+        private static readonly List<int> recipientsCache = new List<int>();
+
         /// <summary>
         /// Obsolete: use <see cref="identity"/> instead
         /// </summary>
@@ -238,13 +241,23 @@ namespace Mirror
         public virtual bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             // pack message and send
-            byte[] message = MessagePacker.Pack(msg);
-            NetworkDiagnostics.OnSend(msg, channelId, message.Length, 1);
-            return SendBytes(message, channelId);
+            if (Transport.activeTransport.ClientConnected())
+            {
+                return Transport.activeTransport.ClientSend(channelId, msg);
+            }
+            else if (Transport.activeTransport.ServerActive())
+            {
+                recipientsCache.Clear();
+                recipientsCache.Add(connectionId);
+                Transport.activeTransport.ServerSend(recipientsCache, channelId, msg);
+                return true;
+            }
+            return false;
         }
 
         // internal because no one except Mirror should send bytes directly to
         // the client. they would be detected as a message. send messages instead.
+        [Obsolete]
         internal virtual bool SendBytes(byte[] bytes, int channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend con:" + connectionId + " bytes:" + BitConverter.ToString(bytes));
@@ -261,7 +274,6 @@ namespace Mirror
                 Debug.LogError("NetworkConnection.SendBytes cannot send zero bytes");
                 return false;
             }
-
             return TransportSend(channelId, bytes);
         }
 
@@ -334,7 +346,7 @@ namespace Mirror
         /// <returns></returns>
         public bool InvokeHandler<T>(T msg) where T : IMessageBase
         {
-            int msgType = MessagePacker.GetId<T>();
+            int msgType = MessagePacker.GetId(msg.GetType());
             byte[] data = MessagePacker.Pack(msg);
             return InvokeHandler(msgType, new NetworkReader(data));
         }
@@ -377,13 +389,15 @@ namespace Mirror
         /// <param name="channelId">Channel to send data on.</param>
         /// <param name="bytes">Data to send.</param>
         /// <returns></returns>
+        [Obsolete("Use Send<T>(T message) instead") ]
         public virtual bool TransportSend(int channelId, byte[] bytes)
         {
             if (Transport.activeTransport.ClientConnected())
             {
                 return Transport.activeTransport.ClientSend(channelId, bytes);
             }
-            else if (Transport.activeTransport.ServerActive())
+
+            if (Transport.activeTransport.ServerActive())
             {
                 return Transport.activeTransport.ServerSend(connectionId, channelId, bytes);
             }

--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -9,6 +10,10 @@ namespace Mirror
     public class MultiplexTransport : Transport
     {
         public Transport[] transports;
+
+        // used to partition recipients for each one of the base transports
+        // without allocating a new list every time
+        private List<int>[] recipientsCache;
 
         public void Awake()
         {
@@ -62,9 +67,9 @@ namespace Mirror
             GetAvailableTransport().ClientDisconnect();
         }
 
-        public override bool ClientSend(int channelId, byte[] data)
+        public override bool ClientSend<T>(int channelId, T msg)
         {
-            return GetAvailableTransport().ClientSend(channelId, data);
+            return GetAvailableTransport().ClientSend(channelId, msg);
         }
 
         public override int GetMaxPacketSize(int channelId = 0)
@@ -98,9 +103,13 @@ namespace Mirror
 
         void InitServer()
         {
+            recipientsCache = new List<int>[transports.Length];
+
             // wire all the base transports to my events
             for (int i = 0; i < transports.Length; i++)
             {
+                recipientsCache[i] = new List<int>();
+
                 // this is required for the handlers,  if I use i directly
                 // then all the handlers will use the last i
                 int locali = i;
@@ -146,11 +155,31 @@ namespace Mirror
             return transports[transportId].ServerDisconnect(baseConnectionId);
         }
 
-        public override bool ServerSend(int connectionId, int channelId, byte[] data)
+        public override void ServerSend<T>(IList<int> recipients, int channelId, T msg)
         {
-            int baseConnectionId = ToBaseId(connectionId);
-            int transportId = ToTransportId(connectionId);
-            return transports[transportId].ServerSend(baseConnectionId, channelId, data);
+            // the message may be for different transports,
+            // partition the recipients by transport and update the base
+
+            foreach (List<int> list in recipientsCache)
+            {
+                list.Clear();
+            }
+
+            foreach (int connectionId in recipients)
+            {
+                int baseConnectionId = ToBaseId(connectionId);
+                int transportId = ToTransportId(connectionId);
+                recipientsCache[transportId].Add(baseConnectionId);
+            }
+
+            for (int i=0; i< transports.Length; i++)
+            {
+                List<int> baseRecipiens = recipientsCache[i];
+                if (baseRecipiens.Count > 0)
+                {
+                    transports[i].ServerSend(baseRecipiens, channelId, msg);
+                }
+            }
         }
 
         public override void ServerStart()

--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -158,8 +158,7 @@ namespace Mirror
         public override void ServerSend<T>(IList<int> recipients, int channelId, T msg)
         {
             // the message may be for different transports,
-            // partition the recipients by transport and update the base
-
+            // partition the recipients by transport send the message
             foreach (List<int> list in recipientsCache)
             {
                 list.Clear();

--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -97,6 +97,7 @@ namespace Mirror
         public override bool ServerActive() => server.Active;
         public override void ServerStart() => server.Start(port);
         public override bool ServerSend(int connectionId, int channelId, byte[] data) => server.Send(connectionId, data);
+
         public bool ProcessServerMessage()
         {
             if (server.GetNextMessage(out Telepathy.Message message))


### PR DESCRIPTION
Transports can choose to implement one of two ServerSend methods.

They can implement 
```cs
        public override bool ServerSend(int connectionId, int channelId, byte[] data)
        {
            // do your thing
        }
```

or they can implement:
```cs
        public override void ServerSend<T>(IList<int> recipients, int channelId, T msg) 
        {
            ...
        }
```

You may want to implement the second one if you want an allocation free transport.


In a similar way,  transports can chose to implement one of two ClientSend methods.