### PR TITLE
fix: set hasAuthority before calling OnStartClient

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -475,15 +475,15 @@ namespace Mirror
 
             identity.netId = msg.netId;
             NetworkIdentity.spawned[msg.netId] = identity;
-            identity.pendingAuthority = msg.isOwner;
+            identity.hasAuthority = msg.isOwner;
 
             // objects spawned as part of initial state are started on a second pass
             if (isSpawnFinished)
             {
+                identity.NotifyAuthority();
                 identity.OnStartClient();
                 if (msg.isLocalPlayer)
                     OnSpawnMessageForLocalPlayer(identity);
-                identity.hasAuthority = identity.pendingAuthority;
             }
         }
 
@@ -581,7 +581,7 @@ namespace Mirror
             // use data from scene objects
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values.OrderBy(uv => uv.netId))
             {
-                identity.hasAuthority = identity.pendingAuthority;
+                identity.NotifyAuthority();
                 identity.OnStartClient();
             }
             if (localPlayer != null)
@@ -653,14 +653,15 @@ namespace Mirror
             {
                 if (msg.isLocalPlayer)
                     localPlayer = identity;
+                identity.hasAuthority = msg.isOwner;
 
                 identity.OnSetLocalVisibility(true);
+                identity.NotifyAuthority();
                 identity.OnStartClient();
                 if (msg.isLocalPlayer)
                 {
                     OnSpawnMessageForLocalPlayer(identity);
                 }
-                identity.hasAuthority = msg.isOwner;
             }
         }
 


### PR DESCRIPTION
hasAuthority is now guaranteed to be set before OnStartClient:

Before, for host mode player:
```
OnStartServer IsClient True  isServer True hasAuthority False localPlayer False
OnStartClient IsClient True  isServer True hasAuthority False localPlayer True
OnStartLocalPlayer Client IsClient True  isServer True hasAuthority True localPlayer True
OnStart IsClient True  isServer True hasAuthority True localPlayer True
```

After:
```
OnStartServer IsClient True  isServer True hasAuthority False localPlayer False
OnStartClient IsClient True  isServer True hasAuthority True localPlayer True
OnStartLocalPlayer Client IsClient True  isServer True hasAuthority True localPlayer True
OnStart IsClient True  isServer True hasAuthority True localPlayer True
```

Note ideally they would all be true,  more PR's to follow