### PR TITLE
feat: Pass SpawnMessage to spawn handler

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -52,7 +52,7 @@ namespace Mirror
         public static Dictionary<ulong, NetworkIdentity> spawnableObjects;
 
         // spawn handlers
-        static readonly Dictionary<Guid, SpawnDelegate> spawnHandlers = new Dictionary<Guid, SpawnDelegate>();
+        static readonly Dictionary<Guid, SpawnHandlerDelegate> spawnHandlers = new Dictionary<Guid, SpawnHandlerDelegate>();
         static readonly Dictionary<Guid, UnSpawnDelegate> unspawnHandlers = new Dictionary<Guid, UnSpawnDelegate>();
 
         // this is never called, and if we do call it in NetworkClient.Shutdown
@@ -288,6 +288,20 @@ namespace Mirror
         /// <param name="unspawnHandler">A method to use as a custom un-spawnhandler on clients.</param>
         public static void RegisterPrefab(GameObject prefab, SpawnDelegate spawnHandler, UnSpawnDelegate unspawnHandler)
         {
+            RegisterPrefab(prefab, msg => spawnHandler(msg.position, msg.assetId), unspawnHandler);
+        }
+
+        /// <summary>
+        /// Registers a prefab with the spawning system.
+        /// <para>When a NetworkIdentity object is spawned on a server with NetworkServer.SpawnObject(), and the prefab that the object was created from was registered with RegisterPrefab(), the client will use that prefab to instantiate a corresponding client object with the same netId.</para>
+        /// <para>The NetworkManager has a list of spawnable prefabs, it uses this function to register those prefabs with the ClientScene.</para>
+        /// <para>The set of current spawnable object is available in the ClientScene static member variable ClientScene.prefabs, which is a dictionary of NetworkAssetIds and prefab references.</para>
+        /// </summary>
+        /// <param name="prefab">A Prefab that will be spawned.</param>
+        /// <param name="spawnHandler">A method to use as a custom spawnhandler on clients.</param>
+        /// <param name="unspawnHandler">A method to use as a custom un-spawnhandler on clients.</param>
+        public static void RegisterPrefab(GameObject prefab, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler)
+        {
             NetworkIdentity identity = prefab.GetComponent<NetworkIdentity>();
             if (identity == null)
             {
@@ -337,6 +351,18 @@ namespace Mirror
         /// <param name="spawnHandler">A method to use as a custom spawnhandler on clients.</param>
         /// <param name="unspawnHandler">A method to use as a custom un-spawnhandler on clients.</param>
         public static void RegisterSpawnHandler(Guid assetId, SpawnDelegate spawnHandler, UnSpawnDelegate unspawnHandler)
+        {
+            RegisterSpawnHandler(assetId, msg => spawnHandler(msg.position, msg.assetId), unspawnHandler);
+        }
+
+        /// <summary>
+        /// This is an advanced spawning function that registers a custom assetId with the UNET spawning system.
+        /// <para>This can be used to register custom spawning methods for an assetId - instead of the usual method of registering spawning methods for a prefab. This should be used when no prefab exists for the spawned objects - such as when they are constructed dynamically at runtime from configuration data.</para>
+        /// </summary>
+        /// <param name="assetId">Custom assetId string.</param>
+        /// <param name="spawnHandler">A method to use as a custom spawnhandler on clients.</param>
+        /// <param name="unspawnHandler">A method to use as a custom un-spawnhandler on clients.</param>
+        public static void RegisterSpawnHandler(Guid assetId, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler)
         {
             if (spawnHandler == null || unspawnHandler == null)
             {
@@ -505,9 +531,9 @@ namespace Mirror
 
                 return obj.GetComponent<NetworkIdentity>();
             }
-            if (spawnHandlers.TryGetValue(msg.assetId, out SpawnDelegate handler))
+            if (spawnHandlers.TryGetValue(msg.assetId, out SpawnHandlerDelegate handler))
             {
-                GameObject obj = handler(msg.position, msg.assetId);
+                GameObject obj = handler(msg);
                 if (obj == null)
                 {
                     Debug.LogWarning("Client spawn handler for " + msg.assetId + " returned null");

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -11,6 +11,8 @@ namespace Mirror
     // Handles requests to spawn objects on the client
     public delegate GameObject SpawnDelegate(Vector3 position, Guid assetId);
 
+    public delegate GameObject SpawnHandlerDelegate(SpawnMessage msg);
+
     // Handles requests to unspawn objects on the client
     public delegate void UnSpawnDelegate(GameObject spawned);
 


### PR DESCRIPTION
Spawn handler should receive entire message,  not just position.  Note this PR keeps backwards compatibility.

Before,  this is how you would register a spawn handler:

```cs
public GameObject MySpawnHandler(Vector3 position, Guid guid)
{
       //  hmmm,  I don't have access to the rotation or scale,  only the position.
      return Instantiate(myPrefab);
}

public void Start()
{
      ClientScene.RegisterSpawnHandler(myguid,  MySpawnHandler,  myUnspawnHandler);
}
```
That still works fine.

But now you can instead register a handler that receives the message:
```cs
public GameObject MySpawnHandler(SpawnMessage msg)
{
      // yay,  now I have access to position, rotation, scale,  or anything else in SpawnMessage
      return Instantiate(msg.position, msg.rotation, myPrefab);
}

public void Start()
{
      ClientScene.RegisterSpawnHandler(myguid,  MySpawnHandler,  myUnspawnHandler);
}
```

