### PR TITLE
feat: NetworkConnection is optional for handlers

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -477,7 +477,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnSpawn(NetworkConnection _, SpawnMessage msg)
+        internal static void OnSpawn(SpawnMessage msg)
         {
             if (msg.assetId == Guid.Empty && msg.sceneId == 0)
             {
@@ -560,7 +560,7 @@ namespace Mirror
             return spawnedId;
         }
 
-        internal static void OnObjectSpawnStarted(NetworkConnection _, ObjectSpawnStartedMessage msg)
+        internal static void OnObjectSpawnStarted(ObjectSpawnStartedMessage _)
         {
             if (LogFilter.Debug) Debug.Log("SpawnStarted");
 
@@ -568,7 +568,7 @@ namespace Mirror
             isSpawnFinished = false;
         }
 
-        internal static void OnObjectSpawnFinished(NetworkConnection _, ObjectSpawnFinishedMessage msg)
+        internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage _)
         {
             if (LogFilter.Debug) Debug.Log("SpawnFinished");
 
@@ -586,12 +586,12 @@ namespace Mirror
             isSpawnFinished = true;
         }
 
-        internal static void OnObjectHide(NetworkConnection _, ObjectHideMessage msg)
+        internal static void OnObjectHide(ObjectHideMessage msg)
         {
             DestroyObject(msg.netId);
         }
 
-        internal static void OnObjectDestroy(NetworkConnection _, ObjectDestroyMessage msg)
+        internal static void OnObjectDestroy(ObjectDestroyMessage msg)
         {
             DestroyObject(msg.netId);
         }
@@ -627,14 +627,14 @@ namespace Mirror
             }
         }
 
-        internal static void OnLocalClientObjectDestroy(NetworkConnection _, ObjectDestroyMessage msg)
+        internal static void OnLocalClientObjectDestroy(ObjectDestroyMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnLocalObjectObjDestroy netId:" + msg.netId);
 
             NetworkIdentity.spawned.Remove(msg.netId);
         }
 
-        internal static void OnLocalClientObjectHide(NetworkConnection _, ObjectHideMessage msg)
+        internal static void OnLocalClientObjectHide(ObjectHideMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene::OnLocalObjectObjHide netId:" + msg.netId);
 
@@ -644,7 +644,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnLocalClientSpawn(NetworkConnection _, SpawnMessage msg)
+        internal static void OnLocalClientSpawn(SpawnMessage msg)
         {
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
@@ -652,7 +652,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnUpdateVarsMessage(NetworkConnection _, UpdateVarsMessage msg)
+        internal static void OnUpdateVarsMessage(UpdateVarsMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnUpdateVarsMessage " + msg.netId);
 
@@ -666,7 +666,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnRPCMessage(NetworkConnection _, RpcMessage msg)
+        internal static void OnRPCMessage(RpcMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnRPCMessage hash:" + msg.functionHash + " netId:" + msg.netId);
 
@@ -676,7 +676,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnSyncEventMessage(NetworkConnection _, SyncEventMessage msg)
+        internal static void OnSyncEventMessage(SyncEventMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnSyncEventMessage " + msg.netId);
 
@@ -690,7 +690,7 @@ namespace Mirror
             }
         }
 
-        internal static void OnClientAuthority(NetworkConnection _, ClientAuthorityMessage msg)
+        internal static void OnClientAuthority(ClientAuthorityMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnClientAuthority for netId: " + msg.netId);
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -596,6 +596,18 @@ namespace Mirror
         }
 
         /// <summary>
+        /// Register a handler for a particular message type.
+        /// <para>There are several system message types which you can add handlers for. You can also add your own message types.</para>
+        /// </summary>
+        /// <typeparam name="T">Message type</typeparam>
+        /// <param name="handler">Function handler which will be invoked for when this message type is received.</param>
+        /// <param name="requireAuthentication">True if the message requires an authenticated connection</param>
+        public static void RegisterHandler<T>(Action<T> handler, bool requireAuthentication = true) where T : IMessageBase, new()
+        {
+            RegisterHandler<T>((_, value) => { handler(value); }, requireAuthentication);
+        }
+
+        /// <summary>
         /// Obsolete: Use <see cref="UnregisterHandler{T}"/> instead.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Use UnregisterHandler<T> instead.")]

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -81,7 +81,7 @@ namespace Mirror
         // Executed at the client when we receive a Pong message
         // find out how long it took since we sent the Ping
         // and update time offset
-        internal static void OnClientPong(NetworkConnection _, NetworkPongMessage msg)
+        internal static void OnClientPong(NetworkPongMessage msg)
         {
             double now = LocalTime();
 


### PR DESCRIPTION
Most message handlers in the client don't really need the connection object.  So make it optional.  Note this does not break anything,  handlers with connection still work fine.