### PR TITLE
fix: Add missing channelId to NetworkConnectionToClient.Send calls

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -246,7 +246,10 @@ namespace Mirror
 
                     // send to all internet connections at once
                     if (connectionIdsCache.Count > 0)
+                    {
                         result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
+                    }
+
                     NetworkDiagnostics.OnSend(msg, Channels.DefaultReliable, segment.Count, identity.observers.Count);
 
                     return result;
@@ -312,7 +315,10 @@ namespace Mirror
 
                 // send to all internet connections at once
                 if (connectionIdsCache.Count > 0)
+                {
                     result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
+                }
+
                 NetworkDiagnostics.OnSend(msg, channelId, segment.Count, connections.Count);
 
                 return result;
@@ -394,7 +400,10 @@ namespace Mirror
 
                     // send to all internet connections at once
                     if (connectionIdsCache.Count > 0)
+                    {
                         result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
+                    }
+
                     NetworkDiagnostics.OnSend(msg, channelId, segment.Count, count);
 
                     return result;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -216,7 +216,7 @@ namespace Mirror
 
         // this is like SendToReady - but it doesn't check the ready flag on the connection.
         // this is used for ObjectDestroy messages.
-        static bool SendToObservers<T>(NetworkIdentity identity, T msg) where T : IMessageBase
+        static bool SendToObservers<T>(NetworkIdentity identity, T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToObservers id:" + typeof(T));
 
@@ -246,7 +246,7 @@ namespace Mirror
 
                     // send to all internet connections at once
                     if (connectionIdsCache.Count > 0)
-                        result &= NetworkConnectionToClient.Send(connectionIdsCache, segment);
+                        result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
                     NetworkDiagnostics.OnSend(msg, Channels.DefaultReliable, segment.Count, identity.observers.Count);
 
                     return result;
@@ -312,7 +312,7 @@ namespace Mirror
 
                 // send to all internet connections at once
                 if (connectionIdsCache.Count > 0)
-                    result &= NetworkConnectionToClient.Send(connectionIdsCache, segment);
+                    result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
                 NetworkDiagnostics.OnSend(msg, channelId, segment.Count, connections.Count);
 
                 return result;
@@ -394,7 +394,7 @@ namespace Mirror
 
                     // send to all internet connections at once
                     if (connectionIdsCache.Count > 0)
-                        result &= NetworkConnectionToClient.Send(connectionIdsCache, segment);
+                        result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
                     NetworkDiagnostics.OnSend(msg, channelId, segment.Count, count);
 
                     return result;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -707,11 +707,11 @@ namespace Mirror
         /// <typeparam name="T">Message type</typeparam>
         /// <param name="identity"></param>
         /// <param name="msg"></param>
-        public static void SendToClientOfPlayer<T>(NetworkIdentity identity, T msg) where T : IMessageBase
+        public static void SendToClientOfPlayer<T>(NetworkIdentity identity, T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             if (identity != null)
             {
-                identity.connectionToClient.Send(msg);
+                identity.connectionToClient.Send(msg, channelId);
             }
             else
             {

--- a/doc/General/ChangeLog.md
+++ b/doc/General/ChangeLog.md
@@ -15,6 +15,7 @@ Mirror uses semantic versioning, and the versions shown here are those that were
 - Fixed: Host Player race condition for Ready message.
 - Fixed: NetworkAnimator and NetworkTransform now correctly check for client authority in their respective Command methods.
 - Fixed: Network Room Manager Script Template had a virtual method instead of an override.
+- Fixed: NetworkServer's calls to NetworkConnectionToClient.Send now includes the channelId parameter that was missing.
 - Changed: NetworkSceneChecker now works from OnEnable instead of Awake, and uses Scene instead of scene name.
 - Changed: Renamed NeworkWriter.Write to WriteMessage for consistency.
 


### PR DESCRIPTION
@SoftwareGuy discovered this one with @rxmarccall and @AnthonE 
![image](https://user-images.githubusercontent.com/9826063/74906155-25992680-537e-11ea-8781-bab6dadafc78.png)

Broken by bc7e116a