### PR TITLE
Remove DDOL escape

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -448,13 +448,6 @@ namespace Mirror
         {
             OnRoomStopClient();
             CallOnClientExitRoom();
-
-            if (!string.IsNullOrEmpty(offlineScene))
-            {
-                // Move the RoomManager from the virtual DontDestroyOnLoad scene to the Game scene.
-                // This let's it be destroyed when client changes to the Offline scene.
-                SceneManager.MoveGameObjectToScene(gameObject, SceneManager.GetActiveScene());
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
This trick no longer works in Unity 2018.4.x.

Per Unity Docs DDOL scene is not accessible at runtime, and they recommend putting persistent objects in an additive scene.

https://docs.unity3d.com/Manual/MultiSceneEditing.html