### PR TITLE
Hasauthority reimplemented

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -7,10 +7,9 @@ namespace Mirror
     /// A component to synchronize Mecanim animation states for networked objects.
     /// </summary>
     /// <remarks>
-    /// <para>The animation of game objects can be networked by this component. There are two models of authority for networked movement:</para>
-    /// <para>If the object has authority on the client, then it should animated locally on the owning client. The animation state information will be sent from the owning client to the server, then broadcast to all of the other clients. This is common for player objects.</para>
-    /// <para>If the object has authority on the server, then it should be animated on the server and state information will be sent to all clients. This is common for objects not related to a specific client, such as an enemy unit.</para>
-    /// <para>The NetworkAnimator synchronizes the animation parameters that are checked in the inspector view. It does not automatically sychronize triggers. The function SetTrigger can by used by an object with authority to fire an animation trigger on other clients.</para>
+    /// <para>The animation of game objects can be networked by this component.</para>
+    /// <para>The object should be animated on the server and state information will be sent to all clients. This is common for objects not related to a specific client, such as an enemy unit.</para>
+    /// <para>The NetworkAnimator synchronizes the animation parameters that are checked in the inspector view. It does not automatically sychronize triggers. The function SetTrigger can be used by the server to fire an animation trigger on other clients.</para>
     /// </remarks>
     [DisallowMultipleComponent]
     [AddComponentMenu("Network/NetworkAnimator")]
@@ -34,29 +33,6 @@ namespace Mirror
         int[] transitionHash;
         float sendTimer;
 
