### PR TITLE
Make StartHost Not virtual

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -444,7 +444,7 @@ namespace Mirror
         /// This starts a network "host" - a server and client in the same application.
         /// <para>The client returned from StartHost() is a special "local" client that communicates to the in-process server using a message queue instead of the real network. But in almost all other cases, it can be treated as a normal client.</para>
         /// </summary>
-        public virtual void StartHost()
+        public void StartHost()
         {
             mode = NetworkManagerMode.Host;
 


### PR DESCRIPTION
Per Discord discussion...all other Start methods are not virtual and this one shouldn't be.
Comparable to the others, it calls OnStartHost which is virtual.