### PR TITLE
fix: hasAuthority is now visible in all overrides

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -479,6 +479,7 @@ namespace Mirror
             identity.transform.localPosition = msg.position;
             identity.transform.localRotation = msg.rotation;
             identity.transform.localScale = msg.scale;
+            identity.hasAuthority = msg.isOwner;
 
             // deserialize components if any payload
             // (Count is 0 if there were no components)
@@ -490,14 +491,13 @@ namespace Mirror
 
             identity.netId = msg.netId;
             NetworkIdentity.spawned[msg.netId] = identity;
-            identity.pendingAuthority = msg.isOwner;
 
             // objects spawned as part of initial state are started on a second pass
             if (isSpawnFinished)
             {
+                identity.NotifyAuthority();
                 identity.OnStartClient();
                 CheckForLocalPlayer(identity);
-                identity.hasAuthority = identity.pendingAuthority;
             }
         }
 
@@ -595,9 +595,9 @@ namespace Mirror
             // use data from scene objects
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values.OrderBy(uv => uv.netId))
             {
-                identity.hasAuthority = identity.pendingAuthority;
                 if (!identity.isClient)
                 {
+                    identity.NotifyAuthority();
                     identity.OnStartClient();
                     CheckForLocalPlayer(identity);
                 }
@@ -669,6 +669,7 @@ namespace Mirror
             {
                 localObject.hasAuthority = msg.isOwner;
                 localObject.OnSetHostVisibility(true);
+                localObject.NotifyAuthority();
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -84,29 +84,7 @@ namespace Mirror
         /// </summary>
         bool isOwner;
 
-        public bool hasAuthority
-        {
-            get => isOwner;
-            set
-            {
-                bool previous = isOwner;
-                isOwner = value;
-
-                if (previous && !isOwner)
-                {
-                    OnStopAuthority();
-                }
-                if (!previous && isOwner)
-                {
-                    OnStartAuthority();
-                }
-            }
-        }
-
-        // whether this object has been spawned with authority
-        // we need hasAuthority and pendingOwner because
-        // we need to wait until all of them spawn before updating hasAuthority
-        internal bool pendingAuthority { get; set; }
+        public bool hasAuthority { get; internal set; }
 
         /// <summary>
         /// The set of network connections (players) that can see this object.
@@ -237,6 +215,7 @@ namespace Mirror
                 return;
             }
             hasAuthority = false;
+            NotifyAuthority();
         }
 
         // this is used when a connection is destroyed, since the "observers" property is read-only
@@ -572,6 +551,16 @@ namespace Mirror
             }
         }
 
+        bool hadAuthority;
+        internal void NotifyAuthority()
+        {
+            if (!hadAuthority && hasAuthority)
+                OnStartAuthority();
+            if (hadAuthority && !hasAuthority)
+                OnStopAuthority();
+            hadAuthority = hasAuthority;
+        }
+
         void OnStartAuthority()
         {
             if (networkBehavioursCache == null)
@@ -886,6 +875,7 @@ namespace Mirror
         {
             isLocalPlayer = true;
             hasAuthority = true;
+            NotifyAuthority();
 
             foreach (NetworkBehaviour comp in networkBehavioursCache)
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -817,6 +817,10 @@ namespace Mirror
             // Set the connection on the NetworkIdentity on the server, NetworkIdentity.SetLocalPlayer is not called on the server (it is on clients)
             identity.connectionToClient = (NetworkConnectionToClient)conn;
 
+            // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
+            if (conn is ULocalConnectionToClient)
+                identity.hasAuthority = true;
+
             // set ready if not set yet
             SetClientReady(conn);
 
@@ -1050,6 +1054,11 @@ namespace Mirror
             identity.Reset();
             identity.connectionToClient = (NetworkConnectionToClient)ownerConnection;
 
+            // special case to make sure hasAuthority is set
+            // on start server in host mode
+            if (ownerConnection is ULocalConnectionToClient)
+                identity.hasAuthority = true;
+                
             identity.OnStartServer(false);
 
             if (LogFilter.Debug) Debug.Log("SpawnObject instance ID " + identity.netId + " asset ID " + identity.assetId);


### PR DESCRIPTION
See #1250

Before:
```
Void Awake() hasAuthority=False isClient=False isLocalPlayer=False
Void OnStartServer() hasAuthority=False isClient=False isLocalPlayer=False
Void OnStartClient() hasAuthority=False isClient=True isLocalPlayer=False
Void OnStartAuthority() hasAuthority=True isClient=True isLocalPlayer=True
Void OnStartLocalPlayer() hasAuthority=True isClient=True isLocalPlayer=True
Void Start() hasAuthority=True isClient=True isLocalPlayer=True
```

After:
```
Void Awake() hasAuthority=False isClient=False isLocalPlayer=False
Void OnStartServer() hasAuthority=True isClient=False isLocalPlayer=False
Void OnStartClient() hasAuthority=True isClient=True isLocalPlayer=False
Void OnStartAuthority() hasAuthority=True isClient=True isLocalPlayer=True
Void OnStartLocalPlayer() hasAuthority=True isClient=True isLocalPlayer=True
Void Start() hasAuthority=True isClient=True isLocalPlayer=True
```