### PR TITLE
fix: properly detect NT rotation

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -36,7 +36,7 @@ namespace Mirror
         [Header("Sensitivity")]
         [Tooltip("Changes to the transform must exceed these values to be transmitted on the network.")]
         public float localPositionSensitivity = .01f;
-        [Tooltip("Changes to the transform must exceed these values to be transmitted on the network.")]
+        [Tooltip("If rotation exceeds this angle, it will be transmitted on the network")]
         public float localRotationSensitivity = .01f;
         [Tooltip("Changes to the transform must exceed these values to be transmitted on the network.")]
         public float localScaleSensitivity = .01f;
@@ -344,8 +344,8 @@ namespace Mirror
             // moved or rotated or scaled?
             // local position/rotation/scale for VR support
             bool moved = Vector3.Distance(lastPosition, targetComponent.transform.localPosition) > localPositionSensitivity;
-            bool rotated = Vector3.Distance(lastRotation.eulerAngles, targetComponent.transform.localRotation.eulerAngles) > localRotationSensitivity;
             bool scaled = Vector3.Distance(lastScale, targetComponent.transform.localScale) > localScaleSensitivity;
+            bool rotated = Quaternion.Angle(lastRotation, targetComponent.transform.localRotation) > localRotationSensitivity;
 
             // save last for next frame to compare
             // (only if change was detected. otherwise slow moving objects might


### PR DESCRIPTION
NetworkTransform was comparing rotations by getting the euler angles and comparing the distance between them.

The problem with that is that euler angles suffer from gimbal lock.  This will cause problem when you look straight up. even if you are not rotating much,  there could be lots of false positives.

The correct way to compare rotations is by either getting the dot product (cosine if they are normalized) or by calling Quaternion.Angle