### PR TITLE
Convert IsLocalPlayer to behave as isClient && hasAuthority.

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -719,7 +719,7 @@ namespace Mirror
 
         static void CheckForLocalPlayer(NetworkIdentity identity)
         {
-            if (identity == localPlayer)
+            if (identity.hasAuthority || identity == localPlayer)
             {
                 // Set isLocalPlayer to true on this NetworkIdentity and trigger OnStartLocalPlayer in all scripts on the same GO
                 identity.connectionToServer = readyConnection;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -68,7 +68,7 @@ namespace Mirror
         /// This returns true if this object is the one that represents the player on the local machine.
         /// <para>This is set when the server has spawned an object for this particular client.</para>
         /// </summary>
-        public bool isLocalPlayer => ClientScene.localPlayer == this;
+        public bool isLocalPlayer => (hasAuthority || ClientScene.localPlayer == this);
 
         /// <summary>
         /// This returns true if this object is the authoritative player object on the client.


### PR DESCRIPTION
- Convert IsLocalPlayer to be true if on client and has authority rather than if 'player prefab'.

- OnStartLocalPlayer is now called for authoritive objects on client.