### PR TITLE
refactor: reuse connectionToClient for authority

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -51,7 +51,7 @@ namespace Mirror
                     //
                     // So we check here for a clientAuthorityOwner and if it is null we will
                     // let the server send animation data until we receive an owner.
-                    if (netIdentity != null && netIdentity.clientAuthorityOwner == null)
+                    if (netIdentity != null && netIdentity.connectionToClient == null)
                         return true;
                 }
 

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -165,10 +165,10 @@ namespace Mirror
                     }
                 }
 
-                if (identity.clientAuthorityOwner != null)
+                if (identity.connectionToClient != null)
                 {
                     Rect ownerRect = new Rect(initialX, lastY + 10, 400, 20);
-                    GUI.Label(ownerRect, new GUIContent("Client Authority: " + identity.clientAuthorityOwner), styles.labelStyle);
+                    GUI.Label(ownerRect, new GUIContent("Client Authority: " + identity.connectionToClient), styles.labelStyle);
                 }
             }
         }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -106,6 +106,9 @@ namespace Mirror
         [FormerlySerializedAs("m_ServerOnly")]
         public bool serverOnly;
 
+        [Obsolete("Use connectionToClient instead")]
+        public NetworkConnectionToClient clientAuthorityOwner => connectionToClient;
+
         /// <summary>
         /// The NetworkConnection associated with this NetworkIdentity. This is only valid for player objects on a local client.
         /// </summary>
@@ -116,9 +119,6 @@ namespace Mirror
         /// <para>Use it to return details such as the connection&apos;s identity, IP address and ready status.</para>
         /// </summary>
         public NetworkConnectionToClient connectionToClient { get; internal set; }
-
-        [Obsolete("Use connectionToClient instead")]
-        public NetworkConnectionToClient clientAuthorityOwner => connectionToClient;
 
         /// <summary>
         /// All spawned NetworkIdentities by netId. Available on server and client.

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -183,7 +183,7 @@ namespace Mirror
         {
             if (connectionToClient != null && conn != connectionToClient)
             {
-                Debug.LogError("SetClientOwner m_ClientAuthorityOwner already set!");
+                Debug.LogError($"Object {this} netId={netId} already has an owner", this);
             }
             connectionToClient = (NetworkConnectionToClient)conn;
             connectionToClient.AddOwnedObject(this);

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -106,6 +106,9 @@ namespace Mirror
         [FormerlySerializedAs("m_ServerOnly")]
         public bool serverOnly;
 
+        /// <summary>
+        /// Obsolete: Use connectionToClient instead
+        /// </summary>
         [Obsolete("Use connectionToClient instead")]
         public NetworkConnectionToClient clientAuthorityOwner => connectionToClient;
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -107,21 +107,18 @@ namespace Mirror
         public bool serverOnly;
 
         /// <summary>
-        /// The client that has authority for this object. This will be null if no client has authority.
-        /// <para>This is set for player objects with localPlayerAuthority, and for objects set with AssignClientAuthority, and spawned with SpawnWithClientAuthority.</para>
-        /// </summary>
-        public NetworkConnectionToClient clientAuthorityOwner { get; internal set; }
-
-        /// <summary>
         /// The NetworkConnection associated with this NetworkIdentity. This is only valid for player objects on a local client.
         /// </summary>
         public NetworkConnection connectionToServer { get; internal set; }
 
         /// <summary>
-        /// The NetworkConnection associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the server.
+        /// The NetworkConnection associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is valid for player and other owned objects in the server.
         /// <para>Use it to return details such as the connection&apos;s identity, IP address and ready status.</para>
         /// </summary>
         public NetworkConnectionToClient connectionToClient { get; internal set; }
+
+        [Obsolete("Use connectionToClient instead")]
+        public NetworkConnectionToClient clientAuthorityOwner => connectionToClient;
 
         /// <summary>
         /// All spawned NetworkIdentities by netId. Available on server and client.
@@ -184,12 +181,12 @@ namespace Mirror
         // used when adding players
         internal void SetClientOwner(NetworkConnection conn)
         {
-            if (clientAuthorityOwner != null)
+            if (connectionToClient != null && conn != connectionToClient)
             {
                 Debug.LogError("SetClientOwner m_ClientAuthorityOwner already set!");
             }
-            clientAuthorityOwner = (NetworkConnectionToClient)conn;
-            clientAuthorityOwner.AddOwnedObject(this);
+            connectionToClient = (NetworkConnectionToClient)conn;
+            connectionToClient.AddOwnedObject(this);
         }
 
         internal void ForceAuthority(bool authority)
@@ -1068,13 +1065,13 @@ namespace Mirror
                 return;
             }
 
