### PR TITLE
Changed namespace in code snippet for SyncVar hooks.

### DIFF
--- a/doc/Guides/Sync/SyncVarHook.md
+++ b/doc/Guides/Sync/SyncVarHook.md
@@ -12,7 +12,7 @@ Below is a simple example of assigning a random color to each player when they'r
 
 ```cs
 using UnityEngine;
-using UnityEngine.Networking;
+using Mirror;
 
 public class PlayerController : NetworkBehaviour
 {


### PR DESCRIPTION
Added "using Mirror;" instead of "using UnityEngine.Networking;"