### PR TITLE
feat: WeaverExclude Attribute for (I)MessageBase woven method bodies

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -9,16 +9,9 @@ namespace Mirror.Weaver
     static class MessageClassProcessor
     {
 
-        static readonly OpCode[] emptyBodyTemplate = { OpCodes.Nop, OpCodes.Ret };
-
         static bool IsEmptyDefault(this MethodBody body)
         {
-            if (body.Instructions.Count != emptyBodyTemplate.Length) return false;
-            for (int i = 0; i < emptyBodyTemplate.Length; i++)
-            {
-                if (body.Instructions[i].OpCode != emptyBodyTemplate[i]) return false;
-            }
-            return true;
+            return body.Instructions.All(instruction => instruction.OpCode == OpCodes.Nop || instruction.OpCode == OpCodes.Ret);
         }
 
         public static void Process(TypeDefinition td)

--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -6,6 +6,19 @@ namespace Mirror.Weaver
 {
     static class MessageClassProcessor
     {
+
+        static OpCode[] emptyBodyTemplate = { OpCodes.Nop, OpCodes.Ret };
+
+        static bool IsEmptyDefault(this MethodBody body)
+        {
+            if (body.Instructions.Count != emptyBodyTemplate.Length) return false;
+            for (int i = 0; i < emptyBodyTemplate.Length; i++)
+            {
+                if (body.Instructions[i].OpCode != emptyBodyTemplate[i]) return false;
+            }
+            return true;
+        }
+
         public static void Process(TypeDefinition td)
         {
             Weaver.DLog(td, "MessageClassProcessor Start");
@@ -23,10 +36,18 @@ namespace Mirror.Weaver
         static void GenerateSerialization(TypeDefinition td)
         {
             Weaver.DLog(td, "  GenerateSerialization");
+            MethodDefinition existingInterfaceMethod = null;
             foreach (MethodDefinition m in td.Methods)
             {
                 if (m.Name == "Serialize")
+                {
+                    if (m.Body.IsEmptyDefault()) //in case of struct(IMessageBase)
+                    {
+                        existingInterfaceMethod = m;
+                        break;
+                    }
                     return;
+                }
             }
 
             if (td.Fields.Count == 0)
@@ -44,20 +65,30 @@ namespace Mirror.Weaver
                 }
             }
 
-            MethodDefinition serializeFunc = new MethodDefinition("Serialize",
+            MethodDefinition serializeFunc = existingInterfaceMethod??new MethodDefinition("Serialize",
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.voidType);
 
-            serializeFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkWriterType)));
-            ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
-
-            // call base
-            MethodReference baseSerialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Serialize");
-            if (baseSerialize != null)
+            if (existingInterfaceMethod == null) //only add to new method
             {
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-                serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
+                serializeFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkWriterType)));
+            }
+            ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
+            if (existingInterfaceMethod != null)
+            {
+                serWorker.Body.Instructions.Clear(); //remove default nop&ret from existing empty interface method
+            }
+
+            if (!td.IsValueType) //if not struct(IMessageBase), likely same as using else {} here in all cases
+            {
+                // call base
+                MethodReference baseSerialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Serialize");
+                if (baseSerialize != null)
+                {
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
+                    serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
+                }
             }
 
             foreach (FieldDefinition field in td.Fields)
@@ -81,16 +112,28 @@ namespace Mirror.Weaver
             }
             serWorker.Append(serWorker.Create(OpCodes.Ret));
 
-            td.Methods.Add(serializeFunc);
+            if (existingInterfaceMethod == null) //only add if not just replaced body
+            {
+                td.Methods.Add(serializeFunc);
+            }
         }
 
         static void GenerateDeSerialization(TypeDefinition td)
         {
             Weaver.DLog(td, "  GenerateDeserialization");
+            MethodDefinition existingInterfaceMethod = null;
+
             foreach (MethodDefinition m in td.Methods)
             {
                 if (m.Name == "Deserialize")
+                {
+                    if (m.Body.IsEmptyDefault())//in case of struct(IMessageBase)
+                    {
+                        existingInterfaceMethod = m;
+                        break;
+                    }
                     return;
+                }
             }
 
             if (td.Fields.Count == 0)
@@ -98,20 +141,30 @@ namespace Mirror.Weaver
                 return;
             }
 
