### PR TITLE
fix: Command and Rpc debugging information

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -4,7 +4,7 @@ using Mono.CecilX.Cil;
 
 namespace Mirror.Weaver
 {
-    public static class CommandProcessor
+    public static class CommandProcessor 
     {
         const string CmdPrefix = "InvokeCmd";
 
@@ -33,20 +33,7 @@ namespace Mirror.Weaver
         */
         public static MethodDefinition ProcessCommandCall(TypeDefinition td, MethodDefinition md, CustomAttribute ca)
         {
-            MethodDefinition cmd = new MethodDefinition("Call" + md.Name,
-                    MethodAttributes.Public | MethodAttributes.HideBySig,
-                    Weaver.voidType);
-
-            // add parameters
-            foreach (ParameterDefinition pd in md.Parameters)
-            {
-                cmd.Parameters.Add(new ParameterDefinition(pd.Name, ParameterAttributes.None, pd.ParameterType));
-            }
-
-            // move the old body to the new function
-            MethodBody newBody = cmd.Body;
-            cmd.Body = md.Body;
-            md.Body = newBody;
+            MethodDefinition cmd = MethodProcessor.SubstituteMethod(md, "Call" + md.Name);
 
             ILProcessor cmdWorker = md.Body.GetILProcessor();
 

--- a/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
@@ -3,7 +3,7 @@ using Mono.CecilX.Cil;
 
 namespace Mirror.Weaver
 {
-    public  class MethodProcessor
+    public static class MethodProcessor
     {
 
         // creates a method substitute

--- a/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
@@ -1,0 +1,59 @@
+using Mono.CecilX;
+using Mono.CecilX.Cil;
+
+namespace Mirror.Weaver
+{
+    public  class MethodProcessor
+    {
+
+        // creates a method substitute
+        // For example, if we have this:
+        //  public void CmdThrust(float thrusting, int spin)
+        //  {
+        //      xxxxx   
+        //  }
+        //
+        //  it will substitute the method and move the code to a new method with a provided name
+        //  for example:
+        //
+        //  public void CmdTrust(float thrusting, int spin)
+        //  {
+        //  }
+        //
+        //  public void <newName>(float thrusting, int spin)
+        //  {
+        //      xxxxx
+        //  }
+        //
+        //  Note that all the calls to the method remain untouched
+        //
+        //  the original method definition loses all code
+        //  this returns the newly created method with all the user provided code
+        public static MethodDefinition SubstituteMethod(MethodDefinition md, string newName)
+        {
+            MethodDefinition cmd = new MethodDefinition(newName,md.Attributes, md.ReturnType);
+
+            // add parameters
+            foreach (ParameterDefinition pd in md.Parameters)
+            {
+                cmd.Parameters.Add(new ParameterDefinition(pd.Name, ParameterAttributes.None, pd.ParameterType));
+            }
+
+            // swap bodies
+            (cmd.Body, md.Body) = (md.Body, cmd.Body);
+
+            // Move over all the debugging information
+            foreach (SequencePoint sequencePoint in md.DebugInformation.SequencePoints)
+                cmd.DebugInformation.SequencePoints.Add(sequencePoint);
+            md.DebugInformation.SequencePoints.Clear();
+
+            foreach (CustomDebugInformation customInfo in md.CustomDebugInformations)
+                cmd.CustomDebugInformations.Add(customInfo);
+            md.CustomDebugInformations.Clear();
+
+            (md.DebugInformation.Scope, cmd.DebugInformation.Scope) = (cmd.DebugInformation.Scope, md.DebugInformation.Scope);
+
+            return cmd;
+        }
+    }
+}

--- a/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs.meta
+++ b/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 661e1af528e3441f79e1552fb5ec4e0e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -59,20 +59,7 @@ namespace Mirror.Weaver
         */
         public static MethodDefinition ProcessRpcCall(TypeDefinition td, MethodDefinition md, CustomAttribute ca)
         {
-            MethodDefinition rpc = new MethodDefinition("Call" + md.Name, MethodAttributes.Public |
-                    MethodAttributes.HideBySig,
-                    Weaver.voidType);
-
-            // add paramters
-            foreach (ParameterDefinition pd in md.Parameters)
-            {
-                rpc.Parameters.Add(new ParameterDefinition(pd.Name, ParameterAttributes.None, pd.ParameterType));
-            }
-
-            // move the old body to the new function
-            MethodBody newBody = rpc.Body;
-            rpc.Body = md.Body;
-            md.Body = newBody;
+            MethodDefinition rpc = MethodProcessor.SubstituteMethod(md, "Call" + md.Name);
 
             ILProcessor rpcWorker = md.Body.GetILProcessor();
 

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -87,20 +87,7 @@ namespace Mirror.Weaver
         */
         public static MethodDefinition ProcessTargetRpcCall(TypeDefinition td, MethodDefinition md, CustomAttribute ca)
         {
-            MethodDefinition rpc = new MethodDefinition("Call" + md.Name, MethodAttributes.Public |
-                    MethodAttributes.HideBySig,
-                    Weaver.voidType);
-
-            // add parameters
-            foreach (ParameterDefinition pd in md.Parameters)
-            {
-                rpc.Parameters.Add(new ParameterDefinition(pd.Name, ParameterAttributes.None, pd.ParameterType));
-            }
-
-            // move the old body to the new function
-            MethodBody newBody = rpc.Body;
-            rpc.Body = md.Body;
-            md.Body = newBody;
+            MethodDefinition rpc = MethodProcessor.SubstituteMethod(md, "Call" + md.Name);
 
             ILProcessor rpcWorker = md.Body.GetILProcessor();
 


### PR DESCRIPTION
When replacing command and rpc methods,  we now correctly move over
the debugging information.

Now you can put breakpoints in commands and Rpc

Should fix #1550