### PR TITLE
Restore Room Player Authority

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -161,6 +161,7 @@ namespace Mirror
 
             // replace room player with game player
             NetworkServer.ReplacePlayerForConnection(conn, gamePlayer);
+            roomPlayer.GetComponent<NetworkIdentity>().AssignClientAuthority(conn);
         }
 
         /// <summary>


### PR DESCRIPTION
`ReplacePlayerForConnection` strips authority so this reapplies it.