### PR TITLE
breaking: Observers is just a set of connections

### DIFF
--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -157,9 +157,9 @@ namespace Mirror
                     observerRect.x += 20; // indent names
                     observerRect.y += observerRect.height;
 
-                    foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                    foreach (NetworkConnection conn in identity.observers)
                     {
-                        GUI.Label(observerRect, kvp.Value.address + ":" + kvp.Value, styles.componentName);
+                        GUI.Label(observerRect, conn.address + ":" + conn, styles.componentName);
                         observerRect.y += observerRect.height;
                         lastY = observerRect.y;
                     }

--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
@@ -36,7 +36,7 @@ namespace Mirror.Examples.Additive
             GameObject target = null;
             float distance = 100f;
 
-            foreach (NetworkConnection networkConnection in netIdentity.observers.Values)
+            foreach (NetworkConnection networkConnection in netIdentity.observers)
             {
                 GameObject tempTarget = networkConnection.identity.gameObject;
                 float tempDistance = Vector3.Distance(tempTarget.transform.position, transform.position);

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -81,7 +81,7 @@ namespace Mirror
         /// The set of network connections (players) that can see this object.
         /// <para>null until OnStartServer was called. this is necessary for SendTo* to work properly in server-only mode.</para>
         /// </summary>
-        public Dictionary<int, NetworkConnection> observers;
+        public HashSet<NetworkConnection> observers;
 
         /// <summary>
         /// Unique identifier for this particular object instance, used for tracking objects between networked clients and the server.
@@ -226,7 +226,7 @@ namespace Mirror
         // this is used when a connection is destroyed, since the "observers" property is read-only
         internal void RemoveObserverInternal(NetworkConnection conn)
         {
-            observers?.Remove(conn.connectionId);
+            observers?.Remove(conn);
         }
 
         void Awake()
@@ -496,7 +496,7 @@ namespace Mirror
             }
 
             netId = GetNextNetworkId();
-            observers = new Dictionary<int, NetworkConnection>();
+            observers = new HashSet<NetworkConnection>();
 
             if (LogFilter.Debug) Debug.Log("OnStartServer " + this + " NetId:" + netId + " SceneId:" + sceneId);
 
@@ -877,7 +877,7 @@ namespace Mirror
         {
             if (observers != null)
             {
-                foreach (NetworkConnection conn in observers.Values)
+                foreach (NetworkConnection conn in observers)
                 {
                     conn.RemoveFromVisList(this, true);
                 }
@@ -893,7 +893,7 @@ namespace Mirror
                 return;
             }
 
-            if (observers.ContainsKey(conn.connectionId))
+            if (observers.Contains(conn))
             {
                 // if we try to add a connectionId that was already added, then
                 // we may have generated one that was already in use.
@@ -902,7 +902,7 @@ namespace Mirror
 
             if (LogFilter.Debug) Debug.Log("Added observer " + conn.address + " added for " + gameObject);
 
-            observers[conn.connectionId] = conn;
+            observers.Add(conn);
             conn.AddToVisList(this);
         }
 
@@ -971,7 +971,7 @@ namespace Mirror
                     continue;
                 }
 
-                if (initialize || !observers.ContainsKey(conn.connectionId))
+                if (initialize || !observers.Contains(conn))
                 {
                     // new observer
                     conn.AddToVisList(this);
@@ -980,7 +980,7 @@ namespace Mirror
                 }
             }
 
-            foreach (NetworkConnection conn in observers.Values)
+            foreach (NetworkConnection conn in observers)
             {
                 if (!newObservers.Contains(conn))
                 {
@@ -1026,7 +1026,7 @@ namespace Mirror
                 foreach (NetworkConnection conn in newObservers)
                 {
                     if (conn.isReady)
-                        observers.Add(conn.connectionId, conn);
+                        observers.Add(conn);
                 }
             }
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -231,14 +231,14 @@ namespace Mirror
                 //    avoid allocations, allow for multicast, etc.
                 connectionIdsCache.Clear();
                 bool result = true;
-                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                foreach (NetworkConnection conn in identity.observers)
                 {
                     // use local connection directly because it doesn't send via transport
-                    if (kvp.Value is ULocalConnectionToClient)
-                        result &= localConnection.Send(segment);
+                    if (conn is ULocalConnectionToClient)
+                        result &= conn.Send(segment);
                     // gather all internet connections
                     else
-                        connectionIdsCache.Add(kvp.Key);
+                        connectionIdsCache.Add(conn.connectionId);
                 }
 
                 // send to all internet connections at once
@@ -332,11 +332,11 @@ namespace Mirror
 
                 // send to all ready observers
                 bool result = true;
-                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                foreach (NetworkConnection conn in identity.observers)
                 {
-                    if (kvp.Value.isReady)
+                    if (conn.isReady)
                     {
-                        result &= kvp.Value.Send(new ArraySegment<byte>(bytes), channelId);
+                        result &= conn.Send(new ArraySegment<byte>(bytes), channelId);
                     }
                 }
                 return result;
@@ -373,19 +373,19 @@ namespace Mirror
                 connectionIdsCache.Clear();
                 bool result = true;
                 int count = 0;
-                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                foreach (NetworkConnection conn in identity.observers)
                 {
-                    bool isOwner = kvp.Value == identity.connectionToClient;
-                    if ((!isOwner || includeOwner) && kvp.Value.isReady)
+                    bool isOwner = conn == identity.connectionToClient;
+                    if ((!isOwner || includeOwner) && conn.isReady)
                     {
                         count++;
 
                         // use local connection directly because it doesn't send via transport
-                        if (kvp.Value is ULocalConnectionToClient)
-                            result &= localConnection.Send(segment);
+                        if (conn is ULocalConnectionToClient)
+                            result &= conn.Send(segment);
                         // gather all internet connections
                         else
-                            connectionIdsCache.Add(kvp.Key);
+                            connectionIdsCache.Add(conn.connectionId);
                     }
                 }
 


### PR DESCRIPTION
Previously, observers was a Dictionary<Connection id, Connection>
This simplifies the whole thing,  observers is just a set of connections
this reduces the dependency on connectionid, which is a leaky abstraction