### PR TITLE
refactor: Remove special case for host mode

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -649,10 +649,15 @@ namespace Mirror
 
         internal static void OnLocalClientSpawn(SpawnMessage msg)
         {
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
+            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity) && identity != null)
             {
-                localObject.OnSetLocalVisibility(true);
-                localObject.hasAuthority = msg.isOwner;
+                identity.OnSetLocalVisibility(true);
+                identity.OnStartClient();
+                if (msg.isLocalPlayer)
+                {
+                    OnSpawnMessageForLocalPlayer(identity.netId);
+                }
+                identity.hasAuthority = identity.pendingAuthority;
             }
         }
 

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -657,7 +657,7 @@ namespace Mirror
                 {
                     OnSpawnMessageForLocalPlayer(identity.netId);
                 }
-                identity.hasAuthority = identity.pendingAuthority;
+                identity.hasAuthority = msg.isOwner;
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -115,25 +115,6 @@ namespace Mirror
             connectionToClient.Send(new ConnectMessage());
         }
 
-        /// <summary>
-        /// Called by the server to set the LocalClient's LocalPlayer object during NetworkServer.AddPlayer()
-        /// </summary>
-        /// <param name="localPlayer"></param>
-        internal static void AddLocalPlayer(NetworkIdentity localPlayer)
-        {
-            if (LogFilter.Debug) Debug.Log("Local client AddLocalPlayer " + localPlayer.gameObject.name + " " + connection);
-            connection.isReady = true;
-            connection.identity = localPlayer;
-            if (localPlayer != null)
-            {
-                localPlayer.isClient = true;
-                NetworkIdentity.spawned[localPlayer.netId] = localPlayer;
-                localPlayer.connectionToServer = connection;
-            }
-            // there is no SystemOwnerMessage for local client. add to ClientScene here instead
-            ClientScene.InternalAddPlayer(localPlayer);
-        }
-
         static void InitializeTransportHandlers()
         {
             Transport.activeTransport.OnClientConnected.AddListener(OnConnected);

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -526,17 +526,6 @@ namespace Mirror
                     Debug.LogError("Exception in OnStartServer:" + e.Message + " " + e.StackTrace);
                 }
             }
-
-            if (NetworkClient.active && NetworkServer.localClientActive)
-            {
-                // there will be no spawn message, so start the client here too
-                OnStartClient();
-            }
-
-            if (hasAuthority)
-            {
-                OnStartAuthority();
-            }
         }
 
         internal void OnStartClient()

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1050,34 +1050,10 @@ namespace Mirror
                 scale = identity.transform.localScale
             };
 
-            // conn is != null when spawning it for a client
-            if (conn != null)
-            {
-                // use owner segment if 'conn' owns this identity, otherwise
-                // use observers segment
-                msg.payload = msg.isOwner ? ownerSegment : observersSegment;
-
-                conn.Send(msg);
-            }
-            // conn is == null when spawning it for the local player
-            else
-            {
-                // send ownerWriter to owner
-                // (spawn no matter what, even if no components were
-                //  serialized because the spawn message contains more data.
-                //  components might still be updated later on.)
-                msg.payload = ownerSegment;
-                msg.isOwner = true;
-                SendToClientOfPlayer(identity, msg);
-
-                // send observersWriter to everyone but owner
-                // (spawn no matter what, even if no components were
-                //  serialized because the spawn message contains more data.
-                //  components might still be updated later on.)
-                msg.payload = observersSegment;
-                msg.isOwner = false;
-                SendToReady(identity, msg, false);
-            }
+            // use owner segment if 'conn' owns this identity, otherwise
+            // use observers segment
+            msg.payload = msg.isOwner ? ownerSegment : observersSegment;
+            conn.Send(msg);
 
             NetworkWriterPool.Recycle(ownerWriter);
             NetworkWriterPool.Recycle(observersWriter);

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -825,45 +825,11 @@ namespace Mirror
             // set ready if not set yet
             SetClientReady(conn);
 
-            if (SetupLocalPlayerForConnection(conn, identity))
-            {
-                return true;
-            }
-
             if (LogFilter.Debug) Debug.Log("Adding new playerGameObject object netId: " + identity.netId + " asset ID " + identity.assetId);
 
             FinishPlayerForConnection(identity, player);
             identity.SetClientOwner(conn);
             return true;
-        }
-
-        static bool SetupLocalPlayerForConnection(NetworkConnection conn, NetworkIdentity identity)
-        {
-            if (LogFilter.Debug) Debug.Log("NetworkServer SetupLocalPlayerForConnection netID:" + identity.netId);
-
-            if (conn is ULocalConnectionToClient)
-            {
-                if (LogFilter.Debug) Debug.Log("NetworkServer AddPlayer handling ULocalConnectionToClient");
-
-                // Spawn this player for other players, instead of SpawnObject:
-                if (identity.netId == 0)
-                {
-                    // it is allowed to provide an already spawned object as the new player object.
-                    // so dont spawn it again.
-                    identity.OnStartServer(true);
-                }
-                identity.RebuildObservers(true);
-                SendSpawnMessage(identity, null);
-
-                // Set up local player instance on the client instance and update local object map
-                NetworkClient.AddLocalPlayer(identity);
-                identity.SetClientOwner(conn);
-
-                // Trigger OnStartLocalPlayer
-                identity.SetLocalPlayer();
-                return true;
-            }
-            return false;
         }
 
         static void FinishPlayerForConnection(NetworkIdentity identity, GameObject playerGameObject)
@@ -903,11 +869,6 @@ namespace Mirror
             SpawnObserversForConnection(conn);
 
             if (LogFilter.Debug) Debug.Log("NetworkServer ReplacePlayer setup local");
-
-            if (SetupLocalPlayerForConnection(conn, identity))
-            {
-                return true;
-            }
 
             if (LogFilter.Debug) Debug.Log("Replacing playerGameObject object netId: " + player.GetComponent<NetworkIdentity>().netId + " asset ID " + player.GetComponent<NetworkIdentity>().assetId);
 


### PR DESCRIPTION
Player object in host mode does not need special case.  Follow the same code path as client/server mode.  This reduces a lot of complexity and makes host mode more consistent with client/server mode.