### PR TITLE
feat: Script Templates

### DIFF
--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -11,11 +11,19 @@ public class #SCRIPTNAME# : NetworkManager
         base.OnValidate();
     }
 
+    /// <summary>
+    /// Runs on both Server and Client
+    /// Networking is NOT initialized when this fires
+    /// </summary>
     public override void Awake()
     {
         base.Awake();
     }
 
+    /// <summary>
+    /// Runs on both Server and Client
+    /// Networking is NOT initialized when this fires
+    /// </summary>
     public override void Start()
     {
         base.Start();

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -1,0 +1,263 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Mirror;
+
+public class #SCRIPTNAME# : NetworkManager
+{
+    #region Unity Callbacks
+
+    public override void OnValidate()
+    {
+        base.OnValidate();
+    }
+
+    public override void Awake()
+    {
+        base.Awake();
+    }
+
+    public override void Start()
+    {
+        base.Start();
+    }
+
+    public override void LateUpdate()
+    {
+        base.LateUpdate();
+    }
+
+    public override void OnDestroy()
+    {
+        base.OnDestroy();
+    }
+
+    #endregion
+
+    #region Start & Stop
+
+    /// <summary>
+    /// Set the frame rate for a headless server.
+    /// <para>Override if you wish to disable the behavior or set your own tick rate.</para>
+    /// </summary>
+    public override void ConfigureServerFrameRate()
+    {
+        base.ConfigureServerFrameRate();
+    }
+
+    /// <summary>
+    /// This starts a network "host" - a server and client in the same application.
+    /// <para>The client returned from StartHost() is a special "local" client that communicates to the in-process server using a message queue instead of the real network. But in almost all other cases, it can be treated as a normal client.</para>
+    /// </summary>
+    public override void StartHost()
+    {
+        base.StartHost();
+    }
+
+    /// <summary>
+    /// called when quitting the application by closing the window / pressing stop in the editor
+    /// <para>virtual so that inheriting classes' OnApplicationQuit() can call base.OnApplicationQuit() too</para>
+    /// </summary>
+    public override void OnApplicationQuit()
+    {
+        base.OnApplicationQuit();
+    }
+
+    #endregion
+
+    #region Scene Management
+
+    /// <summary>
+    /// This causes the server to switch scenes and sets the networkSceneName.
+    /// <para>Clients that connect to this server will automatically switch to this scene. This is called autmatically if onlineScene or offlineScene are set, but it can be called from user code to switch scenes again while the game is in progress. This automatically sets clients to be not-ready. The clients must call NetworkClient.Ready() again to participate in the new scene.</para>
+    /// </summary>
+    /// <param name="newSceneName"></param>
+    public override void ServerChangeScene(string newSceneName)
+    {
+        base.ServerChangeScene(newSceneName);
+    }
+
+    /// <summary>
+    /// This causes the server to switch scenes and sets the networkSceneName.
+    /// <para>Clients that connect to this server will automatically switch to this scene. This is called autmatically if onlineScene or offlineScene are set, but it can be called from user code to switch scenes again while the game is in progress. This automatically sets clients to be not-ready. The clients must call NetworkClient.Ready() again to participate in the new scene.</para>
+    /// </summary>
+    /// <param name="newSceneName"></param>
+    /// <param name="sceneMode"></param>
+    /// <param name="physicsMode"></param>
+    public override void ServerChangeScene(string newSceneName, LoadSceneMode sceneMode, LocalPhysicsMode physicsMode)
+    {
+        base.ServerChangeScene(newSceneName, sceneMode, physicsMode);
+    }
+
+    #endregion
+
+    #region Server System Callbacks
+
+    /// <summary>
+    /// Called on the server when a new client connects.
+    /// <para>Unity calls this on the Server when a Client connects to the Server. Use an override to tell the NetworkManager what to do when a client connects to the server.</para>
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    public override void OnServerConnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// Called on the server when a client is ready.
+    /// <para>The default implementation of this function calls NetworkServer.SetClientReady() to continue the network setup process.</para>
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    public override void OnServerReady(NetworkConnection conn)
+    {
+        base.OnServerReady(conn);
+    }
+
+    /// <summary>
+    /// Called on the server when a client disconnects.
+    /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    public override void OnServerDisconnect(NetworkConnection conn)
+    {
+        base.OnServerDisconnect(conn);
+    }
+
+    /// <summary>
+    /// Called on the server when a client adds a new player with ClientScene.AddPlayer.
+    /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    public override void OnServerAddPlayer(NetworkConnection conn)
+    {
+        base.OnServerAddPlayer(conn);
+    }
+
+    /// <summary>
+    /// Called on the server when a client removes a player.
+    /// <para>The default implementation of this function destroys the corresponding player object.</para>
+    /// </summary>
+    /// <param name="conn">The connection to remove the player from.</param>
+    /// <param name="player">The player controller to remove.</param>
+    public override void OnServerRemovePlayer(NetworkConnection conn, NetworkIdentity player)
+    {
+        base.OnServerRemovePlayer(conn, player);
+    }
+
+    /// <summary>
+    /// Called on the server when a network error occurs for a client connection.
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    /// <param name="errorCode">Error code.</param>
+    public override void OnServerError(NetworkConnection conn, int errorCode) { }
+
+    /// <summary>
+    /// Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed
+    /// <para>This allows server to do work / cleanup / prep before the scene changes.</para>
+    /// </summary>
+    /// <param name="newSceneName">Name of the scene that's about to be loaded</param>
+    public override void OnServerChangeScene(string newSceneName) { }
+
+    /// <summary>
+    /// Called on the server when a scene is completed loaded, when the scene load was initiated by the server with ServerChangeScene().
+    /// </summary>
+    /// <param name="sceneName">The name of the new scene.</param>
+    public override void OnServerSceneChanged(string sceneName) { }
+
+    #endregion
+
+    #region Client System Callbacks
+
+    /// <summary>
+    /// Called on the client when connected to a server.
+    /// <para>The default implementation of this function sets the client as ready and adds a player. Override the function to dictate what happens when the client connects.</para>
+    /// </summary>
+    /// <param name="conn">Connection to the server.</param>
+    public override void OnClientConnect(NetworkConnection conn)
+    {
+        base.OnClientConnect(conn);
+    }
+
+    /// <summary>
+    /// Called on clients when disconnected from a server.
+    /// <para>This is called on the client when it disconnects from the server. Override this function to decide what happens when the client disconnects.</para>
+    /// </summary>
+    /// <param name="conn">Connection to the server.</param>
+    public override void OnClientDisconnect(NetworkConnection conn)
+    {
+        base.OnClientDisconnect(conn);
+    }
+
+    /// <summary>
+    /// Called on clients when a network error occurs.
+    /// </summary>
+    /// <param name="conn">Connection to a server.</param>
+    /// <param name="errorCode">Error code.</param>
+    public override void OnClientError(NetworkConnection conn, int errorCode) { }
+
+    /// <summary>
+    /// Called on clients when a servers tells the client it is no longer ready.
+    /// <para>This is commonly used when switching scenes.</para>
+    /// </summary>
+    /// <param name="conn">Connection to the server.</param>
+    public override void OnClientNotReady(NetworkConnection conn) { }
+
+    /// <summary>
+    /// Called from ClientChangeScene immediately before SceneManager.LoadSceneAsync is executed
+    /// <para>This allows client to do work / cleanup / prep before the scene changes.</para>
+    /// </summary>
+    /// <param name="newSceneName">Name of the scene that's about to be loaded</param>
+    /// <param name="sceneOperation">Scene operation that's about to happen</param>
+    public override void OnClientChangeScene(string newSceneName, SceneOperation sceneOperation) { }
+
+    /// <summary>
+    /// Called on clients when a scene has completed loaded, when the scene load was initiated by the server.
+    /// <para>Scene changes can cause player objects to be destroyed. The default implementation of OnClientSceneChanged in the NetworkManager is to add a player object for the connection if no player object exists.</para>
+    /// </summary>
+    /// <param name="conn">The network connection that the scene change message arrived on.</param>
+    public override void OnClientSceneChanged(NetworkConnection conn)
+    {
+        base.OnClientSceneChanged(conn);
+    }
+
+    #endregion
+
+    #region Start & Stop callbacks
+
+    // Since there are multiple versions of StartServer, StartClient and StartHost, to reliably customize
+    // their functionality, users would need override all the versions. Instead these callbacks are invoked
+    // from all versions, so users only need to implement this one case.
+
+    /// <summary>
+    /// This is invoked when a host is started.
+    /// <para>StartHost has multiple signatures, but they all cause this hook to be called.</para>
+    /// </summary>
+    public override void OnStartHost() { }
+
+    /// <summary>
+    /// This is invoked when a server is started - including when a host is started.
+    /// <para>StartServer has multiple signatures, but they all cause this hook to be called.</para>
+    /// </summary>
+    public override void OnStartServer() { }
+
+    /// <summary>
+    /// This is invoked when the client is started.
+    /// </summary>
+    public override void OnStartClient()
+    {
+        base.OnStartClient();
+    }
+
+    /// <summary>
+    /// This is called when a server is stopped - including when a host is stopped.
+    /// </summary>
+    public override void OnStopServer() { }
+
+    /// <summary>
+    /// This is called when a client is stopped.
+    /// </summary>
+    public override void OnStopClient() { }
+
+    /// <summary>
+    /// This is called when a host is stopped.
+    /// </summary>
+    public override void OnStopHost() { }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -2,6 +2,11 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using Mirror;
 
+/*
+	Documentation: https://mirror-networking.com/docs/Components/NetworkManager.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkManager.html
+*/
+
 public class #SCRIPTNAME# : NetworkManager
 {
     #region Unity Callbacks

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -226,7 +226,7 @@ public class #SCRIPTNAME# : NetworkManager
 
     #endregion
 
-    #region Start & Stop callbacks
+    #region Start & Stop Callbacks
 
     // Since there are multiple versions of StartServer, StartClient and StartHost, to reliably customize
     // their functionality, users would need override all the versions. Instead these callbacks are invoked

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt.meta
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ed73cc79a95879d4abd948a36043c798
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
+++ b/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
@@ -2,6 +2,12 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using Mirror;
 
+/*
+	Authenticators: https://mirror-networking.com/docs/Components/Authenticators/
+	Documentation: https://mirror-networking.com/docs/Guides/Authentication.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkAuthenticator.html
+*/
+
 public class #SCRIPTNAME# : NetworkAuthenticator
 {
     #region Messages

--- a/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
+++ b/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
@@ -12,7 +12,7 @@ public class #SCRIPTNAME# : NetworkAuthenticator
 
     #endregion
 
-    #region server
+    #region Server
 
     /// <summary>
     /// Called on server from StartServer to initialize the Authenticator
@@ -42,7 +42,7 @@ public class #SCRIPTNAME# : NetworkAuthenticator
 
     #endregion
 
-    #region client
+    #region Client
 
     /// <summary>
     /// Called on client from StartClient to initialize the Authenticator

--- a/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
+++ b/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
@@ -1,0 +1,75 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Mirror;
+
+public class #SCRIPTNAME# : NetworkAuthenticator
+{
+    #region Messages
+
+    public class AuthRequestMessage : MessageBase { }
+
+    public class AuthResponseMessage : MessageBase { }
+
+    #endregion
+
+    #region server
+
+    /// <summary>
+    /// Called on server from StartServer to initialize the Authenticator
+    /// <para>Server message handlers should be registered in this method.</para>
+    /// </summary>
+    public override void OnStartServer()
+    {
+        // register a handler for the authentication request we expect from client
+        NetworkServer.RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage, false);
+    }
+
+    /// <summary>
+    /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate
+    /// </summary>
+    /// <param name="conn">Connection to client.</param>
+    public override void OnServerAuthenticate(NetworkConnection conn) { }
+
+    public void OnAuthRequestMessage(NetworkConnection conn, AuthRequestMessage msg)
+    {
+        AuthResponseMessage authResponseMessage = new AuthResponseMessage();
+
+        conn.Send(authResponseMessage);
+
+        // Invoke the event to complete a successful authentication
+        base.OnServerAuthenticated.Invoke(conn);
+    }
+
+    #endregion
+
+    #region client
+
+    /// <summary>
+    /// Called on client from StartClient to initialize the Authenticator
+    /// <para>Client message handlers should be registered in this method.</para>
+    /// </summary>
+    public override void OnStartClient()
+    {
+        // register a handler for the authentication response we expect from server
+        NetworkClient.RegisterHandler<AuthResponseMessage>(OnAuthResponseMessage, false);
+    }
+
+    /// <summary>
+    /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
+    /// </summary>
+    /// <param name="conn">Connection of the client.</param>
+    public override void OnClientAuthenticate(NetworkConnection conn)
+    {
+        AuthRequestMessage authRequestMessage = new AuthRequestMessage();
+
+        NetworkClient.Send(authRequestMessage);
+    }
+
+    public void OnAuthResponseMessage(NetworkConnection conn, AuthResponseMessage msg)
+    {
+        // Invoke the event to complete a successful authentication
+        base.OnClientAuthenticated.Invoke(conn);
+    }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt.meta
+++ b/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 12dc04aca2d89f744bef5a65622ba708
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
+++ b/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
@@ -4,36 +4,6 @@ using System.Collections.Generic;
 
 public class #SCRIPTNAME# : NetworkBehaviour
 {
-    #region Serialization
-
-    /// <summary>
-    /// Virtual function to override to send custom serialization data. The corresponding function to send serialization data is OnDeserialize().
-    /// </summary>
-    /// <remarks>
-    /// <para>The initialState flag is useful to differentiate between the first time an object is serialized and when incremental updates can be sent. The first time an object is sent to a client, it must include a full state snapshot, but subsequent updates can save on bandwidth by including only incremental changes. Note that SyncVar hook functions are not called when initialState is true, only for incremental updates.</para>
-    /// <para>If a class has SyncVars, then an implementation of this function and OnDeserialize() are added automatically to the class. So a class that has SyncVars cannot also have custom serialization functions.</para>
-    /// <para>The OnSerialize function should return true to indicate that an update should be sent. If it returns true, then the dirty bits for that script are set to zero, if it returns false then the dirty bits are not changed. This allows multiple changes to a script to be accumulated over time and sent when the system is ready, instead of every frame.</para>
-    /// </remarks>
-    /// <param name="writer">Writer to use to write to the stream.</param>
-    /// <param name="initialState">If this is being called to send initial state.</param>
-    /// <returns>True if data was written.</returns>
-    public override bool OnSerialize(NetworkWriter writer, bool initialState)
-    {
-        return base.OnSerialize(writer, initialState);
-    }
-
-    /// <summary>
-    /// Virtual function to override to receive custom serialization data. The corresponding function to send serialization data is OnSerialize().
-    /// </summary>
-    /// <param name="reader">Reader to read from the stream.</param>
-    /// <param name="initialState">True if being sent initial state.</param>
-    public override void OnDeserialize(NetworkReader reader, bool initialState)
-    {
-        base.OnDeserialize(reader, initialState);
-    }
-
-    #endregion
-
     #region Start & Stop callbacks
 
     /// <summary>
@@ -102,5 +72,35 @@ public class #SCRIPTNAME# : NetworkBehaviour
         return base.OnCheckObserver(conn);
     }
     
+    #endregion
+
+    #region Serialization
+
+    /// <summary>
+    /// Virtual function to override to send custom serialization data. The corresponding function to send serialization data is OnDeserialize().
+    /// </summary>
+    /// <remarks>
+    /// <para>The initialState flag is useful to differentiate between the first time an object is serialized and when incremental updates can be sent. The first time an object is sent to a client, it must include a full state snapshot, but subsequent updates can save on bandwidth by including only incremental changes. Note that SyncVar hook functions are not called when initialState is true, only for incremental updates.</para>
+    /// <para>If a class has SyncVars, then an implementation of this function and OnDeserialize() are added automatically to the class. So a class that has SyncVars cannot also have custom serialization functions.</para>
+    /// <para>The OnSerialize function should return true to indicate that an update should be sent. If it returns true, then the dirty bits for that script are set to zero, if it returns false then the dirty bits are not changed. This allows multiple changes to a script to be accumulated over time and sent when the system is ready, instead of every frame.</para>
+    /// </remarks>
+    /// <param name="writer">Writer to use to write to the stream.</param>
+    /// <param name="initialState">If this is being called to send initial state.</param>
+    /// <returns>True if data was written.</returns>
+    public override bool OnSerialize(NetworkWriter writer, bool initialState)
+    {
+        return base.OnSerialize(writer, initialState);
+    }
+
+    /// <summary>
+    /// Virtual function to override to receive custom serialization data. The corresponding function to send serialization data is OnSerialize().
+    /// </summary>
+    /// <param name="reader">Reader to read from the stream.</param>
+    /// <param name="initialState">True if being sent initial state.</param>
+    public override void OnDeserialize(NetworkReader reader, bool initialState)
+    {
+        base.OnDeserialize(reader, initialState);
+    }
+
     #endregion
 }

--- a/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
+++ b/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 public class #SCRIPTNAME# : NetworkBehaviour
 {
-    #region Start & Stop callbacks
+    #region Start & Stop Callbacks
 
     /// <summary>
     /// This is invoked for NetworkBehaviour objects when they become active on the server.

--- a/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
+++ b/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
@@ -1,0 +1,106 @@
+using UnityEngine;
+using Mirror;
+using System.Collections.Generic;
+
+public class #SCRIPTNAME# : NetworkBehaviour
+{
+    #region Serialization
+
+    /// <summary>
+    /// Virtual function to override to send custom serialization data. The corresponding function to send serialization data is OnDeserialize().
+    /// </summary>
+    /// <remarks>
+    /// <para>The initialState flag is useful to differentiate between the first time an object is serialized and when incremental updates can be sent. The first time an object is sent to a client, it must include a full state snapshot, but subsequent updates can save on bandwidth by including only incremental changes. Note that SyncVar hook functions are not called when initialState is true, only for incremental updates.</para>
+    /// <para>If a class has SyncVars, then an implementation of this function and OnDeserialize() are added automatically to the class. So a class that has SyncVars cannot also have custom serialization functions.</para>
+    /// <para>The OnSerialize function should return true to indicate that an update should be sent. If it returns true, then the dirty bits for that script are set to zero, if it returns false then the dirty bits are not changed. This allows multiple changes to a script to be accumulated over time and sent when the system is ready, instead of every frame.</para>
+    /// </remarks>
+    /// <param name="writer">Writer to use to write to the stream.</param>
+    /// <param name="initialState">If this is being called to send initial state.</param>
+    /// <returns>True if data was written.</returns>
+    public override bool OnSerialize(NetworkWriter writer, bool initialState)
+    {
+        return base.OnSerialize(writer, initialState);
+    }
+
+    /// <summary>
+    /// Virtual function to override to receive custom serialization data. The corresponding function to send serialization data is OnSerialize().
+    /// </summary>
+    /// <param name="reader">Reader to read from the stream.</param>
+    /// <param name="initialState">True if being sent initial state.</param>
+    public override void OnDeserialize(NetworkReader reader, bool initialState)
+    {
+        base.OnDeserialize(reader, initialState);
+    }
+
+    #endregion
+
+    #region Start & Stop callbacks
+
+    /// <summary>
+    /// This is invoked for NetworkBehaviour objects when they become active on the server.
+    /// <para>This could be triggered by NetworkServer.Listen() for objects in the scene, or by NetworkServer.Spawn() for objects that are dynamically created.</para>
+    /// <para>This will be called for objects on a "host" as well as for object on a dedicated server.</para>
+    /// </summary>
+    public override void OnStartServer() { }
+
+    /// <summary>
+    /// Called on every NetworkBehaviour when it is activated on a client.
+    /// <para>Objects on the host have this function called, as there is a local client on the host. The values of SyncVars on object are guaranteed to be initialized correctly with the latest state from the server when this function is called on the client.</para>
+    /// </summary>
+    public override void OnStartClient() { }
+
+    /// <summary>
+    /// Called when the local player object has been set up.
+    /// <para>This happens after OnStartClient(), as it is triggered by an ownership message from the server. This is an appropriate place to activate components or functionality that should only be active for the local player, such as cameras and input.</para>
+    /// </summary>
+    public override void OnStartLocalPlayer() { }
+
+    /// <summary>
+    /// This is invoked on behaviours that have authority, based on context and <see cref="NetworkIdentity.hasAuthority">NetworkIdentity.hasAuthority</see>.
+    /// <para>This is called after <see cref="OnStartServer">OnStartServer</see> and <see cref="OnStartClient">OnStartClient.</see></para>
+    /// <para>When <see cref="NetworkIdentity.AssignClientAuthority"/> is called on the server, this will be called on the client that owns the object. When an object is spawned with <see cref="NetworkServer.Spawn">NetworkServer.Spawn</see> with a NetworkConnection parameter included, this will be called on the client that owns the object.</para>
+    /// </summary>
+    public override void OnStartAuthority() { }
+
+    /// <summary>
+    /// This is invoked on behaviours when authority is removed.
+    /// <para>When NetworkIdentity.RemoveClientAuthority is called on the server, this will be called on the client that owns the object.</para>
+    /// </summary>
+    public override void OnStopAuthority() { }
+
+    #endregion
+
+    #region Observers
+
+    /// <summary>
+    /// Callback used by the visibility system to (re)construct the set of observers that can see this object.
+    /// <para>Implementations of this callback should add network connections of players that can see this object to the observers set.</para>
+    /// </summary>
+    /// <param name="observers">The new set of observers for this object.</param>
+    /// <param name="initialize">True if the set of observers is being built for the first time.</param>
+    /// <returns>true when overwriting so that Mirror knows that we wanted to rebuild observers ourselves. otherwise it uses built in rebuild.</returns>
+    public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
+    {
+        return base.OnRebuildObservers(observers, initialize);
+    }
+
+    /// <summary>
+    /// Callback used by the visibility system for objects on a host.
+    /// <para>Objects on a host (with a local client) cannot be disabled or destroyed when they are not visibile to the local client. So this function is called to allow custom code to hide these objects. A typical implementation will disable renderer components on the object. This is only called on local clients on a host.</para>
+    /// </summary>
+    /// <param name="vis">New visibility state.</param>
+    public override void OnSetLocalVisibility(bool vis) { }
+
+    /// <summary>
+    /// Callback used by the visibility system to determine if an observer (player) can see this object.
+    /// <para>If this function returns true, the network connection will be added as an observer.</para>
+    /// </summary>
+    /// <param name="conn">Network connection of a player.</param>
+    /// <returns>True if the player can see this object.</returns>
+    public override bool OnCheckObserver(NetworkConnection conn)
+    {
+        return base.OnCheckObserver(conn);
+    }
+    
+    #endregion
+}

--- a/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
+++ b/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
@@ -2,6 +2,11 @@ using UnityEngine;
 using Mirror;
 using System.Collections.Generic;
 
+/*
+	Documentation: https://mirror-networking.com/docs/Guides/NetworkBehaviour.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkBehaviour.html
+*/
+
 public class #SCRIPTNAME# : NetworkBehaviour
 {
     #region Start & Stop Callbacks

--- a/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt.meta
+++ b/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 29b2ae9aeacc49b47b711838dd1876a4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/53-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt
+++ b/Assets/ScriptTemplates/53-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt
@@ -1,6 +1,21 @@
 using UnityEngine;
 using Mirror;
 
+/*
+	Documentation: https://mirror-networking.com/docs/Components/NetworkRoomManager.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkRoomManager.html
+
+	See Also: NetworkManager
+	Documentation: https://mirror-networking.com/docs/Components/NetworkManager.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkManager.html
+*/
+
+/// <summary>
+/// This is a specialized NetworkManager that includes a networked room.
+/// The room has slots that track the joined players, and a maximum player count that is enforced.
+/// It requires that the NetworkRoomPlayer component be on the room player objects.
+/// NetworkRoomManager is derived from NetworkManager, and so it implements many of the virtual functions provided by the NetworkManager class.
+/// </summary>
 public class #SCRIPTNAME# : NetworkRoomManager
 {
     #region Server Callbacks

--- a/Assets/ScriptTemplates/53-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt
+++ b/Assets/ScriptTemplates/53-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt
@@ -1,0 +1,143 @@
+using UnityEngine;
+using Mirror;
+
+public class #SCRIPTNAME# : NetworkRoomManager
+{
+    #region Server Callbacks
+
+    /// <summary>
+    /// This is called on the server when the server is started - including when a host is started.
+    /// </summary>
+    public override void OnRoomStartServer() { }
+
+    /// <summary>
+    /// This is called on the host when a host is started.
+    /// </summary>
+    public override void OnRoomStartHost() { }
+
+    /// <summary>
+    /// This is called on the host when the host is stopped.
+    /// </summary>
+    public override void OnRoomStopHost() { }
+
+    /// <summary>
+    /// This is called on the server when a new client connects to the server.
+    /// </summary>
+    /// <param name="conn">The new connection.</param>
+    public override void OnRoomServerConnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// This is called on the server when a client disconnects.
+    /// </summary>
+    /// <param name="conn">The connection that disconnected.</param>
+    public override void OnRoomServerDisconnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// This is called on the server when a networked scene finishes loading.
+    /// </summary>
+    /// <param name="sceneName">Name of the new scene.</param>
+    public override void OnRoomServerSceneChanged(string sceneName) { }
+
+    /// <summary>
+    /// This allows customization of the creation of the room-player object on the server.
+    /// <para>By default the roomPlayerPrefab is used to create the room-player, but this function allows that behaviour to be customized.</para>
+    /// </summary>
+    /// <param name="conn">The connection the player object is for.</param>
+    /// <returns>The new room-player object.</returns>
+    public override GameObject OnRoomServerCreateRoomPlayer(NetworkConnection conn)
+    {
+        return base.OnRoomServerCreateRoomPlayer(conn);
+    }
+
+    /// <summary>
+    /// This allows customization of the creation of the GamePlayer object on the server.
+    /// <para>By default the gamePlayerPrefab is used to create the game-player, but this function allows that behaviour to be customized. The object returned from the function will be used to replace the room-player on the connection.</para>
+    /// </summary>
+    /// <param name="conn">The connection the player object is for.</param>
+    /// <returns>A new GamePlayer object.</returns>
+    public override GameObject OnRoomServerCreateGamePlayer(NetworkConnection conn)
+    {
+        return base.OnRoomServerCreateGamePlayer(conn);
+    }
+
+    /// <summary>
+    /// This is called on the server when it is told that a client has finished switching from the room scene to a game player scene.
+    /// <para>When switching from the room, the room-player is replaced with a game-player object. This callback function gives an opportunity to apply state from the room-player to the game-player object.</para>
+    /// </summary>
+    /// <param name="roomPlayer">The room player object.</param>
+    /// <param name="gamePlayer">The game player object.</param>
+    /// <returns>False to not allow this player to replace the room player.</returns>
+    public override bool OnRoomServerSceneLoadedForPlayer(GameObject roomPlayer, GameObject gamePlayer)
+    {
+        return base.OnRoomServerSceneLoadedForPlayer(roomPlayer, gamePlayer);
+    }
+
+    /// <summary>
+    /// This is called on the server when all the players in the room are ready.
+    /// <para>The default implementation of this function uses ServerChangeScene() to switch to the game player scene. By implementing this callback you can customize what happens when all the players in the room are ready, such as adding a countdown or a confirmation for a group leader.</para>
+    /// </summary>
+    public override void OnRoomServerPlayersReady()
+    {
+        base.OnRoomServerPlayersReady();
+    }
+
+    #endregion
+
+    #region Client Callbacks
+
+    /// <summary>
+    /// This is a hook to allow custom behaviour when the game client enters the room.
+    /// </summary>
+    public override void OnRoomClientEnter() { }
+
+    /// <summary>
+    /// This is a hook to allow custom behaviour when the game client exits the room.
+    /// </summary>
+    public override void OnRoomClientExit() { }
+
+    /// <summary>
+    /// This is called on the client when it connects to server.
+    /// </summary>
+    /// <param name="conn">The connection that connected.</param>
+    public override void OnRoomClientConnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// This is called on the client when disconnected from a server.
+    /// </summary>
+    /// <param name="conn">The connection that disconnected.</param>
+    public override void OnRoomClientDisconnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// This is called on the client when a client is started.
+    /// </summary>
+    /// <param name="roomClient">The connection for the room.</param>
+    public override void OnRoomStartClient() { }
+
+    /// <summary>
+    /// This is called on the client when the client stops.
+    /// </summary>
+    public override void OnRoomStopClient() { }
+
+    /// <summary>
+    /// This is called on the client when the client is finished loading a new networked scene.
+    /// </summary>
+    /// <param name="conn">The connection that finished loading a new networked scene.</param>
+    public override void OnRoomClientSceneChanged(NetworkConnection conn) { }
+
+    /// <summary>
+    /// Called on the client when adding a player to the room fails.
+    /// <para>This could be because the room is full, or the connection is not allowed to have more players.</para>
+    /// </summary>
+    public override void OnRoomClientAddPlayerFailed() { }
+
+    #endregion
+
+    #region Optional UI
+
+    public override void OnGUI()
+    {
+        base.OnGUI();
+    }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/53-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt.meta
+++ b/Assets/ScriptTemplates/53-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2e5656107e61a93439544b91e5f541f6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/54-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt
+++ b/Assets/ScriptTemplates/54-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt
@@ -3,7 +3,7 @@ using Mirror;
 
 public class #SCRIPTNAME# : NetworkRoomPlayer
 {
-    #region Room Client Virtuals
+    #region Room Client Callbacks
 
     /// <summary>
     /// This is a hook that is invoked on all player objects when entering the room.

--- a/Assets/ScriptTemplates/54-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt
+++ b/Assets/ScriptTemplates/54-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt
@@ -1,6 +1,17 @@
 using UnityEngine;
 using Mirror;
 
+/*
+	Documentation: https://mirror-networking.com/docs/Components/NetworkRoomPlayer.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkRoomPlayer.html
+*/
+
+/// <summary>
+/// This component works in conjunction with the NetworkRoomManager to make up the multiplayer room system.
+/// The RoomPrefab object of the NetworkRoomManager must have this component on it.
+/// This component holds basic room player data required for the room to function.
+/// Game specific data for room players can be put in other components on the RoomPrefab or in scripts derived from NetworkRoomPlayer.
+/// </summary>
 public class #SCRIPTNAME# : NetworkRoomPlayer
 {
     #region Room Client Callbacks

--- a/Assets/ScriptTemplates/54-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt
+++ b/Assets/ScriptTemplates/54-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt
@@ -1,0 +1,36 @@
+using UnityEngine;
+using Mirror;
+
+public class #SCRIPTNAME# : NetworkRoomPlayer
+{
+    #region Room Client Virtuals
+
+    /// <summary>
+    /// This is a hook that is invoked on all player objects when entering the room.
+    /// <para>Note: isLocalPlayer is not guaranteed to be set until OnStartLocalPlayer is called.</para>
+    /// </summary>
+    public override void OnClientEnterRoom() { }
+
+    /// <summary>
+    /// This is a hook that is invoked on all player objects when exiting the room.
+    /// </summary>
+    public override void OnClientExitRoom() { }
+
+    /// <summary>
+    /// This is a hook that is invoked on clients when a RoomPlayer switches between ready or not ready.
+    /// <para>This function is called when the a client player calls SendReadyToBeginMessage() or SendNotReadyToBeginMessage().</para>
+    /// </summary>
+    /// <param name="readyState">Whether the player is ready or not.</param>
+    public override void OnClientReady(bool readyState) { }
+
+    #endregion
+
+    #region Optional UI
+
+    public override void OnGUI()
+    {
+        base.OnGUI();
+    }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/54-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt.meta
+++ b/Assets/ScriptTemplates/54-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1ca8a6309173d4248bc7fa0c6ae001e0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds script templates to Mirror for improved ease of use.

Given all the virtual methods we have in these classes, users invariably need to make their own custom versions of them that inherit from ours.  These templates have all the available overrides included, calling base methods where necessary, and are fully documented with summary comments so devs can easily learn what all is available to them and what everything does as a supplement to the docs.

Notes:
- The ScriptTemplates folder has to be in the root Assets folder for Unity to find it.  It won't work from inside the Mirror folder.
- The naming of the files is specific to Unity and the pattern it expects.
- Just like the Add Component menu, Unity must be restarted after Mirror is imported for the menus to show these templates.

In early development, having all these built out for the dev is just convenient.  I'd expect that empty methods will compile away, and of course the unused methods can be deleted when approaching a production release.

As shown in the image below, a Mirror menu is added to the Assets > Create menu, and the user is prompted for the name they want, like any other asset they'd create.  This also works from right-clicking the Project pane in the editor.

![image](https://user-images.githubusercontent.com/9826063/69011657-fcaa6500-093a-11ea-8932-d29cc53971e9.png)
