### PR TITLE
breaking: authority to reuse connectionToClient

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -34,17 +34,19 @@ namespace Mirror
         int[] transitionHash;
         float sendTimer;
 
+        [Tooltip("Set to true if animations come from owner client,  set to false if animations always come from server")]
+        public bool clientAuthority;
+
         bool sendMessagesAllowed
         {
             get
             {
                 if (isServer)
                 {
-                    if (!localPlayerAuthority)
+                    if (!clientAuthority)
                         return true;
 
-                    // This is a special case where we have localPlayerAuthority set
-                    // on a NetworkIdentity but we have not assigned the client who has
+                    // This is a special case where we have client authority but we have not assigned the client who has
                     // authority over it, no animator data will be sent over the network by the server.
                     //
                     // So we check here for a clientAuthorityOwner and if it is null we will
@@ -360,7 +362,7 @@ namespace Mirror
         /// <param name="hash">Hash id of trigger (from the Animator).</param>
         public void SetTrigger(int hash)
         {
-            if (hasAuthority && localPlayerAuthority)
+            if (hasAuthority && clientAuthority)
             {
                 if (ClientScene.readyConnection != null)
                 {
@@ -369,7 +371,7 @@ namespace Mirror
                 return;
             }
 
-            if (isServer && !localPlayerAuthority)
+            if (isServer && !clientAuthority)
             {
                 RpcOnAnimationTriggerClientMessage(hash);
             }

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -51,7 +51,7 @@ namespace Mirror
                     //
                     // So we check here for a clientAuthorityOwner and if it is null we will
                     // let the server send animation data until we receive an owner.
-                    if (netIdentity != null && netIdentity.clientAuthorityOwner == null)
+                    if (netIdentity != null && netIdentity.connectionToClient == null)
                         return true;
                 }
 

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -165,10 +165,10 @@ namespace Mirror
                     }
                 }
 
-                if (identity.clientAuthorityOwner != null)
+                if (identity.connectionToClient != null)
                 {
                     Rect ownerRect = new Rect(initialX, lastY + 10, 400, 20);
-                    GUI.Label(ownerRect, new GUIContent("Client Authority: " + identity.clientAuthorityOwner), styles.labelStyle);
+                    GUI.Label(ownerRect, new GUIContent("Client Authority: " + identity.connectionToClient), styles.labelStyle);
                 }
             }
         }

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -711,7 +711,7 @@ namespace Mirror
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
-                identity.HandleClientAuthority(msg.authority);
+                identity.ForceAuthority(msg.authority);
             }
         }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -72,6 +72,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.LogWarning("ClientScene.InternalAddPlayer");
 
