### PR TITLE
fix: Prevent Compiler Paradox

### DIFF
--- a/Assets/Mirror/CompilerSymbols.meta
+++ b/Assets/Mirror/CompilerSymbols.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f8b918bcd89f5c488b06f5574f34760
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/CompilerSymbols/Mirror.CompilerSymbols.asmdef
+++ b/Assets/Mirror/CompilerSymbols/Mirror.CompilerSymbols.asmdef
@@ -1,3 +1,14 @@
-﻿{
-	"name": "Mirror.CompilerSymbols"
+{
+    "name": "Mirror.CompilerSymbols",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
 }

--- a/Assets/Mirror/CompilerSymbols/Mirror.CompilerSymbols.asmdef
+++ b/Assets/Mirror/CompilerSymbols/Mirror.CompilerSymbols.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "Mirror.CompilerSymbols"
+}

--- a/Assets/Mirror/CompilerSymbols/Mirror.CompilerSymbols.asmdef.meta
+++ b/Assets/Mirror/CompilerSymbols/Mirror.CompilerSymbols.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 325984b52e4128546bc7558552f8b1d2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
+++ b/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using UnityEditor;
+
+namespace Mirror
+{
+    static class PreprocessorDefine
+    {
+        /// <summary>
+        /// Add define symbols as soon as Unity gets done compiling.
+        /// </summary>
+        [InitializeOnLoadMethod]
+        static void AddDefineSymbols()
+        {
+            HashSet<string> defines = new HashSet<string>(PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup).Split(';'))
+            {
+                "MIRROR",
+                "MIRROR_1726_OR_NEWER",
+                "MIRROR_3_0_OR_NEWER",
+                "MIRROR_3_12_OR_NEWER",
+                "MIRROR_4_0_OR_NEWER"
+            };
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, string.Join(";", defines));
+        }
+    }
+}

--- a/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs.meta
+++ b/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 42760e6965bea614ca5706a6ba059531
+guid: f1d66fe74ec6f42dd974cba37d25d453
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Mirror/Editor/PreprocessorDefine.cs
+++ b/Assets/Mirror/Editor/PreprocessorDefine.cs
@@ -1,25 +1,4 @@
-using System.Collections.Generic;
-using UnityEditor;
-
-namespace Mirror
-{
-    static class PreprocessorDefine
-    {
-        /// <summary>
-        /// Add define symbols as soon as Unity gets done compiling.
-        /// </summary>
-        [InitializeOnLoadMethod]
-        static void AddDefineSymbols()
-        {
-            HashSet<string> defines = new HashSet<string>(PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup).Split(';'))
-            {
-                "MIRROR",
-                "MIRROR_1726_OR_NEWER",
-                "MIRROR_3_0_OR_NEWER",
-                "MIRROR_3_12_OR_NEWER",
-                "MIRROR_4_0_OR_NEWER"
-            };
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, string.Join(";", defines));
-        }
-    }
-}
+﻿// This file was moved to Mirror/CompilerSymbols in Mirror 4.0
+// The purpose of this file is to get the old file overwritten
+// when users update from the asset store to prevent a flood of errors
+// from having the old file still in the project as a straggler.

--- a/Assets/Mirror/Editor/PreprocessorDefine.cs
+++ b/Assets/Mirror/Editor/PreprocessorDefine.cs
@@ -1,4 +1,4 @@
-﻿// This file was moved to Mirror/CompilerSymbols in Mirror 4.0
+// This file was moved to Mirror/CompilerSymbols in Mirror 4.0
 // The purpose of this file is to get the old file overwritten
 // when users update from the asset store to prevent a flood of errors
 // from having the old file still in the project as a straggler.

--- a/Assets/Mirror/Runtime/Mirror.asmdef
+++ b/Assets/Mirror/Runtime/Mirror.asmdef
@@ -1,8 +1,14 @@
 {
     "name": "Mirror",
-    "references": [],
+    "references": [
+        "Mirror.CompilerSymbols"
+    ],
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
 }


### PR DESCRIPTION
**The Paradox:**
Compiler errors prevented the editor script from adding the symbol that would cure them.

Move the PreprocessorDefine script to its own folder "CompilerSymbols" with its own AsmDef, and make Mirror's core AsmDef dependent on it to force the MIRROR_4_0_OR_NEWER symbol to get added first so that all the transports and whatever else can compile.

An empty PreprocessorDefine.cs is left in the Editor folder to replace the old one to prevent duplicates when upgrading.