-            if (connectionToClient != null)
+            if (connectionToClient?.identity == this)
             {
                 Debug.LogError("RemoveClientAuthority cannot remove authority for a player object");
                 return;
             }
 
-            if (clientAuthorityOwner != null)
+            if (connectionToClient != null)
             {
                 // send msg to that client
                 ClientAuthorityMessage msg = new ClientAuthorityMessage
@@ -1083,13 +1080,13 @@ namespace Mirror
                     authority = false
                 };
 
-                clientAuthorityOwner.Send(msg);
+                connectionToClient.Send(msg);
 #pragma warning disable CS0618 // Type or member is obsolete
-                clientAuthorityCallback?.Invoke(clientAuthorityOwner, this, false);
+                clientAuthorityCallback?.Invoke(connectionToClient, this, false);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-                clientAuthorityOwner.RemoveOwnedObject(this);
-                clientAuthorityOwner = null;
+                connectionToClient.RemoveOwnedObject(this);
+                connectionToClient = null;
             }
 
             // server now has authority (this is only called on server)
@@ -1111,7 +1108,7 @@ namespace Mirror
                 return false;
             }
 
-            if (clientAuthorityOwner != null && conn != clientAuthorityOwner)
+            if (connectionToClient != null && conn != connectionToClient)
             {
                 Debug.LogError("AssignClientAuthority for " + gameObject + " already has an owner. Use RemoveClientAuthority() first.");
                 return false;
@@ -1123,11 +1120,7 @@ namespace Mirror
                 return false;
             }
 
-            clientAuthorityOwner = (NetworkConnectionToClient)conn;
-            clientAuthorityOwner.AddOwnedObject(this);
-
-            // server no longer has authority (this is called on server). Note that local client could re-acquire authority below
-            ForceAuthority(false);
+            SetClientOwner(conn);
 
             // send msg to that client
             ClientAuthorityMessage msg = new ClientAuthorityMessage
@@ -1165,7 +1158,6 @@ namespace Mirror
             networkBehavioursCache = null;
 
             ClearObservers();
-            clientAuthorityOwner = null;
         }
 
         // MirrorUpdate is a hot path. Caching the vars msg is really worth it to

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -808,7 +808,7 @@ namespace Mirror
             conn.identity = identity;
 
             // Set the connection on the NetworkIdentity on the server, NetworkIdentity.SetLocalPlayer is not called on the server (it is on clients)
-            identity.connectionToClient = (Mirror.NetworkConnectionToClient)conn;
+            identity.connectionToClient = (NetworkConnectionToClient)conn;
 
             // set ready if not set yet
             SetClientReady(conn);
@@ -1009,13 +1009,10 @@ namespace Mirror
             // Commands can be for player objects, OR other objects with client-authority
             // -> so if this connection's controller has a different netId then
             //    only allow the command if clientAuthorityOwner
-            if (conn.identity != null && conn.identity.netId != identity.netId)
+            if (identity.connectionToClient != conn)
             {
-                if (identity.clientAuthorityOwner != conn)
-                {
-                    Debug.LogWarning("Command for object without authority [netId=" + msg.netId + "]");
-                    return;
-                }
+                Debug.LogWarning("Command for object without authority [netId=" + msg.netId + "]");
+                return;
             }
 
             if (LogFilter.Debug) Debug.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn);
@@ -1306,7 +1303,7 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("DestroyObject instance:" + identity.netId);
             NetworkIdentity.spawned.Remove(identity.netId);
 
-            identity.clientAuthorityOwner?.RemoveOwnedObject(identity);
+            identity.connectionToClient?.RemoveOwnedObject(identity);
 
             ObjectDestroyMessage msg = new ObjectDestroyMessage
             {


### PR DESCRIPTION
connectionToClient is now used for player and for owned objects.

