### PR TITLE
refactor: break if statements into new lines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -116,7 +116,7 @@ csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
 csharp_space_between_method_call_name_and_opening_parenthesis = false 
 csharp_space_between_method_call_empty_parameter_list_parentheses = false 
 # Wrapping preferences 
-csharp_preserve_single_line_statements = true 
+csharp_preserve_single_line_statements = false 
 csharp_preserve_single_line_blocks = true 
 ############################### 
 # VB Coding Conventions       # 

--- a/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
@@ -30,13 +30,15 @@ namespace Mirror.Authenticators
 
         IEnumerator BeginClientAuthentication(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log($"Authentication countdown started {conn} {timeout}");
+            if (LogFilter.Debug)
+                Debug.Log($"Authentication countdown started {conn} {timeout}");
 
             yield return new WaitForSecondsRealtime(timeout);
 
             if (!conn.isAuthenticated)
             {
-                if (LogFilter.Debug) Debug.Log($"Authentication Timeout {conn}");
+                if (LogFilter.Debug)
+                    Debug.Log($"Authentication Timeout {conn}");
 
                 conn.Disconnect();
             }
@@ -51,13 +53,15 @@ namespace Mirror.Authenticators
 
         IEnumerator BeginServerAuthentication(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log($"Authentication countdown started {conn} {timeout}");
+            if (LogFilter.Debug)
+                Debug.Log($"Authentication countdown started {conn} {timeout}");
 
             yield return new WaitForSecondsRealtime(timeout);
 
             if (!conn.isAuthenticated)
             {
-                if (LogFilter.Debug) Debug.Log($"Authentication Timeout {conn}");
+                if (LogFilter.Debug)
+                    Debug.Log($"Authentication Timeout {conn}");
 
                 conn.Disconnect();
             }

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -381,7 +381,8 @@ namespace Mirror
         [Command]
         void CmdOnAnimationServerMessage(int stateHash, float normalizedTime, int layerId, byte[] parameters)
         {
-            if (LogFilter.Debug) Debug.Log("OnAnimationMessage for netId=" + netId);
+            if (LogFilter.Debug)
+                Debug.Log("OnAnimationMessage for netId=" + netId);
 
             // handle and broadcast
             HandleAnimMsg(stateHash, normalizedTime, layerId, new NetworkReader(parameters));

--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -112,7 +112,8 @@ namespace Mirror
                     {
                         // cast without allocating GC for maximum performance
                         int hitCount = Physics.OverlapSphereNonAlloc(transform.position, visRange, hitsBuffer3D, castLayers);
-                        if (hitCount == hitsBuffer3D.Length) Debug.LogWarning("NetworkProximityChecker's OverlapSphere test for " + name + " has filled the whole buffer(" + hitsBuffer3D.Length + "). Some results might have been omitted. Consider increasing buffer size.");
+                        if (hitCount == hitsBuffer3D.Length)
+                            Debug.LogWarning("NetworkProximityChecker's OverlapSphere test for " + name + " has filled the whole buffer(" + hitsBuffer3D.Length + "). Some results might have been omitted. Consider increasing buffer size.");
 
                         for (int i = 0; i < hitCount; i++)
                         {
@@ -133,7 +134,8 @@ namespace Mirror
                     {
                         // cast without allocating GC for maximum performance
                         int hitCount = Physics2D.OverlapCircleNonAlloc(transform.position, visRange, hitsBuffer2D, castLayers);
-                        if (hitCount == hitsBuffer2D.Length) Debug.LogWarning("NetworkProximityChecker's OverlapCircle test for " + name + " has filled the whole buffer(" + hitsBuffer2D.Length + "). Some results might have been omitted. Consider increasing buffer size.");
+                        if (hitCount == hitsBuffer2D.Length)
+                            Debug.LogWarning("NetworkProximityChecker's OverlapCircle test for " + name + " has filled the whole buffer(" + hitsBuffer2D.Length + "). Some results might have been omitted. Consider increasing buffer size.");
 
                         for (int i = 0; i < hitCount; i++)
                         {

--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -121,7 +121,8 @@ namespace Mirror
         /// <param name="conn">Connection from client.</param>
         public override void OnServerReady(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkRoomManager OnServerReady");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkRoomManager OnServerReady");
             base.OnServerReady(conn);
 
             if (conn != null && conn.identity != null)
@@ -136,7 +137,8 @@ namespace Mirror
 
         void SceneLoadedForPlayer(NetworkConnection conn, GameObject roomPlayer)
         {
-            if (LogFilter.Debug) Debug.LogFormat("NetworkRoom SceneLoadedForPlayer scene: {0} {1}", SceneManager.GetActiveScene().name, conn);
+            if (LogFilter.Debug)
+                Debug.LogFormat("NetworkRoom SceneLoadedForPlayer scene: {0} {1}", SceneManager.GetActiveScene().name, conn);
 
             if (SceneManager.GetActiveScene().name == RoomScene)
             {
@@ -172,7 +174,8 @@ namespace Mirror
         /// </summary>
         public void CheckReadyToBegin()
         {
-            if (SceneManager.GetActiveScene().name != RoomScene) return;
+            if (SceneManager.GetActiveScene().name != RoomScene)
+                return;
 
             if (minPlayers > 0 && NetworkServer.connections.Count(conn => conn.Value != null && conn.Value.identity.gameObject.GetComponent<NetworkRoomPlayer>().readyToBegin) < minPlayers)
             {
@@ -268,13 +271,16 @@ namespace Mirror
         /// <param name="conn">Connection from client.</param>
         public override void OnServerAddPlayer(NetworkConnection conn)
         {
-            if (SceneManager.GetActiveScene().name != RoomScene) return;
+            if (SceneManager.GetActiveScene().name != RoomScene)
+                return;
 
-            if (roomSlots.Count == maxConnections) return;
+            if (roomSlots.Count == maxConnections)
+                return;
 
             allPlayersReady = false;
 
-            if (LogFilter.Debug) Debug.LogFormat("NetworkRoomManager.OnServerAddPlayer playerPrefab:{0}", roomPlayerPrefab.name);
+            if (LogFilter.Debug)
+                Debug.LogFormat("NetworkRoomManager.OnServerAddPlayer playerPrefab:{0}", roomPlayerPrefab.name);
 
             GameObject newRoomGameObject = OnRoomServerCreateRoomPlayer(conn);
             if (newRoomGameObject == null)
@@ -311,7 +317,8 @@ namespace Mirror
             {
                 foreach (NetworkRoomPlayer roomPlayer in roomSlots)
                 {
-                    if (roomPlayer == null) continue;
+                    if (roomPlayer == null)
+                        continue;
 
                     // find the game-player object for this connection, and destroy it
                     NetworkIdentity identity = roomPlayer.GetComponent<NetworkIdentity>();

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -443,11 +443,14 @@ namespace Mirror
         void OnDrawGizmos()
         {
             // draw start and goal points
-            if (start != null) DrawDataPointGizmo(start, Color.gray);
-            if (goal != null) DrawDataPointGizmo(goal, Color.white);
+            if (start != null)
+                DrawDataPointGizmo(start, Color.gray);
+            if (goal != null)
+                DrawDataPointGizmo(goal, Color.white);
 
             // draw line between them
-            if (start != null && goal != null) DrawLineBetweenDataPoints(start, goal, Color.cyan);
+            if (start != null && goal != null)
+                DrawLineBetweenDataPoints(start, goal, Color.cyan);
         }
     }
 }

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -82,7 +82,8 @@ namespace Mirror
                     }
                     // throwing an exception would only show it for one object
                     // because this function would return afterwards.
-                    else Debug.LogError("Scene " + identity.gameObject.scene.path + " needs to be opened and resaved, because the scene object " + identity.name + " has no valid sceneId yet.");
+                    else
+                        Debug.LogError("Scene " + identity.gameObject.scene.path + " needs to be opened and resaved, because the scene object " + identity.name + " has no valid sceneId yet.");
                 }
             }
         }

--- a/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
+++ b/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
@@ -25,22 +25,28 @@ namespace Mirror.Weaver
         // debug message handler that also calls OnMessageMethod delegate
         static void HandleMessage(string msg)
         {
-            if (UnityLogEnabled) Debug.Log(msg);
-            if (OnWeaverMessage != null) OnWeaverMessage.Invoke(msg);
+            if (UnityLogEnabled)
+                Debug.Log(msg);
+            if (OnWeaverMessage != null)
+                OnWeaverMessage.Invoke(msg);
         }
 
         // warning message handler that also calls OnWarningMethod delegate
         static void HandleWarning(string msg)
         {
-            if (UnityLogEnabled) Debug.LogWarning(msg);
-            if (OnWeaverWarning != null) OnWeaverWarning.Invoke(msg);
+            if (UnityLogEnabled)
+                Debug.LogWarning(msg);
+            if (OnWeaverWarning != null)
+                OnWeaverWarning.Invoke(msg);
         }
 
         // error message handler that also calls OnErrorMethod delegate
         static void HandleError(string msg)
         {
-            if (UnityLogEnabled) Debug.LogError(msg);
-            if (OnWeaverError != null) OnWeaverError.Invoke(msg);
+            if (UnityLogEnabled)
+                Debug.LogError(msg);
+            if (OnWeaverError != null)
+                OnWeaverError.Invoke(msg);
         }
 
         [InitializeOnLoadMethod]
@@ -142,7 +148,8 @@ namespace Mirror.Weaver
             dependencyPaths.Add(Path.GetDirectoryName(assemblyPath));
             foreach (UnityAssembly unityAsm in CompilationPipeline.GetAssemblies())
             {
-                if (unityAsm.outputPath != assemblyPath) continue;
+                if (unityAsm.outputPath != assemblyPath)
+                    continue;
 
                 foreach (string unityAsmRef in unityAsm.compiledAssemblyReferences)
                 {
@@ -159,7 +166,8 @@ namespace Mirror.Weaver
             else
             {
                 WeaveFailed = true;
-                if (UnityLogEnabled) Debug.LogError("Weaving failed for: " + assemblyPath);
+                if (UnityLogEnabled)
+                    Debug.LogError("Weaving failed for: " + assemblyPath);
             }
         }
     }

--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/PlayerController.cs
@@ -51,7 +51,8 @@ namespace Mirror.Examples.Additive
 
         void Update()
         {
-            if (!isLocalPlayer) return;
+            if (!isLocalPlayer)
+                return;
 
             horizontal = Input.GetAxis("Horizontal");
             vertical = Input.GetAxis("Vertical");
@@ -80,7 +81,8 @@ namespace Mirror.Examples.Additive
 
         void FixedUpdate()
         {
-            if (!isLocalPlayer || characterController == null) return;
+            if (!isLocalPlayer || characterController == null)
+                return;
 
             transform.Rotate(0f, turn * Time.fixedDeltaTime, 0f);
 

--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/RandomColor.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/RandomColor.cs
@@ -20,7 +20,8 @@ namespace Mirror.Examples.Additive
 
         void SetColor(Color32 newColor)
         {
-            if (cachedMaterial == null) cachedMaterial = GetComponent<Renderer>().material;
+            if (cachedMaterial == null)
+                cachedMaterial = GetComponent<Renderer>().material;
             cachedMaterial.color = newColor;
         }
 

--- a/Assets/Mirror/Examples/Chat/Scripts/ChatWindow.cs
+++ b/Assets/Mirror/Examples/Chat/Scripts/ChatWindow.cs
@@ -14,7 +14,8 @@ namespace Mirror.Examples.Chat
 
         public void OnSend()
         {
-            if (chatMessage.text.Trim() == "") return;
+            if (chatMessage.text.Trim() == "")
+                return;
 
             // get our player
             Player player = NetworkClient.connection.identity.GetComponent<Player>();

--- a/Assets/Mirror/Examples/ListServer/ListServer.cs
+++ b/Assets/Mirror/Examples/ListServer/ListServer.cs
@@ -118,7 +118,8 @@ namespace Mirror.Examples.ListServer
                 // send it
                 gameServerToListenConnection.Send(((MemoryStream)writer.BaseStream).ToArray());
             }
-            else Debug.LogError("[List Server] List Server will reject messages longer than 128 bytes. Please use a shorter title.");
+            else
+                Debug.LogError("[List Server] List Server will reject messages longer than 128 bytes. Please use a shorter title.");
         }
 
         void TickGameServer()
@@ -311,7 +312,8 @@ namespace Mirror.Examples.ListServer
                     NetworkManager.singleton.StartServer();
                 });
             }
-            else mainPanel.SetActive(false);
+            else
+                mainPanel.SetActive(false);
 
             // show connecting panel while connecting
             if (IsConnecting())
@@ -326,7 +328,8 @@ namespace Mirror.Examples.ListServer
                 connectingCancelButton.onClick.RemoveAllListeners();
                 connectingCancelButton.onClick.AddListener(NetworkManager.singleton.StopClient);
             }
-            else connectingPanel.SetActive(false);
+            else
+                connectingPanel.SetActive(false);
         }
 
         // disconnect everything when pressing Stop in the Editor

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomPlayerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomPlayerExt.cs
@@ -8,19 +8,22 @@ namespace Mirror.Examples.NetworkRoom
     {
         public override void OnStartClient()
         {
-            if (LogFilter.Debug) Debug.LogFormat("OnStartClient {0}", SceneManager.GetActiveScene().name);
+            if (LogFilter.Debug)
+                Debug.LogFormat("OnStartClient {0}", SceneManager.GetActiveScene().name);
 
             base.OnStartClient();
         }
 
         public override void OnClientEnterRoom()
         {
-            if (LogFilter.Debug) Debug.LogFormat("OnClientEnterRoom {0}", SceneManager.GetActiveScene().name);
+            if (LogFilter.Debug)
+                Debug.LogFormat("OnClientEnterRoom {0}", SceneManager.GetActiveScene().name);
         }
 
         public override void OnClientExitRoom()
         {
-            if (LogFilter.Debug) Debug.LogFormat("OnClientExitRoom {0}", SceneManager.GetActiveScene().name);
+            if (LogFilter.Debug)
+                Debug.LogFormat("OnClientExitRoom {0}", SceneManager.GetActiveScene().name);
         }
     }
 }

--- a/Assets/Mirror/Examples/Room/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/PlayerController.cs
@@ -51,7 +51,8 @@ namespace Mirror.Examples.NetworkRoom
 
         void Update()
         {
-            if (!isLocalPlayer) return;
+            if (!isLocalPlayer)
+                return;
 
             horizontal = Input.GetAxis("Horizontal");
             vertical = Input.GetAxis("Vertical");
@@ -80,7 +81,8 @@ namespace Mirror.Examples.NetworkRoom
 
         void FixedUpdate()
         {
-            if (!isLocalPlayer || characterController == null) return;
+            if (!isLocalPlayer || characterController == null)
+                return;
 
             transform.Rotate(0f, turn * Time.fixedDeltaTime, 0f);
 

--- a/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
@@ -22,7 +22,8 @@ namespace Mirror.Examples.NetworkRoom
 
             if (isLocalPlayer && controllerColliderHitObject.name.StartsWith("Prize"))
             {
-                if (LogFilter.Debug) Debug.LogFormat("OnControllerColliderHit {0}[{1}] with {2}[{3}]", name, netId, controllerColliderHitObject.name, controllerColliderHitObject.GetComponent<NetworkIdentity>().netId);
+                if (LogFilter.Debug)
+                    Debug.LogFormat("OnControllerColliderHit {0}[{1}] with {2}[{3}]", name, netId, controllerColliderHitObject.name, controllerColliderHitObject.GetComponent<NetworkIdentity>().netId);
 
                 // Disable the prize gameobject so it doesn't impede player movement
                 // It's going to be destroyed in a few frames and we don't want to spam CmdClaimPrize.

--- a/Assets/Mirror/Examples/Room/Scripts/RandomColor.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/RandomColor.cs
@@ -20,7 +20,8 @@ namespace Mirror.Examples.NetworkRoom
 
         void SetColor(Color32 newColor)
         {
-            if (cachedMaterial == null) cachedMaterial = GetComponent<Renderer>().material;
+            if (cachedMaterial == null)
+                cachedMaterial = GetComponent<Renderer>().material;
             cachedMaterial.color = newColor;
         }
 

--- a/Assets/Mirror/Examples/Room/Scripts/Reward.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/Reward.cs
@@ -32,7 +32,8 @@ namespace Mirror.Examples.NetworkRoom
                 // calculate the points from the color ... lighter scores higher as the average approaches 255
                 // UnityEngine.Color RGB values are float fractions of 255
                 points = (uint)(((prizeColor.r * 255) + (prizeColor.g * 255) + (prizeColor.b * 255)) / 3);
-                if (LogFilter.Debug) Debug.LogFormat("Scored {0} points R:{1} G:{2} B:{3}", points, prizeColor.r, prizeColor.g, prizeColor.b);
+                if (LogFilter.Debug)
+                    Debug.LogFormat("Scored {0} points R:{1} G:{2} B:{3}", points, prizeColor.r, prizeColor.g, prizeColor.b);
 
                 // award the points via SyncVar on the PlayerController
                 player.GetComponent<PlayerScore>().score += points;

--- a/Assets/Mirror/Examples/Tanks/Scripts/Tank.cs
+++ b/Assets/Mirror/Examples/Tanks/Scripts/Tank.cs
@@ -20,7 +20,8 @@ namespace Mirror.Examples.Tanks
         void Update()
         {
             // movement for local player
-            if (!isLocalPlayer) return;
+            if (!isLocalPlayer)
+                return;
 
             // rotate
             float horizontal = Input.GetAxis("Horizontal");

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -70,7 +70,8 @@ namespace Mirror
         // this is called from message handler for Owner message
         internal static void InternalAddPlayer(NetworkIdentity identity)
         {
-            if (LogFilter.Debug) Debug.LogWarning("ClientScene.InternalAddPlayer");
+            if (LogFilter.Debug)
+                Debug.LogWarning("ClientScene.InternalAddPlayer");
 
             // NOTE: It can be "normal" when changing scenes for the player to be destroyed and recreated.
             // But, the player structures are not cleaned up, we'll just replace the old player
@@ -127,7 +128,8 @@ namespace Mirror
                 return false;
             }
 
-            if (LogFilter.Debug) Debug.Log("ClientScene.AddPlayer() called with connection [" + readyConnection + "]");
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene.AddPlayer() called with connection [" + readyConnection + "]");
 
             AddPlayerMessage message = new AddPlayerMessage
             {
@@ -145,7 +147,8 @@ namespace Mirror
         /// <returns>True if succcessful</returns>
         public static bool RemovePlayer()
         {
-            if (LogFilter.Debug) Debug.Log("ClientScene.RemovePlayer() called with connection [" + readyConnection + "]");
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene.RemovePlayer() called with connection [" + readyConnection + "]");
 
             if (readyConnection.identity != null)
             {
@@ -175,7 +178,8 @@ namespace Mirror
                 return false;
             }
 
-            if (LogFilter.Debug) Debug.Log("ClientScene.Ready() called with connection [" + conn + "]");
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene.Ready() called with connection [" + conn + "]");
 
             if (conn != null)
             {
@@ -258,7 +262,8 @@ namespace Mirror
             {
                 identity.assetId = newAssetId;
 
-                if (LogFilter.Debug) Debug.Log("Registering prefab '" + prefab.name + "' as asset:" + identity.assetId);
+                if (LogFilter.Debug)
+                    Debug.Log("Registering prefab '" + prefab.name + "' as asset:" + identity.assetId);
                 prefabs[identity.assetId] = prefab;
             }
             else
@@ -279,7 +284,8 @@ namespace Mirror
             NetworkIdentity identity = prefab.GetComponent<NetworkIdentity>();
             if (identity)
             {
-                if (LogFilter.Debug) Debug.Log("Registering prefab '" + prefab.name + "' as asset:" + identity.assetId);
+                if (LogFilter.Debug)
+                    Debug.Log("Registering prefab '" + prefab.name + "' as asset:" + identity.assetId);
                 prefabs[identity.assetId] = prefab;
 
                 NetworkIdentity[] identities = prefab.GetComponentsInChildren<NetworkIdentity>();
@@ -339,7 +345,8 @@ namespace Mirror
                 return;
             }
 
-            if (LogFilter.Debug) Debug.Log("Registering custom prefab '" + prefab.name + "' as asset:" + identity.assetId + " " + spawnHandler.GetMethodName() + "/" + unspawnHandler.GetMethodName());
+            if (LogFilter.Debug)
+                Debug.Log("Registering custom prefab '" + prefab.name + "' as asset:" + identity.assetId + " " + spawnHandler.GetMethodName() + "/" + unspawnHandler.GetMethodName());
 
             spawnHandlers[identity.assetId] = spawnHandler;
             unspawnHandlers[identity.assetId] = unspawnHandler;
@@ -388,7 +395,8 @@ namespace Mirror
                 return;
             }
 
-            if (LogFilter.Debug) Debug.Log("RegisterSpawnHandler asset '" + assetId + "' " + spawnHandler.GetMethodName() + "/" + unspawnHandler.GetMethodName());
+            if (LogFilter.Debug)
+                Debug.Log("RegisterSpawnHandler asset '" + assetId + "' " + spawnHandler.GetMethodName() + "/" + unspawnHandler.GetMethodName());
 
             spawnHandlers[assetId] = spawnHandler;
             unspawnHandlers[assetId] = unspawnHandler;
@@ -512,7 +520,8 @@ namespace Mirror
                 Debug.LogError("OnObjSpawn netId: " + msg.netId + " has invalid asset Id");
                 return;
             }
-            if (LogFilter.Debug) Debug.Log($"Client spawn handler instantiating netId={msg.netId} assetID={msg.assetId} sceneId={msg.sceneId} pos={msg.position}");
+            if (LogFilter.Debug)
+                Debug.Log($"Client spawn handler instantiating netId={msg.netId} assetID={msg.assetId} sceneId={msg.sceneId} pos={msg.position}");
 
             // was the object already spawned?
             NetworkIdentity identity = GetExistingObject(msg.netId);
@@ -578,13 +587,15 @@ namespace Mirror
                 }
             }
 
-            if (LogFilter.Debug) Debug.Log("Client spawn for [netId:" + msg.netId + "] [sceneId:" + msg.sceneId + "] obj:" + spawnedId.gameObject.name);
+            if (LogFilter.Debug)
+                Debug.Log("Client spawn for [netId:" + msg.netId + "] [sceneId:" + msg.sceneId + "] obj:" + spawnedId.gameObject.name);
             return spawnedId;
         }
 
         internal static void OnObjectSpawnStarted(ObjectSpawnStartedMessage _)
         {
-            if (LogFilter.Debug) Debug.Log("SpawnStarted");
+            if (LogFilter.Debug)
+                Debug.Log("SpawnStarted");
 
             PrepareToSpawnSceneObjects();
             isSpawnFinished = false;
@@ -592,7 +603,8 @@ namespace Mirror
 
         internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage _)
         {
-            if (LogFilter.Debug) Debug.Log("SpawnFinished");
+            if (LogFilter.Debug)
+                Debug.Log("SpawnFinished");
 
             // paul: Initialize the objects in the same order as they were initialized
             // in the server.   This is important if spawned objects
@@ -618,7 +630,8 @@ namespace Mirror
 
         static void DestroyObject(uint netId)
         {
-            if (LogFilter.Debug) Debug.Log("ClientScene.OnObjDestroy netId:" + netId);
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene.OnObjDestroy netId:" + netId);
 
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity localObject) && localObject != null)
             {
@@ -643,20 +656,23 @@ namespace Mirror
             }
             else
             {
-                if (LogFilter.Debug) Debug.LogWarning("Did not find target for destroy message for " + netId);
+                if (LogFilter.Debug)
+                    Debug.LogWarning("Did not find target for destroy message for " + netId);
             }
         }
 
         internal static void OnHostClientObjectDestroy(ObjectDestroyMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("ClientScene.OnLocalObjectObjDestroy netId:" + msg.netId);
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene.OnLocalObjectObjDestroy netId:" + msg.netId);
 
             NetworkIdentity.spawned.Remove(msg.netId);
         }
 
         internal static void OnHostClientObjectHide(ObjectHideMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("ClientScene::OnLocalObjectObjHide netId:" + msg.netId);
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene::OnLocalObjectObjHide netId:" + msg.netId);
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
@@ -681,7 +697,8 @@ namespace Mirror
 
         internal static void OnUpdateVarsMessage(UpdateVarsMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("ClientScene.OnUpdateVarsMessage " + msg.netId);
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene.OnUpdateVarsMessage " + msg.netId);
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
@@ -695,7 +712,8 @@ namespace Mirror
 
         internal static void OnRPCMessage(RpcMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("ClientScene.OnRPCMessage hash:" + msg.functionHash + " netId:" + msg.netId);
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene.OnRPCMessage hash:" + msg.functionHash + " netId:" + msg.netId);
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
@@ -705,7 +723,8 @@ namespace Mirror
 
         internal static void OnSyncEventMessage(SyncEventMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("ClientScene.OnSyncEventMessage " + msg.netId);
+            if (LogFilter.Debug)
+                Debug.Log("ClientScene.OnSyncEventMessage " + msg.netId);
 
             if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
@@ -725,7 +744,8 @@ namespace Mirror
                 identity.connectionToServer = readyConnection;
                 identity.OnStartLocalPlayer();
 
-                if (LogFilter.Debug) Debug.Log("ClientScene.OnOwnerMessage - player=" + identity.name);
+                if (LogFilter.Debug)
+                    Debug.Log("ClientScene.OnOwnerMessage - player=" + identity.name);
             }
         }
     }

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -387,7 +387,8 @@ namespace Mirror
                 invokeFunction = func
             };
             cmdHandlerDelegates[cmdHash] = invoker;
-            if (LogFilter.Debug) Debug.Log("RegisterDelegate hash:" + cmdHash + " invokerType: " + invokerType + " method:" + func.GetMethodName());
+            if (LogFilter.Debug)
+                Debug.Log("RegisterDelegate hash:" + cmdHash + " invokerType: " + invokerType + " method:" + func.GetMethodName());
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -420,7 +421,8 @@ namespace Mirror
             // debug message if not found, or null, or mismatched type
             // (no need to throw an error, an attacker might just be trying to
             //  call an cmd with an rpc's hash)
-            if (LogFilter.Debug) Debug.Log("GetInvokerForHash hash:" + cmdHash + " not found");
+            if (LogFilter.Debug)
+                Debug.Log("GetInvokerForHash hash:" + cmdHash + " not found");
             return false;
         }
 
@@ -497,7 +499,8 @@ namespace Mirror
                 }
             }
 
-            if (LogFilter.Debug) Debug.Log("SetSyncVar GameObject " + GetType().Name + " bit [" + dirtyBit + "] netfieldId:" + netIdField + "->" + newNetId);
+            if (LogFilter.Debug)
+                Debug.Log("SetSyncVar GameObject " + GetType().Name + " bit [" + dirtyBit + "] netfieldId:" + netIdField + "->" + newNetId);
             SetDirtyBit(dirtyBit);
             gameObjectField = newGameObject; // assign new one on the server, and in case we ever need it on client too
             netIdField = newNetId;
@@ -556,7 +559,8 @@ namespace Mirror
                 }
             }
 
