### PR TITLE
refactor: Simplify spawn message

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -505,15 +505,14 @@ namespace Mirror
             ApplySpawnPayload(identity, msg);
         }
 
-        private static NetworkIdentity GetExistingObject(uint netid)
+        static NetworkIdentity GetExistingObject(uint netid)
         {
             NetworkIdentity.spawned.TryGetValue(netid, out NetworkIdentity localObject);
             return localObject;
         }
 
-        private static NetworkIdentity SpawnPrefab(SpawnMessage msg)
+        static NetworkIdentity SpawnPrefab(SpawnMessage msg)
         {
-
             if (GetPrefab(msg.assetId, out GameObject prefab))
             {
                 GameObject obj = Object.Instantiate(prefab, msg.position, msg.rotation);
@@ -542,7 +541,7 @@ namespace Mirror
             }
         }
 
-        internal static NetworkIdentity SpawnSceneObject(SpawnMessage msg)
+        static NetworkIdentity SpawnSceneObject(SpawnMessage msg)
         {
             NetworkIdentity spawnedId = SpawnSceneObject(msg.sceneId);
             if (spawnedId == null)

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -523,8 +523,7 @@ namespace Mirror
 
                 return obj.GetComponent<NetworkIdentity>();
             }
-            // lookup registered factory for type:
-            else if (spawnHandlers.TryGetValue(msg.assetId, out SpawnDelegate handler))
+            if (spawnHandlers.TryGetValue(msg.assetId, out SpawnDelegate handler))
             {
                 GameObject obj = handler(msg.position, msg.assetId);
                 if (obj == null)
@@ -534,11 +533,8 @@ namespace Mirror
                 }
                 return obj.GetComponent<NetworkIdentity>();
             }
-            else
-            {
-                Debug.LogError("Failed to spawn server object, did you forget to add it to the NetworkManager? assetId=" + msg.assetId + " netId=" + msg.netId);
-                return null;
-            }
+            Debug.LogError("Failed to spawn server object, did you forget to add it to the NetworkManager? assetId=" + msg.assetId + " netId=" + msg.netId);
+            return null;
         }
 
         static NetworkIdentity SpawnSceneObject(SpawnMessage msg)

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -507,11 +507,8 @@ namespace Mirror
 
         private static NetworkIdentity GetExistingObject(uint netid)
         {
-            if (NetworkIdentity.spawned.TryGetValue(netid, out NetworkIdentity localObject))
-            {
-                return localObject;
-            }
-            return null;
+            NetworkIdentity.spawned.TryGetValue(netid, out NetworkIdentity localObject);
+            return localObject;
         }
 
         private static NetworkIdentity SpawnPrefab(SpawnMessage msg)

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -345,7 +345,7 @@ namespace Mirror
             writer.WritePackedUInt32(netId);
             writer.WriteBoolean(isLocalPlayer);
             writer.WritePackedUInt64(sceneId);
-            if (sceneId > 0)
+            if (sceneId != 0)
             {
                 writer.WriteGuid(assetId);
             }

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -330,7 +330,7 @@ namespace Mirror
             netId = reader.ReadPackedUInt32();
             isLocalPlayer = reader.ReadBoolean();
             sceneId = reader.ReadPackedUInt64();
-            if (sceneId != 0)
+            if (sceneId == 0)
             {
                 assetId = reader.ReadGuid();
             }
@@ -345,7 +345,7 @@ namespace Mirror
             writer.WritePackedUInt32(netId);
             writer.WriteBoolean(isLocalPlayer);
             writer.WritePackedUInt64(sceneId);
-            if (sceneId != 0)
+            if (sceneId == 0)
             {
                 writer.WriteGuid(assetId);
             }

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -312,10 +312,11 @@ namespace Mirror
     #endregion
 
     #region Internal System Messages
