### PR TITLE
feat: generate serializers for IMessageBase structs

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -9,16 +9,9 @@ namespace Mirror.Weaver
     static class MessageClassProcessor
     {
 
-        static readonly OpCode[] emptyBodyTemplate = { OpCodes.Nop, OpCodes.Ret };
-
         static bool IsEmptyDefault(this MethodBody body)
         {
-            if (body.Instructions.Count != emptyBodyTemplate.Length) return false;
-            for (int i = 0; i < emptyBodyTemplate.Length; i++)
-            {
-                if (body.Instructions[i].OpCode != emptyBodyTemplate[i]) return false;
-            }
-            return true;
+            return body.Instructions.All(instruction => instruction.OpCode == OpCodes.Nop || instruction.OpCode == OpCodes.Ret);
         }
 
         public static void Process(TypeDefinition td)

--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -6,6 +6,19 @@ namespace Mirror.Weaver
 {
     static class MessageClassProcessor
     {
+
+        static OpCode[] emptyBodyTemplate = { OpCodes.Nop, OpCodes.Ret };
+
+        static bool IsEmptyDefault(this MethodBody body)
+        {
+            if (body.Instructions.Count != emptyBodyTemplate.Length) return false;
+            for (int i = 0; i < emptyBodyTemplate.Length; i++)
+            {
+                if (body.Instructions[i].OpCode != emptyBodyTemplate[i]) return false;
+            }
+            return true;
+        }
+
         public static void Process(TypeDefinition td)
         {
             Weaver.DLog(td, "MessageClassProcessor Start");
@@ -23,10 +36,18 @@ namespace Mirror.Weaver
         static void GenerateSerialization(TypeDefinition td)
         {
             Weaver.DLog(td, "  GenerateSerialization");
+            MethodDefinition existingInterfaceMethod = null;
             foreach (MethodDefinition m in td.Methods)
             {
                 if (m.Name == "Serialize")
+                {
+                    if (m.Body.IsEmptyDefault()) //in case of struct(IMessageBase)
+                    {
+                        existingInterfaceMethod = m;
+                        break;
+                    }
                     return;
+                }
             }
 
             if (td.Fields.Count == 0)
@@ -44,20 +65,30 @@ namespace Mirror.Weaver
                 }
             }
 
-            MethodDefinition serializeFunc = new MethodDefinition("Serialize",
+            MethodDefinition serializeFunc = existingInterfaceMethod??new MethodDefinition("Serialize",
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.voidType);
 
-            serializeFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkWriterType)));
-            ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
-
-            // call base
-            MethodReference baseSerialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Serialize");
-            if (baseSerialize != null)
+            if (existingInterfaceMethod == null) //only add to new method
             {
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-                serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
+                serializeFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkWriterType)));
+            }
+            ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
+            if (existingInterfaceMethod != null)
+            {
+                serWorker.Body.Instructions.Clear(); //remove default nop&ret from existing empty interface method
+            }
+
+            if (!td.IsValueType) //if not struct(IMessageBase), likely same as using else {} here in all cases
+            {
+                // call base
+                MethodReference baseSerialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Serialize");
+                if (baseSerialize != null)
+                {
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
+                    serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
+                }
             }
 
             foreach (FieldDefinition field in td.Fields)
@@ -81,16 +112,28 @@ namespace Mirror.Weaver
             }
             serWorker.Append(serWorker.Create(OpCodes.Ret));
 
-            td.Methods.Add(serializeFunc);
+            if (existingInterfaceMethod == null) //only add if not just replaced body
+            {
+                td.Methods.Add(serializeFunc);
+            }
         }
 
         static void GenerateDeSerialization(TypeDefinition td)
         {
             Weaver.DLog(td, "  GenerateDeserialization");
+            MethodDefinition existingInterfaceMethod = null;
+
             foreach (MethodDefinition m in td.Methods)
             {
                 if (m.Name == "Deserialize")
+                {
+                    if (m.Body.IsEmptyDefault())//in case of struct(IMessageBase)
+                    {
+                        existingInterfaceMethod = m;
+                        break;
+                    }
                     return;
+                }
             }
 
             if (td.Fields.Count == 0)
@@ -98,20 +141,30 @@ namespace Mirror.Weaver
                 return;
             }
 
-            MethodDefinition serializeFunc = new MethodDefinition("Deserialize",
+            MethodDefinition serializeFunc = existingInterfaceMethod??new MethodDefinition("Deserialize",
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.voidType);
 
-            serializeFunc.Parameters.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkReaderType)));
-            ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
-
-            // call base
-            MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Deserialize");
-            if (baseDeserialize != null)
+            if (existingInterfaceMethod == null) //only add to new method
             {
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-                serWorker.Append(serWorker.Create(OpCodes.Call, baseDeserialize));
+                serializeFunc.Parameters.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkReaderType)));
+            }
+            ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
+            if (existingInterfaceMethod != null)
+            {
+                serWorker.Body.Instructions.Clear(); //remove default nop&ret from existing empty interface method
+            }
+
+            if (!td.IsValueType) //if not struct(IMessageBase), likely same as using else {} here in all cases
+            {
+                // call base
+                MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Deserialize");
+                if (baseDeserialize != null)
+                {
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
+                    serWorker.Append(serWorker.Create(OpCodes.Call, baseDeserialize));
+                }
             }
 
             foreach (FieldDefinition field in td.Fields)
@@ -135,7 +188,10 @@ namespace Mirror.Weaver
             }
             serWorker.Append(serWorker.Create(OpCodes.Ret));
 
-            td.Methods.Add(serializeFunc);
+            if (existingInterfaceMethod == null) //only add if not just replaced body
+            {
+                td.Methods.Add(serializeFunc);
+            }
         }
     }
 }

