### PR TITLE
fix: Host Player Ready Race Condition

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -182,10 +182,15 @@ namespace Mirror
 
             if (conn != null)
             {
-                conn.Send(new ReadyMessage());
+                // Set these before sending the ReadyMessage, otherwise host client
+                // will fail in InternalAddPlayer with null readyConnection.
                 ready = true;
                 readyConnection = conn;
                 readyConnection.isReady = true;
+
+                // Tell server we're ready to have a player object spawned
+                conn.Send(new ReadyMessage());
+
                 return true;
             }
             Debug.LogError("Ready() called with invalid connection object: conn=null");


### PR DESCRIPTION
`readyConnection` needs to be completed before sending `ReadyMessage`.

In master we have this in ClientScene.Ready
```cs
conn.Send(new ReadyMessage());
ready = true;
readyConnection = conn;
readyConnection.isReady = true;
```
This is fine for remote clients because by the time the server round-trips the lines after the Send have executed, however for Host client, the `Send` goes straight through to ClientScene.InternalAddPlayer and fails for a null `readyConnection`.

**To reproduce the fault in master:**
Create an empty scene with an empty game object with a custom Network Manager with the code below and the HUD and Telepathy, and assign any appropriate prefab to the playerPrefab field and **uncheck** Auto Create Player, and play as Host:
```cs
public class NetManager : NetworkManager
{
    public override void OnServerReady(NetworkConnection conn)
    {
        base.OnServerReady(conn);
        base.OnServerAddPlayer(conn);
    }
}
```
You'll get the following warning in the console, and the player won't be spawned:
```
No ready connection found for setting player controller during InternalAddPlayer
UnityEngine.Debug:LogWarning(Object)
Mirror.ClientScene:InternalAddPlayer(NetworkIdentity) (at Assets/Mirror/Runtime/ClientScene.cs:87)
Mirror.NetworkServer:AddPlayerForConnection(NetworkConnection, GameObject) (at Assets/Mirror/Runtime/NetworkServer.cs:832)
Mirror.NetworkManager:OnServerAddPlayer(NetworkConnection) (at Assets/Mirror/Runtime/NetworkManager.cs:1302)
ReadyTest.NetManager:OnServerReady(NetworkConnection) (at Assets/ReadyTest/NetManager.cs:17)
Mirror.NetworkManager:OnServerReadyMessageInternal(NetworkConnection, ReadyMessage) (at Assets/Mirror/Runtime/NetworkManager.cs:1120)
Mirror.<>c__DisplayClass7_0`1:<MessageHandler>b__0(NetworkMessage) (at Assets/Mirror/Runtime/MessagePacker.cs:164)
Mirror.NetworkConnection:InvokeHandler(Int32, NetworkReader, Int32) (at Assets/Mirror/Runtime/NetworkConnection.cs:308)
Mirror.NetworkConnection:TransportReceive(ArraySegment`1, Int32) (at Assets/Mirror/Runtime/NetworkConnection.cs:361)
Mirror.ULocalConnectionToServer:Send(ArraySegment`1, Int32) (at Assets/Mirror/Runtime/LocalConnections.cs:69)
Mirror.NetworkConnection:Send(ReadyMessage, Int32) (at Assets/Mirror/Runtime/NetworkConnection.cs:219)
Mirror.ClientScene:Ready(NetworkConnection) (at Assets/Mirror/Runtime/ClientScene.cs:185)
Mirror.NetworkManager:OnClientConnect(NetworkConnection) (at Assets/Mirror/Runtime/NetworkManager.cs:1381)
Mirror.NetworkManager:OnClientAuthenticated(NetworkConnection) (at Assets/Mirror/Runtime/NetworkManager.cs:1200)
Mirror.NetworkManager:OnClientConnectInternal(NetworkConnection, ConnectMessage) (at Assets/Mirror/Runtime/NetworkManager.cs:1183)
Mirror.<>c__DisplayClass7_0`1:<MessageHandler>b__0(NetworkMessage) (at Assets/Mirror/Runtime/MessagePacker.cs:164)
Mirror.NetworkConnection:InvokeHandler(Int32, NetworkReader, Int32) (at Assets/Mirror/Runtime/NetworkConnection.cs:308)
Mirror.NetworkConnection:TransportReceive(ArraySegment`1, Int32) (at Assets/Mirror/Runtime/NetworkConnection.cs:361)
Mirror.ULocalConnectionToServer:Update() (at Assets/Mirror/Runtime/LocalConnections.cs:81)
Mirror.NetworkClient:Update() (at Assets/Mirror/Runtime/NetworkClient.cs:279)
Mirror.NetworkManager:LateUpdate() (at Assets/Mirror/Runtime/NetworkManager.cs:271)
```