### PR TITLE
refactor:use ToString() to display connections

### DIFF
--- a/Assets/Mirror/Editor/NetworkIdentityEditor.cs
+++ b/Assets/Mirror/Editor/NetworkIdentityEditor.cs
@@ -79,9 +79,9 @@ namespace Mirror
                     foreach (KeyValuePair<int, NetworkConnection> kvp in networkIdentity.observers)
                     {
                         if (kvp.Value.identity != null)
-                            EditorGUILayout.ObjectField("Connection " + kvp.Value.connectionId, kvp.Value.identity.gameObject, typeof(GameObject), false);
+                            EditorGUILayout.ObjectField(kvp.Value.ToString(), kvp.Value.identity.gameObject, typeof(GameObject), false);
                         else
-                            EditorGUILayout.TextField("Connection " + kvp.Value.connectionId);
+                            EditorGUILayout.TextField(kvp.Value.ToString());
                     }
                     EditorGUI.indentLevel -= 1;
                 }

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -159,7 +159,7 @@ namespace Mirror
 
                     foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
                     {
-                        GUI.Label(observerRect, kvp.Value.address + ":" + kvp.Value.connectionId, styles.componentName);
+                        GUI.Label(observerRect, kvp.Value.address + ":" + kvp.Value, styles.componentName);
                         observerRect.y += observerRect.height;
                         lastY = observerRect.y;
                     }

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -726,7 +726,7 @@ namespace Mirror
         // called for the one object in the spawn message which is the owner!
         internal static void OnSpawnMessageForOwner(uint netId)
         {
-            if (LogFilter.Debug) Debug.Log("ClientScene.OnOwnerMessage - connectionId=" + readyConnection.connectionId + " netId: " + netId);
+            if (LogFilter.Debug) Debug.Log("ClientScene.OnOwnerMessage - " + readyConnection + " netId: " + netId);
 
             // is there already an owner that is a different object??
             if (readyConnection.identity != null)

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -141,7 +141,7 @@ namespace Mirror
                 if (requireAuthenication && !networkMessage.conn.isAuthenticated)
                 {
                     // message requires authentication, but the connection was not authenticated
-                    Debug.LogWarning($"Closing connection: {networkMessage.conn.connectionId}. Received message {typeof(T)} that required authentication, but the user has not authenticated yet");
+                    Debug.LogWarning($"Closing connection: {networkMessage.conn}. Received message {typeof(T)} that required authentication, but the user has not authenticated yet");
                     networkMessage.conn.Disconnect();
                     return;
                 }
@@ -150,7 +150,7 @@ namespace Mirror
             }
             catch (Exception exception)
             {
-                Debug.LogError("Closed connection: " + networkMessage.conn.connectionId + ". This can happen if the other side accidentally (or an attacker intentionally) sent invalid data. Reason: " + exception);
+                Debug.LogError("Closed connection: " + networkMessage.conn + ". This can happen if the other side accidentally (or an attacker intentionally) sent invalid data. Reason: " + exception);
                 networkMessage.conn.Disconnect();
                 return;
             }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -122,7 +122,7 @@ namespace Mirror
         /// <param name="localPlayer"></param>
         internal static void AddLocalPlayer(NetworkIdentity localPlayer)
         {
-            if (LogFilter.Debug) Debug.Log("Local client AddLocalPlayer " + localPlayer.gameObject.name + " conn=" + connection.connectionId);
+            if (LogFilter.Debug) Debug.Log("Local client AddLocalPlayer " + localPlayer.gameObject.name + " " + connection);
             connection.isReady = true;
             connection.identity = localPlayer;
             if (localPlayer != null)

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -278,7 +278,7 @@ namespace Mirror
         List<int> singleConnectionId = new List<int>{-1};
         internal virtual bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
-            if (logNetworkMessages) Debug.Log("ConnectionSend con:" + connectionId + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
+            if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
             // validate packet size first.
             if (ValidatePacketSize(segment, channelId))
@@ -315,7 +315,7 @@ namespace Mirror
 
         public override string ToString()
         {
-            return $"connectionId: {connectionId} isReady: {isReady}";
+            return $"connection({connectionId})";
         }
 
         internal void AddToVisList(NetworkIdentity identity)
@@ -370,7 +370,7 @@ namespace Mirror
                 msgDelegate(message);
                 return true;
             }
-            Debug.LogError("Unknown message ID " + msgType + " connId:" + connectionId);
+            Debug.LogError("Unknown message ID " + msgType + " " + this);
             return false;
         }
 
@@ -418,7 +418,7 @@ namespace Mirror
             if (MessagePacker.UnpackMessage(reader, out int msgType))
             {
                 // logging
-                if (logNetworkMessages) Debug.Log("ConnectionRecv con:" + connectionId + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));
+                if (logNetworkMessages) Debug.Log("ConnectionRecv " + this + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));
 
                 // try to invoke the handler for that message
                 if (InvokeHandler(msgType, reader, channelId))
@@ -428,7 +428,7 @@ namespace Mirror
             }
             else
             {
-                Debug.LogError("Closed connection: " + connectionId + ". Invalid message header.");
+                Debug.LogError("Closed connection: " + this + ". Invalid message header.");
                 Disconnect();
             }
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -516,7 +516,7 @@ namespace Mirror
 
         static void OnConnected(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("Server accepted client:" + conn.connectionId);
+            if (LogFilter.Debug) Debug.Log("Server accepted client:" + conn);
 
             // add connection and invoke connected event
             AddConnection(conn);
@@ -540,7 +540,7 @@ namespace Mirror
         static void OnDisconnected(NetworkConnection conn)
         {
             conn.InvokeHandler(new DisconnectMessage(), -1);
-            if (LogFilter.Debug) Debug.Log("Server lost client:" + conn.connectionId);
+            if (LogFilter.Debug) Debug.Log("Server lost client:" + conn);
         }
 
         static void OnDataReceived(int connectionId, ArraySegment<byte> data, int channelId)
@@ -749,7 +749,7 @@ namespace Mirror
 
         static void SpawnObserversForConnection(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("Spawning " + NetworkIdentity.spawned.Count + " objects for conn " + conn.connectionId);
+            if (LogFilter.Debug) Debug.Log("Spawning " + NetworkIdentity.spawned.Count + " objects for conn " + conn);
 
             if (!conn.isReady)
             {
@@ -942,7 +942,7 @@ namespace Mirror
         /// <param name="conn">The connection of the client to make ready.</param>
         public static void SetClientReady(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("SetClientReadyInternal for conn:" + conn.connectionId);
+            if (LogFilter.Debug) Debug.Log("SetClientReadyInternal for conn:" + conn);
 
             // set ready
             conn.isReady = true;


### PR DESCRIPTION
use ToString to display connections.

Users should not need the connection id at all.  That should be encapsulated by mirror.
This is the first of many patches that clean up connections