### PR TITLE
Update SyncVarHook.md

### DIFF
--- a/doc/Guides/Sync/SyncVarHook.md
+++ b/doc/Guides/Sync/SyncVarHook.md
@@ -35,6 +35,10 @@ public class PlayerController : NetworkBehaviour
             cachedMaterial = GetComponent<Renderer>().material;
 
         cachedMaterial.color = color;
+        
+        //If above line does not work, try this for the new (Universel) Render Pipeline
+        //cachedMaterial.SetColor("_BaseColor", color);
+        
     }
 
     void OnDestroy()


### PR DESCRIPTION
It seems the line "cachedMaterial.color = color;" is not working in the Universal Render Pipeline.
I had to add this line of code otherwise it would not work. 
In my version I have deleted the old line of code.
Here I have just commented it out as people with old/new versions can switch between or atleast try them.