-            if (LogFilter.Debug) Debug.Log("SetSyncVarNetworkIdentity NetworkIdentity " + GetType().Name + " bit [" + dirtyBit + "] netIdField:" + netIdField + "->" + newNetId);
+            if (LogFilter.Debug)
+                Debug.Log("SetSyncVarNetworkIdentity NetworkIdentity " + GetType().Name + " bit [" + dirtyBit + "] netIdField:" + netIdField + "->" + newNetId);
             SetDirtyBit(dirtyBit);
             netIdField = newNetId;
             identityField = newIdentity; // assign new one on the server, and in case we ever need it on client too
@@ -589,7 +593,8 @@ namespace Mirror
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void SetSyncVar<T>(T value, ref T fieldValue, ulong dirtyBit)
         {
-            if (LogFilter.Debug) Debug.Log("SetSyncVar " + GetType().Name + " bit [" + dirtyBit + "] " + fieldValue + "->" + value);
+            if (LogFilter.Debug)
+                Debug.Log("SetSyncVar " + GetType().Name + " bit [" + dirtyBit + "] " + fieldValue + "->" + value);
             SetDirtyBit(dirtyBit);
             fieldValue = value;
         }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -76,7 +76,8 @@ namespace Mirror
         /// <param name="address"></param>
         public static void Connect(string address)
         {
-            if (LogFilter.Debug) Debug.Log("Client Connect: " + address);
+            if (LogFilter.Debug)
+                Debug.Log("Client Connect: " + address);
 
             RegisterSystemHandlers(false);
             Transport.activeTransport.enabled = true;
@@ -96,7 +97,8 @@ namespace Mirror
         /// <param name="uri">Address of the server to connect to</param>
         public static void Connect(Uri uri)
         {
-            if (LogFilter.Debug) Debug.Log("Client Connect: " + uri);
+            if (LogFilter.Debug)
+                Debug.Log("Client Connect: " + uri);
 
             RegisterSystemHandlers(false);
             Transport.activeTransport.enabled = true;
@@ -112,7 +114,8 @@ namespace Mirror
 
         internal static void ConnectHost()
         {
-            if (LogFilter.Debug) Debug.Log("Client Connect Host to Server");
+            if (LogFilter.Debug)
+                Debug.Log("Client Connect Host to Server");
 
             RegisterSystemHandlers(true);
 
@@ -167,7 +170,8 @@ namespace Mirror
             {
                 connection.TransportReceive(data, channelId);
             }
-            else Debug.LogError("Skipped Data message handling because connection is null.");
+            else
+                Debug.LogError("Skipped Data message handling because connection is null.");
         }
 
         static void OnConnected()
@@ -183,7 +187,8 @@ namespace Mirror
                 NetworkTime.UpdateClient();
                 connection.InvokeHandler(new ConnectMessage(), -1);
             }
-            else Debug.LogError("Skipped Connect message handling because connection is null.");
+            else
+                Debug.LogError("Skipped Connect message handling because connection is null.");
         }
 
         /// <summary>
