### PR TITLE
Remove Authority Set

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -855,9 +855,6 @@ namespace Mirror
                 NetworkClient.AddLocalPlayer(identity);
                 identity.SetClientOwner(conn);
 
-                // Trigger OnAuthority
-                identity.ForceAuthority(true);
-
                 // Trigger OnStartLocalPlayer
                 identity.SetLocalPlayer();
                 return true;


### PR DESCRIPTION
Don't force authority in `SetupLocalPlayerForConnection` because `SetLocalPlayer` that immediately follows will set it correctly in any case.

This is called by `AddPlayerForConnection` and `InternalReplacePlayerForConnection`, neither of which need authority to be forced here.

This PR will be followed by a couple more to simplify authority, especially with regard to the host player.

`SetLocalPlayer` and `SetNotLocalPlayer` can likely be simplified after this is merged.

Baby steps.