### PR TITLE
fix: weaver support array of custom types

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -27,6 +27,19 @@ namespace Mirror.Weaver
                 return foundFunc;
             }
 
+            MethodDefinition newReaderFunc;
+
+            // Arrays are special,  if we resolve them, we get teh element type,
+            // so the following ifs might choke on it for scriptable objects
+            // or other objects that require a custom serializer
+            // thus check if it is an array and skip all the checks.
+            if (variable.IsArray)
+            {
+                newReaderFunc = GenerateArrayReadFunc(variable, recursionCount);
+                RegisterReadFunc(variable.FullName, newReaderFunc);
+                return newReaderFunc;
+            }
+
             TypeDefinition td = variable.Resolve();
             if (td == null)
             {
@@ -60,13 +73,7 @@ namespace Mirror.Weaver
                 return null;
             }
 
-            MethodDefinition newReaderFunc;
-
-            if (variable.IsArray)
-            {
-                newReaderFunc = GenerateArrayReadFunc(variable, recursionCount);
-            }
-            else if (td.IsEnum)
+            if (td.IsEnum)
             {
                 return GetReadFunc(td.GetEnumUnderlyingType(), recursionCount);
             }

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -18,7 +18,6 @@ namespace Mirror.Weaver
 
         public static void Register(TypeReference dataType, MethodReference methodReference)
         {
-            Log.Warning("registering writer for " + dataType.FullName);
             writeFuncs[dataType.FullName] = methodReference;
         }
 

--- a/Assets/Mirror/Tests/Editor/WeaverTest.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTest.cs
@@ -728,5 +728,12 @@ namespace Mirror.Tests
             Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for interface MirrorTest.SuperCoolInterface. Use a concrete type or provide a custom writer"));
         }
         #endregion
+
+         [Test]
+        public void TestingScriptableObjectArraySerialization()
+        {
+            UnityEngine.Debug.Log(string.Join("\n",weaverErrors));
+            Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/TestingScriptableObjectArraySerialization.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/TestingScriptableObjectArraySerialization.cs
@@ -1,0 +1,38 @@
+using Mirror;
+using UnityEngine;
+
+namespace MirrorTest
+{
+    public static class CustomSerializer
+    {
+        public static void Writedata(this NetworkWriter writer, Data arg)
+        {
+            writer.WriteInt32(arg.Var1);
+        }
+
+        public static Data Readdata(this NetworkReader reader)
+        {
+            return new Data
+            {
+                Var1 = reader.ReadInt32()
+            };
+        }
+    }
+
+    public class Data : ScriptableObject
+    {
+        public int Var1;
+    }
+
+    public class PlayerScript : NetworkBehaviour
+    {
+        [Command]
+        public void
+            CmdwriteArraydata(
+                Data[] arg) //This gonna give error saying-- Mirror.Weaver error: Cannot generate writer for scriptable object Data[]. Use a supported type or provide a custom writer
+        {
+
+            //some code
+        }
+    }
+}


### PR DESCRIPTION
With this fix,  you can now serialize an array of unsupported types
if you provide a custom serializer for scriptable object

Big thanks to Uchiha who found the problem and showed how
it could be fixed in #1466