### PR TITLE
breaking: Replace 'local client' naming with 'host' to be less confusing. This breaks NetworkProximityChecker.OnSetLocalVisibility because it needs to be renamed to OnSetHostVisibility

### DIFF
--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -157,10 +157,13 @@ namespace Mirror
         }
 
         /// <summary>
-        /// Called when hiding and showing objects on the host
+        /// Called when hiding and showing objects on the host.
+        /// On regular clients, objects simply spawn/despawn.
+        /// On host, objects need to remain in scene because the host is also the server.
+        ///    In that case, we simply hide/show meshes for the host player.
         /// </summary>
         /// <param name="visible"></param>
-        public override void OnSetLocalVisibility(bool visible)
+        public override void OnSetHostVisibility(bool visible)
         {
             foreach (Renderer rend in GetComponentsInChildren<Renderer>())
             {

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -630,24 +630,24 @@ namespace Mirror
             }
         }
 
-        internal static void OnLocalClientObjectDestroy(ObjectDestroyMessage msg)
+        internal static void OnHostClientObjectDestroy(ObjectDestroyMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnLocalObjectObjDestroy netId:" + msg.netId);
 
             NetworkIdentity.spawned.Remove(msg.netId);
         }
 
-        internal static void OnLocalClientObjectHide(ObjectHideMessage msg)
+        internal static void OnHostClientObjectHide(ObjectHideMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene::OnLocalObjectObjHide netId:" + msg.netId);
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
-                localObject.OnSetLocalVisibility(false);
+                localObject.OnSetHostVisibility(false);
             }
         }
 
-        internal static void OnLocalClientSpawn(SpawnMessage msg)
+        internal static void OnHostClientSpawn(SpawnMessage msg)
         {
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity) && identity != null)
             {
@@ -655,7 +655,7 @@ namespace Mirror
                     localPlayer = identity;
                 identity.hasAuthority = msg.isOwner;
 
-                identity.OnSetLocalVisibility(true);
+                identity.OnSetHostVisibility(true);
                 identity.NotifyAuthority();
                 identity.OnStartClient();
                 if (msg.isLocalPlayer)

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -806,6 +806,9 @@ namespace Mirror
             return false;
         }
 
+        [Obsolete("Rename to OnSetHostVisibility instead.")]
+        public virtual void OnSetLocalVisibility(bool visible) {}
+
         /// <summary>
         /// Callback used by the visibility system for objects on a host.
         /// <para>Objects on a host (with a local client) cannot be disabled or destroyed when they are not visibile to the local client. So this function is called to allow custom code to hide these objects. A typical implementation will disable renderer components on the object. This is only called on local clients on a host.</para>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -811,7 +811,7 @@ namespace Mirror
         /// <para>Objects on a host (with a local client) cannot be disabled or destroyed when they are not visibile to the local client. So this function is called to allow custom code to hide these objects. A typical implementation will disable renderer components on the object. This is only called on local clients on a host.</para>
         /// </summary>
         /// <param name="vis">New visibility state.</param>
-        public virtual void OnSetLocalVisibility(bool vis) {}
+        public virtual void OnSetHostVisibility(bool vis) {}
 
         /// <summary>
         /// Callback used by the visibility system to determine if an observer (player) can see this object.

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -810,8 +810,8 @@ namespace Mirror
         /// Callback used by the visibility system for objects on a host.
         /// <para>Objects on a host (with a local client) cannot be disabled or destroyed when they are not visibile to the local client. So this function is called to allow custom code to hide these objects. A typical implementation will disable renderer components on the object. This is only called on local clients on a host.</para>
         /// </summary>
-        /// <param name="vis">New visibility state.</param>
-        public virtual void OnSetHostVisibility(bool vis) {}
+        /// <param name="visible">New visibility state.</param>
+        public virtual void OnSetHostVisibility(bool visible) {}
 
         /// <summary>
         /// Callback used by the visibility system to determine if an observer (player) can see this object.

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -315,17 +315,17 @@ namespace Mirror
             return (float)NetworkTime.rtt;
         }
 
-        internal static void RegisterSystemHandlers(bool localClient)
+        internal static void RegisterSystemHandlers(bool hostMode)
         {
-            // local client / regular client react to some messages differently.
+            // host mode client / regular client react to some messages differently.
             // but we still need to add handlers for all of them to avoid
             // 'message id not found' errors.
-            if (localClient)
+            if (hostMode)
             {
-                RegisterHandler<ObjectDestroyMessage>(ClientScene.OnLocalClientObjectDestroy);
-                RegisterHandler<ObjectHideMessage>(ClientScene.OnLocalClientObjectHide);
+                RegisterHandler<ObjectDestroyMessage>(ClientScene.OnHostClientObjectDestroy);
+                RegisterHandler<ObjectHideMessage>(ClientScene.OnHostClientObjectHide);
                 RegisterHandler<NetworkPongMessage>((conn, msg) => { }, false);
-                RegisterHandler<SpawnMessage>(ClientScene.OnLocalClientSpawn);
+                RegisterHandler<SpawnMessage>(ClientScene.OnHostClientSpawn);
                 RegisterHandler<ObjectSpawnStartedMessage>((conn, msg) => { }); // host mode doesn't need spawning
                 RegisterHandler<ObjectSpawnFinishedMessage>((conn, msg) => { }); // host mode doesn't need spawning
                 RegisterHandler<UpdateVarsMessage>((conn, msg) => { });

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -570,6 +570,9 @@ namespace Mirror
             {
                 try
                 {
+#pragma warning disable 618
+                    comp.OnSetLocalVisibility(vis); // remove later!
+#pragma warning restore 618
                     comp.OnSetHostVisibility(vis);
                 }
                 catch (Exception e)

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -564,16 +564,16 @@ namespace Mirror
             }
         }
 
-        internal void OnSetHostVisibility(bool vis)
+        internal void OnSetHostVisibility(bool visible)
         {
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {
                 try
                 {
 #pragma warning disable 618
-                    comp.OnSetLocalVisibility(vis); // remove later!
+                    comp.OnSetLocalVisibility(visible); // remove later!
 #pragma warning restore 618
-                    comp.OnSetHostVisibility(vis);
+                    comp.OnSetHostVisibility(visible);
                 }
                 catch (Exception e)
                 {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -564,13 +564,13 @@ namespace Mirror
             }
         }
 
-        internal void OnSetLocalVisibility(bool vis)
+        internal void OnSetHostVisibility(bool vis)
         {
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {
                 try
                 {
-                    comp.OnSetLocalVisibility(vis);
+                    comp.OnSetHostVisibility(vis);
                 }
                 catch (Exception e)
                 {
@@ -977,12 +977,12 @@ namespace Mirror
                 }
             }
 
-            // special case for local client.
+            // special case for host mode client.
             if (initialize)
             {
                 if (!newObservers.Contains(NetworkServer.localConnection))
                 {
-                    OnSetLocalVisibility(false);
+                    OnSetHostVisibility(false);
                 }
             }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -20,6 +20,9 @@ namespace Mirror
         static bool initialized;
         static int maxConnections;
 
+        /// <summary>
+        /// The connection to the host mode client (if any).
+        /// </summary>
         // original HLAPI has .localConnections list with only m_LocalConnection in it
         // (for backwards compatibility because they removed the real localConnections list a while ago)
         // => removed it for easier code. use .localConnection now!


### PR DESCRIPTION
prepares for OnSetLocalVisibility improvements