-        bool sendMessagesAllowed
-        {
-            get
-            {
-                if (isServer)
-                {
-                    if (!localPlayerAuthority)
-                        return true;
-
-                    // This is a special case where we have localPlayerAuthority set
-                    // on a NetworkIdentity but we have not assigned the client who has
-                    // authority over it, no animator data will be sent over the network by the server.
-                    //
-                    // So we check here for a clientAuthorityOwner and if it is null we will
-                    // let the server send animation data until we receive an owner.
-                    if (netIdentity != null && netIdentity.clientAuthorityOwner == null)
-                        return true;
-                }
-
-                return hasAuthority;
-            }
-        }
-
         void Awake()
         {
             // store the animator parameters in a variable - the "Animator.parameters" getter allocates
@@ -72,7 +48,7 @@ namespace Mirror
 
         void FixedUpdate()
         {
-            if (!sendMessagesAllowed)
+            if (!isServer)
                 return;
 
             CheckSendRate();
@@ -130,7 +106,7 @@ namespace Mirror
 
         void CheckSendRate()
         {
-            if (sendMessagesAllowed && syncInterval != 0 && sendTimer < Time.time)
+            if (isServer && syncInterval != 0 && sendTimer < Time.time)
             {
                 sendTimer = Time.time + syncInterval;
 
@@ -148,10 +124,6 @@ namespace Mirror
             {
                 RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, parameters);
             }
-            else if (ClientScene.readyConnection != null)
-            {
-                CmdOnAnimationServerMessage(stateHash, normalizedTime, layerId, parameters);
-            }
         }
 
         void SendAnimationParametersMessage(byte[] parameters)
@@ -160,15 +132,11 @@ namespace Mirror
             {
                 RpcOnAnimationParametersClientMessage(parameters);
             }
-            else if (ClientScene.readyConnection != null)
-            {
-                CmdOnAnimationParametersServerMessage(parameters);
-            }
         }
 
         void HandleAnimMsg(int stateHash, float normalizedTime, int layerId, NetworkReader reader)
         {
-            if (hasAuthority)
+            if (isServer)
                 return;
 
             // usually transitions will be triggered by parameters, if not, play anims directly.
@@ -184,7 +152,7 @@ namespace Mirror
 
         void HandleAnimParamsMsg(NetworkReader reader)
         {
-            if (hasAuthority)
+            if (isServer)
                 return;
 
             ReadParameters(reader);
@@ -346,7 +314,6 @@ namespace Mirror
 
         /// <summary>
         /// Causes an animation trigger to be invoked for a networked object.
-        /// <para>If local authority is set, and this is called from the client, then the trigger will be invoked on the server and all clients. If not, then this is called on the server, and the trigger will be called on all clients.</para>
         /// </summary>
         /// <param name="triggerName">Name of trigger.</param>
         public void SetTrigger(string triggerName)
@@ -360,48 +327,11 @@ namespace Mirror
         /// <param name="hash">Hash id of trigger (from the Animator).</param>
         public void SetTrigger(int hash)
         {
-            if (hasAuthority && localPlayerAuthority)
-            {
-                if (ClientScene.readyConnection != null)
-                {
-                    CmdOnAnimationTriggerServerMessage(hash);
-                }
-                return;
-            }
-
-            if (isServer && !localPlayerAuthority)
+            if (isServer)
             {
                 RpcOnAnimationTriggerClientMessage(hash);
             }
         }
-
-        #region server message handlers
-        [Command]
-        void CmdOnAnimationServerMessage(int stateHash, float normalizedTime, int layerId, byte[] parameters)
-        {
-            if (LogFilter.Debug) Debug.Log("OnAnimationMessage for netId=" + netId);
-
-            // handle and broadcast
-            HandleAnimMsg(stateHash, normalizedTime, layerId, new NetworkReader(parameters));
-            RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, parameters);
-        }
-
-        [Command]
-        void CmdOnAnimationParametersServerMessage(byte[] parameters)
-        {
-            // handle and broadcast
-            HandleAnimParamsMsg(new NetworkReader(parameters));
-            RpcOnAnimationParametersClientMessage(parameters);
-        }
-
-        [Command]
-        void CmdOnAnimationTriggerServerMessage(int hash)
-        {
-            // handle and broadcast
-            HandleAnimTriggerMsg(hash);
-            RpcOnAnimationTriggerClientMessage(hash);
-        }
-        #endregion
 
         #region client message handlers
         [ClientRpc]

--- a/Assets/Mirror/Editor/NetworkIdentityEditor.cs
+++ b/Assets/Mirror/Editor/NetworkIdentityEditor.cs
@@ -9,10 +9,8 @@ namespace Mirror
     public class NetworkIdentityEditor : Editor
     {
         SerializedProperty serverOnlyProperty;
-        SerializedProperty localPlayerAuthorityProperty;
 
         readonly GUIContent serverOnlyLabel = new GUIContent("Server Only", "True if the object should only exist on the server.");
-        readonly GUIContent localPlayerAuthorityLabel = new GUIContent("Local Player Authority", "True if this object will be controlled by a player on a client.");
         readonly GUIContent spawnLabel = new GUIContent("Spawn Object", "This causes an unspawned server object to be spawned on clients");
 
         NetworkIdentity networkIdentity;
@@ -29,7 +27,6 @@ namespace Mirror
             networkIdentity = target as NetworkIdentity;
 
             serverOnlyProperty = serializedObject.FindProperty("serverOnly");
-            localPlayerAuthorityProperty = serializedObject.FindProperty("localPlayerAuthority");
         }
 
         public override void OnInspectorGUI()
@@ -46,17 +43,10 @@ namespace Mirror
             if (serverOnlyProperty.boolValue)
             {
                 EditorGUILayout.PropertyField(serverOnlyProperty, serverOnlyLabel);
-                EditorGUILayout.LabelField("Local Player Authority cannot be set for server-only objects");
-            }
-            else if (localPlayerAuthorityProperty.boolValue)
-            {
-                EditorGUILayout.LabelField("Server Only cannot be set for Local Player Authority objects");
-                EditorGUILayout.PropertyField(localPlayerAuthorityProperty, localPlayerAuthorityLabel);
             }
             else
             {
                 EditorGUILayout.PropertyField(serverOnlyProperty, serverOnlyLabel);
-                EditorGUILayout.PropertyField(localPlayerAuthorityProperty, localPlayerAuthorityLabel);
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -164,6 +164,12 @@ namespace Mirror
                         lastY = observerRect.y;
                     }
                 }
+
+                if (identity.authorityOwner != null)
+                {
+                    Rect ownerRect = new Rect(initialX, lastY + 10, 400, 20);
+                    GUI.Label(ownerRect, new GUIContent("Authority owner: " + identity.authorityOwner), styles.labelStyle);
+                }
             }
         }
 