@@ -378,7 +383,8 @@ namespace Mirror
         {
             if (handlers.ContainsKey(msgType))
             {
-                if (LogFilter.Debug) Debug.Log("NetworkClient.RegisterHandler replacing " + handler + " - " + msgType);
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkClient.RegisterHandler replacing " + handler + " - " + msgType);
             }
             handlers[msgType] = handler;
         }
@@ -404,7 +410,8 @@ namespace Mirror
             int msgType = MessagePacker.GetId<T>();
             if (handlers.ContainsKey(msgType))
             {
-                if (LogFilter.Debug) Debug.Log("NetworkClient.RegisterHandler replacing " + handler + " - " + msgType);
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkClient.RegisterHandler replacing " + handler + " - " + msgType);
             }
             handlers[msgType] = MessagePacker.MessageHandler<T>(handler, requireAuthentication);
         }
@@ -456,7 +463,8 @@ namespace Mirror
         /// </summary>
         public static void Shutdown()
         {
-            if (LogFilter.Debug) Debug.Log("Shutting down client.");
+            if (LogFilter.Debug)
+                Debug.Log("Shutting down client.");
             ClientScene.Shutdown();
             connectState = ConnectState.None;
             handlers.Clear();

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -169,7 +169,8 @@ namespace Mirror
         {
             if (messageHandlers.ContainsKey(msgType))
             {
-                if (LogFilter.Debug) Debug.Log("NetworkConnection.RegisterHandler replacing " + msgType);
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkConnection.RegisterHandler replacing " + msgType);
             }
             messageHandlers[msgType] = handler;
         }
@@ -347,7 +348,8 @@ namespace Mirror
             if (MessagePacker.UnpackMessage(reader, out int msgType))
             {
                 // logging
-                if (logNetworkMessages) Debug.Log("ConnectionRecv " + this + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));
+                if (logNetworkMessages)
+                    Debug.Log("ConnectionRecv " + this + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));
 
                 // try to invoke the handler for that message
                 if (InvokeHandler(msgType, reader, channelId))

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -18,7 +18,8 @@ namespace Mirror
 
         internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
