### PR TITLE
Refactor: simplify Message Unpacking

### DIFF
--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -103,10 +103,7 @@ namespace Mirror
             }
         }
 
-        // unpack message after receiving
-        // -> pass NetworkReader so it's less strange if we create it in here
-        //    and pass it upwards.
-        // -> NetworkReader will point at content afterwards!
+        [Obsolete("use UnpackId instead")]
         public static bool UnpackMessage(NetworkReader messageReader, out int msgType)
         {
             // read message type (varint)
@@ -120,6 +117,15 @@ namespace Mirror
                 msgType = 0;
                 return false;
             }
+        }
+
+        // unpack message after receiving
+        // -> pass NetworkReader so it's less strange if we create it in here
+        //    and pass it upwards.
+        // -> NetworkReader will point at content afterwards!
+        public static int UnpackId(NetworkReader messageReader)
+        {
+            return messageReader.ReadUInt16();
         }
 
         internal static NetworkMessageDelegate MessageHandler<T>(Action<NetworkConnection, T> handler, bool requireAuthenication) where T : IMessageBase, new() => networkMessage =>

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using UnityEngine;
 
 namespace Mirror
@@ -352,8 +353,9 @@ namespace Mirror
             // unpack message
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(buffer))
             {
-                if (MessagePacker.UnpackMessage(networkReader, out int msgType))
+                try
                 {
+                    int msgType = MessagePacker.UnpackId(networkReader);
                     // logging
                     if (logNetworkMessages) Debug.Log("ConnectionRecv " + this + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));
 
@@ -363,9 +365,9 @@ namespace Mirror
                         lastMessageTime = Time.time;
                     }
                 }
-                else
+                catch (IOException ex)
                 {
-                    Debug.LogError("Closed connection: " + this + ". Invalid message header.");
+                    Debug.LogError("Closed connection: " + this + ". Invalid message " + ex);
                     Disconnect();
                 }
             }

--- a/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
@@ -65,14 +65,12 @@ namespace Mirror.Tests
             byte[] data = MessagePacker.Pack(message);
             NetworkReader reader = new NetworkReader(data);
 
-            bool result = MessagePacker.UnpackMessage(reader, out int msgType);
-            Assert.That(result, Is.EqualTo(true));
+            int msgType = MessagePacker.UnpackId(reader);
             Assert.That(msgType, Is.EqualTo(BitConverter.ToUInt16(data, 0)));
 
             // try an invalid message
             NetworkReader reader2 = new NetworkReader(new byte[0]);
-            bool result2 = MessagePacker.UnpackMessage(reader2, out int msgType2);
-            Assert.That(result2, Is.EqualTo(false));
+            int msgType2 = MessagePacker.UnpackId(reader2);
             Assert.That(msgType2, Is.EqualTo(0));
         }
     }

--- a/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using NUnit.Framework;
 namespace Mirror.Tests
 {
@@ -66,12 +67,18 @@ namespace Mirror.Tests
             NetworkReader reader = new NetworkReader(data);
 
             int msgType = MessagePacker.UnpackId(reader);
-            Assert.That(msgType, Is.EqualTo(BitConverter.ToUInt16(data, 0)));
+            Assert.That(msgType, Is.EqualTo(MessagePacker.GetId<SceneMessage>()));
+        }
 
+        [Test]
+        public void TestUnpackInvalidMessage()
+        {
             // try an invalid message
-            NetworkReader reader2 = new NetworkReader(new byte[0]);
-            int msgType2 = MessagePacker.UnpackId(reader2);
-            Assert.That(msgType2, Is.EqualTo(0));
+            Assert.Throws<EndOfStreamException>(() =>
+            {
+                NetworkReader reader2 = new NetworkReader(new byte[0]);
+                int msgType2 = MessagePacker.UnpackId(reader2);
+            });
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
@@ -77,7 +77,7 @@ namespace Mirror.Tests
             Assert.Throws<EndOfStreamException>(() =>
             {
                 NetworkReader reader2 = new NetworkReader(new byte[0]);
-                int msgType2 = MessagePacker.UnpackId(reader2);
+                _ = MessagePacker.UnpackId(reader2);
             });
         }
     }


### PR DESCRIPTION
Unpack message id using exceptions instead of returning false.

Way more intuitive. 

Notice the slight behavior change,  if unpacking any part of the message throws IOException,  then we also log an error and disconnect,  not just the header.