### PR TITLE
Unused isOwner

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -75,8 +75,6 @@ namespace Mirror
         /// <para>This value is determined at runtime. For most objects, authority is held by the server.</para>
         /// <para>For objects that had their authority set by AssignClientAuthority on the server, this will be true on the client that owns the object. NOT on other clients.</para>
         /// </summary>
-        bool isOwner;
-
         public bool hasAuthority { get; internal set; }
 
         /// <summary>


### PR DESCRIPTION
This field isn't used anywhere anymore.

The comment above it actually belongs to hasAuthority.