### PR TITLE
fix: Cmds can be called from any assembly, fix #1108

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -841,17 +841,17 @@ namespace Mirror.Weaver
             names.Add(md.Name);
             commands.Add(md);
 
-            MethodDefinition cmdFunc = CommandProcessor.ProcessCommandInvoke(netBehaviourSubclass, md);
+            MethodDefinition cmdCallFunc = CommandProcessor.ProcessCommandCall(netBehaviourSubclass, md, ca);
+
+            MethodDefinition cmdFunc = CommandProcessor.ProcessCommandInvoke(netBehaviourSubclass, md, cmdCallFunc);
             if (cmdFunc != null)
             {
                 commandInvocationFuncs.Add(cmdFunc);
             }
 
-            MethodDefinition cmdCallFunc = CommandProcessor.ProcessCommandCall(netBehaviourSubclass, md, ca);
             if (cmdCallFunc != null)
             {
                 commandCallFuncs.Add(cmdCallFunc);
-                Weaver.WeaveLists.replaceMethods[md.FullName] = cmdCallFunc;
             }
         }
     }


### PR DESCRIPTION
This changes how code is generated for commands.
Previously,  it generated code like this:

```cs
private void CmdUpdate(int something, string other)
{
        Debug.Log((object)$"id {something} data {other}");
}

private void Update()
{
        if (base.isClient && Input.GetKeyDown(32))
        {
                CallCmdUpdate(playerNo, playerData.ToString());
        }
        if (base.isLocalPlayer)
        {
                image.set_color(new Color(1f, 1f, 1f, 0.1f));
        }
        playerNameText.set_color(playerColor);
        playerNameText.set_text($"Player {playerNo:00}");
        playerDataText.set_text($"Data: {playerData:000}");
}

private void MirrorProcessed()
{
}

protected static void InvokeCmdCmdUpdate(NetworkBehaviour obj, NetworkReader reader)
{
        if (!NetworkServer.active)
        {
                Debug.LogError((object)"Command CmdUpdate called on client.");
        }
        else
        {
                ((Player)obj).CmdUpdate(reader.ReadPackedInt32(), reader.ReadString());
        }
}

public void CallCmdUpdate(int something, string other)
{
        if (base.isServer)
        {
                CmdUpdate(something, other);
                return;
        }
        NetworkWriter writer = NetworkWriterPool.GetWriter();
        writer.WritePackedInt32(something);
        writer.WriteString(other);
        SendCommandInternal(typeof(Player), "CmdUpdate", writer, 0);
        NetworkWriterPool.Recycle(writer);
}

static Player()
{
        NetworkBehaviour.RegisterCommandDelegate(typeof(Player), "CmdUpdate", InvokeCmdCmdUpdate);
}
```

Notice that every call to CmdUpdate  was replaced by CallCmdUpdate,  which is troublesome for refection as well as problematic when replacing code in dependent assemblies.

With this pull request,  we no longer replace calls,  instead we generate this code:

```cs
private void CmdUpdate(int something, string other)
{
        if (base.isServer)
        {
                CallCmdUpdate(something, other);
                return;
        }
        NetworkWriter writer = NetworkWriterPool.GetWriter();
        writer.WritePackedInt32(something);
        writer.WriteString(other);
        SendCommandInternal(typeof(Player), "CmdUpdate", writer, 0);
        NetworkWriterPool.Recycle(writer);
}

private void Update()
{
        //IL_0055: Unknown result type (might be due to invalid IL or missing references)
        //IL_0067: Unknown result type (might be due to invalid IL or missing references)
        if (base.isClient && Input.GetKeyDown(32))
        {
                CmdUpdate(playerNo, playerData.ToString());
        }
        if (base.isLocalPlayer)
        {
                image.set_color(new Color(1f, 1f, 1f, 0.1f));
        }
        playerNameText.set_color(playerColor);
        playerNameText.set_text($"Player {playerNo:00}");
        playerDataText.set_text($"Data: {playerData:000}");
}

private void MirrorProcessed()
{
}

protected static void InvokeCmdCmdUpdate(NetworkBehaviour obj, NetworkReader reader)
{
        if (!NetworkServer.active)
        {
                Debug.LogError((object)"Command CmdUpdate called on client.");
        }
        else
        {
                ((Player)obj).CallCmdUpdate(reader.ReadPackedInt32(), reader.ReadString());
        }
}

public void CallCmdUpdate(int something, string other)
{
        Debug.Log((object)$"id {something} data {other}");
}

static Player()
{
        NetworkBehaviour.RegisterCommandDelegate(typeof(Player), "CmdUpdate", InvokeCmdCmdUpdate);
}
```

notice the body of the original function has been moved to CallCmdUpdate and CmdUpdate is now the proxy method.
