### PR TITLE
refactor: remove redundant authority set on host

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1091,9 +1091,6 @@ namespace Mirror
                 connectionToClient.RemoveOwnedObject(this);
                 connectionToClient = null;
             }
-
-            // server now has authority (this is only called on server)
-            ForceAuthority(false);
         }
 
         /// <summary>


### PR DESCRIPTION
This code should not be here.

it calls OnStopAuthority on the server if it previously had authority.  But that can only happen in host mode.   This is redundant because the client will do it again when it receives the message.
