### PR TITLE
fix: Draw SyncVar label for Unity objects inline 

### DIFF
--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -101,43 +101,37 @@ namespace Mirror
             while (property.NextVisible(expanded))
             {
                 bool isSyncVar = syncVarNames.Contains(property.name);
-                if (property.propertyType == SerializedPropertyType.ObjectReference)
+
+                if (property.name == "m_Script")
                 {
-                    if (property.name == "m_Script")
+                    if (HideScriptField)
                     {
-                        if (HideScriptField)
-                        {
-                            continue;
-                        }
-
-                        EditorGUI.BeginDisabledGroup(true);
+                        continue;
                     }
 
-                    EditorGUILayout.PropertyField(property, true);
-
-                    if (isSyncVar)
-                    {
-                        GUILayout.Label(syncVarIndicatorContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(syncVarIndicatorContent).x));
-                    }
-
-                    if (property.name == "m_Script")
-                    {
-                        EditorGUI.EndDisabledGroup();
-                    }
+                    EditorGUI.BeginDisabledGroup(true);
                 }
-                else
+
+                if (isSyncVar)
                 {
                     EditorGUILayout.BeginHorizontal();
+                    EditorGUILayout.BeginVertical();
+                }
 
-                    EditorGUILayout.PropertyField(property, true);
+                EditorGUILayout.PropertyField(property, true);
 
-                    if (isSyncVar)
-                    {
-                        GUILayout.Label(syncVarIndicatorContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(syncVarIndicatorContent).x));
-                    }
-
+                if (isSyncVar)
+                {
+                    EditorGUILayout.EndVertical();
+                    GUILayout.Label(syncVarIndicatorContent, EditorStyles.miniLabel, GUILayout.Width(EditorStyles.miniLabel.CalcSize(syncVarIndicatorContent).x));
                     EditorGUILayout.EndHorizontal();
                 }
+
+                if (property.name == "m_Script")
+                {
+                    EditorGUI.EndDisabledGroup();
+                }
+                
                 expanded = false;
             }
             serializedObject.ApplyModifiedProperties();

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -17,7 +17,7 @@ namespace Mirror
         bool syncsAnything;
         bool[] showSyncLists;
 
-        readonly GUIContent syncVarIndicatorContent = new GUIContent("SyncVar", "This variable has been marked with the [SyncVar] attribute.");
+        static readonly GUIContent syncVarIndicatorContent = new GUIContent("SyncVar", "This variable has been marked with the [SyncVar] attribute.");
 
         internal virtual bool HideScriptField => false;
 


### PR DESCRIPTION
As described. Since this required a minor refactor anyways, I also took the liberty to do the following:

- Horizontal groups aren't pointlessly allocated for all non-SyncVar properties. This is both an optimization (layout groups are expensive) and a bug fix, since it can cause a bunch of layouting issues to call arbitrary property drawers while in a horizontal scope.
- Drawing of the actual SyncVar property is now also wrapped in an additional vertical group scope, for the same reason as outlined above; it's a bad idea to be in a horizontal layout scope when invoking other code that is usually implicitly assuming a vertical scope, since that is the default.
- Made syncVarIndicatorContent static to avoid superfluous allocations per editor instance - originally this was in #1289 as a requirement for the Odin integration, but MrGadget requested it be added here.

