### PR TITLE
Add Header to NetworkBehaviourInspector

### DIFF
--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -178,6 +178,8 @@ namespace Mirror
                 NetworkBehaviour networkBehaviour = target as NetworkBehaviour;
                 if (networkBehaviour != null)
                 {
+                    EditorGUILayout.LabelField("Sync Settings", EditorStyles.boldLabel);
+
                     // syncMode
                     serializedObject.FindProperty("syncMode").enumValueIndex = (int)(SyncMode)
                         EditorGUILayout.EnumPopup("Network Sync Mode", networkBehaviour.syncMode);


### PR DESCRIPTION
Added a header to the Sync properties so they're nicely separated from whatever else might be in the component.

In the image below, the header only shows when Sync Mode and Sync Interval are visible.  Player Controller is a Network Behaviour without SyncVars, and so, correctly, no header appears.

![image](https://user-images.githubusercontent.com/9826063/73613024-7576a000-45bf-11ea-8d82-6d502a9cfd51.png)
