### PR TITLE
fix: Restore Empty NetworkIdentityEditor

### DIFF
--- a/Assets/Mirror/Editor/NetworkIdentityEditor.cs
+++ b/Assets/Mirror/Editor/NetworkIdentityEditor.cs
@@ -1,0 +1,1 @@
+﻿// This file has been removed

--- a/Assets/Mirror/Editor/NetworkIdentityEditor.cs.meta
+++ b/Assets/Mirror/Editor/NetworkIdentityEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae4acb8316d250d4f9e9604c3b0051a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Restore NetworkIdentityEditor as empty file to replace existing file for those updating from previous Mirror version.

This file was deleted in 
https://github.com/vis2k/Mirror/commit/6fb8a32f5b442ef7f43791c1d137ff69683ce678