-            if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
+            if (logNetworkMessages)
+                Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
             // validate packet size first.
             if (ValidatePacketSize(segment, channelId))

--- a/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
@@ -9,7 +9,8 @@ namespace Mirror
 
         internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
-            if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
+            if (logNetworkMessages)
+                Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
             // validate packet size first.
             if (ValidatePacketSize(segment, channelId))

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -173,7 +173,8 @@ namespace Mirror
                 {
                     m_AssetId = newAssetIdString;
                 }
-                else Debug.LogWarning($"SetDynamicAssetId object {this.name} already has an assetId {m_AssetId}, new asset id {newAssetIdString}");
+                else
+                    Debug.LogWarning($"SetDynamicAssetId object {this.name} already has an assetId {m_AssetId}, new asset id {newAssetIdString}");
             }
         }
 
@@ -419,7 +420,8 @@ namespace Mirror
             m_SceneId = (m_SceneId & 0xFFFFFFFF) | shiftedHash;
 
             // log it. this is incredibly useful to debug sceneId issues.
-            if (LogFilter.Debug) Debug.Log(name + " in scene=" + gameObject.scene.name + " scene index hash(" + pathHash.ToString("X") + ") copied into sceneId: " + m_SceneId.ToString("X"));
+            if (LogFilter.Debug)
+                Debug.Log(name + " in scene=" + gameObject.scene.name + " scene index hash(" + pathHash.ToString("X") + ") copied into sceneId: " + m_SceneId.ToString("X"));
         }
 
         void SetupIDs()
