### PR TITLE
refactor: remove pending Owner

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -73,9 +73,7 @@ namespace Mirror
         /// This returns true if this object is the one that represents the player on the local machine.
         /// <para>This is set when the server has spawned an object for this particular client.</para>
         /// </summary>
-        public bool isLocalPlayer { get; private set; }
-
-        internal bool pendingLocalPlayer { get; set; }
+        public bool isLocalPlayer => ClientScene.localPlayer == this;
 
         /// <summary>
         /// This returns true if this object is the authoritative version of the object in the distributed network application.
@@ -236,19 +234,6 @@ namespace Mirror
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Host Migration was removed")]
         public static ClientAuthorityCallback clientAuthorityCallback;
-
-        // used when the player object for a connection changes
-        internal void SetNotLocalPlayer()
-        {
-            isLocalPlayer = false;
-
-            if (NetworkServer.active && NetworkServer.localClientActive)
-            {
-                // dont change authority for objects on the host
-                return;
-            }
-            hasAuthority = false;
-        }
 
         // this is used when a connection is destroyed, since the "observers" property is read-only
         internal void RemoveObserverInternal(NetworkConnection conn)
@@ -872,8 +857,6 @@ namespace Mirror
 
         internal void SetLocalPlayer()
         {
-            isLocalPlayer = true;
-
             // There is an ordering issue here that originAuthority solves:
             // OnStartAuthority should only be called if hasAuthority was false when this function began,
             // or it will be called twice for this object, but that state is lost by the time OnStartAuthority
@@ -1157,7 +1140,6 @@ namespace Mirror
             hasAuthority = false;
 
             netId = 0;
-            isLocalPlayer = false;
             connectionToServer = null;
             connectionToClient = null;
             networkBehavioursCache = null;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -876,13 +876,6 @@ namespace Mirror
             //NOTE: there can be an existing player
             if (LogFilter.Debug) Debug.Log("NetworkServer ReplacePlayer");
 
-            // is there already an owner that is a different object??
-            if (conn.identity != null)
-            {
-                conn.identity.SetNotLocalPlayer();
-                conn.identity.clientAuthorityOwner = null;
-            }
-
             conn.identity = identity;
 
             // Set the connection on the NetworkIdentity on the server, NetworkIdentity.SetLocalPlayer is not called on the server (it is on clients)


### PR DESCRIPTION
Previously,  in master when spawning the sequence was:

1)  Begin spawn
2) spawn  object
3) spawn object
4) spawn player  (client sets pendingOwner = true)
5) spawn object
6) End spawn  (client loops through all spawned objects looking for the one with pendingOwner = true and initializes it as local player)

With this PR,  logic is simpler:
1)  Begin spawn
2) spawn  object
3) spawn object
4) spawn player  (client sets ClientScene.localPlayer = object)
5) spawn object
6) End spawn  (client initializes localPlayer as local player)


