### PR TITLE
fix: Don't give host player authority by default

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1118,7 +1118,7 @@ namespace Mirror
             clientAuthorityOwner = null;
 
             // server now has authority (this is only called on server)
-            ForceAuthority(true);
+            ForceAuthority(false);
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -511,7 +511,6 @@ namespace Mirror
                 return;
             }
             m_IsServer = true;
-            hasAuthority = !localPlayerAuthority;
 
             observers = new Dictionary<int, NetworkConnection>();
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1453,7 +1453,7 @@ namespace Mirror
                     Spawn(identity.gameObject);
 
                     // these objects are server authority - even if "localPlayerAuthority" is set on them
-                    identity.ForceAuthority(true);
+                    identity.ForceAuthority(false);
                 }
             }
             return true;


### PR DESCRIPTION
Server always has "god rights" on everything.  Host Player needs to act like a client as much as possible, so should only have `hasAuthority == true` if explicitly assigned.

This PR only effects scene and spawned objects.

Player objects that have Local Player Authority checked are not effected, nor are objects spawned via `NetworkServer.SpawnedWithClientAuthority()`.

Fixes #959 