@@ -498,7 +500,8 @@ namespace Mirror
             netId = GetNextNetworkId();
             observers = new Dictionary<int, NetworkConnection>();
 
-            if (LogFilter.Debug) Debug.Log("OnStartServer " + this + " NetId:" + netId + " SceneId:" + sceneId);
+            if (LogFilter.Debug)
+                Debug.Log("OnStartServer " + this + " NetId:" + netId + " SceneId:" + sceneId);
 
             // add to spawned (note: the original EnableIsServer isn't needed
             // because we already set m_isServer=true above)
@@ -524,7 +527,8 @@ namespace Mirror
                 return;
             clientStarted = true;
 
-            if (LogFilter.Debug) Debug.Log("OnStartClient " + gameObject + " netId:" + netId);
+            if (LogFilter.Debug)
+                Debug.Log("OnStartClient " + gameObject + " netId:" + netId);
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {
                 try
@@ -645,7 +649,8 @@ namespace Mirror
             writer.WriteInt32(endPosition - contentPosition);
             writer.Position = endPosition;
 
-            if (LogFilter.Debug) Debug.Log("OnSerializeSafely written for object=" + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId.ToString("X") + "header@" + headerPosition + " content@" + contentPosition + " end@" + endPosition + " contentSize=" + (endPosition - contentPosition));
+            if (LogFilter.Debug)
+                Debug.Log("OnSerializeSafely written for object=" + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId.ToString("X") + "header@" + headerPosition + " content@" + contentPosition + " end@" + endPosition + " contentSize=" + (endPosition - contentPosition));
 
             return result;
         }
@@ -691,7 +696,8 @@ namespace Mirror
                 // -> note: IsDirty() is false if the component isn't dirty or sendInterval isn't elapsed yet
                 if (initialState || comp.IsDirty())
                 {
-                    if (LogFilter.Debug) Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState);
+                    if (LogFilter.Debug)
+                        Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState);
 
                     // serialize into ownerWriter first
                     // (owner always gets everything!)
@@ -765,7 +771,8 @@ namespace Mirror
             // way to mess up another component's deserialization
             try
             {
-                if (LogFilter.Debug) Debug.Log("OnDeserializeSafely: " + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId.ToString("X") + " length=" + contentSize);
+                if (LogFilter.Debug)
+                    Debug.Log("OnDeserializeSafely: " + comp.name + " component=" + comp.GetType() + " sceneId=" + m_SceneId.ToString("X") + " length=" + contentSize);
                 comp.OnDeserialize(reader, initialState);
             }
             catch (Exception e)
@@ -900,7 +907,8 @@ namespace Mirror
                 return;
             }
 
-            if (LogFilter.Debug) Debug.Log("Added observer " + conn.address + " added for " + gameObject);
+            if (LogFilter.Debug)
+                Debug.Log("Added observer " + conn.address + " added for " + gameObject);
 
             observers[conn.connectionId] = conn;
             conn.AddToVisList(this);
@@ -967,7 +975,8 @@ namespace Mirror
 
                 if (!conn.isReady)
                 {
-                    if (LogFilter.Debug) Debug.Log("Observer is not ready for " + gameObject + " " + conn);
+                    if (LogFilter.Debug)
+                        Debug.Log("Observer is not ready for " + gameObject + " " + conn);
                     continue;
                 }
 
@@ -975,7 +984,8 @@ namespace Mirror
                 {
                     // new observer
                     conn.AddToVisList(this);
-                    if (LogFilter.Debug) Debug.Log("New Observer for " + gameObject + " " + conn);
+                    if (LogFilter.Debug)
+                        Debug.Log("New Observer for " + gameObject + " " + conn);
                     changed = true;
                 }
             }
@@ -986,7 +996,8 @@ namespace Mirror
                 {
                     // removed observer
                     conn.RemoveFromVisList(this, false);
-                    if (LogFilter.Debug) Debug.Log("Removed Observer for " + gameObject + " " + conn);
+                    if (LogFilter.Debug)
+                        Debug.Log("Removed Observer for " + gameObject + " " + conn);
                     changed = true;
                 }
             }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -275,7 +275,8 @@ namespace Mirror
         // full server setup code, without spawning objects yet
         void SetupServer()
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager SetupServer");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager SetupServer");
             InitializeSingleton();
 
             if (runInBackground)
@@ -371,7 +372,8 @@ namespace Mirror
                 Debug.LogError("Must set the Network Address field in the manager");
                 return;
             }
-            if (LogFilter.Debug) Debug.Log("NetworkManager StartClient address:" + networkAddress);
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager StartClient address:" + networkAddress);
 
             NetworkClient.Connect(networkAddress);
 
@@ -400,7 +402,8 @@ namespace Mirror
 
             RegisterClientMessages();
 
-            if (LogFilter.Debug) Debug.Log("NetworkManager StartClient address:" + uri);
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager StartClient address:" + uri);
             this.networkAddress = uri.Host;
 
             NetworkClient.Connect(uri);
@@ -410,7 +413,8 @@ namespace Mirror
 
         void StartHostClient()
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager ConnectLocalClient");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager ConnectLocalClient");
 
             if (authenticator != null)
             {
@@ -527,7 +531,8 @@ namespace Mirror
 
             OnStopServer();
 
-            if (LogFilter.Debug) Debug.Log("NetworkManager StopServer");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager StopServer");
             isNetworkActive = false;
             NetworkServer.Shutdown();
             if (!string.IsNullOrEmpty(offlineScene))
@@ -549,7 +554,8 @@ namespace Mirror
 
             OnStopClient();
 
-            if (LogFilter.Debug) Debug.Log("NetworkManager StopClient");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager StopClient");
             isNetworkActive = false;
 
             // shutdown client
@@ -629,13 +635,16 @@ namespace Mirror
                     Destroy(gameObject);
                     return;
                 }
-                if (LogFilter.Debug) Debug.Log("NetworkManager created singleton (DontDestroyOnLoad)");
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkManager created singleton (DontDestroyOnLoad)");
                 singleton = this;
-                if (Application.isPlaying) DontDestroyOnLoad(gameObject);
+                if (Application.isPlaying)
+                    DontDestroyOnLoad(gameObject);
             }
             else
             {
-                if (LogFilter.Debug) Debug.Log("NetworkManager created singleton (ForScene)");
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkManager created singleton (ForScene)");
                 singleton = this;
             }
 
@@ -705,7 +714,8 @@ namespace Mirror
         /// </summary>
         public virtual void OnDestroy()
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager destroyed");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager destroyed");
         }
 
         #endregion
@@ -737,7 +747,8 @@ namespace Mirror
                 return;
             }
 
-            if (LogFilter.Debug) Debug.Log("ServerChangeScene " + newSceneName);
+            if (LogFilter.Debug)
+                Debug.Log("ServerChangeScene " + newSceneName);
             NetworkServer.SetAllClientsNotReady();
             networkSceneName = newSceneName;
 
@@ -765,12 +776,14 @@ namespace Mirror
                 return;
             }
 
-            if (LogFilter.Debug) Debug.Log("ClientChangeScene newSceneName:" + newSceneName + " networkSceneName:" + networkSceneName);
+            if (LogFilter.Debug)
+                Debug.Log("ClientChangeScene newSceneName:" + newSceneName + " networkSceneName:" + networkSceneName);
 
             // vis2k: pause message handling while loading scene. otherwise we will process messages and then lose all
             // the state as soon as the load is finishing, causing all kinds of bugs because of missing state.
             // (client may be null after StopClient etc.)
-            if (LogFilter.Debug) Debug.Log("ClientChangeScene: pausing handlers while scene is loading to avoid data loss after scene was loaded.");
+            if (LogFilter.Debug)
+                Debug.Log("ClientChangeScene: pausing handlers while scene is loading to avoid data loss after scene was loaded.");
             Transport.activeTransport.enabled = false;
 
             // Let client prepare for scene change
