### PR TITLE
Breaking: Renamed localEulerAnglesSensitivity

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -37,7 +37,7 @@ namespace Mirror
         [Tooltip("Changes to the transform must exceed these values to be transmitted on the network.")]
         public float localPositionSensitivity = .01f;
         [Tooltip("Changes to the transform must exceed these values to be transmitted on the network.")]
-        public float localEulerAnglesSensitivity = .01f;
+        public float localRotationSensitivity = .01f;
         [Tooltip("Changes to the transform must exceed these values to be transmitted on the network.")]
         public float localScaleSensitivity = .01f;
 
@@ -341,7 +341,7 @@ namespace Mirror
             // moved or rotated or scaled?
             // local position/rotation/scale for VR support
             bool moved = Vector3.Distance(lastPosition, targetComponent.transform.localPosition) > localPositionSensitivity;
-            bool rotated = Vector3.Distance(lastRotation.eulerAngles, targetComponent.transform.localRotation.eulerAngles) > localEulerAnglesSensitivity;
+            bool rotated = Vector3.Distance(lastRotation.eulerAngles, targetComponent.transform.localRotation.eulerAngles) > localRotationSensitivity;
             bool scaled = Vector3.Distance(lastScale, targetComponent.transform.localScale) > localScaleSensitivity;
 
             // save last for next frame to compare


### PR DESCRIPTION
This feature was only added 2 weeks ago, so I think the rename is safe without an obsolete.