### PR TITLE
feat: Support for Odin Inspector 

### DIFF
--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -84,8 +84,14 @@ namespace Mirror
             return false;
         }
 
+#if ODIN_INSPECTOR
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+#else
         void OnEnable()
         {
+#endif
             initialized = false;
         }
 

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -25,8 +25,6 @@ namespace Mirror
         [DrawerPriority(DrawerPriorityLevel.WrapperPriority)]
         private class SyncVarDrawer<T> : OdinAttributeDrawer<SyncVarAttribute, T>
         {
-            private static readonly bool IsUnityObject = typeof(UnityEngine.Object).IsAssignableFrom(typeof(T));
-
             protected override bool CanDrawAttributeValueProperty(InspectorProperty property)
             {
                 // Only draw for direct roots of the inspected object
@@ -35,20 +33,12 @@ namespace Mirror
 
             protected override void DrawPropertyLayout(GUIContent label)
             {
-                if (IsUnityObject)
-                {
-                    CallNextDrawer(label);
-                    GUILayout.Label(syncVarIndicatorContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(syncVarIndicatorContent).x));
-                }
-                else
-                {
-                    EditorGUILayout.BeginHorizontal();
-                    EditorGUILayout.BeginVertical();
-                    CallNextDrawer(label);
-                    EditorGUILayout.EndVertical();
-                    GUILayout.Label(syncVarIndicatorContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(syncVarIndicatorContent).x));
-                    EditorGUILayout.EndHorizontal();
-                }
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.BeginVertical();
+                CallNextDrawer(label);
+                EditorGUILayout.EndVertical();
+                GUILayout.Label(syncVarIndicatorContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(syncVarIndicatorContent).x));
+                EditorGUILayout.EndHorizontal();
             }
         }
 #endif

--- a/Assets/Mirror/Editor/NetworkManagerEditor.cs
+++ b/Assets/Mirror/Editor/NetworkManagerEditor.cs
@@ -6,7 +6,11 @@ namespace Mirror
 {
     [CustomEditor(typeof(NetworkManager), true)]
     [CanEditMultipleObjects]
+#if ODIN_INSPECTOR
+    public class NetworkManagerEditor : Sirenix.OdinInspector.Editor.OdinEditor
+#else
     public class NetworkManagerEditor : Editor
+#endif
     {
         SerializedProperty spawnListProperty;
 


### PR DESCRIPTION
This PR adds support for Odin Inspector to types derived from NetworkManager and NetworkBehaviour. The code will toggle based on the ODIN_INSPECTOR preprocessor define, which is set by Odin Inspector when it is present in the project.

I've tested this by modifying some the examples provided in the Mirror project to use Odin (these testing modifications are not part of the PR), and confirming that SyncVars are still drawn properly like they would be in a "vanilla" Mirror inspector, both in the case of Unity objects and regular values. When Odin is installed, Odin's attributes also work and are fully supported in Mirror types.