### PR TITLE
Fixing exceptions

### DIFF
--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -43,7 +43,7 @@ namespace Mirror
 
         void OnEnable()
         {
-            if (target == null) { Debug.LogWarning("NetworkBehaviourInspector had no target object", serializedObject.context); return; }
+            if (target == null) { Debug.LogWarning("NetworkBehaviourInspector had no target object"); return; }
 
             Type scriptClass = target.GetType();
 

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -68,10 +68,6 @@ namespace Mirror
         public override void OnInspectorGUI()
         {
             DrawDefaultInspector();
-
-             // If target's base class is changed from NetworkBehaviour to MonoBehaviour
-            // then Unity temporarily keep using this Inspector causing things to break
-            if (!(target is NetworkBehaviour)) { return; }
             DrawDefaultSyncLists();
             DrawDefaultSyncSettings();
         }
@@ -81,6 +77,9 @@ namespace Mirror
         /// </summary>
         protected void DrawDefaultSyncLists()
         {
+            // Need this check incase OnEnable returns early
+            if (syncListDrawer == null) { return; }
+
             syncListDrawer.Draw();
         }
 

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -44,6 +44,10 @@ namespace Mirror
         void OnEnable()
         {
             if (target == null) { Debug.LogWarning("NetworkBehaviourInspector had no target object"); return; }
+           
+            // If target's base class is changed from NetworkBehaviour to MonoBehaviour
+            // then Unity temporarily keep using this Inspector causing things to break
+            if (!(target is NetworkBehaviour)) { return; }
 
             Type scriptClass = target.GetType();
 
@@ -64,6 +68,10 @@ namespace Mirror
         public override void OnInspectorGUI()
         {
             DrawDefaultInspector();
+
+             // If target's base class is changed from NetworkBehaviour to MonoBehaviour
+            // then Unity temporarily keep using this Inspector causing things to break
+            if (!(target is NetworkBehaviour)) { return; }
             DrawDefaultSyncLists();
             DrawDefaultSyncSettings();
         }


### PR DESCRIPTION
If target's base class is changed from `NetworkBehaviour` to `MonoBehaviour` then Unity temporarily keep using this Inspector causing things to break.