### PR TITLE
fix: Pass the name of the invoking class and desired command when an object has no authority.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -196,7 +196,7 @@ namespace Mirror
             // local players can always send commands, regardless of authority, other objects must have authority.
             if (!(isLocalPlayer || hasAuthority))
             {
-                Debug.LogWarning("Trying to send command for object without authority.");
+                Debug.LogWarning($"Trying to send command for object without authority. {invokeClass.ToString()}.{cmdName}");
                 return;
             }
 


### PR DESCRIPTION
Per @GabeBigBoxVR this was a useful fix for us!