### PR TITLE
refactor: reuse connectionToClient for authority (#1200)

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -51,7 +51,7 @@ namespace Mirror
                     //
                     // So we check here for a connectionToClient and if it is null we will
                     // let the server send animation data until we receive an owner.
-                    if (netIdentity != null && netIdentity.clientAuthorityOwner == null)
+                    if (netIdentity != null && netIdentity.connectionToClient == null)
                         return true;
                 }
 

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -165,10 +165,10 @@ namespace Mirror
                     }
                 }
 
-                if (identity.clientAuthorityOwner != null)
+                if (identity.connectionToClient != null)
                 {
                     Rect ownerRect = new Rect(initialX, lastY + 10, 400, 20);
-                    GUI.Label(ownerRect, new GUIContent("Client Authority: " + identity.clientAuthorityOwner), styles.labelStyle);
+                    GUI.Label(ownerRect, new GUIContent("Client Authority: " + identity.connectionToClient), styles.labelStyle);
                 }
             }
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -895,7 +895,7 @@ namespace Mirror
             if (conn.identity != null)
             {
                 conn.identity.SetNotLocalPlayer();
-                conn.identity.clientAuthorityOwner = null;
+                conn.identity.connectionToClient = null;
             }
 
             conn.identity = identity;
@@ -1031,13 +1031,10 @@ namespace Mirror
             // Commands can be for player objects, OR other objects with client-authority
             // -> so if this connection's controller has a different netId then
             //    only allow the command if clientAuthorityOwner
-            if (conn.identity != null && conn.identity.netId != identity.netId)
+            if (identity.connectionToClient != conn)
             {
-                if (identity.clientAuthorityOwner != conn)
-                {
-                    Debug.LogWarning("Command for object without authority [netId=" + msg.netId + "]");
-                    return;
-                }
+                Debug.LogWarning("Command for object without authority [netId=" + msg.netId + "]");
+                return;
             }
 
             if (LogFilter.Debug) Debug.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn);
@@ -1310,7 +1307,7 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("DestroyObject instance:" + identity.netId);
             NetworkIdentity.spawned.Remove(identity.netId);
 
-            identity.clientAuthorityOwner?.RemoveOwnedObject(identity);
+            identity.connectionToClient?.RemoveOwnedObject(identity);
 
             ObjectDestroyMessage msg = new ObjectDestroyMessage
             {


### PR DESCRIPTION
NEED TO TEST AGAIN.
**NetworkServer.InternalReplacePlayerForConnection (line 898) is new here. make sure this makes sense.**


* refactor: reuse connectionToClient for authority

* Fix compilation issue

* Make PR easier to read

* Better error message

* Update Assets/Mirror/Runtime/NetworkIdentity.cs

Co-Authored-By: @MrGadget1024 