### PR TITLE
fix: Prevent AddPlayer after Additve Scene operation

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -810,6 +810,11 @@ namespace Mirror
             startPositions.Clear();
         }
 
+        // This is only set in ClientChangeScene below...never on server.
+        // We need to check this in OnClientSceneChanged called from FinishLoadSceneClientOnly
+        // to prevent AddPlayer message after loading/unloading additive scenes
+        SceneOperation clientSceneOperation = SceneOperation.Normal;
+
         internal void ClientChangeScene(string newSceneName, SceneOperation sceneOperation = SceneOperation.Normal, bool customHandling = false)
         {
             if (string.IsNullOrEmpty(newSceneName))
@@ -835,6 +840,9 @@ namespace Mirror
                 FinishLoadScene();
                 return;
             }
+
+            // cache sceneOperation so we know what was done in OnClientSceneChanged called from FinishLoadSceneClientOnly
+            clientSceneOperation = sceneOperation;
 
             switch (sceneOperation)
             {
@@ -1438,7 +1446,8 @@ namespace Mirror
             // always become ready.
             if (!ClientScene.ready) ClientScene.Ready(conn);
 
-            if (autoCreatePlayer && ClientScene.localPlayer == null)
+            // Only call AddPlayer for normal scene changes, not additive load/unload
+            if (clientSceneOperation == SceneOperation.Normal && autoCreatePlayer && ClientScene.localPlayer == null)
             {
                 // add player if existing one is null
                 ClientScene.AddPlayer();


### PR DESCRIPTION
When a game has additive scenes on server, the client has to be told to load one or more additive scenes before spawning the player so that spawn messages for networked objects in those additive scenes are known on the client and work correctly.

This is best handled by overriding OnServerAddPlayer and sending out one or more Scene messages with the LoadAdditive SceneOperation before instantiating the player object, optionally putting the player object into an additive scene on the server (which effects Observers), and finally invoking NetworkServer.AddPlayerForConnection when the client is ready for that to happen.

Since the client doesn't have the player object yet, we don't want it to keep sending more AddPlayer messages after each additive load and throwing errors on the server.