@@ -225,6 +231,7 @@ namespace Mirror
                 info.Add(GetBoolean("Is Client", identity.isClient));
                 info.Add(GetBoolean("Is Server", identity.isServer));
                 info.Add(GetBoolean("Is Local Player", identity.isLocalPlayer));
+                info.Add(GetBoolean("Has Authority", identity.hasAuthority));
 
                 NetworkBehaviour[] behaviours = gameObject.GetComponents<NetworkBehaviour>();
                 if (behaviours.Length > 0)

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -164,12 +164,6 @@ namespace Mirror
                         lastY = observerRect.y;
                     }
                 }
-
-                if (identity.clientAuthorityOwner != null)
-                {
-                    Rect ownerRect = new Rect(initialX, lastY + 10, 400, 20);
-                    GUI.Label(ownerRect, new GUIContent("Client Authority: " + identity.clientAuthorityOwner), styles.labelStyle);
-                }
             }
         }
 
@@ -230,7 +224,6 @@ namespace Mirror
 
                 info.Add(GetBoolean("Is Client", identity.isClient));
                 info.Add(GetBoolean("Is Server", identity.isServer));
-                info.Add(GetBoolean("Has Authority", identity.hasAuthority));
                 info.Add(GetBoolean("Is Local Player", identity.isLocalPlayer));
 
                 NetworkBehaviour[] behaviours = gameObject.GetComponents<NetworkBehaviour>();

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -165,10 +165,10 @@ namespace Mirror
                     }
                 }
 
-                if (identity.authorityOwner != null)
+                if (identity.owner != null)
                 {
                     Rect ownerRect = new Rect(initialX, lastY + 10, 400, 20);
-                    GUI.Label(ownerRect, new GUIContent("Authority owner: " + identity.authorityOwner), styles.labelStyle);
+                    GUI.Label(ownerRect, new GUIContent("Owner: " + identity.owner.name), styles.labelStyle);
                 }
             }
         }
@@ -231,7 +231,7 @@ namespace Mirror
                 info.Add(GetBoolean("Is Client", identity.isClient));
                 info.Add(GetBoolean("Is Server", identity.isServer));
                 info.Add(GetBoolean("Is Local Player", identity.isLocalPlayer));
-                info.Add(GetBoolean("Has Authority", identity.hasAuthority));
+                info.Add(GetBoolean("Is Local Player Owned", identity.isLocalPlayerOwned));
 
                 NetworkBehaviour[] behaviours = gameObject.GetComponents<NetworkBehaviour>();
                 if (behaviours.Length > 0)

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -713,16 +713,6 @@ namespace Mirror
             }
         }
 
-        internal static void OnClientAuthority(NetworkConnection _, ClientAuthorityMessage msg)
-        {
-            if (LogFilter.Debug) Debug.Log("ClientScene.OnClientAuthority for netId: " + msg.netId);
-
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
-            {
-                identity.HandleClientAuthority(msg.authority);
-            }
-        }
-
         // called for the one object in the spawn message which is the local player!
         internal static void OnSpawnMessageForLocalPlayer(uint netId)
         {

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -438,7 +438,7 @@ namespace Mirror
             return null;
         }
 
