### PR TITLE
feat: SO Array Weaver Support

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -28,38 +28,6 @@ namespace Mirror.Weaver
             }
 
             TypeDefinition td = variable.Resolve();
-
-            #region  Before it was below the Error handeling part of the function.So it doesn't get executed if Class inherits from scriptableObject
-
-            MethodDefinition newReaderFunc;
-
-            if (variable.IsArray)
-            {
-                newReaderFunc = GenerateArrayReadFunc(variable, recursionCount);
-            }
-            else if (td.IsEnum)
-            {
-                return GetReadFunc(td.GetEnumUnderlyingType(), recursionCount);
-            }
-            else if (variable.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
-            {
-                newReaderFunc = GenerateArraySegmentReadFunc(variable, recursionCount);
-            }
-            else
-            {
-                newReaderFunc = GenerateStructReadFunction(variable, recursionCount);
-            }
-
-            if (newReaderFunc != null)
-            {
-                RegisterReadFunc(variable.FullName, newReaderFunc);
-                return newReaderFunc;
-            }
-
-            #endregion
-
-            #region MyRegion
-
             if (td == null)
             {
                 Weaver.Error($"{variable} is not a supported type");
@@ -92,11 +60,34 @@ namespace Mirror.Weaver
                 return null;
             }
 
-            #endregion
+            MethodDefinition newReaderFunc;
 
-            Weaver.Error($"{variable} is not a supported type");
-            return null;
+            if (variable.IsArray)
+            {
+                newReaderFunc = GenerateArrayReadFunc(variable, recursionCount);
+            }
+            else if (td.IsEnum)
+            {
+                return GetReadFunc(td.GetEnumUnderlyingType(), recursionCount);
+            }
+            else if (variable.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
+            {
+                newReaderFunc = GenerateArraySegmentReadFunc(variable, recursionCount);
+            }
+            else
+            {
+                newReaderFunc = GenerateStructReadFunction(variable, recursionCount);
+            }
+
+            if (newReaderFunc == null)
+            {
+                Weaver.Error($"{variable} is not a supported type");
+                return null;
+            }
+            RegisterReadFunc(variable.FullName, newReaderFunc);
+            return newReaderFunc;
         }
+
         static void RegisterReadFunc(string name, MethodDefinition newReaderFunc)
         {
             readFuncs[name] = newReaderFunc;

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -28,6 +28,38 @@ namespace Mirror.Weaver
             }
 
             TypeDefinition td = variable.Resolve();
+
+            #region  Before it was below the Error handeling part of the function.So it doesn't get executed if Class inherits from scriptableObject
+
+            MethodDefinition newReaderFunc;
+
+            if (variable.IsArray)
+            {
+                newReaderFunc = GenerateArrayReadFunc(variable, recursionCount);
+            }
+            else if (td.IsEnum)
+            {
+                return GetReadFunc(td.GetEnumUnderlyingType(), recursionCount);
+            }
+            else if (variable.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
+            {
+                newReaderFunc = GenerateArraySegmentReadFunc(variable, recursionCount);
+            }
+            else
+            {
+                newReaderFunc = GenerateStructReadFunction(variable, recursionCount);
+            }
+
+            if (newReaderFunc != null)
+            {
+                RegisterReadFunc(variable.FullName, newReaderFunc);
+                return newReaderFunc;
+            }
+
+            #endregion
+
+            #region MyRegion
+
             if (td == null)
             {
                 Weaver.Error($"{variable} is not a supported type");
@@ -60,34 +92,11 @@ namespace Mirror.Weaver
                 return null;
             }
 
-            MethodDefinition newReaderFunc;
+            #endregion
 
-            if (variable.IsArray)
-            {
-                newReaderFunc = GenerateArrayReadFunc(variable, recursionCount);
-            }
-            else if (td.IsEnum)
-            {
-                return GetReadFunc(td.GetEnumUnderlyingType(), recursionCount);
-            }
-            else if (variable.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
-            {
-                newReaderFunc = GenerateArraySegmentReadFunc(variable, recursionCount);
-            }
-            else
-            {
-                newReaderFunc = GenerateStructReadFunction(variable, recursionCount);
-            }
-
-            if (newReaderFunc == null)
-            {
-                Weaver.Error($"{variable} is not a supported type");
-                return null;
-            }
-            RegisterReadFunc(variable.FullName, newReaderFunc);
-            return newReaderFunc;
+            Weaver.Error($"{variable} is not a supported type");
+            return null;
         }
-
         static void RegisterReadFunc(string name, MethodDefinition newReaderFunc)
         {
             readFuncs[name] = newReaderFunc;

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -34,7 +34,40 @@ namespace Mirror.Weaver
                 Weaver.Error($"Cannot pass {variable} by reference");
                 return null;
             }
+
             TypeDefinition td = variable.Resolve();
+
+            MethodDefinition newWriterFunc;
+
+            #region Before it was below the Error handeling part of the function.So it doesn't get executed if Class inherits from scriptableObject
+
+            if (variable.IsArray)
+            {
+                newWriterFunc = GenerateArrayWriteFunc(variable, recursionCount);
+            }
+            else if (variable.Resolve().IsEnum)
+            {
+                return GetWriteFunc(variable.Resolve().GetEnumUnderlyingType(), recursionCount);
+            }
+            else if (variable.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
+            {
+                newWriterFunc = GenerateArraySegmentWriteFunc(variable, recursionCount);
+            }
+            else
+            {
+                newWriterFunc = GenerateStructWriterFunction(variable, recursionCount);
+            }
+
+            if (newWriterFunc != null)
+            {
+                RegisterWriteFunc(variable.FullName, newWriterFunc);
+                return newWriterFunc;
+            }
+
+            #endregion
+
+            #region I shifted this code to lower part of the Function so That it Logs error only when newWriterFunc==null 
+
             if (td == null)
             {
                 Weaver.Error($"{variable} is not a supported type. Use a supported type or provide a custom writer");
@@ -61,34 +94,10 @@ namespace Mirror.Weaver
                 return null;
             }
 
-            MethodDefinition newWriterFunc;
+            #endregion
 
-            if (variable.IsArray)
-            {
-                newWriterFunc = GenerateArrayWriteFunc(variable, recursionCount);
-            }
-            else if (variable.Resolve().IsEnum)
-            {
-                return GetWriteFunc(variable.Resolve().GetEnumUnderlyingType(), recursionCount);
-            }
-            else if (variable.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
-            {
-                newWriterFunc = GenerateArraySegmentWriteFunc(variable, recursionCount);
-            }
-            else
-            {
-                newWriterFunc = GenerateStructWriterFunction(variable, recursionCount);
-            }
-
-            if (newWriterFunc == null)
-            {
-                return null;
-            }
-
-            RegisterWriteFunc(variable.FullName, newWriterFunc);
-            return newWriterFunc;
+            return null;
         }
-
         static void RegisterWriteFunc(string name, MethodDefinition newWriterFunc)
         {
             writeFuncs[name] = newWriterFunc;


### PR DESCRIPTION
This comes from a Discord user (Uchiha I_A_H_) and needs review.

Before if we use Array of custom class (having its custom network reader/writer) which is derived from `ScriptableObject` then weaver gives error. Fixed by rearranging the code.

Test case attached below.
- new project, import Mirror master and the package below
- **bug** observer weaver errors
- apply this PR
- weaver errors gone
- Play in editor as LAN Host
- Select PlayerPrefab (Clone) in scene
- observe array has correct objects
- press P and X and observe correct debug logs

[WeaverTest.zip](https://github.com/vis2k/Mirror/files/4073220/WeaverTest.zip)
