### PR TITLE
fix: isLocalPlayer works in host mode onStartServer

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -723,10 +723,11 @@ namespace Mirror
 
                 // Set isLocalPlayer to true on this NetworkIdentity and trigger OnStartLocalPlayer in all scripts on the same GO
                 identity.connectionToServer = readyConnection;
+                InternalAddPlayer(identity);
+
                 identity.SetLocalPlayer();
 
                 if (LogFilter.Debug) Debug.Log("ClientScene.OnOwnerMessage - player=" + identity.name);
-                InternalAddPlayer(identity);
 
                 identity.pendingLocalPlayer = false;
             }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -73,7 +73,7 @@ namespace Mirror
         /// This returns true if this object is the one that represents the player on the local machine.
         /// <para>This is set when the server has spawned an object for this particular client.</para>
         /// </summary>
-        public bool isLocalPlayer { get; private set; }
+        public bool isLocalPlayer => ClientScene.localPlayer == this;
 
         internal bool pendingLocalPlayer { get; set; }
 
@@ -207,8 +207,6 @@ namespace Mirror
         // used when the player object for a connection changes
         internal void SetNotLocalPlayer()
         {
-            isLocalPlayer = false;
-
             if (NetworkServer.active && NetworkServer.localClientActive)
             {
                 // dont change authority for objects on the host
@@ -873,7 +871,6 @@ namespace Mirror
 
         internal void SetLocalPlayer()
         {
-            isLocalPlayer = true;
             hasAuthority = true;
             NotifyAuthority();
 
@@ -1150,7 +1147,6 @@ namespace Mirror
             isClient = false;
 
             netId = 0;
-            isLocalPlayer = false;
             connectionToServer = null;
             connectionToClient = null;
             networkBehavioursCache = null;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -819,7 +819,10 @@ namespace Mirror
 
             // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
             if (conn is ULocalConnectionToClient)
+            {
                 identity.hasAuthority = true;
+                ClientScene.InternalAddPlayer(identity);
+            }
 
             // set ready if not set yet
             SetClientReady(conn);


### PR DESCRIPTION
See #1250

Before:
```
Void Awake() hasAuthority=False isClient=False isLocalPlayer=False
Void OnStartServer() hasAuthority=False isClient=False isLocalPlayer=False
Void OnStartClient() hasAuthority=False isClient=True isLocalPlayer=False
Void OnStartAuthority() hasAuthority=True isClient=True isLocalPlayer=True
Void OnStartLocalPlayer() hasAuthority=True isClient=True isLocalPlayer=True
Void Start() hasAuthority=True isClient=True isLocalPlayer=True
```

after

```
Void Awake() hasAuthority=False isClient=False isLocalPlayer=False
Void OnStartServer() hasAuthority=False isClient=False isLocalPlayer=True
Void OnStartClient() hasAuthority=False isClient=True isLocalPlayer=True
Void OnStartAuthority() hasAuthority=True isClient=True isLocalPlayer=True
Void OnStartLocalPlayer() hasAuthority=True isClient=True isLocalPlayer=True
Void Start() hasAuthority=True isClient=True isLocalPlayer=True
```

Note it is not possible to fix Awake because it gets called before we
have any chance of setting any property