-        static void ApplySpawnPayload(NetworkIdentity identity, Vector3 position, Quaternion rotation, Vector3 scale, ArraySegment<byte> payload, uint netId)
+        static void ApplySpawnPayload(NetworkIdentity identity, Vector3 position, Quaternion rotation, Vector3 scale, ArraySegment<byte> payload, uint netId, uint ownerNetId)
         {
             if (!identity.gameObject.activeSelf)
             {
@@ -460,6 +460,8 @@ namespace Mirror
 
             identity.netId = netId;
             NetworkIdentity.spawned[netId] = identity;
+
+            identity.ownerNetId = ownerNetId;
 
             // objects spawned as part of initial state are started on a second pass
             if (isSpawnFinished)
@@ -488,7 +490,7 @@ namespace Mirror
             {
                 // this object already exists (was in the scene), just apply the update to existing object
                 localObject.Reset();
-                ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId);
+                ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId, msg.ownerNetId);
                 return;
             }
 
@@ -508,7 +510,7 @@ namespace Mirror
                 }
                 localObject.Reset();
                 localObject.pendingLocalPlayer = msg.isLocalPlayer;
-                ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId);
+                ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId, msg.ownerNetId);
             }
             // lookup registered factory for type:
             else if (spawnHandlers.TryGetValue(msg.assetId, out SpawnDelegate handler))
@@ -528,7 +530,7 @@ namespace Mirror
                 localObject.Reset();
                 localObject.pendingLocalPlayer = msg.isLocalPlayer;
                 localObject.assetId = msg.assetId;
-                ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId);
+                ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId, msg.ownerNetId);
             }
             else
             {
@@ -550,7 +552,7 @@ namespace Mirror
             {
                 // this object already exists (was in the scene)
                 localObject.Reset();
-                ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId);
+                ApplySpawnPayload(localObject, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId, msg.ownerNetId);
                 return;
             }
 
@@ -572,7 +574,7 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("Client spawn for [netId:" + msg.netId + "] [sceneId:" + msg.sceneId + "] obj:" + spawnedId.gameObject.name);
             spawnedId.Reset();
             spawnedId.pendingLocalPlayer = msg.isLocalPlayer;
-            ApplySpawnPayload(spawnedId, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId);
+            ApplySpawnPayload(spawnedId, msg.position, msg.rotation, msg.scale, msg.payload, msg.netId, msg.ownerNetId);
         }
 
         internal static void OnObjectSpawnStarted(NetworkConnection _, ObjectSpawnStartedMessage msg)

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -426,24 +426,6 @@ namespace Mirror
         }
     }
 
