### PR TITLE
Weaver test for adding guard code

### DIFF
--- a/Assets/Mirror/Editor/Weaver/AssemblyInfo.cs
+++ b/Assets/Mirror/Editor/Weaver/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Mirror.Tests")]

--- a/Assets/Mirror/Editor/Weaver/AssemblyInfo.cs.meta
+++ b/Assets/Mirror/Editor/Weaver/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 929924d95663264478d4238d4910d22e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -27,7 +27,7 @@ namespace Mirror.Weaver
         public Dictionary<string, int> numSyncVars = new Dictionary<string, int>();
     }
 
-    class Weaver
+    internal class Weaver
     {
         public static WeaverLists WeaveLists { get; private set; }
         public static AssemblyDefinition CurrentAssembly { get; private set; }

--- a/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
+++ b/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
@@ -18,7 +18,8 @@
     "precompiledReferences": [
         "NSubstitute.dll",
         "Castle.Core.dll",
-        "System.Threading.Tasks.Extensions.dll"
+        "System.Threading.Tasks.Extensions.dll",
+        "Mono.CecilX.dll"
     ],
     "autoReferenced": true,
     "defineConstraints": []

--- a/Assets/Mirror/Tests/Editor/WeaverTest.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTest.cs
@@ -671,13 +671,13 @@ namespace Mirror.Tests
 
         static void CheckAddedCodeServer()
         {
-            const string networkServerGetActive = "System.Boolean Mirror.NetworkServer::get_active()";
+            string networkServerGetActive = Weaver.Weaver.NetworkServerGetActive.ToString();
             CheckAddedCode(networkServerGetActive, "ServerOnlyMethod");
         }
 
         static void CheckAddedCodeClient()
         {
-            const string networkClientGetActive = "System.Boolean Mirror.NetworkClient::get_active()";
+            string networkClientGetActive = Weaver.Weaver.NetworkClientGetActive.ToString();
             CheckAddedCode(networkClientGetActive, "ClientOnlyMethod");
         }
 

--- a/Assets/Mirror/Tests/Editor/WeaverTest.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTest.cs
@@ -669,13 +669,13 @@ namespace Mirror.Tests
             CheckAddedCodeClient();
         }
 
-        void CheckAddedCodeServer()
+        static void CheckAddedCodeServer()
         {
             const string networkServerGetActive = "System.Boolean Mirror.NetworkServer::get_active()";
             CheckAddedCode(networkServerGetActive, "ServerOnlyMethod");
         }
 
-        void CheckAddedCodeClient()
+        static void CheckAddedCodeClient()
         {
             const string networkClientGetActive = "System.Boolean Mirror.NetworkClient::get_active()";
             CheckAddedCode(networkClientGetActive, "ClientOnlyMethod");
@@ -686,7 +686,7 @@ namespace Mirror.Tests
         /// </summary>
         /// <param name="addedString"></param>
         /// <param name="methodName"></param>
-        void CheckAddedCode(string addedString, string methodName)
+        static void CheckAddedCode(string addedString, string methodName)
         {
             string className = "MirrorTest.MirrorTestPlayer";
             

--- a/Assets/Mirror/Tests/Editor/WeaverTest.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTest.cs
@@ -653,6 +653,22 @@ namespace Mirror.Tests
         #endregion
 
         #region Server Client Attribute Tests 
+        [Test]
+        public void NetworkBehaviourServer()
+        {
+            Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
+            Assert.That(weaverErrors, Is.Empty);
+            CheckAddedCodeServer();
+        }
+
+        [Test] 
+        public void NetworkBehaviourClient()
+        {
+            Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
+            Assert.That(weaverErrors, Is.Empty);
+            CheckAddedCodeClient();
+        }
+
         void CheckAddedCodeServer()
         {
             const string networkServerGetActive = "System.Boolean Mirror.NetworkServer::get_active()";

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourClient.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourClient.cs
@@ -8,6 +8,9 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [Client]
-        void ClientOnlyMethod() {}
+        void ClientOnlyMethod() 
+        {
+            // test method
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourClient.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourClient.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using Mirror;
+
+namespace MirrorTest
+{
+    class MirrorTestPlayer : NetworkBehaviour
+    {
+        [Client]
+        void ClientOnlyMethod() {}
+    }
+}

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourServer.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourServer.cs
@@ -8,6 +8,9 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [Server]
-        void ServerOnlyMethod() {}
+        void ServerOnlyMethod() 
+        {
+            // test method
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourServer.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourServer.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using Mirror;
+
+namespace MirrorTest
+{
+    class MirrorTestPlayer : NetworkBehaviour
+    {
+        [Server]
+        void ServerOnlyMethod() {}
+    }
+}


### PR DESCRIPTION
- Adding check to make sure weaver adds code
- Adding tests for NetworkBehaviour


Using hard coded strings `"System.Boolean Mirror.NetworkServer::get_active()"` because `Weaver` is private making it hard to access `Weaver.NetworkServerGetActive`