### PR TITLE
fix: No more "thanks for using Mirror" Debug.Log on built headless/standalone instances.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -221,7 +221,7 @@ namespace Mirror
 			// Coburn: We shouldn't blurt out the Mirror thank you if we're running in a standalone build
 			// or a server (headless) build. While it's nice to advertise the library, I don't think having
 			// it pop its head up outside of the Editor is a good idea.
-#if !UNITY_SERVER || !UNITY_STANDALONE
+#if UNITY_EDITOR
             Debug.Log("Thank you for using Mirror! https://mirror-networking.com");
 #endif
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -218,7 +218,12 @@ namespace Mirror
         /// </summary>
         public virtual void Awake()
         {
+			// Coburn: We shouldn't blurt out the Mirror thank you if we're running in a standalone build
+			// or a server (headless) build. While it's nice to advertise the library, I don't think having
+			// it pop its head up outside of the Editor is a good idea.
+#if !UNITY_SERVER || !UNITY_STANDALONE
             Debug.Log("Thank you for using Mirror! https://mirror-networking.com");
+#endif
 
             // Set the networkSceneName to prevent a scene reload
             // if client connection to server fails.


### PR DESCRIPTION
MrGadget and I discussed this in the developer channel of the Discord. Basically, Mirror shouldn't be advertising itself outside of the Editor, mainly because the message takes up 4 - 5 lines (consisting of the "Thanks for using Mirror" text, then some line breaks and the Debug.Log stacktrace).

Other network libraries keep quiet in built applications and only emit warnings/errors unless they're on debug mode or initializing (ie. "SomeNetworkLibX v1.0 initializing on Win64")

We simply wrap the thank you with a check to ensure that it only gets emitted if we're on something that's not a server instance or a standalone instance.