+            localPlayer = identity;
             // NOTE: It can be "normal" when changing scenes for the player to be destroyed and recreated.
             // But, the player structures are not cleaned up, we'll just replace the old player
             if (readyConnection != null)

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -441,7 +441,6 @@ namespace Mirror
         static void ApplySpawnPayload(NetworkIdentity identity, SpawnMessage msg)
         {
             identity.Reset();
-            identity.pendingLocalPlayer = msg.isLocalPlayer;
             identity.assetId = msg.assetId;
 
             if (msg.isLocalPlayer)

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -316,6 +316,7 @@ namespace Mirror
     {
         public uint netId;
         public bool isLocalPlayer;
+        public bool hasAuthority;
         public Guid assetId;
         public Vector3 position;
         public Quaternion rotation;
@@ -328,6 +329,7 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             isLocalPlayer = reader.ReadBoolean();
+            hasAuthority = reader.ReadBoolean();
             assetId = reader.ReadGuid();
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
@@ -339,6 +341,7 @@ namespace Mirror
         {
             writer.WritePackedUInt32(netId);
             writer.WriteBoolean(isLocalPlayer);
+            writer.WriteBoolean(hasAuthority);
             writer.WriteGuid(assetId);
             writer.WriteVector3(position);
             writer.WriteQuaternion(rotation);
@@ -351,6 +354,7 @@ namespace Mirror
     {
         public uint netId;
         public bool isLocalPlayer;
+        public bool hasAuthority;
         public ulong sceneId;
         public Vector3 position;
         public Quaternion rotation;
@@ -363,6 +367,7 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             isLocalPlayer = reader.ReadBoolean();
+            hasAuthority = reader.ReadBoolean();
             sceneId = reader.ReadUInt64();
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
@@ -374,6 +379,7 @@ namespace Mirror
         {
             writer.WritePackedUInt32(netId);
             writer.WriteBoolean(isLocalPlayer);
+            writer.WriteBoolean(hasAuthority);
             writer.WriteUInt64(sceneId);
             writer.WriteVector3(position);
             writer.WriteQuaternion(rotation);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -37,11 +37,6 @@ namespace Mirror
         [HideInInspector] public float syncInterval = 0.1f;
 
         /// <summary>
-        /// This value is set on the NetworkIdentity and is accessible here for convenient access for scripts.
-        /// </summary>
-        public bool localPlayerAuthority => netIdentity.localPlayerAuthority;
-
-        /// <summary>
         /// Returns true if this object is active on an active server.
         /// <para>This is only true if the object has been spawned. This is different from NetworkServer.active, which is true if the server itself is active rather than this object being active.</para>
         /// </summary>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -779,10 +779,13 @@ namespace Mirror
         public virtual void OnStartLocalPlayer() {}
 
         /// <summary>
+        /// Invoked in the client if the client has authority over the object
+        /// </summary>
+        /// <remarks>
         /// This is invoked on behaviours that have authority, based on context and <see cref="NetworkIdentity.localPlayerAuthority">'NetworkIdentity.localPlayerAuthority.'</see>
         /// <para>This is called after <see cref="OnStartServer">OnStartServer</see> and <see cref="OnStartClient">OnStartClient.</see></para>
         /// <para>When <see cref="NetworkIdentity.AssignClientAuthority"/> is called on the server, this will be called on the client that owns the object. When an object is spawned with NetworkServer.SpawnWithClientAuthority, this will be called on the client that owns the object.</para>
-        /// </summary>
+        /// </remarks>
         public virtual void OnStartAuthority() {}
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -7,13 +7,6 @@ namespace Mirror
 {
     public class NetworkConnectionToClient : NetworkConnection
     {
-        /// <summary>
-        /// A list of the NetworkIdentity objects owned by this connection. This list is read-only.
-        /// <para>This includes the player object for the connection - if it has localPlayerAutority set, and any objects spawned with local authority or set with AssignLocalAuthority.</para>
-        /// <para>This list can be used to validate messages from clients, to ensure that clients are only trying to control objects that they own.</para>
-        /// </summary>
-        public readonly HashSet<NetworkIdentity> clientOwnedObjects = new HashSet<NetworkIdentity>();
-
         public NetworkConnectionToClient(int networkConnectionId) : base(networkConnectionId)
         {
         }
@@ -66,28 +59,19 @@ namespace Mirror
             DestroyOwnedObjects();
         }
 
-        internal void AddOwnedObject(NetworkIdentity obj)
-        {
-            clientOwnedObjects.Add(obj);
-        }
-
-        internal void RemoveOwnedObject(NetworkIdentity obj)
-        {
-            clientOwnedObjects.Remove(obj);
-        }
-
         protected void DestroyOwnedObjects()
         {
+            // TODO: keep a set of owned objects instead of looping through every object
+
             // work on copy because the list may be modified when we destroy the objects
-            HashSet<NetworkIdentity> objects = new HashSet<NetworkIdentity>(clientOwnedObjects);
+            HashSet<NetworkIdentity> objects = new HashSet<NetworkIdentity>(NetworkIdentity.spawned.Values);
             foreach (NetworkIdentity netId in objects)
             {
-                if (netId != null)
+                if (netId != null && netId.connectionToClient == this)
                 {
                     NetworkServer.Destroy(netId.gameObject);
                 }
             }
-            clientOwnedObjects.Clear();
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -73,9 +73,7 @@ namespace Mirror
         /// This returns true if this object is the one that represents the player on the local machine.
         /// <para>This is set when the server has spawned an object for this particular client.</para>
         /// </summary>
-        public bool isLocalPlayer { get; private set; }
-
-        internal bool pendingLocalPlayer { get; set; }
+        public bool isLocalPlayer => ClientScene.localPlayer == this;
 
         /// <summary>
         /// This returns true if this object is the authoritative version of the object in the distributed network application.
@@ -247,8 +245,6 @@ namespace Mirror
         // used when the player object for a connection changes
         internal void SetNotLocalPlayer()
         {
-            isLocalPlayer = false;
-
             if (NetworkServer.active && NetworkServer.localClientActive)
             {
                 // dont change authority for objects on the host
@@ -897,8 +893,6 @@ namespace Mirror
 
         internal void SetLocalPlayer()
         {
-            isLocalPlayer = true;
-
             // There is an ordering issue here that originAuthority solves:
             // OnStartAuthority should only be called if hasAuthority was false when this function began,
             // or it will be called twice for this object, but that state is lost by the time OnStartAuthority
@@ -1190,7 +1184,6 @@ namespace Mirror
             hasAuthority = false;
 
             netId = 0;
-            isLocalPlayer = false;
             connectionToServer = null;
             connectionToClient = null;
             networkBehavioursCache = null;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1096,6 +1096,8 @@ namespace Mirror
             };
             conn.Send(msg);
 
+            OnStartAuthority();
+
             return true;
         }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -840,6 +840,8 @@ namespace Mirror
             OnDeserializeAllSafely(reader, initialState);
         }
 
+        // Set this object as the local player and call the hooks
+        // note this is client side only.
         internal void SetLocalPlayer()
         {
             // There is an ordering issue here that originAuthority solves:

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -80,7 +80,7 @@ namespace Mirror
         /// <para>This value is determined at runtime, as opposed to localPlayerAuthority which is set on the prefab. For most objects, authority is held by the server / host. For objects with localPlayerAuthority set, authority is held by the client of that player.</para>
         /// <para>For objects that had their authority set by AssignClientAuthority on the server, this will be true on the client that owns the object. NOT on other clients.</para>
         /// </summary>
-        public bool hasAuthority { get; private set; }
+        public bool hasAuthority { get; internal set; }
 
         /// <summary>
         /// The set of network connections (players) that can see this object.
@@ -219,25 +219,6 @@ namespace Mirror
         /// <param name="authorityState">The new state of client authority of the object for the connection.</param>
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Host Migration was removed")]
         public delegate void ClientAuthorityCallback(NetworkConnection conn, NetworkIdentity identity, bool authorityState);
-
-        /// <summary>
-        /// Obsolete: Host Migration was removed
-        /// <para>Whenever an object is spawned using SpawnWithClientAuthority, or the client authority status of an object is changed with AssignClientAuthority or RemoveClientAuthority, then this callback will be invoked.</para>
-        /// <para>This callback is used by the NetworkMigrationManager to distribute client authority state to peers for host migration. If the NetworkMigrationManager is not being used, this callback does not need to be populated.</para>
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Host Migration was removed")]
-        public static ClientAuthorityCallback clientAuthorityCallback;
-
-        // used when the player object for a connection changes
-        internal void SetNotLocalPlayer()
-        {
-            if (NetworkServer.active && NetworkServer.localClientActive)
-            {
-                // dont change authority for objects on the host
-                return;
-            }
-            hasAuthority = false;
-        }
 
         // this is used when a connection is destroyed, since the "observers" property is read-only
         internal void RemoveObserverInternal(NetworkConnection conn)
@@ -1071,9 +1052,6 @@ namespace Mirror
             };
 
             connectionToClient.Send(msg);
-#pragma warning disable CS0618 // Type or member is obsolete
-            clientAuthorityCallback?.Invoke(connectionToClient, this, false);
-#pragma warning restore CS0618 // Type or member is obsolete
             connectionToClient = null;
 
             OnStopAuthority();
@@ -1116,9 +1094,6 @@ namespace Mirror
             };
             conn.Send(msg);
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            clientAuthorityCallback?.Invoke(conn, this, true);
-#pragma warning restore CS0618 // Type or member is obsolete
             return true;
         }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -107,13 +107,6 @@ namespace Mirror
         public bool serverOnly;
 
         /// <summary>
-        /// localPlayerAuthority means that the client of the "owning" player has authority over their own player object.
-        /// <para>Authority for this object will be on the player's client. So hasAuthority will be true on that client - and false on the server and on other clients.</para>
-        /// </summary>
-        [FormerlySerializedAs("m_LocalPlayerAuthority")]
-        public bool localPlayerAuthority;
-
-        /// <summary>
         /// The client that has authority for this object. This will be null if no client has authority.
         /// <para>This is set for player objects with localPlayerAuthority, and for objects set with AssignClientAuthority, and spawned with SpawnWithClientAuthority.</para>
         /// </summary>
@@ -290,12 +283,6 @@ namespace Mirror
         void OnValidate()
         {
 #if UNITY_EDITOR
-            if (serverOnly && localPlayerAuthority)
-            {
-                Debug.LogWarning("Disabling Local Player Authority for " + gameObject + " because it is server-only.");
-                localPlayerAuthority = false;
-            }
-
             SetupIDs();
 #endif
         }
@@ -558,7 +545,7 @@ namespace Mirror
         {
             isClient = true;
 
-            if (LogFilter.Debug) Debug.Log("OnStartClient " + gameObject + " netId:" + netId + " localPlayerAuthority:" + localPlayerAuthority);
+            if (LogFilter.Debug) Debug.Log("OnStartClient " + gameObject + " netId:" + netId);
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {
                 try
@@ -832,18 +819,6 @@ namespace Mirror
             }
         }
 
-        // happens on client
-        internal void HandleClientAuthority(bool authority)
-        {
-            if (!localPlayerAuthority)
-            {
-                Debug.LogError("HandleClientAuthority " + gameObject + " does not have localPlayerAuthority");
-                return;
-            }
-
-            ForceAuthority(authority);
-        }
-
         // helper function to handle SyncEvent/Command/Rpc
         void HandleRemoteCall(int componentIndex, int functionHash, MirrorInvokeType invokeType, NetworkReader reader)
         {
@@ -898,16 +873,13 @@ namespace Mirror
             // or it will be called twice for this object, but that state is lost by the time OnStartAuthority
             // is called below, so the original value is cached here to be checked below.
             bool originAuthority = hasAuthority;
-            if (localPlayerAuthority)
-            {
-                hasAuthority = true;
-            }
+            hasAuthority = true;
 
             foreach (NetworkBehaviour comp in networkBehavioursCache)
             {
                 comp.OnStartLocalPlayer();
 
-                if (localPlayerAuthority && !originAuthority)
+                if (!originAuthority)
                 {
                     comp.OnStartAuthority();
                 }
@@ -1127,11 +1099,6 @@ namespace Mirror
             if (!isServer)
             {
                 Debug.LogError("AssignClientAuthority can only be called on the server for spawned objects.");
-                return false;
-            }
-            if (!localPlayerAuthority)
-            {
-                Debug.LogError("AssignClientAuthority can only be used for NetworkIdentity components with LocalPlayerAuthority set.");
                 return false;
             }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -821,10 +821,7 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("Adding new playerGameObject object netId: " + identity.netId + " asset ID " + identity.assetId);
 
             FinishPlayerForConnection(identity, player);
-            if (identity.localPlayerAuthority)
-            {
-                identity.SetClientOwner(conn);
-            }
+            identity.SetClientOwner(conn);
             return true;
         }
 
@@ -910,10 +907,7 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("Replacing playerGameObject object netId: " + player.GetComponent<NetworkIdentity>().netId + " asset ID " + player.GetComponent<NetworkIdentity>().assetId);
 
             FinishPlayerForConnection(identity, player);
-            if (identity.localPlayerAuthority)
-            {
-                identity.SetClientOwner(conn);
-            }
+            identity.SetClientOwner(conn);
             return true;
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -880,7 +880,6 @@ namespace Mirror
             if (conn.identity != null)
             {
                 conn.identity.SetNotLocalPlayer();
-                conn.identity.clientAuthorityOwner = null;
             }
 
             conn.identity = identity;
@@ -1016,13 +1015,10 @@ namespace Mirror
             // Commands can be for player objects, OR other objects with client-authority
             // -> so if this connection's controller has a different netId then
             //    only allow the command if clientAuthorityOwner
-            if (conn.identity != null && conn.identity.netId != identity.netId)
+            if (identity.connectionToClient != conn)
             {
-                if (identity.clientAuthorityOwner != conn)
-                {
-                    Debug.LogWarning("Command for object without authority [netId=" + msg.netId + "]");
-                    return;
-                }
+                Debug.LogWarning("Command for object without authority [netId=" + msg.netId + "]");
+                return;
             }
 
             if (LogFilter.Debug) Debug.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn);
@@ -1312,8 +1308,6 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("DestroyObject instance:" + identity.netId);
             NetworkIdentity.spawned.Remove(identity.netId);
-
-            identity.clientAuthorityOwner?.RemoveOwnedObject(identity);
 
             ObjectDestroyMessage msg = new ObjectDestroyMessage
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -876,12 +876,6 @@ namespace Mirror
             //NOTE: there can be an existing player
             if (LogFilter.Debug) Debug.Log("NetworkServer ReplacePlayer");
 
-            // is there already an owner that is a different object??
-            if (conn.identity != null)
-            {
-                conn.identity.SetNotLocalPlayer();
-            }
-
             conn.identity = identity;
 
             // Set the connection on the NetworkIdentity on the server, NetworkIdentity.SetLocalPlayer is not called on the server (it is on clients)
@@ -1077,6 +1071,7 @@ namespace Mirror
                 {
                     netId = identity.netId,
                     isLocalPlayer = conn?.identity == identity,
+                    hasAuthority = conn == identity.connectionToClient,
                     assetId = identity.assetId,
                     // use local values for VR support
                     position = identity.transform.localPosition,
@@ -1119,6 +1114,7 @@ namespace Mirror
                 {
                     netId = identity.netId,
                     isLocalPlayer = conn?.identity == identity,
+                    hasAuthority = conn == identity.connectionToClient,
                     sceneId = identity.sceneId,
                     // use local values for VR support
                     position = identity.transform.localPosition,
@@ -1252,16 +1248,18 @@ namespace Mirror
                 return false;
             }
 
+            NetworkIdentity identity = obj.GetComponent<NetworkIdentity>();
+            identity.connectionToClient = conn;
+
             Spawn(obj);
 
-            NetworkIdentity identity = obj.GetComponent<NetworkIdentity>();
             if (identity == null || !identity.isServer)
             {
                 // spawning the object failed.
                 return false;
             }
 
-            return identity.AssignClientAuthority(conn);
+            return true;
         }
 
         /// <summary>
@@ -1274,16 +1272,18 @@ namespace Mirror
         /// <returns></returns>
         public static bool SpawnWithClientAuthority(GameObject obj, Guid assetId, NetworkConnection conn)
         {
+            NetworkIdentity identity = obj.GetComponent<NetworkIdentity>();
+
+            identity.connectionToClient = conn;
             Spawn(obj, assetId);
 
-            NetworkIdentity identity = obj.GetComponent<NetworkIdentity>();
             if (identity == null || !identity.isServer)
             {
                 // spawning the object failed.
                 return false;
             }
 
-            return identity.AssignClientAuthority(conn);
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Refactored client authority to use connectionToClient and keep things simple.

All objects have connectionToClient.  If set,  then that connection has authority over the object,  meaning it can call [commands] and it will be destroyed if the connection disconnects.

Player objects are automatically given authority to the owning client thus `isLocalPlayer` implies `hasAuthority`  notice this is a behavior change from previous versions.  You can call commands on an object if and only if `hasAuthority` is set.

This is a performance improvement because ClientAuthorityMessage is no longer used during spawn,  only when changing authority,  so it is 1 message per pets instead of 2.

It also opens the door for using synctoowner with pets.  Which will follow in another PR.
