### PR TITLE
fix: StopHost with offline scene calls scene change twice

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -559,7 +559,7 @@ namespace Mirror
             mode = NetworkManagerMode.Offline;
 
             StopServer();
-            StopHostClient();
+            StopClient();
         }
 
         /// <summary>
@@ -593,31 +593,6 @@ namespace Mirror
         }
 
         /// <summary>
-        /// Stops the host client without invoking a scene change to the offline scene.
-        /// <para>This is called from StopHost which also calls StopServer where the scene change to the offline scene is already invoked.</para>
-        /// </summary>
-        public void StopHostClient()
-        {
-            if (authenticator != null)
-                authenticator.OnClientAuthenticated.RemoveListener(OnClientAuthenticated);
-
-            OnStopClient();
-
-            if (LogFilter.Debug) Debug.Log("NetworkManager StopClient");
-            isNetworkActive = false;
-
-            // shutdown client
-            NetworkClient.Disconnect();
-            NetworkClient.Shutdown();
-
-            // set offline mode BEFORE changing scene so that FinishStartScene
-            // doesn't think we need initialize anything.
-            mode = NetworkManagerMode.Offline;
-
-            CleanupNetworkIdentities();
-        }
-
-        /// <summary>
         /// Stops the client that the manager is using.
         /// </summary>
         public void StopClient()
@@ -638,7 +613,7 @@ namespace Mirror
             // doesn't think we need initialize anything.
             mode = NetworkManagerMode.Offline;
 
-            if (!string.IsNullOrEmpty(offlineScene) && SceneManager.GetActiveScene().name != offlineScene)
+            if (!string.IsNullOrEmpty(offlineScene) && SceneManager.GetActiveScene().name != offlineScene && loadingSceneAsync == null)
             {
                 ClientChangeScene(offlineScene, SceneOperation.Normal);
             }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -592,6 +592,10 @@ namespace Mirror
             startPositionIndex = 0;
         }
 
+        /// <summary>
+        /// Stops the host client without invoking a scene change to the offline scene.
+        /// <para>This is called from StopHost which also calls StopServer where the scene change to the offline scene is already invoked.</para>
+        /// </summary>
         public void StopHostClient()
         {
             if (authenticator != null)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -559,7 +559,7 @@ namespace Mirror
             mode = NetworkManagerMode.Offline;
 
             StopServer();
-            StopClient();
+            StopHostClient();
         }
 
         /// <summary>
@@ -590,6 +590,27 @@ namespace Mirror
             CleanupNetworkIdentities();
 
             startPositionIndex = 0;
+        }
+
+        public void StopHostClient()
+        {
+            if (authenticator != null)
+                authenticator.OnClientAuthenticated.RemoveListener(OnClientAuthenticated);
+
+            OnStopClient();
+
+            if (LogFilter.Debug) Debug.Log("NetworkManager StopClient");
+            isNetworkActive = false;
+
+            // shutdown client
+            NetworkClient.Disconnect();
+            NetworkClient.Shutdown();
+
+            // set offline mode BEFORE changing scene so that FinishStartScene
+            // doesn't think we need initialize anything.
+            mode = NetworkManagerMode.Offline;
+
+            CleanupNetworkIdentities();
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -613,6 +613,8 @@ namespace Mirror
             // doesn't think we need initialize anything.
             mode = NetworkManagerMode.Offline;
 
+            // If this is the host player, StopServer will already be changing scenes.
+            // Check loadingSceneAsync to ensure we don't double-invoke the scene change.
             if (!string.IsNullOrEmpty(offlineScene) && SceneManager.GetActiveScene().name != offlineScene && loadingSceneAsync == null)
             {
                 ClientChangeScene(offlineScene, SceneOperation.Normal);

--- a/doc/General/ChangeLog.md
+++ b/doc/General/ChangeLog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Version 7.x.x - In progress
+## Version 6.7.7 - 2020-Jan-01
 - Added: [Script Templates](ScriptTemplates.md) -- See the new Mirror section in the Assets > Create menu.
 - Added: Full Text Search added to docs
 - Added: Basic Chat example


### PR DESCRIPTION
StopHost calls StopServer and StopClient, both of which invoke a scene change to the offline scene.  This PR creates a separate method for StopHostClient that does exactly what StopClient does without the scene change.

I considered just adding an optional bool to StopClient to indicate it was the host client but that would break the list server example.  If you want to change the example to accommodate something like
```cs
public void StopClient(bool hostClient = false) { }
```
then we can do that instead.