--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -52,7 +52,7 @@ namespace Mirror.Weaver
                 }
             }
 
-            MethodDefinition serializeFunc = existingMethod??new MethodDefinition("Serialize",
+            MethodDefinition serializeFunc = existingMethod ?? new MethodDefinition("Serialize",
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.voidType);
 

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -392,30 +392,6 @@ namespace Mirror.Weaver
                 MessageClassProcessor.Process(td);
                 didWork = true;
             }
-            else
-            {
-                // are ANY parent classes MessageBase
-                TypeReference parent = td.BaseType;
-                while (parent != null)
-                {
-                    if (parent.FullName == MessageBaseType.FullName)
-                    {
-                        MessageClassProcessor.Process(td);
-                        didWork = true;
-                        break;
-                    }
-                    try
-                    {
-                        parent = parent.Resolve().BaseType;
-                    }
-                    catch (AssemblyResolutionException)
-                    {
-                        // this can happen for plugins.
-                        //Console.WriteLine("AssemblyResolutionException: "+ ex.ToString());
-                        break;
-                    }
-                }
-            }
 
             // check for embedded types
             foreach (TypeDefinition embedded in td.NestedTypes)

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -48,6 +48,7 @@ namespace Mirror.Weaver
         public static TypeReference NetworkConnectionType;
 
         public static TypeReference MessageBaseType;
+        public static TypeReference IMessageBaseType;
         public static TypeReference SyncListType;
         public static TypeReference SyncSetType;
         public static TypeReference SyncDictionaryType;
@@ -273,6 +274,7 @@ namespace Mirror.Weaver
             NetworkConnectionType = CurrentAssembly.MainModule.ImportReference(NetworkConnectionType);
 
             MessageBaseType = NetAssembly.MainModule.GetType("Mirror.MessageBase");
+            IMessageBaseType = NetAssembly.MainModule.GetType("Mirror.IMessageBase");
             SyncListType = NetAssembly.MainModule.GetType("Mirror.SyncList`1");
             SyncSetType = NetAssembly.MainModule.GetType("Mirror.SyncSet`1");
             SyncDictionaryType = NetAssembly.MainModule.GetType("Mirror.SyncDictionary`2");
@@ -385,25 +387,33 @@ namespace Mirror.Weaver
 
             bool didWork = false;
 
-            // are ANY parent classes MessageBase
-            TypeReference parent = td.BaseType;
-            while (parent != null)
+            if (td.ImplementsInterface(IMessageBaseType))
             {
-                if (parent.FullName == MessageBaseType.FullName)
+                MessageClassProcessor.Process(td);
+                didWork = true;
+            }
+            else
+            {
+                // are ANY parent classes MessageBase
+                TypeReference parent = td.BaseType;
+                while (parent != null)
                 {
-                    MessageClassProcessor.Process(td);
-                    didWork = true;
-                    break;
-                }
-                try
-                {
-                    parent = parent.Resolve().BaseType;
-                }
-                catch (AssemblyResolutionException)
-                {
-                    // this can happen for plugins.
-                    //Console.WriteLine("AssemblyResolutionException: "+ ex.ToString());
-                    break;
+                    if (parent.FullName == MessageBaseType.FullName)
+                    {
+                        MessageClassProcessor.Process(td);
+                        didWork = true;
+                        break;
+                    }
+                    try
+                    {
+                        parent = parent.Resolve().BaseType;
+                    }
+                    catch (AssemblyResolutionException)
+                    {
+                        // this can happen for plugins.
+                        //Console.WriteLine("AssemblyResolutionException: "+ ex.ToString());
+                        break;
+                    }
                 }
             }
 

--- a/Assets/Mirror/Tests/MessageBaseTests.cs
+++ b/Assets/Mirror/Tests/MessageBaseTests.cs
@@ -30,6 +30,16 @@ namespace Mirror.Tests
         }
     }
 
+    struct WovenTestMessage: IMessageBase
+    {
+        public int IntValue;
+        public string StringValue;
+        public double DoubleValue;
+
+        public void Deserialize(NetworkReader reader) {}
+        public void Serialize(NetworkWriter writer) {}
+    }
+
     [TestFixture]
     public class MessageBaseTests
     {
@@ -46,6 +56,23 @@ namespace Mirror.Tests
             t.Deserialize(r);
 
             Assert.AreEqual(1, t.IntValue);
+        }
+
+        [Test]
+        public void WovenSerializationBodyRoundtrip()
+        {
+            NetworkWriter w = new NetworkWriter();
+            w.Write(new WovenTestMessage{IntValue = 1, StringValue = "2", DoubleValue = 3.3});
+
+            byte[] arr = w.ToArray();
+
+            NetworkReader r = new NetworkReader(arr);
+            WovenTestMessage t = new WovenTestMessage();
+            t.Deserialize(r);
+
+            Assert.AreEqual(1, t.IntValue);
+            Assert.AreEqual("2", t.StringValue);
+            Assert.AreEqual(3.3, t.DoubleValue);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Mirror supports many different low level networking transports:
 * https://github.com/MichalPetryka/LiteNetLib4Mirror (LiteNetLib)
 
 ## Donations & Priority Support
-Please support [Mirror on Patreon](https://www.patreon.com/MirrorNetworking). Priority support included!
+Please support [Mirror on GitHub](https://github.com/sponsors/vis2k). Priority support included!
 
 ## Benchmarks
 * Telepathy [1000 connections](https://github.com/vis2k/Telepathy) test


### PR DESCRIPTION
Allow Weaver to add bodies to IMessageBase structs with empty de/serialize methods

This checks whether both methods added via the interface are empty (nop/ret) and uses the usual path to weave in the readers/writers, effectively just replacing the empty bodies.