-            MethodDefinition serializeFunc = new MethodDefinition("Deserialize",
+            MethodDefinition serializeFunc = existingInterfaceMethod??new MethodDefinition("Deserialize",
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.voidType);
 
-            serializeFunc.Parameters.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkReaderType)));
-            ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
-
-            // call base
-            MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Deserialize");
-            if (baseDeserialize != null)
+            if (existingInterfaceMethod == null) //only add to new method
             {
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-                serWorker.Append(serWorker.Create(OpCodes.Call, baseDeserialize));
+                serializeFunc.Parameters.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkReaderType)));
+            }
+            ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
+            if (existingInterfaceMethod != null)
+            {
+                serWorker.Body.Instructions.Clear(); //remove default nop&ret from existing empty interface method
+            }
+
+            if (!td.IsValueType) //if not struct(IMessageBase), likely same as using else {} here in all cases
+            {
+                // call base
+                MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Deserialize");
+                if (baseDeserialize != null)
+                {
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
+                    serWorker.Append(serWorker.Create(OpCodes.Call, baseDeserialize));
+                }
             }
 
             foreach (FieldDefinition field in td.Fields)
@@ -135,7 +188,10 @@ namespace Mirror.Weaver
             }
             serWorker.Append(serWorker.Create(OpCodes.Ret));
 
-            td.Methods.Add(serializeFunc);
+            if (existingInterfaceMethod == null) //only add if not just replaced body
+            {
+                td.Methods.Add(serializeFunc);
+            }
         }
     }
 }

--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -14,6 +14,11 @@ namespace Mirror.Weaver
             return body.Instructions.All(instruction => instruction.OpCode == OpCodes.Nop || instruction.OpCode == OpCodes.Ret);
         }
 
