### PR TITLE
No point in calling this here

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -768,7 +768,6 @@ namespace Mirror
             if (clientReadyConnection != null)
             {
                 clientLoadedScene = true;
-                OnClientConnect(clientReadyConnection);
                 clientReadyConnection = null;
             }
 


### PR DESCRIPTION
Right above this line we set `clientLoadedScene` to `true`, and then call this:
```cs
public virtual void OnClientConnect(NetworkConnection conn)
{
    if (!clientLoadedScene)
    {
        // Ready/AddPlayer is usually triggered by a scene load completing. if no scene was loaded, then Ready/AddPlayer it here instead.
        if (!ClientScene.ready) ClientScene.Ready(conn);
        if (autoCreatePlayer)
        {
            ClientScene.AddPlayer();
        }
    }
}
```

I realize this is a virtual, but there's no reason to call this more than once per connected session, and anyone overriding this would either call the base method or wrap their code in the same `if`.