### PR TITLE
feat: SyncToOwner now works with authority

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -467,7 +467,7 @@ namespace Mirror
 
             identity.netId = msg.netId;
             NetworkIdentity.spawned[msg.netId] = identity;
-            identity.pendingOwner = msg.isOwner;
+            identity.pendingAuthority = msg.isOwner;
 
             // objects spawned as part of initial state are started on a second pass
             if (isSpawnFinished)
@@ -475,7 +475,7 @@ namespace Mirror
                 identity.OnStartClient();
                 if (msg.isLocalPlayer)
                     CheckForLocalPlayer();
-                identity.hasAuthority = identity.pendingOwner;
+                identity.hasAuthority = identity.pendingAuthority;
             }
         }
 
@@ -579,7 +579,7 @@ namespace Mirror
             // use data from scene objects
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values.OrderBy(uv => uv.netId))
             {
-                identity.hasAuthority = identity.pendingOwner;
+                identity.hasAuthority = identity.pendingAuthority;
                 if (!identity.isClient)
                 {
                     identity.OnStartClient();
@@ -652,7 +652,6 @@ namespace Mirror
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 localObject.OnSetLocalVisibility(true);
-                localObject.hasAuthority = msg.isOwner;
             }
         }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -652,6 +652,7 @@ namespace Mirror
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 localObject.OnSetLocalVisibility(true);
+                localObject.hasAuthority = msg.isOwner;
             }
         }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -467,6 +467,7 @@ namespace Mirror
 
             identity.netId = msg.netId;
             NetworkIdentity.spawned[msg.netId] = identity;
+            identity.pendingOwner = msg.isOwner;
 
             // objects spawned as part of initial state are started on a second pass
             if (isSpawnFinished)
@@ -474,6 +475,7 @@ namespace Mirror
                 identity.OnStartClient();
                 if (msg.isLocalPlayer)
                     CheckForLocalPlayer();
+                identity.hasAuthority = identity.pendingOwner;
             }
         }
 
