### PR TITLE
feat: NetworkSceneChecker use Scene instead of string name

### DIFF
--- a/Assets/Mirror/Components/NetworkSceneChecker.cs
+++ b/Assets/Mirror/Components/NetworkSceneChecker.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using UnityEngine.SceneManagement;
 
 namespace Mirror
 {
@@ -20,14 +21,14 @@ namespace Mirror
         [Tooltip("Enable to force this object to be hidden from all observers.")]
         public bool forceHidden;
 
-        public static readonly Dictionary<string, HashSet<NetworkIdentity>> sceneCheckerObjects = new Dictionary<string, HashSet<NetworkIdentity>>();
+        static readonly Dictionary<Scene, HashSet<NetworkIdentity>> sceneCheckerObjects = new Dictionary<Scene, HashSet<NetworkIdentity>>();
 
-        string currentScene;
+        Scene currentScene;
 
         [ServerCallback]
         void OnEnable()
         {
-            currentScene = gameObject.scene.name;
+            currentScene = gameObject.scene;
             if (LogFilter.Debug) Debug.Log($"NetworkSceneChecker.OnEnable currentScene: {currentScene}");
         }
 
@@ -42,7 +43,7 @@ namespace Mirror
         [ServerCallback]
         void Update()
         {
-            if (currentScene == gameObject.scene.name)
+            if (currentScene == gameObject.scene)
                 return;
 
             // This object is in a new scene so observers in the prior scene
@@ -55,7 +56,7 @@ namespace Mirror
             RebuildSceneObservers();
 
             // Set this to the new scene this object just entered
-            currentScene = gameObject.scene.name;
+            currentScene = gameObject.scene;
 
             // Make sure this new scene is in the dictionary
             if (!sceneCheckerObjects.ContainsKey(currentScene))

--- a/Assets/Mirror/Components/NetworkSceneChecker.cs
+++ b/Assets/Mirror/Components/NetworkSceneChecker.cs
@@ -21,6 +21,7 @@ namespace Mirror
         [Tooltip("Enable to force this object to be hidden from all observers.")]
         public bool forceHidden;
 
+        // Use Scene instead of string scene.name because when additively loading multiples of a subscene the name won't be unique
         static readonly Dictionary<Scene, HashSet<NetworkIdentity>> sceneCheckerObjects = new Dictionary<Scene, HashSet<NetworkIdentity>>();
 
         Scene currentScene;


### PR DESCRIPTION
Use Scene instead of scene name because additive subscenes may be loaded at once and the name won't be unique.