### PR TITLE
fix: Prevent Double Call of NetworkServer.Destroy

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -481,7 +481,10 @@ namespace Mirror
             sceneIds.Remove(sceneId);
             sceneIds.Remove(sceneId & 0x00000000FFFFFFFF);
 
-            if (isServer)
+            // Only call NetworkServer.Destroy on server and only if reset is false
+            // reset will be false from incorrect use of Destroy instead of NetworkServer.Destroy
+            // reset will be true if NetworkServer.Destroy was correctly invoked to begin with
+            if (isServer && !reset)
             {
                 NetworkServer.Destroy(gameObject);
             }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -484,8 +484,14 @@ namespace Mirror
             // Only call NetworkServer.Destroy on server and only if reset is false
             // reset will be false from incorrect use of Destroy instead of NetworkServer.Destroy
             // reset will be true if NetworkServer.Destroy was correctly invoked to begin with
+            // Users are supposed to call NetworkServer.Destroy instead of just regular Destroy for networked objects.
+            // This is a safeguard in case users accidentally call regular Destroy instead.
+            // We cover their mistake by calling NetworkServer.Destroy for them.
+            // If, however, they call NetworkServer.Destroy correctly, which leads to NetworkIdentity.MarkForReset,
+            // then we don't need to call it again, so the check for reset is needed to prevent the doubling.
             if (isServer && !reset)
             {
+                Debug.LogWarning("Incorrect use of Destroy. Use NetworkServer.Destroy instead for networked objects.");
                 NetworkServer.Destroy(gameObject);
             }
         }

--- a/doc/General/ChangeLog.md
+++ b/doc/General/ChangeLog.md
@@ -8,6 +8,7 @@ Mirror uses semantic versioning, and the versions shown here are those that were
 - Fixed: Setting breakpoints in an IDE for Command's and Rpc's work correctly now.
 - Fixed: NetworkServer's calls to SendToObservers now reports correct channel to Mirror Profiler.
 - Fixed: NetworkRoomPlayer inspector and documentation updated to be less confusing.
+- Fixed: NetworkIdentity no longer double calls NetworkServer.Destroy.
 - Changed: NetworkSceneChecker initializes in Awake again because OnEnable proved to be unreliable in some cases.
 - Changed: **Breaking** Many obsolete methods and properties removed. Use version 10 first if upgrading from UNet or older Mirror. See [Deprecations](Deprecations.md) for complete list.
 


### PR DESCRIPTION
Fixes #1525 