### PR TITLE
feat: Multiplex based on url

### DIFF
--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -67,6 +67,26 @@ namespace Mirror
             throw new Exception("No transport suitable for this platform");
         }
 
+        public override void ClientConnect(Uri uri)
+        {
+            foreach (Transport transport in transports)
+            {
+                if (transport.Available())
+                {
+                    try
+                    {
+                        transport.ClientConnect(uri);
+                        available = transport;
+                    }
+                    catch (ArgumentException)
+                    {
+                        // transport does not support the schema, just move on to the next one
+                    }
+                }
+            }
+            throw new Exception("No transport suitable for this platform");
+        }
+
         public override bool ClientConnected()
         {
             return available != null && available.ClientConnected();


### PR DESCRIPTION
If the multiplex transport receives an url for connection,
try all the underlying transports until it finds a suitable one

For example,  let's say you configure a multiplex transport with telepathy and websocket,  if you try:
```cs
NetworkManager.StartClient("tcp4://host:port");
```

then the multiplex transport will use telepathy.

if we pass:
```cs
NetworkManager.StartClient("ws://host:port");
```

then the multiplex transport will select websocket