### PR TITLE
perf: Vector3.SqrMagnitude instead of Vector3.Distance

### DIFF
--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -88,7 +88,9 @@ namespace Mirror
             if (forceHidden)
                 return false;
 
-            return Vector3.Distance(newObserver.identity.transform.position, transform.position) < visRange;
+            // SqrMagnitude is faster than Distance per Unity docs
+            // https://docs.unity3d.com/ScriptReference/Vector3-sqrMagnitude.html
+            return Vector3.SqrMagnitude(newObserver.identity.transform.position - transform.position) < visRange * visRange;
         }
 
         /// <summary>

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -343,9 +343,11 @@ namespace Mirror
         {
             // moved or rotated or scaled?
             // local position/rotation/scale for VR support
-            bool moved = Vector3.Distance(lastPosition, targetComponent.transform.localPosition) > localPositionSensitivity;
-            bool rotated = Vector3.Distance(lastRotation.eulerAngles, targetComponent.transform.localRotation.eulerAngles) > localRotationSensitivity;
-            bool scaled = Vector3.Distance(lastScale, targetComponent.transform.localScale) > localScaleSensitivity;
+            // SqrMagnitude is faster than Distance per Unity docs
+            // https://docs.unity3d.com/ScriptReference/Vector3-sqrMagnitude.html
+            bool moved = Vector3.SqrMagnitude(lastPosition - targetComponent.transform.localPosition) > localPositionSensitivity * localPositionSensitivity;
+            bool rotated = Vector3.SqrMagnitude(lastRotation.eulerAngles - targetComponent.transform.localRotation.eulerAngles) > localRotationSensitivity * localRotationSensitivity;
+            bool scaled = Vector3.SqrMagnitude(lastScale - targetComponent.transform.localScale) > localScaleSensitivity * localScaleSensitivity;
 
             // save last for next frame to compare
             // (only if change was detected. otherwise slow moving objects might

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -221,16 +221,18 @@ namespace Mirror
             //
             else
             {
-                float oldDistance = Vector3.Distance(start.localPosition, goal.localPosition);
-                float newDistance = Vector3.Distance(goal.localPosition, temp.localPosition);
+                // SqrMagnitude is faster than Distance per Unity docs
+                // https://docs.unity3d.com/ScriptReference/Vector3-sqrMagnitude.html
+                float oldDistance = Vector3.SqrMagnitude(start.localPosition - goal.localPosition);
+                float newDistance = Vector3.SqrMagnitude(goal.localPosition - temp.localPosition);
 
                 start = goal;
 
                 // teleport / lag / obstacle detection: only continue at current
                 // position if we aren't too far away
-                //
-                // // local position/rotation for VR support
-                if (Vector3.Distance(targetComponent.transform.localPosition, start.localPosition) < oldDistance + newDistance)
+                // local position/rotation for VR support
+                // oldDistance and newDistance are already squared above...don't square them again here
+                if (Vector3.SqrMagnitude(targetComponent.transform.localPosition - start.localPosition) < oldDistance + newDistance)
                 {
                     start.localPosition = targetComponent.transform.localPosition;
                     start.localRotation = targetComponent.transform.localRotation;

--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
@@ -41,6 +41,9 @@ namespace Mirror.Examples.Additive
             foreach (NetworkConnection networkConnection in netIdentity.observers.Values)
             {
                 GameObject tempTarget = networkConnection.identity.gameObject;
+
+                // SqrMagnitude is faster than Distance per Unity docs
+                // https://docs.unity3d.com/ScriptReference/Vector3-sqrMagnitude.html
                 float tempDistance = Vector3.SqrMagnitude(tempTarget.transform.position - transform.position);
 
                 // distance is already squared, don't square again here

--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
@@ -34,14 +34,17 @@ namespace Mirror.Examples.Additive
         void ShootNearestPlayer()
         {
             GameObject target = null;
-            float distance = 100f;
+
+            // squared distance of 100f for SqrMagnitude comparison
+            float distance = 10000f;
 
             foreach (NetworkConnection networkConnection in netIdentity.observers.Values)
             {
                 GameObject tempTarget = networkConnection.identity.gameObject;
-                float tempDistance = Vector3.Distance(tempTarget.transform.position, transform.position);
+                float tempDistance = Vector3.SqrMagnitude(tempTarget.transform.position - transform.position);
 
-                if (target == null || distance > tempDistance)
+                // distance is already squared, don't square again here
+                if (target == null || tempDistance < distance)
                 {
                     target = tempTarget;
                     distance = tempDistance;


### PR DESCRIPTION
SqrMagnitude is faster than Distance per [Unity docs](https://docs.unity3d.com/ScriptReference/Vector3-sqrMagnitude.html).