### PR TITLE
docs: remove redundant "overview" menu item

### DIFF
--- a/doc/Guides/DedicatedServer/toc.yml
+++ b/doc/Guides/DedicatedServer/toc.yml
@@ -1,4 +1,2 @@
-- name: Overview
-  href: index.md
 - name: AWS
   href: AWS/index.md


### PR DESCRIPTION
Stop showing overview on the left. It's the same as the title so doesn't need to be shown