### PR TITLE
feat: Mirror now supports message inheritance

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -51,6 +51,15 @@ namespace Mirror.Weaver
             serializeFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkWriterType)));
             ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
 
+            // call base
+            MethodReference baseSerialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Serialize");
+            if (baseSerialize != null)
+            {
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
+                serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
+            }
+
             foreach (FieldDefinition field in td.Fields)
             {
                 if (field.IsStatic || field.IsPrivate || field.IsSpecialName)
@@ -95,6 +104,15 @@ namespace Mirror.Weaver
 
             serializeFunc.Parameters.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkReaderType)));
             ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
+
+            // call base
+            MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Deserialize");
+            if (baseDeserialize != null)
+            {
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
+                serWorker.Append(serWorker.Create(OpCodes.Call, baseDeserialize));
+            }
 
             foreach (FieldDefinition field in td.Fields)
             {

--- a/Assets/Mirror/Tests/MessageInheritanceTest.cs
+++ b/Assets/Mirror/Tests/MessageInheritanceTest.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    class ParentMessage : MessageBase
+    {
+        public int parentValue;
+    }
+
+    class ChildMessage : ParentMessage
+    {
+        public int childValue;
+    }
+
+    [TestFixture]
+    public class MessageInheritanceTests
+    {
+        [Test]
+        public void Roundtrip()
+        {
+            NetworkWriter w = new NetworkWriter();
+
+            w.Write(new ChildMessage
+            {
+                parentValue = 3,
+                childValue = 4
+            });
+
+            byte[] arr = w.ToArray();
+
+            NetworkReader r = new NetworkReader(arr);
+            ChildMessage received = new ChildMessage();
+            received.Deserialize(r);
+
+            Assert.AreEqual(3, received.parentValue);
+            Assert.AreEqual(4, received.childValue);
+        }
+    }
+}

--- a/Assets/Mirror/Tests/MessageInheritanceTest.cs.meta
+++ b/Assets/Mirror/Tests/MessageInheritanceTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 808855b645f9843d2b3077ab1304b2b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When mirror generates Serialize/Deserialize for messages, it now calls the parents method.

This way messages can now have a rich hierarchy.  

Consider this code:
```cs
abstract class MyBaseMessage : MessageBase
{
     public int commonData;
}

class MyChildMessage : MyBaseMessage
{
   public int childData;
}
```

if you send a `MyChildMessage`,  it now will include both fields.
