### PR TITLE
fix: call callback after update dictionary in host

### DIFF
--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -229,13 +229,14 @@ namespace Mirror
             {
                 if (ContainsKey(i))
                 {
+                    objects[i] = value;
                     AddOperation(Operation.OP_SET, i, value);
                 }
                 else
                 {
+                    objects[i] = value;
                     AddOperation(Operation.OP_ADD, i, value);
                 }
-                objects[i] = value;
             }
         }
 

--- a/Assets/Mirror/Tests/Editor/SyncDictionaryTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncDictionaryTest.cs
@@ -159,9 +159,28 @@ namespace Mirror.Tests
                 Assert.That(op, Is.EqualTo(SyncDictionaryIntString.Operation.OP_ADD));
                 Assert.That(index, Is.EqualTo(3));
                 Assert.That(item, Is.EqualTo("yay"));
+                Assert.That(clientSyncDictionary[index], Is.EqualTo("yay"));
+
             };
             serverSyncDictionary.Add(3, "yay");
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);
+            Assert.That(called, Is.True);
+        }
+
+        [Test]
+        public void ServerCallbackTest()
+        {
+            bool called = false;
+            serverSyncDictionary.Callback += (op, index, item) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncDictionaryIntString.Operation.OP_ADD));
+                Assert.That(index, Is.EqualTo(3));
+                Assert.That(item, Is.EqualTo("yay"));
+                Assert.That(serverSyncDictionary[index], Is.EqualTo("yay"));
+            };
+            serverSyncDictionary[3] = "yay";
             Assert.That(called, Is.True);
         }
 


### PR DESCRIPTION
When the callback for SyncDictionary is called in the server
for set or add
it is getting called before the syncdictionary is updated.

In the client this happens after.  

Example:

```cs
   public void OnScoreUpdatedCallback(ScoreSyncDict.Operation op, uint ident, int score) 
   {
       if (op == ScoreSyncDict.Operation.OP_SET) 
              Debug.Log($"The value in the dictionary is {scoreDict[ident]}");
   }
```

In host mode this prints the previous value.   In client mode this prints the current value.  This PR fixes this problem and makes both print the current value