### PR TITLE
fix: Use hasAuthority instead of isLocalPlayer

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -35,8 +35,9 @@ namespace Mirror
         [Tooltip("Set to true if moves come from owner client, set to false if moves always come from server")]
         public bool clientAuthority;
 
-        // is this a local player with authority over his own transform?
-        bool isLocalPlayerWithAuthority => hasAuthority && clientAuthority;
+        // Is this a client with authority over this transform?
+        // This component could be on the player object or any object that has been assigned authority to this client.
+        bool isClientWithAuthority => hasAuthority && clientAuthority;
 
         // server
         Vector3 lastPosition;
@@ -370,7 +371,7 @@ namespace Mirror
             {
                 // send to server if we have local authority (and aren't the server)
                 // -> only if connectionToServer has been initialized yet too
-                if (!isServer && isLocalPlayerWithAuthority)
+                if (!isServer && isClientWithAuthority)
                 {
                     // check only each 'syncInterval'
                     if (Time.time - lastClientSendTime >= syncInterval)
@@ -392,7 +393,7 @@ namespace Mirror
                 // apply interpolation on client for all players
                 // unless this client has authority over the object. could be
                 // himself or another object that he was assigned authority over
-                if (!isLocalPlayerWithAuthority)
+                if (!isClientWithAuthority)
                 {
                     // received one yet? (initialized?)
                     if (goal != null)

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -36,7 +36,7 @@ namespace Mirror
         public bool clientAuthority;
 
         // is this a local player with authority over his own transform?
-        bool isLocalPlayerWithAuthority => isLocalPlayer && clientAuthority;
+        bool isLocalPlayerWithAuthority => hasAuthority && clientAuthority;
 
         // server
         Vector3 lastPosition;


### PR DESCRIPTION
This allows non-player objects that have been assigned authority to the client to be moved around by the client and their positions updated from that client appropriately when clientAuthority is also true.