### PR TITLE
feat: transports can now send to multiple connections

### DIFF
--- a/Assets/Mirror/Components/NetworkLobbyManager.cs
+++ b/Assets/Mirror/Components/NetworkLobbyManager.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-using UnityEngine.Serialization;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Components/NetworkLobbyPlayer.cs
+++ b/Assets/Mirror/Components/NetworkLobbyPlayer.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Mirror
 {


### PR DESCRIPTION
Transports can choose to implement one of two ServerSend methods.

They can implement 
```cs
        public override bool ServerSend(int connectionId, int channelId, byte[] data)
        {
            // do your thing
        }
```

or they can implement:
```cs
        public override void ServerSend<T>(IList<int> recipients, int channelId, T msg) 
        {
            ...
        }
```

You may want to implement the second one if you want an allocation free transport.


In a similar way,  transports can chose to implement one of two ClientSend methods.