@@ -577,6 +579,7 @@ namespace Mirror
             // use data from scene objects
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values.OrderBy(uv => uv.netId))
             {
+                identity.hasAuthority = identity.pendingOwner;
                 if (!identity.isClient)
                 {
                     identity.OnStartClient();
@@ -687,16 +690,6 @@ namespace Mirror
             else
             {
                 Debug.LogWarning("Did not find target for SyncEvent message for " + msg.netId);
-            }
-        }
-
-        internal static void OnClientAuthority(ClientAuthorityMessage msg)
-        {
-            if (LogFilter.Debug) Debug.Log("ClientScene.OnClientAuthority for netId: " + msg.netId);
-
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
-            {
-                identity.ForceAuthority(msg.authority);
             }
         }
 

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -316,6 +316,7 @@ namespace Mirror
     {
         public uint netId;
         public bool isLocalPlayer;
+        public bool isOwner;
         public ulong sceneId;
         public Guid assetId;
         public Vector3 position;
@@ -329,6 +330,7 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             isLocalPlayer = reader.ReadBoolean();
+            isOwner = reader.ReadBoolean();
             sceneId = reader.ReadPackedUInt64();
             if (sceneId == 0)
             {
@@ -344,6 +346,7 @@ namespace Mirror
         {
             writer.WritePackedUInt32(netId);
             writer.WriteBoolean(isLocalPlayer);
+            writer.WriteBoolean(isOwner);
             writer.WritePackedUInt64(sceneId);
             if (sceneId == 0)
             {
@@ -397,24 +400,6 @@ namespace Mirror
         public void Serialize(NetworkWriter writer)
         {
             writer.WritePackedUInt32(netId);
-        }
-    }
-
-    public struct ClientAuthorityMessage : IMessageBase
-    {
-        public uint netId;
-        public bool authority;
-
-        public void Deserialize(NetworkReader reader)
-        {
-            netId = reader.ReadPackedUInt32();
-            authority = reader.ReadBoolean();
-        }
-
-        public void Serialize(NetworkWriter writer)
-        {
-            writer.WritePackedUInt32(netId);
-            writer.WriteBoolean(authority);
         }
     }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -359,7 +359,6 @@ namespace Mirror
                 RegisterHandler<ObjectSpawnFinishedMessage>(ClientScene.OnObjectSpawnFinished);
                 RegisterHandler<UpdateVarsMessage>(ClientScene.OnUpdateVarsMessage);
             }
-            RegisterHandler<ClientAuthorityMessage>(ClientScene.OnClientAuthority);
             RegisterHandler<RpcMessage>(ClientScene.OnRPCMessage);
             RegisterHandler<SyncEventMessage>(ClientScene.OnSyncEventMessage);
         }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -90,7 +90,7 @@ namespace Mirror
                 bool previous = isOwner;
                 isOwner = value;
 
-                if (prev && !isOwner)
+                if (previous && !isOwner)
                 {
                     OnStopAuthority();
                 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1059,7 +1059,7 @@ namespace Mirror
 
             if (connectionToClient != null)
             {
-                var previousOwner = connectionToClient;
+                NetworkConnectionToClient previousOwner = connectionToClient;
 
                 connectionToClient.RemoveOwnedObject(this);
                 connectionToClient = null;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -224,23 +224,6 @@ namespace Mirror
         /// </summary>
         public static void ResetNextNetworkId() => nextNetworkId = 1;
 
-        /// <summary>
-        /// Obsolete: Host Migration was removed
-        /// </summary>
-        /// <param name="conn">The network connection that is gaining or losing authority.</param>
-        /// <param name="identity">The object whose client authority status is being changed.</param>
-        /// <param name="authorityState">The new state of client authority of the object for the connection.</param>
-        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Host Migration was removed")]
-        public delegate void ClientAuthorityCallback(NetworkConnection conn, NetworkIdentity identity, bool authorityState);
-
-        /// <summary>
-        /// Obsolete: Host Migration was removed
-        /// <para>Whenever an object is spawned using SpawnWithClientAuthority, or the client authority status of an object is changed with AssignClientAuthority or RemoveClientAuthority, then this callback will be invoked.</para>
-        /// <para>This callback is used by the NetworkMigrationManager to distribute client authority state to peers for host migration. If the NetworkMigrationManager is not being used, this callback does not need to be populated.</para>
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Host Migration was removed")]
-        public static ClientAuthorityCallback clientAuthorityCallback;
-
         // this is used when a connection is destroyed, since the "observers" property is read-only
         internal void RemoveObserverInternal(NetworkConnection conn)
         {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -94,7 +94,7 @@ namespace Mirror
                 {
                     OnStopAuthority();
                 }
-                if (!prev && isOwner)
+                if (!previous && isOwner)
                 {
                     OnStartAuthority();
                 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -104,7 +104,7 @@ namespace Mirror
         // whether this object has been spawned with authority
         // we need hasAuthority and pendingOwner because
         // we need to wait until all of them spawn before updating hasAuthority
-        internal bool pendingOwner { get; set; }
+        internal bool pendingAuthority { get; set; }
 
         /// <summary>
         /// The set of network connections (players) that can see this object.

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -101,7 +101,7 @@ namespace Mirror
             }
         }
 
-        // wether this object has been spawned with authority
+        // whether this object has been spawned with authority
         // we need hasAuthority and pendingOwner because
         // we need to wait until all of them spawn before updating hasAuthority
         internal bool pendingOwner { get; set; }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -87,7 +87,7 @@ namespace Mirror
             get => isOwner;
             set
             {
-                bool prev = isOwner;
+                bool previous = isOwner;
                 isOwner = value;
 
                 if (prev && !isOwner)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1080,6 +1080,7 @@ namespace Mirror
             {
                 netId = identity.netId,
                 isLocalPlayer = conn?.identity == identity,
+                isOwner = identity.connectionToClient == conn && conn != null,
                 sceneId = identity.sceneId,
                 assetId = identity.assetId,
                 // use local values for VR support
@@ -1093,8 +1094,7 @@ namespace Mirror
             {
                 // use owner segment if 'conn' owns this identity, otherwise
                 // use observers segment
-                bool isOwner = identity.connectionToClient == conn;
-                msg.payload = isOwner ? ownerSegment : observersSegment;
+                msg.payload = msg.isOwner ? ownerSegment : observersSegment;
 
                 conn.Send(msg);
             }
@@ -1106,6 +1106,7 @@ namespace Mirror
                 //  serialized because the spawn message contains more data.
                 //  components might still be updated later on.)
                 msg.payload = ownerSegment;
+                msg.isOwner = true;
                 SendToClientOfPlayer(identity, msg);
 
                 // send observersWriter to everyone but owner
@@ -1113,6 +1114,7 @@ namespace Mirror
                 //  serialized because the spawn message contains more data.
                 //  components might still be updated later on.)
                 msg.payload = observersSegment;
+                msg.isOwner = false;
                 SendToReady(identity, msg, false);
             }
 


### PR DESCRIPTION
Now when Authority is granted/removed,  we respawn the object,  which resets all the variables and authority (does not create a new one).

With this change, sync2owner should work with authority.

fixes #1061 