### PR TITLE
Removed non-implemented overload

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -612,18 +612,6 @@ namespace Mirror
         /// <param name="newSceneName"></param>
         public virtual void ServerChangeScene(string newSceneName)
         {
-            ServerChangeScene(newSceneName, LoadSceneMode.Single, LocalPhysicsMode.None);
-        }
-
-        /// <summary>
-        /// This causes the server to switch scenes and sets the networkSceneName.
-        /// <para>Clients that connect to this server will automatically switch to this scene. This is called autmatically if onlineScene or offlineScene are set, but it can be called from user code to switch scenes again while the game is in progress. This automatically sets clients to be not-ready. The clients must call NetworkClient.Ready() again to participate in the new scene.</para>
-        /// </summary>
-        /// <param name="newSceneName"></param>
-        /// <param name="sceneMode"></param>
-        /// <param name="physicsMode"></param>
-        public virtual void ServerChangeScene(string newSceneName, LoadSceneMode sceneMode, LocalPhysicsMode physicsMode)
-        {
             if (string.IsNullOrEmpty(newSceneName))
             {
                 Debug.LogError("ServerChangeScene empty scene name");

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -89,18 +89,6 @@ public class #SCRIPTNAME# : NetworkManager
         base.ServerChangeScene(newSceneName);
     }
 
-    /// <summary>
-    /// This causes the server to switch scenes and sets the networkSceneName.
-    /// <para>Clients that connect to this server will automatically switch to this scene. This is called autmatically if onlineScene or offlineScene are set, but it can be called from user code to switch scenes again while the game is in progress. This automatically sets clients to be not-ready. The clients must call NetworkClient.Ready() again to participate in the new scene.</para>
-    /// </summary>
-    /// <param name="newSceneName"></param>
-    /// <param name="sceneMode"></param>
-    /// <param name="physicsMode"></param>
-    public override void ServerChangeScene(string newSceneName, LoadSceneMode sceneMode, LocalPhysicsMode physicsMode)
-    {
-        base.ServerChangeScene(newSceneName, sceneMode, physicsMode);
-    }
-
     #endregion
 
     #region Server System Callbacks


### PR DESCRIPTION
I put this overload in and later determined that I can't extend ServerChangeScene the way I thought.  Since these extra parameters were never wired up to anything, no one could be using this method in a useful way, so I'd like to just quietly remove it without obsoleting it.

This would have no impact on uSurvival or uMMORPG.