### PR TITLE
breaking: SyncList.Callback passes old and new entries instead of only passing one entry which is sometimes the old, sometimes the new entry. This is more consistent and it's very useful to know the previous value in a hook for OP_SET and OP_DIRTY.

### DIFF
--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -47,7 +47,7 @@ namespace Mirror
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class SyncList<T> : IList<T>, IReadOnlyList<T>, SyncObject
     {
-        public delegate void SyncListChanged(Operation op, int itemIndex, T item);
+        public delegate void SyncListChanged(Operation op, int itemIndex, T oldItem, T newItem);
 
         readonly IList<T> objects;
         readonly IEqualityComparer<T> comparer;
@@ -105,7 +105,7 @@ namespace Mirror
         // this should be called after a successfull sync
         public void Flush() => changes.Clear();
 
-        void AddOperation(Operation op, int itemIndex, T item)
+        void AddOperation(Operation op, int itemIndex, T oldItem, T newItem)
         {
             if (IsReadOnly)
             {
@@ -116,15 +116,13 @@ namespace Mirror
             {
                 operation = op,
                 index = itemIndex,
-                item = item
+                item = newItem
             };
 
             changes.Add(change);
 
-            Callback?.Invoke(op, itemIndex, item);
+            Callback?.Invoke(op, itemIndex, oldItem, newItem);
         }
-
-        void AddOperation(Operation op, int itemIndex) => AddOperation(op, itemIndex, default);
 
         public void OnSerializeAll(NetworkWriter writer)
         {
@@ -214,16 +212,17 @@ namespace Mirror
                 // that we have not applied yet
                 bool apply = changesAhead == 0;
                 int index = 0;
-                T item = default;
+                T oldItem = default;
+                T newItem = default;
 
                 switch (operation)
                 {
                     case Operation.OP_ADD:
-                        item = DeserializeItem(reader);
+                        newItem = DeserializeItem(reader);
                         if (apply)
                         {
                             index = objects.Count;
-                            objects.Add(item);
+                            objects.Add(newItem);
                         }
                         break;
 
@@ -236,10 +235,10 @@ namespace Mirror
 
                     case Operation.OP_INSERT:
                         index = (int)reader.ReadPackedUInt32();
-                        item = DeserializeItem(reader);
+                        newItem = DeserializeItem(reader);
                         if (apply)
                         {
-                            objects.Insert(index, item);
+                            objects.Insert(index, newItem);
                         }
                         break;
 
@@ -247,24 +246,25 @@ namespace Mirror
                         index = (int)reader.ReadPackedUInt32();
                         if (apply)
                         {
-                            item = objects[index];
+                            oldItem = objects[index];
                             objects.RemoveAt(index);
                         }
                         break;
 
                     case Operation.OP_SET:
                         index = (int)reader.ReadPackedUInt32();
-                        item = DeserializeItem(reader);
+                        newItem = DeserializeItem(reader);
                         if (apply)
                         {
-                            objects[index] = item;
+                            oldItem = objects[index];
+                            objects[index] = newItem;
                         }
                         break;
                 }
 
                 if (apply)
                 {
-                    Callback?.Invoke(operation, index, item);
+                    Callback?.Invoke(operation, index, oldItem, newItem);
                 }
                 // we just skipped this change
                 else
@@ -277,13 +277,13 @@ namespace Mirror
         public void Add(T item)
         {
             objects.Add(item);
-            AddOperation(Operation.OP_ADD, objects.Count - 1, item);
+            AddOperation(Operation.OP_ADD, objects.Count - 1, default, item);
         }
 
         public void Clear()
         {
             objects.Clear();
-            AddOperation(Operation.OP_CLEAR, 0);
+            AddOperation(Operation.OP_CLEAR, 0, default, default);
         }
 
         public bool Contains(T item) => IndexOf(item) >= 0;
@@ -309,7 +309,7 @@ namespace Mirror
         public void Insert(int index, T item)
         {
             objects.Insert(index, item);
-            AddOperation(Operation.OP_INSERT, index, item);
+            AddOperation(Operation.OP_INSERT, index, default, item);
         }
 
         public bool Remove(T item)
@@ -325,8 +325,9 @@ namespace Mirror
 
         public void RemoveAt(int index)
         {
+            T oldItem = objects[index];
             objects.RemoveAt(index);
-            AddOperation(Operation.OP_REMOVEAT, index);
+            AddOperation(Operation.OP_REMOVEAT, index, oldItem, default);
         }
 
         public T this[int i]
@@ -336,8 +337,9 @@ namespace Mirror
             {
                 if (!comparer.Equals(objects[i], value))
                 {
+                    T oldItem = objects[i];
                     objects[i] = value;
-                    AddOperation(Operation.OP_SET, i, value);
+                    AddOperation(Operation.OP_SET, i, oldItem, value);
                 }
             }
         }

--- a/Assets/Mirror/Tests/SyncListTest.cs
+++ b/Assets/Mirror/Tests/SyncListTest.cs
@@ -185,13 +185,14 @@ namespace Mirror.Tests
         {
             bool called = false;
 
-            clientSyncList.Callback += (op, index, item) =>
+            clientSyncList.Callback += (op, index, oldItem, newItem) =>
             {
                 called = true;
 
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_ADD));
                 Assert.That(index, Is.EqualTo(3));
-                Assert.That(item, Is.EqualTo("yay"));
+                Assert.That(oldItem, Is.EqualTo(default(string)));
+                Assert.That(newItem, Is.EqualTo("yay"));
             };
 
             serverSyncList.Add("yay");
@@ -206,12 +207,13 @@ namespace Mirror.Tests
         {
             bool called = false;
 
-            clientSyncList.Callback += (op, index, item) =>
+            clientSyncList.Callback += (op, index, oldItem, newItem) =>
             {
                 called = true;
 
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
-                Assert.That(item, Is.EqualTo("World"));
+                Assert.That(oldItem, Is.EqualTo("World"));
+                Assert.That(newItem, Is.EqualTo(default(string)));
             };
             serverSyncList.Remove("World");
             SerializeDeltaTo(serverSyncList, clientSyncList);
@@ -224,13 +226,14 @@ namespace Mirror.Tests
         {
             bool called = false;
 
-            clientSyncList.Callback += (op, index, item) =>
+            clientSyncList.Callback += (op, index, oldItem, newItem) =>
             {
                 called = true;
 
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
                 Assert.That(index, Is.EqualTo(1));
-                Assert.That(item, Is.EqualTo("World"));
+                Assert.That(oldItem, Is.EqualTo("World"));
+                Assert.That(newItem, Is.EqualTo(default(string)));
             };
 
             serverSyncList.RemoveAt(1);

--- a/doc/Guides/Sync/SyncLists.md
+++ b/doc/Guides/Sync/SyncLists.md
@@ -77,9 +77,9 @@ class Player : NetworkBehaviour {
         inventory.Callback += OnInventoryUpdated;
     }
 
-    void OnInventoryUpdated(SyncListItem.Operation op, int index, Item item)
+    void OnInventoryUpdated(SyncListItem.Operation op, int index, Item oldItem, Item newItem)
     {
-        switch (op) 
+        switch (op)
         {
             case SyncListItem.Operation.OP_ADD:
                 // index is where it got added in the list
@@ -116,7 +116,7 @@ class Player : NetworkBehaviour {
 By default, SyncList uses a List to store it's data. If you want to use a different list implementation, add a constructor and pass the list implementation to the parent constructor. For example:
 
 ```cs
-class SyncListItem : SyncList<Item> 
+class SyncListItem : SyncList<Item>
 {
     public SyncListItem() : base(new MyIList<Item>()) {}
 }


### PR DESCRIPTION
this is necessary for games that use equipment syncliststructs + skinned mesh equipment.
in those cases, we need to rebind animators when equipment syncliststruct changed.
BUT only if the actual changed. NOT if only durability changed.
in order to check if actual item changed, we need to know old and new value, not only new value.
hence this PR.

**note** that we can't obsolete the old callback because the variable name needs to stay the same. so this will break all SyncList callbacks. we did break them before though, so if someone upgrades from UNET to Mirror then they'll have to change their code either way.

**note** that we should probably do this for SyncDict too afterwards.