### PR TITLE
fix: MultiplexTransport GetMaxMessageSize NullReferenceException when called on server. And fixes potential exploits / out of sync issues where clients with different transports might see different game states because of different max message sizes.

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -177,8 +177,13 @@ namespace Mirror
 
         /// <summary>
         /// The maximum packet size for a given channel.  Unreliable transports
-        /// usually can only deliver small packets.  Reliable fragmented channels
+        /// usually can only deliver small packets. Reliable fragmented channels
         /// can usually deliver large ones.
+        ///
+        /// GetMaxPacketSize needs to return a value at all times. Even if the
+        /// Transport isn't running, or isn't Available(). This is because
+        /// Fallback and Multiplex transports need to find the smallest possible
+        /// packet size at runtime.
         /// </summary>
         /// <param name="channelId">channel id</param>
         /// <returns>the size in bytes that can be sent via the provided channel</returns>


### PR DESCRIPTION
@paulpach we modified your multiplexer's getmaxmessage logic.
see comments for explanation, or discord.