@@ -841,7 +854,8 @@ namespace Mirror
         {
             if (singleton != null && loadingSceneAsync != null && loadingSceneAsync.isDone)
             {
-                if (LogFilter.Debug) Debug.Log("ClientChangeScene done readyCon:" + clientReadyConnection);
+                if (LogFilter.Debug)
+                    Debug.Log("ClientChangeScene done readyCon:" + clientReadyConnection);
                 singleton.FinishLoadScene();
                 loadingSceneAsync.allowSceneActivation = true;
                 loadingSceneAsync = null;
@@ -853,7 +867,8 @@ namespace Mirror
             // NOTE: this cannot use NetworkClient.allClients[0] - that client may be for a completely different purpose.
 
             // process queued messages that we received while loading the scene
-            if (LogFilter.Debug) Debug.Log("FinishLoadScene: resuming handlers after scene was loading.");
+            if (LogFilter.Debug)
+                Debug.Log("FinishLoadScene: resuming handlers after scene was loading.");
             Transport.activeTransport.enabled = true;
 
             // host mode?
@@ -953,7 +968,8 @@ namespace Mirror
         /// <param name="start">Transform to register.</param>
         public static void RegisterStartPosition(Transform start)
         {
-            if (LogFilter.Debug) Debug.Log("RegisterStartPosition: (" + start.gameObject.name + ") " + start.position);
+            if (LogFilter.Debug)
+                Debug.Log("RegisterStartPosition: (" + start.gameObject.name + ") " + start.position);
             startPositions.Add(start);
 
             // reorder the list so that round-robin spawning uses the start positions
@@ -970,7 +986,8 @@ namespace Mirror
         /// <param name="start">Transform to unregister.</param>
         public static void UnRegisterStartPosition(Transform start)
         {
-            if (LogFilter.Debug) Debug.Log("UnRegisterStartPosition: (" + start.gameObject.name + ") " + start.position);
+            if (LogFilter.Debug)
+                Debug.Log("UnRegisterStartPosition: (" + start.gameObject.name + ") " + start.position);
             startPositions.Remove(start);
         }
 
@@ -980,7 +997,8 @@ namespace Mirror
 
         void OnServerConnectInternal(NetworkConnection conn, ConnectMessage connectMsg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerConnectInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnServerConnectInternal");
 
             if (authenticator != null)
             {
@@ -997,7 +1015,8 @@ namespace Mirror
         // called after successful authentication
         void OnServerAuthenticated(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerAuthenticated");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnServerAuthenticated");
 
             // set connection to authenticated
             conn.isAuthenticated = true;
@@ -1014,19 +1033,22 @@ namespace Mirror
 
         void OnServerDisconnectInternal(NetworkConnection conn, DisconnectMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerDisconnectInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnServerDisconnectInternal");
             OnServerDisconnect(conn);
         }
 
         void OnServerReadyMessageInternal(NetworkConnection conn, ReadyMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerReadyMessageInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnServerReadyMessageInternal");
             OnServerReady(conn);
         }
 
         void OnServerAddPlayerInternal(NetworkConnection conn, AddPlayerMessage extraMessage)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerAddPlayer");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnServerAddPlayer");
 
             if (autoCreatePlayer && playerPrefab == null)
             {
@@ -1053,7 +1075,8 @@ namespace Mirror
 
         void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerRemovePlayerMessageInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnServerRemovePlayerMessageInternal");
 
             if (conn.identity != null)
             {
@@ -1064,7 +1087,8 @@ namespace Mirror
 
         void OnServerErrorInternal(NetworkConnection conn, ErrorMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerErrorInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnServerErrorInternal");
             OnServerError(conn, msg.value);
         }
 
@@ -1074,7 +1098,8 @@ namespace Mirror
 
         void OnClientConnectInternal(NetworkConnection conn, ConnectMessage message)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientConnectInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnClientConnectInternal");
 
             if (authenticator != null)
             {
@@ -1091,7 +1116,8 @@ namespace Mirror
         // called after successful authentication
         void OnClientAuthenticated(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientAuthenticated");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnClientAuthenticated");
 
             // set connection to authenticated
             conn.isAuthenticated = true;
@@ -1112,13 +1138,15 @@ namespace Mirror
 
         void OnClientDisconnectInternal(NetworkConnection conn, DisconnectMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientDisconnectInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnClientDisconnectInternal");
             OnClientDisconnect(conn);
         }
 
         void OnClientNotReadyMessageInternal(NetworkConnection conn, NotReadyMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientNotReadyMessageInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnClientNotReadyMessageInternal");
 
             ClientScene.ready = false;
             OnClientNotReady(conn);
@@ -1128,13 +1156,15 @@ namespace Mirror
 
         void OnClientErrorInternal(NetworkConnection conn, ErrorMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager:OnClientErrorInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager:OnClientErrorInternal");
             OnClientError(conn, msg.value);
         }
 
         void OnClientSceneInternal(NetworkConnection conn, SceneMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientSceneInternal");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkManager.OnClientSceneInternal");
 
             if (NetworkClient.isConnected && !NetworkServer.active)
             {
@@ -1161,7 +1191,8 @@ namespace Mirror
         public virtual void OnServerDisconnect(NetworkConnection conn)
         {
             NetworkServer.DestroyPlayerForConnection(conn);
-            if (LogFilter.Debug) Debug.Log("OnServerDisconnect: Client disconnected.");
+            if (LogFilter.Debug)
+                Debug.Log("OnServerDisconnect: Client disconnected.");
         }
 
         /// <summary>
@@ -1174,7 +1205,8 @@ namespace Mirror
             if (conn.identity == null)
             {
                 // this is now allowed (was not for a while)
-                if (LogFilter.Debug) Debug.Log("Ready with no player object");
+                if (LogFilter.Debug)
+                    Debug.Log("Ready with no player object");
             }
             NetworkServer.SetClientReady(conn);
         }
@@ -1279,7 +1311,8 @@ namespace Mirror
             if (!clientLoadedScene)
             {
                 // Ready/AddPlayer is usually triggered by a scene load completing. if no scene was loaded, then Ready/AddPlayer it here instead.
-                if (!ClientScene.ready) ClientScene.Ready(conn);
+                if (!ClientScene.ready)
+                    ClientScene.Ready(conn);
                 if (autoCreatePlayer)
                 {
                     ClientScene.AddPlayer();
@@ -1346,7 +1379,8 @@ namespace Mirror
         public virtual void OnClientSceneChanged(NetworkConnection conn)
         {
             // always become ready.
-            if (!ClientScene.ready) ClientScene.Ready(conn);
+            if (!ClientScene.ready)
+                ClientScene.Ready(conn);
 
             if (autoCreatePlayer && ClientScene.localPlayer == null)
             {

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -73,7 +73,8 @@ namespace Mirror
                     }
                     else
                     {
-                        if (GUILayout.Button("LAN Server Only")) manager.StartServer();
+                        if (GUILayout.Button("LAN Server Only"))
+                            manager.StartServer();
                     }
                 }
                 else

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -341,14 +341,16 @@ namespace Mirror
         public static NetworkIdentity ReadNetworkIdentity(this NetworkReader reader)
         {
             uint netId = reader.ReadPackedUInt32();
-            if (netId == 0) return null;
+            if (netId == 0)
+                return null;
 
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
             {
                 return identity;
             }
 
-            if (LogFilter.Debug) Debug.Log("ReadNetworkIdentity netId:" + netId + " not found in spawned");
+            if (LogFilter.Debug)
+                Debug.Log("ReadNetworkIdentity netId:" + netId + " not found in spawned");
             return null;
         }
     }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -105,7 +105,8 @@ namespace Mirror
                 return;
 
             initialized = true;
-            if (LogFilter.Debug) Debug.Log("NetworkServer Created version " + Version.Current);
+            if (LogFilter.Debug)
+                Debug.Log("NetworkServer Created version " + Version.Current);
 
             //Make sure connections are cleared in case any old connections references exist from previous sessions
             connections.Clear();
@@ -137,7 +138,8 @@ namespace Mirror
             if (!dontListen)
             {
                 Transport.activeTransport.ServerStart();
-                if (LogFilter.Debug) Debug.Log("Server started listening");
+                if (LogFilter.Debug)
+                    Debug.Log("Server started listening");
             }
 
             active = true;
@@ -203,7 +205,8 @@ namespace Mirror
             {
                 if (!identity.isClient)
                 {
-                    if (LogFilter.Debug) Debug.Log("ActivateClientScene " + identity.netId + " " + identity);
+                    if (LogFilter.Debug)
+                        Debug.Log("ActivateClientScene " + identity.netId + " " + identity);
 
                     identity.OnStartClient();
                 }
@@ -214,7 +217,8 @@ namespace Mirror
         // this is used for ObjectDestroy messages.
         static bool SendToObservers<T>(NetworkIdentity identity, T msg) where T : IMessageBase
         {
-            if (LogFilter.Debug) Debug.Log("Server.SendToObservers id:" + typeof(T));
+            if (LogFilter.Debug)
+                Debug.Log("Server.SendToObservers id:" + typeof(T));
 
             if (identity != null && identity.observers != null)
             {
@@ -258,7 +262,8 @@ namespace Mirror
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Use SendToAll<T> instead.")]
         public static bool SendToAll(int msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
-            if (LogFilter.Debug) Debug.Log("Server.SendToAll id:" + msgType);
+            if (LogFilter.Debug)
+                Debug.Log("Server.SendToAll id:" + msgType);
 
             // pack message into byte[] once
             byte[] bytes = MessagePacker.PackMessage((ushort)msgType, msg);
@@ -282,7 +287,8 @@ namespace Mirror
         /// <returns></returns>
         public static bool SendToAll<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
-            if (LogFilter.Debug) Debug.Log("Server.SendToAll id:" + typeof(T));
+            if (LogFilter.Debug)
+                Debug.Log("Server.SendToAll id:" + typeof(T));
 
             // get writer from pool
             NetworkWriter writer = NetworkWriterPool.GetWriter();
@@ -322,7 +328,8 @@ namespace Mirror
         [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Use SendToReady<T> instead.")]
         public static bool SendToReady(NetworkIdentity identity, short msgType, MessageBase msg, int channelId = Channels.DefaultReliable)
         {
-            if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + msgType);
+            if (LogFilter.Debug)
+                Debug.Log("Server.SendToReady msgType:" + msgType);
 
             if (identity != null && identity.observers != null)
             {
@@ -355,7 +362,8 @@ namespace Mirror
         /// <returns></returns>
         public static bool SendToReady<T>(NetworkIdentity identity, T msg, bool includeOwner = true, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
-            if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + typeof(T));
+            if (LogFilter.Debug)
+                Debug.Log("Server.SendToReady msgType:" + typeof(T));
 
             if (identity != null && identity.observers != null)
             {
@@ -467,7 +475,8 @@ namespace Mirror
 
         static void OnConnected(int connectionId)
         {
-            if (LogFilter.Debug) Debug.Log("Server accepted client:" + connectionId);
+            if (LogFilter.Debug)
+                Debug.Log("Server accepted client:" + connectionId);
 
             // connectionId needs to be > 0 because 0 is reserved for local player
             if (connectionId <= 0)
@@ -481,7 +490,8 @@ namespace Mirror
             if (connections.ContainsKey(connectionId))
             {
                 Transport.activeTransport.ServerDisconnect(connectionId);
-                if (LogFilter.Debug) Debug.Log("Server connectionId " + connectionId + " already in use. kicked client:" + connectionId);
+                if (LogFilter.Debug)
+                    Debug.Log("Server connectionId " + connectionId + " already in use. kicked client:" + connectionId);
                 return;
             }
 
@@ -500,13 +510,15 @@ namespace Mirror
             {
                 // kick
                 Transport.activeTransport.ServerDisconnect(connectionId);
-                if (LogFilter.Debug) Debug.Log("Server full, kicked client:" + connectionId);
+                if (LogFilter.Debug)
+                    Debug.Log("Server full, kicked client:" + connectionId);
             }
         }
 
         internal static void OnConnected(NetworkConnectionToClient conn)
         {
-            if (LogFilter.Debug) Debug.Log("Server accepted client:" + conn);
+            if (LogFilter.Debug)
+                Debug.Log("Server accepted client:" + conn);
 
             // add connection and invoke connected event
             AddConnection(conn);
@@ -515,13 +527,15 @@ namespace Mirror
 
         static void OnDisconnected(int connectionId)
         {
-            if (LogFilter.Debug) Debug.Log("Server disconnect client:" + connectionId);
+            if (LogFilter.Debug)
+                Debug.Log("Server disconnect client:" + connectionId);
 
             if (connections.TryGetValue(connectionId, out NetworkConnectionToClient conn))
             {
                 conn.Disconnect();
                 RemoveConnection(connectionId);
-                if (LogFilter.Debug) Debug.Log("Server lost client:" + connectionId);
+                if (LogFilter.Debug)
+                    Debug.Log("Server lost client:" + connectionId);
 
                 OnDisconnected(conn);
             }
@@ -530,7 +544,8 @@ namespace Mirror
         static void OnDisconnected(NetworkConnection conn)
         {
             conn.InvokeHandler(new DisconnectMessage(), -1);
-            if (LogFilter.Debug) Debug.Log("Server lost client:" + conn);
+            if (LogFilter.Debug)
+                Debug.Log("Server lost client:" + conn);
         }
 
         static void OnDataReceived(int connectionId, ArraySegment<byte> data, int channelId)
@@ -559,7 +574,8 @@ namespace Mirror
         {
             if (handlers.ContainsKey(msgType))
             {
-                if (LogFilter.Debug) Debug.Log("NetworkServer.RegisterHandler replacing " + msgType);
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkServer.RegisterHandler replacing " + msgType);
             }
             handlers[msgType] = handler;
         }
@@ -585,7 +601,8 @@ namespace Mirror
             int msgType = MessagePacker.GetId<T>();
             if (handlers.ContainsKey(msgType))
             {
-                if (LogFilter.Debug) Debug.Log("NetworkServer.RegisterHandler replacing " + msgType);
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkServer.RegisterHandler replacing " + msgType);
             }
             handlers[msgType] = MessagePacker.MessageHandler(handler, requireAuthentication);
         }
@@ -754,7 +771,8 @@ namespace Mirror
 
         static void SpawnObserversForConnection(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("Spawning " + NetworkIdentity.spawned.Count + " objects for conn " + conn);
+            if (LogFilter.Debug)
+                Debug.Log("Spawning " + NetworkIdentity.spawned.Count + " objects for conn " + conn);
 
             if (!conn.isReady)
             {
@@ -772,7 +790,8 @@ namespace Mirror
             {
                 if (identity.gameObject.activeSelf) //TODO this is different // try with far away ones in ummorpg!
                 {
-                    if (LogFilter.Debug) Debug.Log("Sending spawn message for current server objects name='" + identity.name + "' netId=" + identity.netId + " sceneId=" + identity.sceneId);
+                    if (LogFilter.Debug)
+                        Debug.Log("Sending spawn message for current server objects name='" + identity.name + "' netId=" + identity.netId + " sceneId=" + identity.sceneId);
 
                     bool visible = identity.OnCheckObserver(conn);
                     if (visible)
@@ -829,7 +848,8 @@ namespace Mirror
             // set ready if not set yet
             SetClientReady(conn);
 
-            if (LogFilter.Debug) Debug.Log("Adding new playerGameObject object netId: " + identity.netId + " asset ID " + identity.assetId);
+            if (LogFilter.Debug)
+                Debug.Log("Adding new playerGameObject object netId: " + identity.netId + " asset ID " + identity.assetId);
 
             Respawn(identity);
             return true;
@@ -865,7 +885,8 @@ namespace Mirror
             }
 
             //NOTE: there can be an existing player
-            if (LogFilter.Debug) Debug.Log("NetworkServer ReplacePlayer");
+            if (LogFilter.Debug)
+                Debug.Log("NetworkServer ReplacePlayer");
 
             NetworkIdentity previousPlayer = conn.identity;
 
@@ -890,7 +911,8 @@ namespace Mirror
             // IMPORTANT: do this in AddPlayerForConnection & ReplacePlayerForConnection!
             SpawnObserversForConnection(conn);
 
-            if (LogFilter.Debug) Debug.Log("Replacing playerGameObject object netId: " + player.GetComponent<NetworkIdentity>().netId + " asset ID " + player.GetComponent<NetworkIdentity>().assetId);
+            if (LogFilter.Debug)
+                Debug.Log("Replacing playerGameObject object netId: " + player.GetComponent<NetworkIdentity>().netId + " asset ID " + player.GetComponent<NetworkIdentity>().assetId);
 
             Respawn(identity);
 
@@ -918,7 +940,8 @@ namespace Mirror
         /// <param name="conn">The connection of the client to make ready.</param>
         public static void SetClientReady(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("SetClientReadyInternal for conn:" + conn);
+            if (LogFilter.Debug)
+                Debug.Log("SetClientReadyInternal for conn:" + conn);
 
             // set ready
             conn.isReady = true;
@@ -964,7 +987,8 @@ namespace Mirror
         {
             if (conn.isReady)
             {
-                if (LogFilter.Debug) Debug.Log("PlayerNotReady " + conn);
+                if (LogFilter.Debug)
+                    Debug.Log("PlayerNotReady " + conn);
                 conn.isReady = false;
                 conn.RemoveObservers();
 
@@ -975,7 +999,8 @@ namespace Mirror
         // default ready handler.
         static void OnClientReadyMessage(NetworkConnection conn, ReadyMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("Default handler for ready message from " + conn);
+            if (LogFilter.Debug)
+                Debug.Log("Default handler for ready message from " + conn);
             SetClientReady(conn);
         }
 
@@ -1011,7 +1036,8 @@ namespace Mirror
                 return;
             }
 
-            if (LogFilter.Debug) Debug.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn);
+            if (LogFilter.Debug)
+                Debug.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn);
             identity.HandleCommand(msg.componentIndex, msg.functionHash, new NetworkReader(msg.payload));
         }
 
@@ -1039,7 +1065,8 @@ namespace Mirror
 
             identity.OnStartServer();
 
-            if (LogFilter.Debug) Debug.Log("SpawnObject instance ID " + identity.netId + " asset ID " + identity.assetId);
+            if (LogFilter.Debug)
+                Debug.Log("SpawnObject instance ID " + identity.netId + " asset ID " + identity.assetId);
 
             identity.RebuildObservers(true);
         }
@@ -1049,7 +1076,8 @@ namespace Mirror
             if (identity.serverOnly)
                 return;
 
-            if (LogFilter.Debug) Debug.Log("Server SendSpawnMessage: name=" + identity.name + " sceneId=" + identity.sceneId.ToString("X") + " netid=" + identity.netId); // for easier debugging
+            if (LogFilter.Debug)
+                Debug.Log("Server SendSpawnMessage: name=" + identity.name + " sceneId=" + identity.sceneId.ToString("X") + " netid=" + identity.netId); // for easier debugging
 
             // one writer for owner, one for observers
             NetworkWriter ownerWriter = NetworkWriterPool.GetWriter();
@@ -1225,7 +1253,8 @@ namespace Mirror
 
         static void DestroyObject(NetworkIdentity identity, bool destroyServerObject)
         {
-            if (LogFilter.Debug) Debug.Log("DestroyObject instance:" + identity.netId);
+            if (LogFilter.Debug)
+                Debug.Log("DestroyObject instance:" + identity.netId);
             NetworkIdentity.spawned.Remove(identity.netId);
 
             identity.connectionToClient?.RemoveOwnedObject(identity);
@@ -1259,7 +1288,8 @@ namespace Mirror
         {
             if (obj == null)
             {
-                if (LogFilter.Debug) Debug.Log("NetworkServer DestroyObject is null");
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkServer DestroyObject is null");
                 return;
             }
 
@@ -1279,7 +1309,8 @@ namespace Mirror
         {
             if (obj == null)
             {
-                if (LogFilter.Debug) Debug.Log("NetworkServer UnspawnObject is null");
+                if (LogFilter.Debug)
+                    Debug.Log("NetworkServer UnspawnObject is null");
                 return;
             }
 
@@ -1331,7 +1362,8 @@ namespace Mirror
             {
                 if (ValidateSceneObject(identity))
                 {
-                    if (LogFilter.Debug) Debug.Log("SpawnObjects sceneId:" + identity.sceneId.ToString("X") + " name:" + identity.gameObject.name);
+                    if (LogFilter.Debug)
+                        Debug.Log("SpawnObjects sceneId:" + identity.sceneId.ToString("X") + " name:" + identity.gameObject.name);
                     identity.Reset();
                     identity.gameObject.SetActive(true);
                 }

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -66,7 +66,8 @@ namespace Mirror
         // and time from the server
         internal static void OnServerPing(NetworkConnection conn, NetworkPingMessage msg)
         {
-            if (LogFilter.Debug) Debug.Log("OnPingServerMessage  conn=" + conn);
+            if (LogFilter.Debug)
+                Debug.Log("OnPingServerMessage  conn=" + conn);
 
             NetworkPongMessage pongMsg = new NetworkPongMessage
             {

--- a/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -117,7 +117,8 @@ namespace Mirror
         void ClientConnect(string address, int port)
         {
             // LLAPI can't handle 'localhost'
-            if (address.ToLower() == "localhost") address = "127.0.0.1";
+            if (address.ToLower() == "localhost")
+                address = "127.0.0.1";
 
             HostTopology hostTopology = new HostTopology(connectionConfig, 1);
 
@@ -167,7 +168,8 @@ namespace Mirror
 
         public bool ProcessClientMessage()
         {
-            if (clientId == -1) return false;
+            if (clientId == -1)
+                return false;
 
             NetworkEventType networkEvent = NetworkTransport.ReceiveFromHost(clientId, out int connectionId, out int channel, clientReceiveBuffer, clientReceiveBuffer.Length, out int receivedSize, out error);
 
@@ -267,7 +269,8 @@ namespace Mirror
 
         public bool ProcessServerMessage()
         {
-            if (serverHostId == -1) return false;
+            if (serverHostId == -1)
+                return false;
 
             NetworkEventType networkEvent = NetworkTransport.ReceiveFromHost(serverHostId, out int connectionId, out int channel, serverReceiveBuffer, serverReceiveBuffer.Length, out int receivedSize, out error);
 
@@ -341,8 +344,10 @@ namespace Mirror
         public void LateUpdate()
         {
             // process all messages
-            while (ProcessClientMessage()) { }
-            while (ProcessServerMessage()) { }
+            while (ProcessClientMessage())
+            { }
+            while (ProcessServerMessage())
+            { }
         }
 
         public override void Shutdown()

--- a/Assets/Mirror/Runtime/Transport/Telepathy/Client.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Client.cs
@@ -104,7 +104,8 @@ namespace Telepathy
         public void Connect(string ip, int port)
         {
             // not if already started
-            if (Connecting || Connected) return;
+            if (Connecting || Connected)
+                return;
 
             // We are connecting from now until Connect succeeds or fails
             _Connecting = true;

--- a/Assets/Mirror/Runtime/Transport/Telepathy/Server.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Server.cs
@@ -180,7 +180,8 @@ namespace Telepathy
         public bool Start(int port)
         {
             // not if already started
-            if (Active) return false;
+            if (Active)
+                return false;
 
             // clear old messages in queue, just to be sure that the caller
             // doesn't receive data from last time and gets out of sync.
@@ -202,7 +203,8 @@ namespace Telepathy
         public void Stop()
         {
             // only if started
-            if (!Active) return;
+            if (!Active)
+                return;
 
             Logger.Log("Server: stopping...");
 
@@ -224,7 +226,9 @@ namespace Telepathy
                 TcpClient client = kvp.Value.client;
                 // close the stream if not closed yet. it may have been closed
                 // by a disconnect already, so use try/catch
-                try { client.GetStream().Close(); } catch { }
+                try
+                { client.GetStream().Close(); }
+                catch { }
                 client.Close();
             }
 

--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -115,8 +115,10 @@ namespace Mirror
             // note: we need to check enabled in case we set it to false
             // when LateUpdate already started.
             // (https://github.com/vis2k/Mirror/pull/379)
-            while (enabled && ProcessClientMessage()) { }
-            while (enabled && ProcessServerMessage()) { }
+            while (enabled && ProcessClientMessage())
+            { }
+            while (enabled && ProcessServerMessage())
+            { }
         }
 
         // server

--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/BufferPool.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/BufferPool.cs
@@ -134,7 +134,8 @@ namespace Ninja.WebSockets
                     if (requiredSize > newSize)
                     {
                         // compute the power of two larger than requiredSize. so 40000 => 65536
-                        newSize = (int)Math.Pow(2, Math.Ceiling(Math.Log(requiredSize) / Math.Log(2))); ;
+                        newSize = (int)Math.Pow(2, Math.Ceiling(Math.Log(requiredSize) / Math.Log(2)));
+                        ;
                     }
 
                     byte[] newBuffer = new byte[newSize];

--- a/Assets/Mirror/Runtime/Transport/Websocket/Server.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Server.cs
@@ -253,7 +253,8 @@ namespace Mirror.Websocket
         public void Stop()
         {
             // only if started
-            if (!Active) return;
+            if (!Active)
+                return;
 
             Debug.Log("Server: stopping...");
             cancellation.Cancel();

--- a/Assets/Mirror/Tests/WeaverAssembler.cs
+++ b/Assets/Mirror/Tests/WeaverAssembler.cs
@@ -86,7 +86,8 @@ namespace Mirror.Tests
         // Delete output dll / pdb / mdb
         public static void DeleteOutput()
         {
-            if (OutputFile.Length < 5) return; // "x.dll" shortest possible dll name
+            if (OutputFile.Length < 5)
+                return; // "x.dll" shortest possible dll name
 
             string projPathFile = OutputDirectory + OutputFile;
 


### PR DESCRIPTION
No code changes,  just reformatted the code with dotnet-format

Previously we had a lot of if statements with the body in the same line.

The problem with this is that I cannot put a breakpoint,  in the body.  This is extremely useful to debug warnings an error messages.