### PR TITLE
fix: Call hooks when initializing objects OnStartServer on host

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -90,10 +90,7 @@ namespace Mirror
             connection.SetHandlers(handlers);
         }
 
-        /// <summary>
-        /// connect host mode
-        /// </summary>
-        internal static void ConnectLocalServer()
+        internal static void SetupLocalConnection()
         {
             if (LogFilter.Debug) Debug.Log("Client Connect Local Server");
 
@@ -112,7 +109,15 @@ namespace Mirror
 
             // create server connection to local client
             NetworkServer.SetLocalConnection(connectionToClient);
-            connectionToClient.Send(new ConnectMessage());
+
+        }
+        /// <summary>
+        /// connect host mode
+        /// </summary>
+        internal static void ConnectLocalServer()
+        {
+            NetworkServer.OnConnected(NetworkServer.localConnection);
+            NetworkServer.localConnection.Send(new ConnectMessage());
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -360,6 +360,7 @@ namespace Mirror
         public virtual void StartHost()
         {
             OnStartHost();
+            NetworkClient.SetupLocalConnection();
             if (StartServer())
             {
                 ConnectLocalClient();
@@ -530,8 +531,8 @@ namespace Mirror
 
             networkAddress = "localhost";
             NetworkServer.ActivateLocalClientScene();
-            NetworkClient.ConnectLocalServer();
             RegisterClientMessages();
+            NetworkClient.ConnectLocalServer();
         }
 
         void RegisterClientMessages()

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -55,7 +55,7 @@ namespace Mirror
         /// <para>True is a local client is currently active on the server.</para>
         /// <para>This will be true for "Hosts" on hosted server games.</para>
         /// </summary>
-        public static bool localClientActive { get; private set; }
+        public static bool localClientActive => localConnection != null;
 
         // cache the Send(connectionIds) list to avoid allocating each time
         static readonly List<int> connectionIdsCache = new List<int>();
@@ -185,7 +185,6 @@ namespace Mirror
             }
 
             localConnection = conn;
-            OnConnected(localConnection);
         }
 
         internal static void RemoveLocalConnection()
@@ -195,17 +194,11 @@ namespace Mirror
                 localConnection.Disconnect();
                 localConnection = null;
             }
-            localClientActive = false;
             RemoveConnection(0);
         }
 
         internal static void ActivateLocalClientScene()
         {
-            if (localClientActive)
-                return;
-
-            // ClientScene for a local connection is becoming active. any spawned objects need to be started as client objects
-            localClientActive = true;
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
             {
                 if (!identity.isClient)
@@ -432,7 +425,6 @@ namespace Mirror
             localConnection = null;
 
             active = false;
-            localClientActive = false;
         }
 
         /// <summary>
@@ -512,7 +504,7 @@ namespace Mirror
             }
         }
 
-        static void OnConnected(NetworkConnectionToClient conn)
+        internal static void OnConnected(NetworkConnectionToClient conn)
         {
             if (LogFilter.Debug) Debug.Log("Server accepted client:" + conn);
 


### PR DESCRIPTION
In Master,  OnStartServer is called before host mode is properly initialized,  which causes the hooks not to fire.

Consider this code:  

```cs
public class PlanetsSpawner : NetworkBehaviour   //  Create Server Only GabeObject in Scene
{
    public GameObject Planet;

    public override void OnStartServer()
    {
        base.OnStartServer();
        for (int i = 0; i < 5; i++)
        {
            GameObject planet = Instantiate(Planet, new Vector3(Random.Range(-5f, 5f), Random.Range(-5f, 5f), 0), 
            Quaternion.identity);

            // this does not fire the hook in host mode.  
            // if this code is in a method after OnStartServer,  the hook fires fine.
            planet.GetComponent<Planet>().Clr = Random.ColorHSV();
            NetworkServer.Spawn(planet);
        }
    }
}

public class Planet : NetworkBehaviour   // This is for prefab to by spawned as Planet
{
    [SyncVar(hook = nameof(SetSprt))]
    public Color Clr;

    void SetSprt(Color clr)
    {
        // this hook gets fire fine in host mode if the object is spawned after OnStartServer
        // this PR makes it so that the hook also gets fired during OnStartServer
        Debug.Log($"Color Set");
    }
}
```