+        static bool HasExcludeAttribute(this FieldDefinition fieldDefinition)
+        {
+            return fieldDefinition.CustomAttributes.Any(attribute => attribute.AttributeType.FullName == Weaver.WeaverExcludeType.FullName);
+        }
+
         public static void Process(TypeDefinition td)
         {
             Weaver.DLog(td, "MessageClassProcessor Start");
@@ -80,7 +85,7 @@ namespace Mirror.Weaver
 
             foreach (FieldDefinition field in td.Fields)
             {
-                if (field.IsStatic || field.IsPrivate || field.IsSpecialName)
+                if (field.IsStatic || field.IsPrivate || field.IsSpecialName || field.HasExcludeAttribute())
                     continue;
 
                 MethodReference writeFunc = Writers.GetWriteFunc(field.FieldType);
@@ -147,7 +152,7 @@ namespace Mirror.Weaver
 
             foreach (FieldDefinition field in td.Fields)
             {
-                if (field.IsStatic || field.IsPrivate || field.IsSpecialName)
+                if (field.IsStatic || field.IsPrivate || field.IsSpecialName || field.HasExcludeAttribute())
                     continue;
 
                 MethodReference readerFunc = Readers.GetReadFunc(field.FieldType);

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -87,6 +87,8 @@ namespace Mirror.Weaver
         public static TypeReference SyncObjectType;
         public static MethodReference InitSyncObjectReference;
 
+        public static TypeReference WeaverExcludeType;
+
         // array segment
         public static TypeReference ArraySegmentType;
         public static MethodReference ArraySegmentConstructorReference;
@@ -203,6 +205,8 @@ namespace Mirror.Weaver
             TargetRpcType = NetAssembly.MainModule.GetType("Mirror.TargetRpcAttribute");
             SyncEventType = NetAssembly.MainModule.GetType("Mirror.SyncEventAttribute");
             SyncObjectType = NetAssembly.MainModule.GetType("Mirror.SyncObject");
+
+            WeaverExcludeType = NetAssembly.MainModule.GetType("Mirror.WeaverExcludeAttribute");
         }
 
         static void SetupCorLib()

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -392,30 +392,6 @@ namespace Mirror.Weaver
                 MessageClassProcessor.Process(td);
                 didWork = true;
             }
-            else
-            {
-                // are ANY parent classes MessageBase
-                TypeReference parent = td.BaseType;
-                while (parent != null)
-                {
-                    if (parent.FullName == MessageBaseType.FullName)
-                    {
-                        MessageClassProcessor.Process(td);
-                        didWork = true;
-                        break;
-                    }
-                    try
-                    {
-                        parent = parent.Resolve().BaseType;
-                    }
-                    catch (AssemblyResolutionException)
-                    {
-                        // this can happen for plugins.
-                        //Console.WriteLine("AssemblyResolutionException: "+ ex.ToString());
-                        break;
-                    }
-                }
-            }
 
             // check for embedded types
             foreach (TypeDefinition embedded in td.NestedTypes)

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -48,6 +48,7 @@ namespace Mirror.Weaver
         public static TypeReference NetworkConnectionType;
 
         public static TypeReference MessageBaseType;
+        public static TypeReference IMessageBaseType;
         public static TypeReference SyncListType;
         public static TypeReference SyncSetType;
         public static TypeReference SyncDictionaryType;
@@ -273,6 +274,7 @@ namespace Mirror.Weaver
             NetworkConnectionType = CurrentAssembly.MainModule.ImportReference(NetworkConnectionType);
 
             MessageBaseType = NetAssembly.MainModule.GetType("Mirror.MessageBase");
+            IMessageBaseType = NetAssembly.MainModule.GetType("Mirror.IMessageBase");
             SyncListType = NetAssembly.MainModule.GetType("Mirror.SyncList`1");
             SyncSetType = NetAssembly.MainModule.GetType("Mirror.SyncSet`1");
             SyncDictionaryType = NetAssembly.MainModule.GetType("Mirror.SyncDictionary`2");
@@ -385,25 +387,33 @@ namespace Mirror.Weaver
 
             bool didWork = false;
 
-            // are ANY parent classes MessageBase
-            TypeReference parent = td.BaseType;
-            while (parent != null)
+            if (td.ImplementsInterface(IMessageBaseType))
             {
-                if (parent.FullName == MessageBaseType.FullName)
+                MessageClassProcessor.Process(td);
+                didWork = true;
+            }
+            else
+            {
+                // are ANY parent classes MessageBase
+                TypeReference parent = td.BaseType;
+                while (parent != null)
                 {
-                    MessageClassProcessor.Process(td);
-                    didWork = true;
-                    break;
-                }
-                try
-                {
-                    parent = parent.Resolve().BaseType;
-                }
-                catch (AssemblyResolutionException)
-                {
-                    // this can happen for plugins.
-                    //Console.WriteLine("AssemblyResolutionException: "+ ex.ToString());
-                    break;
+                    if (parent.FullName == MessageBaseType.FullName)
+                    {
+                        MessageClassProcessor.Process(td);
+                        didWork = true;
+                        break;
+                    }
+                    try
+                    {
+                        parent = parent.Resolve().BaseType;
+                    }
+                    catch (AssemblyResolutionException)
+                    {
+                        // this can happen for plugins.
+                        //Console.WriteLine("AssemblyResolutionException: "+ ex.ToString());
+                        break;
+                    }
                 }
             }
 

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -90,4 +90,10 @@ namespace Mirror
     /// Converts a string property into a Scene property in the inspector
     /// </summary>
     public class SceneAttribute : PropertyAttribute { }
+
+    /// <summary>
+    /// Marks fields of I/MessageBase targets for exclusion by automatic De/Serialize() weaver generation, effectively excluding the linked field from network transmission
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class WeaverExcludeAttribute : Attribute {}
 }

