### PR TITLE
refactor: OnSerializeAllSafely returns 2 values instead of out variables

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -930,7 +930,7 @@ namespace Mirror
             {
                 // serialize all components with initialState = true
                 // (can be null if has none)
-                identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+                (int ownerWritten, int observersWritten) = identity.OnSerializeAllSafely(true, ownerWriter, observersWriter);
 
                 // convert to ArraySegment to avoid reader allocations
                 // (need to handle null case too)

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -825,7 +825,7 @@ namespace Mirror.Tests
             NetworkWriter ownerWriter = new NetworkWriter();
             NetworkWriter observersWriter = new NetworkWriter();
             LogAssert.ignoreFailingMessages = true; // error log because of the exception is expected
-            identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            (int ownerWritten, int observersWritten) = identity.OnSerializeAllSafely(true, ownerWriter, observersWriter);
             LogAssert.ignoreFailingMessages = false;
 
             // owner should have written all components
@@ -874,7 +874,7 @@ namespace Mirror.Tests
             NetworkWriter ownerWriter = new NetworkWriter();
             NetworkWriter observersWriter = new NetworkWriter();
             LogAssert.ignoreFailingMessages = true; // error log is expected because of too many components
-            identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            (int ownerWritten, int observersWritten) = identity.OnSerializeAllSafely(true, ownerWriter, observersWriter);
             LogAssert.ignoreFailingMessages = false;
 
             // shouldn't have written anything because too many components
@@ -904,7 +904,7 @@ namespace Mirror.Tests
             // serialize
             NetworkWriter ownerWriter = new NetworkWriter();
             NetworkWriter observersWriter = new NetworkWriter();
-            identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            (int ownerWritten, int observersWritten) = identity.OnSerializeAllSafely(true, ownerWriter, observersWriter);
 
             // reset component values
             comp1.value = 0;

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -122,7 +122,7 @@ namespace Mirror.Tests
             // serialize all the data as we would for the network
             NetworkWriter ownerWriter = new NetworkWriter();
             NetworkWriter observersWriter = new NetworkWriter(); // not really used in this Test
-            identity1.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            (int ownerWritten, int observersWritten) = identity1.OnSerializeAllSafely(true, ownerWriter, observersWriter);
 
             // set up a "client" object
             GameObject gameObject2 = new GameObject();


### PR DESCRIPTION
previously OnSerializeAllSafely set the out variables ownersWritten and observersWritten.

Instead of using out variables,  just return 2 values.  A lot easier to read IMHO