-    public struct SpawnPrefabMessage : IMessageBase
+    public struct SpawnMessage : IMessageBase
     {
         public uint netId;
         public bool isLocalPlayer;
+        public ulong sceneId;
         public Guid assetId;
         public Vector3 position;
         public Quaternion rotation;
@@ -328,7 +329,11 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             isLocalPlayer = reader.ReadBoolean();
-            assetId = reader.ReadGuid();
+            sceneId = reader.ReadPackedUInt64();
+            if (sceneId != 0)
+            {
+                assetId = reader.ReadGuid();
+            }
             position = reader.ReadVector3();
             rotation = reader.ReadQuaternion();
             scale = reader.ReadVector3();
@@ -339,42 +344,11 @@ namespace Mirror
         {
             writer.WritePackedUInt32(netId);
             writer.WriteBoolean(isLocalPlayer);
-            writer.WriteGuid(assetId);
-            writer.WriteVector3(position);
-            writer.WriteQuaternion(rotation);
-            writer.WriteVector3(scale);
-            writer.WriteBytesAndSizeSegment(payload);
-        }
-    }
-
-    public struct SpawnSceneObjectMessage : IMessageBase
-    {
-        public uint netId;
-        public bool isLocalPlayer;
-        public ulong sceneId;
-        public Vector3 position;
-        public Quaternion rotation;
-        public Vector3 scale;
-        // the serialized component data
-        // -> ArraySegment to avoid unnecessary allocations
-        public ArraySegment<byte> payload;
-
-        public void Deserialize(NetworkReader reader)
-        {
-            netId = reader.ReadPackedUInt32();
-            isLocalPlayer = reader.ReadBoolean();
-            sceneId = reader.ReadUInt64();
-            position = reader.ReadVector3();
-            rotation = reader.ReadQuaternion();
-            scale = reader.ReadVector3();
-            payload = reader.ReadBytesAndSizeSegment();
-        }
-
-        public void Serialize(NetworkWriter writer)
-        {
-            writer.WritePackedUInt32(netId);
-            writer.WriteBoolean(isLocalPlayer);
-            writer.WriteUInt64(sceneId);
+            writer.WritePackedUInt64(sceneId);
+            if (sceneId > 0)
+            {
+                writer.WriteGuid(assetId);
+            }
             writer.WriteVector3(position);
             writer.WriteQuaternion(rotation);
             writer.WriteVector3(scale);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -344,8 +344,7 @@ namespace Mirror
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnLocalClientObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnLocalClientObjectHide);
                 RegisterHandler<NetworkPongMessage>((conn, msg) => { }, false);
-                RegisterHandler<SpawnPrefabMessage>(ClientScene.OnLocalClientSpawnPrefab);
-                RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnLocalClientSpawnSceneObject);
+                RegisterHandler<SpawnMessage>(ClientScene.OnLocalClientSpawn);
                 RegisterHandler<ObjectSpawnStartedMessage>((conn, msg) => { }); // host mode doesn't need spawning
                 RegisterHandler<ObjectSpawnFinishedMessage>((conn, msg) => { }); // host mode doesn't need spawning
                 RegisterHandler<UpdateVarsMessage>((conn, msg) => { });
@@ -355,8 +354,7 @@ namespace Mirror
                 RegisterHandler<ObjectDestroyMessage>(ClientScene.OnObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnObjectHide);
                 RegisterHandler<NetworkPongMessage>(NetworkTime.OnClientPong, false);
-                RegisterHandler<SpawnPrefabMessage>(ClientScene.OnSpawnPrefab);
-                RegisterHandler<SpawnSceneObjectMessage>(ClientScene.OnSpawnSceneObject);
+                RegisterHandler<SpawnMessage>(ClientScene.OnSpawn);
                 RegisterHandler<ObjectSpawnStartedMessage>(ClientScene.OnObjectSpawnStarted);
                 RegisterHandler<ObjectSpawnFinishedMessage>(ClientScene.OnObjectSpawnFinished);
                 RegisterHandler<UpdateVarsMessage>(ClientScene.OnUpdateVarsMessage);

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1077,7 +1077,7 @@ namespace Mirror
             // 'identity' is a prefab that should be spawned
             if (identity.sceneId == 0)
             {
-                SpawnPrefabMessage msg = new SpawnPrefabMessage
+                SpawnMessage msg = new SpawnMessage
                 {
                     netId = identity.netId,
                     isLocalPlayer = conn?.identity == identity,
@@ -1119,7 +1119,7 @@ namespace Mirror
             // 'identity' is a scene object that should be spawned again
             else
             {
-                SpawnSceneObjectMessage msg = new SpawnSceneObjectMessage
+                SpawnMessage msg = new SpawnMessage
                 {
                     netId = identity.netId,
                     isLocalPlayer = conn?.identity == identity,


### PR DESCRIPTION
Previously there were 2 separate messages:
* SpawnPrefabMessage
* SpawnSceneObjectMessage

These were almost the same, except that one of them had an assetId and the other had a sceneId.  The spawning logic also had a lot in common.

This PR changes it to just SpawnMessage.   The spawn message either has a sceneId or it has an assetId, and the client uses that to locate the object to be spawned.
