### PR TITLE
Don't Short Circuit Host Messages

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -381,8 +381,7 @@ namespace Mirror
                 foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
                 {
                     bool isSelf = kvp.Value == identity.connectionToClient;
-                    if ((!isSelf || includeSelf) &&
-                        kvp.Value.isReady)
+                    if ((!isSelf || includeSelf || kvp.Value is ULocalConnectionToClient) && kvp.Value.isReady)
                     {
                         count++;
 


### PR DESCRIPTION
Five lines down Host messages are handled correctly:

```cs
    // use local connection directly because it doesn't send via transport
    if (kvp.Value is ULocalConnectionToClient)
        result &= localConnection.Send(segment);
```