### PR TITLE
feat: new way to connect using uri

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -90,6 +90,26 @@ namespace Mirror
             connection.SetHandlers(handlers);
         }
 
+        /// <summary>
+        /// Connect client to a NetworkServer instance.
+        /// </summary>
+        /// <param name="uri">Address of the server to connect to</param>
+        public static void Connect(Uri uri)
+        {
+            if (LogFilter.Debug) Debug.Log("Client Connect: " + uri);
+
+            RegisterSystemHandlers(false);
+            Transport.activeTransport.enabled = true;
+            InitializeTransportHandlers();
+
+            connectState = ConnectState.Connecting;
+            Transport.activeTransport.ClientConnect(uri);
+
+            // setup all the handlers
+            connection = new NetworkConnectionToServer();
+            connection.SetHandlers(handlers);
+        }
+
         internal static void SetupLocalConnection()
         {
             if (LogFilter.Debug) Debug.Log("Client Connect Local Server");

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -354,6 +354,36 @@ namespace Mirror
         }
 
         /// <summary>
+        /// This starts a network client. It uses the networkAddress and networkPort properties as the address to connect to.
+        /// <para>This makes the newly created client connect to the server immediately.</para>
+        /// </summary>
+        /// <param name="uri">location of the server to connect to</param>
+        public void StartClient(Uri uri)
+        {
+            InitializeSingleton();
+
+            if (authenticator != null)
+            {
+                authenticator.OnStartClient();
+                authenticator.OnClientAuthenticated.AddListener(OnClientAuthenticated);
+            }
+
+            if (runInBackground)
+                Application.runInBackground = true;
+
+            isNetworkActive = true;
+
+            RegisterClientMessages();
+
+            if (LogFilter.Debug) Debug.Log("NetworkManager StartClient address:" + uri);
+
+            NetworkClient.Connect(uri);
+
+            OnStartClient();
+        }
+
+
+        /// <summary>
         /// This starts a network "host" - a server and client in the same application.
         /// <para>The client returned from StartHost() is a special "local" client that communicates to the in-process server using a message queue instead of the real network. But in almost all other cases, it can be treated as a normal client.</para>
         /// </summary>

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -376,6 +376,7 @@ namespace Mirror
             RegisterClientMessages();
 
             if (LogFilter.Debug) Debug.Log("NetworkManager StartClient address:" + uri);
+            this.networkAddress = uri.Host;
 
             NetworkClient.Connect(uri);
 

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -64,6 +64,18 @@ namespace Mirror
         /// <param name="address">The IP address or FQDN of the server we are trying to connect to</param>
         public abstract void ClientConnect(string address);
 
+
+        /// <summary>
+        /// Establish a connecion to a server
+        /// </summary>
+        /// <param name="uri">The address of the server we are trying to connect to</param>
+        public virtual void ClientConnect(Uri uri)
+        {
+            // By default, to keep backwards compatibility, just connect to the host
+            // in the uri
+            ClientConnect(uri.Host);
+        }
+
         /// <summary>
         /// Send data to the server
         /// </summary>


### PR DESCRIPTION
Now you can start the client using a uri instead of host name.

for example,  instead of this:
```cs
networkManager.address = "myhost.xxx.org";
networkManager.StartClient();
```

you have the option of using uri:
```cs
networkManager.StartClient(new Uri("tcp://myhost.xxx.org"));
```

Note the old way is still in place,  not even deprecated.