### PR TITLE
feat: Allow Custom Scene Handling

### DIFF
--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -232,17 +232,20 @@ namespace Mirror
     {
         public string sceneName;
         public SceneOperation sceneOperation; // Normal = 0, LoadAdditive = 1, UnloadAdditive = 2
+        public bool customHandling;
 
         public void Deserialize(NetworkReader reader)
         {
             sceneName = reader.ReadString();
             sceneOperation = (SceneOperation)reader.ReadByte();
+            customHandling = reader.ReadBoolean();
         }
 
         public void Serialize(NetworkWriter writer)
         {
             writer.WriteString(sceneName);
             writer.WriteByte((byte)sceneOperation);
+            writer.WriteBoolean(customHandling);
         }
     }
 

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -205,7 +205,8 @@ public class #SCRIPTNAME# : NetworkManager
     /// </summary>
     /// <param name="newSceneName">Name of the scene that's about to be loaded</param>
     /// <param name="sceneOperation">Scene operation that's about to happen</param>
-    public override void OnClientChangeScene(string newSceneName, SceneOperation sceneOperation) { }
+    /// <param name="customHandling">true to indicate that scene loading will be handled through overrides</param>
+    public override void OnClientChangeScene(string newSceneName, SceneOperation sceneOperation, bool customHandling) { }
 
     /// <summary>
     /// Called on clients when a scene has completed loaded, when the scene load was initiated by the server.


### PR DESCRIPTION
Adds an optional flag `customHandling` to SceneMessage that allows devs to bypass our built-in scene loading and apply their own.

- Some devs have expressed a desire to use their own `AsyncOperation` so they can show a scene loading screen with their own progress bar.
- Addressables / Asset Bundles require unique handling that we can't directly support adequately, especially since Addressables would force a dependency on us for a Unity package.

The transport is disabled and `OnClientChangeScene` is called right before the customHandling bool is checked, and that virtual is where devs can do their own thing.  We can therefore assume that if `customHandling` is true they've done their part and we can go straight to FinishLoadScene where we proceed normally and re-enable the transport.