### PR TITLE
Proper MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
-The MIT License (MIT)
+MIT License
 
 Copyright (c) 2015, Unity Technologies
-Mirror modifications Copyright (c) 2019, vis2k, Paul and Contributors
+Copyright (c) 2019, vis2k, Paul and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
With this change, github recognizes it is MIT license so it shows as MIT when searching github