### PR TITLE
breaking: Destroy Network Manager On Collision

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -681,13 +681,12 @@ namespace Mirror
             if (dontDestroyOnLoad)
             {
                 if (singleton != null)
-                {
-                    Debug.LogWarning("Multiple NetworkManagers detected in the scene. Only one NetworkManager can exist at a time. The duplicate NetworkManager will be destroyed.");
-                    Destroy(gameObject);
-                    return;
-                }
+                    Destroy(singleton.gameObject);
+
                 if (LogFilter.Debug) Debug.Log("NetworkManager created singleton (DontDestroyOnLoad)");
+
                 singleton = this;
+
                 if (Application.isPlaying) DontDestroyOnLoad(gameObject);
             }
             else


### PR DESCRIPTION
This change will destroy the Network Manager singleton object instead of preserving it if it is carried into a scene that has a Network Manager in it, e.g. an offline scene or an alternate network scene.

In the case of an offline scene, one would expect to be in the original offline state without retaining whatever changes had occurred to _any components_ on the Network Manager game object through the course of game play.  Changing to the offline scene should effect a reset of the initial game state, but there's no way now to get the Network Manager out of DontDestroyOnLoad (DDOL) once it's set.

For example, the offline scene may contain a login UI and the Network Manager object may also have an Authenticator component.  That should be reset when a client disconnects.  Various other properties of the Network Manager components may have also changed, especially if it has been extended with additional properties.  I believe these should all be reset when a client or server returns to an offline scene or any scene where a Network Manager exists and a collision occurs via DDOL.