### PR TITLE
feat: add version to package file

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -10,7 +10,7 @@
         {
             "path": "@semantic-release/github",
             "assets": [
-                {"path": "Mirror.unitypackage", "label": "Mirror.unitypackage"}
+                {"path": "Mirror.unitypackage", "label": "Mirror Unity Package", "name": "Mirror-${nextRelease.version}.unitypackage"}
             ]
         }
     ],


### PR DESCRIPTION
Goal is to have the download file name for the unity package include the version like the zip does.

![image](https://user-images.githubusercontent.com/9826063/71482452-a994bf00-27d0-11ea-99f2-bf295c54f405.png)

![image](https://user-images.githubusercontent.com/9826063/71482455-adc0dc80-27d0-11ea-8b43-412bd0a8c733.png)
