### PR TITLE
Replace License.txt

### DIFF
--- a/Assets/Mirror/License.txt
+++ b/Assets/Mirror/License.txt
@@ -1,3 +1,0 @@
-The Mirror DLLs in the Plugins folder are MIT licensed:
-
-https://github.com/vis2k/Mirror

--- a/Assets/Mirror/Plugins/Mono.Cecil/License.txt
+++ b/Assets/Mirror/Plugins/Mono.Cecil/License.txt
@@ -1,0 +1,23 @@
+Copyright (c) 2008 - 2015 Jb Evain
+Copyright (c) 2008 - 2011 Novell, Inc.
+
+https://github.com/jbevain/cecil
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Assets/Mirror/Plugins/Mono.Cecil/License.txt.meta
+++ b/Assets/Mirror/Plugins/Mono.Cecil/License.txt.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dbf30d11d3879431f87403d009e47bf7
+guid: ab858db5ebbb0d542a9acd197669cb5a
 TextScriptImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
Removes the generic license.txt file from Mirror folder and adds the license file from the original Cecil repository with link to that repo in the Plugins/Mono.Cecil folder.