### PR TITLE
fix: Change LogError to Log. Added more details.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -307,7 +307,7 @@ namespace Mirror
                 msgDelegate(message);
                 return true;
             }
-            Debug.LogError("Unknown message ID " + msgType + " " + this);
+            if (Debug.isDebugBuild) Debug.Log("Unknown message ID " + msgType + " " + this + ". May be due to no existing RegisterHandler for this message.");
             return false;
         }
 


### PR DESCRIPTION
Since messages behave similar to events and given the process is not technically breaking, using LogError seems incorrect. Using Log, maybe LogWarning would be more appropriate. Added additional text to clarify why the user may be seeing that log entry.