### PR TITLE
Remove redundant force authority

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1443,12 +1443,7 @@ namespace Mirror
             foreach (NetworkIdentity identity in identities)
             {
                 if (ValidateSceneObject(identity))
-                {
                     Spawn(identity.gameObject);
-
-                    // these objects are server authority - even if "localPlayerAuthority" is set on them
-                    identity.ForceAuthority(false);
-                }
             }
             return true;
         }


### PR DESCRIPTION
Spawn calls SpawnObject which calls Reset which sets hasAuthority = false so calling ForceAuthority(false) does nothing:

```cs
internal void ForceAuthority(bool authority)
{
    if (hasAuthority == authority)
    {
        return;
    }
```