### PR TITLE
fix: Suspend server transport while changing scenes

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -646,7 +646,7 @@ namespace Mirror
             NetworkServer.SendToAll(msg);
 
             // Suspend the server's transport while changing scenes
-            // It will be reneabled in FinishScene.
+            // It will be re-enabled in FinishScene.
             Transport.activeTransport.enabled = false;
 
             startPositionIndex = 0;

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -645,6 +645,10 @@ namespace Mirror
 
             NetworkServer.SendToAll(msg);
 
+            // Suspend the server's transport while changing scenes
+            // It will be reneabled in FinishScene.
+            Transport.activeTransport.enabled = false;
+
             startPositionIndex = 0;
             startPositions.Clear();
         }


### PR DESCRIPTION
Fixes #1159 

When `NetworkManager.ServerSceneChange` is invoked, it's possible for client to change scenes and return a Ready message to server before the server has finished changing scenes.  Without this fix, server fires off a spawn message to that client of all the objects in the prior scene, resulting in the image below.

With this change, server transport is paused until FinishScene re-enables it, and any Ready messages held in abeyance are correctly handled in the context of the new scene.

![image](https://user-images.githubusercontent.com/9826063/67154274-5d586a80-f2c7-11e9-8db7-e0a32bf94065.png)