-    public struct ClientAuthorityMessage : IMessageBase
-    {
-        public uint netId;
-        public bool authority;
-
-        public void Deserialize(NetworkReader reader)
-        {
-            netId = reader.ReadPackedUInt32();
-            authority = reader.ReadBoolean();
-        }
-
-        public void Serialize(NetworkWriter writer)
-        {
-            writer.WritePackedUInt32(netId);
-            writer.WriteBoolean(authority);
-        }
-    }
-
     public struct UpdateVarsMessage : IMessageBase
     {
         public uint netId;

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -316,6 +316,7 @@ namespace Mirror
     {
         public uint netId;
         public bool isLocalPlayer;
+        public uint ownerNetId;
         public Guid assetId;
         public Vector3 position;
         public Quaternion rotation;
@@ -328,6 +329,7 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             isLocalPlayer = reader.ReadBoolean();
+            ownerNetId = reader.ReadPackedUInt32();
             assetId = reader.ReadGuid();
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
@@ -339,6 +341,7 @@ namespace Mirror
         {
             writer.WritePackedUInt32(netId);
             writer.WriteBoolean(isLocalPlayer);
+            writer.WritePackedUInt32(ownerNetId);
             writer.WriteGuid(assetId);
             writer.WriteVector3(position);
             writer.WriteQuaternion(rotation);
@@ -351,6 +354,7 @@ namespace Mirror
     {
         public uint netId;
         public bool isLocalPlayer;
+        public uint ownerNetId;
         public ulong sceneId;
         public Vector3 position;
         public Quaternion rotation;
@@ -363,6 +367,7 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             isLocalPlayer = reader.ReadBoolean();
+            ownerNetId = reader.ReadPackedUInt32();
             sceneId = reader.ReadUInt64();
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
@@ -374,6 +379,7 @@ namespace Mirror
         {
             writer.WritePackedUInt32(netId);
             writer.WriteBoolean(isLocalPlayer);
+            writer.WritePackedUInt32(ownerNetId);
             writer.WriteUInt64(sceneId);
             writer.WriteVector3(position);
             writer.WriteQuaternion(rotation);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -37,11 +37,6 @@ namespace Mirror
         [HideInInspector] public float syncInterval = 0.1f;
 
         /// <summary>
-        /// This value is set on the NetworkIdentity and is accessible here for convenient access for scripts.
-        /// </summary>
-        public bool localPlayerAuthority => netIdentity.localPlayerAuthority;
-
-        /// <summary>
         /// Returns true if this object is active on an active server.
         /// <para>This is only true if the object has been spawned. This is different from NetworkServer.active, which is true if the server itself is active rather than this object being active.</para>
         /// </summary>
@@ -67,12 +62,6 @@ namespace Mirror
         /// True if this object exists on a client that is not also acting as a server
         /// </summary>
         public bool isClientOnly => isClient && !isServer;
-
-        /// <summary>
-        /// This returns true if this object is the authoritative version of the object in the distributed network application.
-        /// <para>The <see cref="localPlayerAuthority">localPlayerAuthority</see> value on the NetworkIdentity determines how authority is determined. For most objects, authority is held by the server / host. For objects with <see cref="localPlayerAuthority">localPlayerAuthority</see> set, authority is held by the client of that player.</para>
-        /// </summary>
-        public bool hasAuthority => netIdentity.hasAuthority;
 
         /// <summary>
         /// The unique network Id of this object.
@@ -195,10 +184,10 @@ namespace Mirror
                 Debug.LogError("Command Function " + cmdName + " called on server without an active client.");
                 return;
             }
-            // local players can always send commands, regardless of authority, other objects must have authority.
-            if (!(isLocalPlayer || hasAuthority))
+            // local players can always send commands.
+            if (!isLocalPlayer)
             {
-                Debug.LogWarning("Trying to send command for object without authority.");
+                Debug.LogWarning("Trying to send command for non local player object.");
                 return;
             }
 
@@ -782,19 +771,6 @@ namespace Mirror
         /// <para>This happens after OnStartClient(), as it is triggered by an ownership message from the server. This is an appropriate place to activate components or functionality that should only be active for the local player, such as cameras and input.</para>
         /// </summary>
         public virtual void OnStartLocalPlayer() {}
-
-        /// <summary>
-        /// This is invoked on behaviours that have authority, based on context and <see cref="NetworkIdentity.localPlayerAuthority">'NetworkIdentity.localPlayerAuthority.'</see>
-        /// <para>This is called after <see cref="OnStartServer">OnStartServer</see> and <see cref="OnStartClient">OnStartClient.</see></para>
-        /// <para>When <see cref="NetworkIdentity.AssignClientAuthority"/> is called on the server, this will be called on the client that owns the object. When an object is spawned with NetworkServer.SpawnWithClientAuthority, this will be called on the client that owns the object.</para>
-        /// </summary>
-        public virtual void OnStartAuthority() {}
-
-        /// <summary>
-        /// This is invoked on behaviours when authority is removed.
-        /// <para>When NetworkIdentity.RemoveClientAuthority is called on the server, this will be called on the client that owns the object.</para>
-        /// </summary>
-        public virtual void OnStopAuthority() {}
 
         /// <summary>
         /// Callback used by the visibility system to (re)construct the set of observers that can see this object.

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -361,7 +361,6 @@ namespace Mirror
                 RegisterHandler<ObjectSpawnFinishedMessage>(ClientScene.OnObjectSpawnFinished);
                 RegisterHandler<UpdateVarsMessage>(ClientScene.OnUpdateVarsMessage);
             }
-            RegisterHandler<ClientAuthorityMessage>(ClientScene.OnClientAuthority);
             RegisterHandler<RpcMessage>(ClientScene.OnRPCMessage);
             RegisterHandler<SyncEventMessage>(ClientScene.OnSyncEventMessage);
         }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -112,16 +112,26 @@ namespace Mirror
         /// </summary>
         public NetworkConnection connectionToClient { get; internal set; }
 
-        // IMPORTANT: we use a separate .connectionToOwner for owned objects,
-        //            because setting .connectionToClient would cause updates to
-        //            be sent to the owner connection twice (once for player,
-        //            once for pet etc.).
-        //
+        // owner netId
+        // => better than saving a NetworkConnection which would only be
+        //    be available on the server
+        // => better than saving a NetworkIdentity which would be null on the
+        //    client if the owner walks out of proximity once
+        // => netId never changes, and lookup is != null whenever owner is
+        //    around!
+        // => can be used by game scripts to identity Pet.owner easily!
+        internal uint ownerNetId = 0;
+
         /// <summary>
-        /// The NetworkConnection associated with the owner of this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player owned objects on the server (e.g. pets).
-        /// <para>Use it to return details such as the connection&apos;s identity, IP address and ready status.</para>
+        /// The owner of this <see cref="NetworkIdentity">NetworkIdentity.</see> This is valid for player owned objects (e.g. pets) on the server and on the client.
         /// </summary>
-        public NetworkConnection connectionToOwner { get; internal set; }
+        public NetworkIdentity owner =>
+            spawned.TryGetValue(ownerNetId, out NetworkIdentity result) ? result : null;
+
+        /// <summary>
+        /// This returns true if this object is owned by the player on the local machine.
+        /// </summary>
+        public bool isLocalPlayerOwned => owner != null && owner.isLocalPlayer;
 
         /// <summary>
         /// All spawned NetworkIdentities by netId. Available on server and client.

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -112,6 +112,17 @@ namespace Mirror
         /// </summary>
         public NetworkConnection connectionToClient { get; internal set; }
 
+        // IMPORTANT: we use a separate .connectionToOwner for owned objects,
+        //            because setting .connectionToClient would cause updates to
+        //            be sent to the owner connection twice (once for player,
+        //            once for pet etc.).
+        //
+        /// <summary>
+        /// The NetworkConnection associated with the owner of this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player owned objects on the server (e.g. pets).
+        /// <para>Use it to return details such as the connection&apos;s identity, IP address and ready status.</para>
+        /// </summary>
+        public NetworkConnection connectionToOwner { get; internal set; }
+
         /// <summary>
         /// All spawned NetworkIdentities by netId. Available on server and client.
         /// </summary>


### PR DESCRIPTION
**better than before because:**

- less confusing
- isLocalPlayerOwned is way more obvious than hasAuthority
- .owner field is less confusing than .clientAuthorityOwner field
- .owner field is convenient, e.g. for Pet.ownerPlayer
- it's WAY shorter
- it works on client and server

**NOTES**
- OnStart/StopAuthority was removed. use OnStartClient() + isLocalPlayerOwned instead
- there is no authority transfer in this version yet

**TODO**
- find perfect name for 'isLocalPlayerOwned'
- add obsoletes, e.g. hasAuthority => isLocalPlayerOwned ?
- test

**this is the most simple solution, because:**
- setting pet.connectionToClient := ownerConnection is shorter, would need extra logic to not sync everything to player's and pet's connection twice. it also means that client wouldn't know who owns the pet
- setting an extra pet.connectionToOwner := ownerConnection is almost what we did before. downside is that client wouldn't know who owns the pet. we would need one more field for that, like '.owner => connectionToOwner.identity'. just extra complicated.
- setting pet.owner := owner covers ALL cases. we can get the owner, both on server AND on clients, and we can get the owner connection via owner.connection.

in other words, '.owner' not only makes the hasAuthority implementation easier, it also makes game development easier where mirror makes pet.owner available for free on the client. previously this required extra code.