--- a/Assets/Mirror/Tests/MessageBaseTests.cs
+++ b/Assets/Mirror/Tests/MessageBaseTests.cs
@@ -30,6 +30,16 @@ namespace Mirror.Tests
         }
     }
 
+    struct WovenTestMessage: IMessageBase
+    {
+        public int IntValue;
+        public string StringValue;
+        public double DoubleValue;
+
+        public void Deserialize(NetworkReader reader) {}
+        public void Serialize(NetworkWriter writer) {}
+    }
+
     [TestFixture]
     public class MessageBaseTests
     {
@@ -46,6 +56,23 @@ namespace Mirror.Tests
             t.Deserialize(r);
 
             Assert.AreEqual(1, t.IntValue);
+        }
+
+        [Test]
+        public void WovenSerializationBodyRoundtrip()
+        {
+            NetworkWriter w = new NetworkWriter();
+            w.Write(new WovenTestMessage{IntValue = 1, StringValue = "2", DoubleValue = 3.3});
+
+            byte[] arr = w.ToArray();
+
+            NetworkReader r = new NetworkReader(arr);
+            WovenTestMessage t = new WovenTestMessage();
+            t.Deserialize(r);
+
+            Assert.AreEqual(1, t.IntValue);
+            Assert.AreEqual("2", t.StringValue);
+            Assert.AreEqual(3.3, t.DoubleValue);
         }
     }
 }

--- a/Assets/Mirror/Tests/MessageBaseTests.cs
+++ b/Assets/Mirror/Tests/MessageBaseTests.cs
@@ -40,6 +40,18 @@ namespace Mirror.Tests
         public void Serialize(NetworkWriter writer) {}
     }
 
+    struct WovenTestMessageWithExclusion: IMessageBase
+    {
+        [WeaverExclude]
+        public int IntValue;
+        [WeaverExclude]
+        public string StringValue;
+        public double DoubleValue;
+
+        public void Deserialize(NetworkReader reader) {}
+        public void Serialize(NetworkWriter writer) {}
+    }
+
     [TestFixture]
     public class MessageBaseTests
     {
@@ -73,6 +85,30 @@ namespace Mirror.Tests
             Assert.AreEqual(1, t.IntValue);
             Assert.AreEqual("2", t.StringValue);
             Assert.AreEqual(3.3, t.DoubleValue);
+        }
+
+        [Test]
+        public void WeaverExcludeOnFieldTest()
+        {
+            NetworkWriter w = new NetworkWriter();
+            WovenTestMessageWithExclusion msg = new WovenTestMessageWithExclusion {IntValue = 123, StringValue = "456", DoubleValue = 3.3};
+            w.Write(msg);
+
+            byte[] arr = w.ToArray();
+
+            NetworkReader r = new NetworkReader(arr);
+            WovenTestMessageWithExclusion t = new WovenTestMessageWithExclusion();
+            t.Deserialize(r);
+
+            Assert.AreEqual(123, msg.IntValue);
+            Assert.AreNotEqual(123, t.IntValue);
+            Assert.AreEqual(default(int), t.IntValue);
+
+            Assert.AreEqual("456", msg.StringValue);
+            Assert.AreNotEqual("456", t.StringValue);
+            Assert.AreEqual(default(string), t.StringValue);
+
+            Assert.AreEqual(msg.DoubleValue, t.DoubleValue);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Mirror supports many different low level networking transports:
 * https://github.com/MichalPetryka/LiteNetLib4Mirror (LiteNetLib)
 
 ## Donations & Priority Support
-Please support [Mirror on Patreon](https://www.patreon.com/MirrorNetworking). Priority support included!
+Please support [Mirror on GitHub](https://github.com/sponsors/vis2k). Priority support included!
 
 ## Benchmarks
 * Telepathy [1000 connections](https://github.com/vis2k/Telepathy) test


### PR DESCRIPTION
This allows fields to be marked with [WeaverExclude] to be skipped by the weaver (auto implemented De/Serialize bodies), effectively ignoring them for network transmission.