### PR TITLE
feat: now you can assign scenes even if not in Editor

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -143,9 +143,9 @@ namespace Mirror
 
         void SceneLoadedForPlayer(NetworkConnection conn, GameObject roomPlayer)
         {
-            if (LogFilter.Debug) Debug.LogFormat("NetworkRoom SceneLoadedForPlayer scene: {0} {1}", SceneManager.GetActiveScene().name, conn);
+            if (LogFilter.Debug) Debug.LogFormat("NetworkRoom SceneLoadedForPlayer scene: {0} {1}", SceneManager.GetActiveScene().path, conn);
 
-            if (SceneManager.GetActiveScene().name == RoomScene)
+            if (SceneManager.GetActiveScene().path == RoomScene)
             {
                 // cant be ready in room, add to ready list
                 PendingPlayer pending;
@@ -179,7 +179,7 @@ namespace Mirror
         /// </summary>
         public void CheckReadyToBegin()
         {
-            if (SceneManager.GetActiveScene().name != RoomScene)
+            if (SceneManager.GetActiveScene().path != RoomScene)
                 return;
 
             if (minPlayers > 0 && NetworkServer.connections.Count(conn => conn.Value != null && conn.Value.identity.gameObject.GetComponent<NetworkRoomPlayer>().readyToBegin) < minPlayers)
@@ -229,7 +229,7 @@ namespace Mirror
             }
 
             // cannot join game in progress
-            if (SceneManager.GetActiveScene().name != RoomScene)
+            if (SceneManager.GetActiveScene().path != RoomScene)
             {
                 conn.Disconnect();
                 return;
@@ -262,7 +262,7 @@ namespace Mirror
                     player.GetComponent<NetworkRoomPlayer>().readyToBegin = false;
             }
 
-            if (SceneManager.GetActiveScene().name == RoomScene)
+            if (SceneManager.GetActiveScene().path == RoomScene)
                 RecalculateRoomPlayerIndices();
 
             base.OnServerDisconnect(conn);
@@ -276,7 +276,7 @@ namespace Mirror
         /// <param name="conn">Connection from client.</param>
         public override void OnServerAddPlayer(NetworkConnection conn)
         {
-            if (SceneManager.GetActiveScene().name == RoomScene)
+            if (SceneManager.GetActiveScene().path == RoomScene)
             {
                 if (roomSlots.Count == maxConnections)
                     return;
@@ -464,7 +464,7 @@ namespace Mirror
         /// <param name="conn">Connection of the client</param>
         public override void OnClientSceneChanged(NetworkConnection conn)
         {
-            if (SceneManager.GetActiveScene().name == RoomScene)
+            if (SceneManager.GetActiveScene().path == RoomScene)
             {
                 if (NetworkClient.isConnected)
                     CallOnClientEnterRoom();
@@ -659,7 +659,7 @@ namespace Mirror
             if (!showRoomGUI)
                 return;
 
-            if (NetworkServer.active && SceneManager.GetActiveScene().name == GameplayScene)
+            if (NetworkServer.active && SceneManager.GetActiveScene().path == GameplayScene)
             {
                 GUILayout.BeginArea(new Rect(Screen.width - 150f, 10f, 140f, 30f));
                 if (GUILayout.Button("Return to Room"))
@@ -667,7 +667,7 @@ namespace Mirror
                 GUILayout.EndArea();
             }
 
-            if (SceneManager.GetActiveScene().name == RoomScene)
+            if (SceneManager.GetActiveScene().path == RoomScene)
                 GUI.Box(new Rect(10f, 180f, 520f, 150f), "PLAYERS");
         }
 

--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -145,7 +145,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.LogFormat("NetworkRoom SceneLoadedForPlayer scene: {0} {1}", SceneManager.GetActiveScene().path, conn);
 
-            if (SceneManager.GetActiveScene().path == RoomScene)
+            if (IsSceneActive(RoomScene))
             {
                 // cant be ready in room, add to ready list
                 PendingPlayer pending;
@@ -179,7 +179,7 @@ namespace Mirror
         /// </summary>
         public void CheckReadyToBegin()
         {
-            if (SceneManager.GetActiveScene().path != RoomScene)
+            if (!IsSceneActive(RoomScene))
                 return;
 
             if (minPlayers > 0 && NetworkServer.connections.Count(conn => conn.Value != null && conn.Value.identity.gameObject.GetComponent<NetworkRoomPlayer>().readyToBegin) < minPlayers)
@@ -229,7 +229,7 @@ namespace Mirror
             }
 
             // cannot join game in progress
-            if (SceneManager.GetActiveScene().path != RoomScene)
+            if (!IsSceneActive(RoomScene))
             {
                 conn.Disconnect();
                 return;
@@ -262,7 +262,7 @@ namespace Mirror
                     player.GetComponent<NetworkRoomPlayer>().readyToBegin = false;
             }
 
-            if (SceneManager.GetActiveScene().path == RoomScene)
+            if (IsSceneActive(RoomScene))
                 RecalculateRoomPlayerIndices();
 
             base.OnServerDisconnect(conn);
@@ -276,7 +276,7 @@ namespace Mirror
         /// <param name="conn">Connection from client.</param>
         public override void OnServerAddPlayer(NetworkConnection conn)
         {
-            if (SceneManager.GetActiveScene().path == RoomScene)
+            if (IsSceneActive(RoomScene))
             {
                 if (roomSlots.Count == maxConnections)
                     return;
@@ -464,7 +464,7 @@ namespace Mirror
         /// <param name="conn">Connection of the client</param>
         public override void OnClientSceneChanged(NetworkConnection conn)
         {
-            if (SceneManager.GetActiveScene().path == RoomScene)
+            if (IsSceneActive(RoomScene))
             {
                 if (NetworkClient.isConnected)
                     CallOnClientEnterRoom();
@@ -659,7 +659,7 @@ namespace Mirror
             if (!showRoomGUI)
                 return;
 
-            if (NetworkServer.active && SceneManager.GetActiveScene().path == GameplayScene)
+            if (NetworkServer.active && IsSceneActive(GameplayScene))
             {
                 GUILayout.BeginArea(new Rect(Screen.width - 150f, 10f, 140f, 30f));
                 if (GUILayout.Button("Return to Room"))
@@ -667,7 +667,7 @@ namespace Mirror
                 GUILayout.EndArea();
             }
 
-            if (SceneManager.GetActiveScene().path == RoomScene)
+            if (IsSceneActive(RoomScene))
                 GUI.Box(new Rect(10f, 180f, 520f, 150f), "PLAYERS");
         }
 

--- a/Assets/Mirror/Components/NetworkRoomPlayer.cs
+++ b/Assets/Mirror/Components/NetworkRoomPlayer.cs
@@ -125,7 +125,7 @@ namespace Mirror
                 if (!room.showRoomGUI)
                     return;
 
-                if (SceneManager.GetActiveScene().path != room.RoomScene)
+                if (!NetworkManager.IsSceneActive(room.RoomScene))
                     return;
 
                 DrawPlayerReadyState();

--- a/Assets/Mirror/Components/NetworkRoomPlayer.cs
+++ b/Assets/Mirror/Components/NetworkRoomPlayer.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Components/NetworkRoomPlayer.cs
+++ b/Assets/Mirror/Components/NetworkRoomPlayer.cs
@@ -125,7 +125,7 @@ namespace Mirror
                 if (!room.showRoomGUI)
                     return;
 
-                if (SceneManager.GetActiveScene().name != room.RoomScene)
+                if (SceneManager.GetActiveScene().path != room.RoomScene)
                     return;
 
                 DrawPlayerReadyState();

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -10,47 +10,14 @@ namespace Mirror
         {
             if (property.propertyType == SerializedPropertyType.String)
             {
-                SceneAsset sceneObject = GetSceneObject(property.stringValue);
+                SceneAsset sceneObject = AssetDatabase.LoadAssetAtPath<SceneAsset>(property.stringValue);
                 SceneAsset scene = (SceneAsset)EditorGUI.ObjectField(position, label, sceneObject, typeof(SceneAsset), true);
-                if (scene == null)
-                {
-                    property.stringValue = "";
-                }
-                else if (scene.name != property.stringValue)
-                {
-                    SceneAsset sceneObj = GetSceneObject(scene.name);
-                    if (sceneObj == null)
-                    {
-                        Debug.LogWarning("The scene " + scene.name + " cannot be used. To use this scene add it to the build settings for the project");
-                    }
-                    else
-                    {
-                        property.stringValue = scene.name;
-                    }
-                }
+                property.stringValue = AssetDatabase.GetAssetPath(scene);
             }
             else
             {
                 EditorGUI.LabelField(position, label.text, "Use [Scene] with strings.");
             }
-        }
-
-        protected SceneAsset GetSceneObject(string sceneObjectName)
-        {
-            if (string.IsNullOrEmpty(sceneObjectName))
-            {
-                return null;
-            }
-
-            foreach (EditorBuildSettingsScene editorScene in EditorBuildSettings.scenes)
-            {
-                if (editorScene.path.IndexOf(sceneObjectName) != -1)
-                {
-                    return AssetDatabase.LoadAssetAtPath(editorScene.path, typeof(SceneAsset)) as SceneAsset;
-                }
-            }
-            Debug.LogWarning("Scene [" + sceneObjectName + "] cannot be used. Add this scene to the 'Scenes in the Build' in build settings.");
-            return null;
         }
     }
 }

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -20,7 +20,7 @@ namespace Mirror
                 }
                 if (sceneObject == null && !string.IsNullOrEmpty(property.stringValue))
                 {
-                    Debug.LogError($"Could not find scene {property.stringValue} in {property.propertyPath}");
+                    Debug.LogError($"Could not find scene {property.stringValue} in {property.propertyPath}, assign the proper scenes in your NetworkManager");
                 }
                 SceneAsset scene = (SceneAsset)EditorGUI.ObjectField(position, label, sceneObject, typeof(SceneAsset), true);
 

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -20,7 +20,7 @@ namespace Mirror
                 }
                 if (sceneObject == null && !string.IsNullOrEmpty(property.stringValue))
                 {
-                    Debug.LogWarning($"Could not find scene {property.stringValue} in {property.propertyPath}");
+                    Debug.LogError($"Could not find scene {property.stringValue} in {property.propertyPath}");
                 }
                 SceneAsset scene = (SceneAsset)EditorGUI.ObjectField(position, label, sceneObject, typeof(SceneAsset), true);
 

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -13,7 +13,7 @@ namespace Mirror
             {
                 SceneAsset sceneObject = AssetDatabase.LoadAssetAtPath<SceneAsset>(property.stringValue);
 
-                if (sceneObject == null)
+                if (sceneObject == null && !string.IsNullOrEmpty(property.stringValue))
                 {
                     // try to load it from the build settings for legacy compatibility
                     sceneObject = GetBuildSettingsSceneObject(property.stringValue);

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -1,5 +1,6 @@
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Mirror
 {
@@ -13,9 +14,9 @@ namespace Mirror
                 SceneAsset sceneObject = AssetDatabase.LoadAssetAtPath<SceneAsset>(property.stringValue);
 
                 if (sceneObject == null)
-                { 
+                {
                     // try to load it from the build settings for legacy compatibility
-                    sceneObject = GetBuildSettingsSceneObject(property);
+                    sceneObject = GetBuildSettingsSceneObject(property.stringValue);
                 }
                 SceneAsset scene = (SceneAsset)EditorGUI.ObjectField(position, label, sceneObject, typeof(SceneAsset), true);
                 property.stringValue = AssetDatabase.GetAssetPath(scene);
@@ -26,25 +27,13 @@ namespace Mirror
             }
         }
 
-        protected SceneAsset GetBuildSettingsSceneObject(SerializedProperty property)
+        protected SceneAsset GetBuildSettingsSceneObject(string sceneName)
         {
-            string sceneObjectName = property.stringValue;
-
-            if (string.IsNullOrEmpty(sceneObjectName))
-            {
+            Scene scene = SceneManager.GetSceneByName(sceneName);
+            if (scene == null)
                 return null;
-            }
 
-            foreach (EditorBuildSettingsScene editorScene in EditorBuildSettings.scenes)
-            {
-                // hack,  but retains backwards compatibility
-                if (editorScene.path.IndexOf(sceneObjectName) != -1)
-                {
-                    return AssetDatabase.LoadAssetAtPath<SceneAsset>(editorScene.path);
-                }
-            }
-            Debug.LogError($"Scene {sceneObjectName} not found in {property.propertyPath}");
-            return null;
+            return AssetDatabase.LoadAssetAtPath<SceneAsset>(scene.path);
         }
     }
 }

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -11,6 +11,12 @@ namespace Mirror
             if (property.propertyType == SerializedPropertyType.String)
             {
                 SceneAsset sceneObject = AssetDatabase.LoadAssetAtPath<SceneAsset>(property.stringValue);
+
+                if (sceneObject == null)
+                { 
+                    // try to load it from the build settings for legacy compatibility
+                    sceneObject = GetBuildSettingsSceneObject(property);
+                }
                 SceneAsset scene = (SceneAsset)EditorGUI.ObjectField(position, label, sceneObject, typeof(SceneAsset), true);
                 property.stringValue = AssetDatabase.GetAssetPath(scene);
             }
@@ -18,6 +24,27 @@ namespace Mirror
             {
                 EditorGUI.LabelField(position, label.text, "Use [Scene] with strings.");
             }
+        }
+
+        protected SceneAsset GetBuildSettingsSceneObject(SerializedProperty property)
+        {
+            string sceneObjectName = property.stringValue;
+
+            if (string.IsNullOrEmpty(sceneObjectName))
+            {
+                return null;
+            }
+
+            foreach (EditorBuildSettingsScene editorScene in EditorBuildSettings.scenes)
+            {
+                // hack,  but retains backwards compatibility
+                if (editorScene.path.IndexOf(sceneObjectName) != -1)
+                {
+                    return AssetDatabase.LoadAssetAtPath<SceneAsset>(editorScene.path);
+                }
+            }
+            Debug.LogError($"Scene {sceneObjectName} not found in {property.propertyPath}");
+            return null;
         }
     }
 }

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -34,8 +34,15 @@ namespace Mirror
 
         protected SceneAsset GetBuildSettingsSceneObject(string sceneName)
         {
-            Scene scene = SceneManager.GetSceneByName(sceneName);
-            return AssetDatabase.LoadAssetAtPath<SceneAsset>(scene.path);
+            foreach (EditorBuildSettingsScene buildScene in EditorBuildSettings.scenes)
+            {
+                SceneAsset sceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(buildScene.path);
+                if (sceneAsset.name == sceneName)
+                {
+                    return sceneAsset;
+                }
+            }
+            return null;
         }
     }
 }

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -30,9 +30,6 @@ namespace Mirror
         protected SceneAsset GetBuildSettingsSceneObject(string sceneName)
         {
             Scene scene = SceneManager.GetSceneByName(sceneName);
-            if (scene == null)
-                return null;
-
             return AssetDatabase.LoadAssetAtPath<SceneAsset>(scene.path);
         }
     }

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -1,6 +1,5 @@
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -18,7 +18,12 @@ namespace Mirror
                     // try to load it from the build settings for legacy compatibility
                     sceneObject = GetBuildSettingsSceneObject(property.stringValue);
                 }
+                if (sceneObject == null && !string.IsNullOrEmpty(property.stringValue))
+                {
+                    Debug.LogWarning($"Could not find scene {property.stringValue} in {property.propertyPath}");
+                }
                 SceneAsset scene = (SceneAsset)EditorGUI.ObjectField(position, label, sceneObject, typeof(SceneAsset), true);
+
                 property.stringValue = AssetDatabase.GetAssetPath(scene);
             }
             else

--- a/Assets/Mirror/Examples/AdditiveScenes/Scenes/MainScene.unity
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scenes/MainScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.43668893, g: 0.48428315, b: 0.56452656, a: 1}
+  m_IndirectSpecularColor: {r: 0.4366757, g: 0.48427194, b: 0.5645252, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Mirror/Examples/AdditiveScenes/Scenes/MainScene.unity
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scenes/MainScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4366757, g: 0.48427194, b: 0.5645252, a: 1}
+  m_IndirectSpecularColor: {r: 0.43668893, g: 0.48428315, b: 0.56452656, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -376,7 +376,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  subScene: SubScene
+  subScene: Assets/Mirror/Examples/AdditiveScenes/Scenes/SubScene.unity
 --- !u!1001 &160176455
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/Room/Scenes/OfflineScene.unity
+++ b/Assets/Mirror/Examples/Room/Scenes/OfflineScene.unity
@@ -268,10 +268,10 @@ MonoBehaviour:
   dontDestroyOnLoad: 1
   runInBackground: 1
   startOnHeadless: 1
-  serverTickRate: 30
   showDebugMessages: 0
-  offlineScene: OfflineScene
-  onlineScene: RoomScene
+  serverTickRate: 30
+  offlineScene: Assets/Mirror/Examples/Room/Scenes/OfflineScene.unity
+  onlineScene: Assets/Mirror/Examples/Room/Scenes/RoomScene.unity
   transport: {fileID: 2008127830}
   networkAddress: localhost
   maxConnections: 5
@@ -286,10 +286,10 @@ MonoBehaviour:
   minPlayers: 1
   roomPlayerPrefab: {fileID: 114033720796874720, guid: deae2134a1d77704b9c595efe69767dd,
     type: 3}
-  RoomScene: RoomScene
-  GameplayScene: OnlineScene
-  roomSlots: []
+  RoomScene: Assets/Mirror/Examples/Room/Scenes/RoomScene.unity
+  GameplayScene: Assets/Mirror/Examples/Room/Scenes/OnlineScene.unity
   allPlayersReady: 0
+  roomSlots: []
 --- !u!4 &2008127832
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomPlayerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomPlayerExt.cs
@@ -8,19 +8,19 @@ namespace Mirror.Examples.NetworkRoom
     {
         public override void OnStartClient()
         {
-            if (LogFilter.Debug) Debug.LogFormat("OnStartClient {0}", SceneManager.GetActiveScene().name);
+            if (LogFilter.Debug) Debug.LogFormat("OnStartClient {0}", SceneManager.GetActiveScene().path);
 
             base.OnStartClient();
         }
 
         public override void OnClientEnterRoom()
         {
-            if (LogFilter.Debug) Debug.LogFormat("OnClientEnterRoom {0}", SceneManager.GetActiveScene().name);
+            if (LogFilter.Debug) Debug.LogFormat("OnClientEnterRoom {0}", SceneManager.GetActiveScene().path);
         }
 
         public override void OnClientExitRoom()
         {
-            if (LogFilter.Debug) Debug.LogFormat("OnClientExitRoom {0}", SceneManager.GetActiveScene().name);
+            if (LogFilter.Debug) Debug.LogFormat("OnClientExitRoom {0}", SceneManager.GetActiveScene().path);
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -263,7 +263,7 @@ namespace Mirror
         bool IsServerOnlineSceneChangeNeeded()
         {
             // Only change scene if the requested online scene is not blank, and is not already loaded
-            string loadedSceneName = SceneManager.GetActiveScene().name;
+            string loadedSceneName = SceneManager.GetActiveScene().path;
             return !string.IsNullOrEmpty(onlineScene) && onlineScene != loadedSceneName && onlineScene != offlineScene;
         }
 
@@ -599,7 +599,7 @@ namespace Mirror
 
             // If this is the host player, StopServer will already be changing scenes.
             // Check loadingSceneAsync to ensure we don't double-invoke the scene change.
-            if (!string.IsNullOrEmpty(offlineScene) && SceneManager.GetActiveScene().name != offlineScene && loadingSceneAsync == null)
+            if (!string.IsNullOrEmpty(offlineScene) && SceneManager.GetActiveScene().path != offlineScene && loadingSceneAsync == null)
             {
                 ClientChangeScene(offlineScene, SceneOperation.Normal);
             }
@@ -1173,7 +1173,7 @@ namespace Mirror
             conn.isAuthenticated = true;
 
             // proceed with the login handshake by calling OnClientConnect
-            string loadedSceneName = SceneManager.GetActiveScene().name;
+            string loadedSceneName = SceneManager.GetActiveScene().path;
             if (string.IsNullOrEmpty(onlineScene) || onlineScene == offlineScene || loadedSceneName == onlineScene)
             {
                 clientLoadedScene = false;

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -263,9 +263,11 @@ namespace Mirror
         bool IsServerOnlineSceneChangeNeeded()
         {
             // Only change scene if the requested online scene is not blank, and is not already loaded
-            string loadedSceneName = SceneManager.GetActiveScene().path;
-            return !string.IsNullOrEmpty(onlineScene) && onlineScene != loadedSceneName && onlineScene != offlineScene;
+            return !string.IsNullOrEmpty(onlineScene) && !IsSceneActive(onlineScene) && onlineScene != offlineScene;
         }
+
+        public static bool IsSceneActive(string scene) =>
+            SceneManager.GetActiveScene().path == scene || SceneManager.GetActiveScene().name == scene;
 
         // full server setup code, without spawning objects yet
         void SetupServer()
@@ -599,7 +601,7 @@ namespace Mirror
 
             // If this is the host player, StopServer will already be changing scenes.
             // Check loadingSceneAsync to ensure we don't double-invoke the scene change.
-            if (!string.IsNullOrEmpty(offlineScene) && SceneManager.GetActiveScene().path != offlineScene && loadingSceneAsync == null)
+            if (!string.IsNullOrEmpty(offlineScene) && !IsSceneActive(offlineScene) && loadingSceneAsync == null)
             {
                 ClientChangeScene(offlineScene, SceneOperation.Normal);
             }
@@ -1173,8 +1175,7 @@ namespace Mirror
             conn.isAuthenticated = true;
 
             // proceed with the login handshake by calling OnClientConnect
-            string loadedSceneName = SceneManager.GetActiveScene().path;
-            if (string.IsNullOrEmpty(onlineScene) || onlineScene == offlineScene || loadedSceneName == onlineScene)
+            if (string.IsNullOrEmpty(onlineScene) || onlineScene == offlineScene || IsSceneActive(onlineScene))
             {
                 clientLoadedScene = false;
                 OnClientConnect(conn);

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -266,8 +266,11 @@ namespace Mirror
             return !string.IsNullOrEmpty(onlineScene) && !IsSceneActive(onlineScene) && onlineScene != offlineScene;
         }
 
-        public static bool IsSceneActive(string scene) =>
-            SceneManager.GetActiveScene().path == scene || SceneManager.GetActiveScene().name == scene;
+        public static bool IsSceneActive(string scene)
+        {
+            Scene activeScene = SceneManager.GetActiveScene();
+            return activeScene.path == scene || activeScene.name == scene;
+        }
 
         // full server setup code, without spawning objects yet
         void SetupServer()


### PR DESCRIPTION
Instead of using scene name, scenes are now identified by path.
This fixes a couple problems:

1) In the room example, now you can assign the scenes even if they have
not been added to the editor.  This was a constant pain because if you
open the offlinescene, all the scenes got wiped.  You had to add the
scenes to the editor and reassign them all again.   With this PR you
will still need to add them to the editor, but they will remain
assigned.

2) It is possible for multiple scenes to have the same name,  but it is
not possible for multiple scenes to have the same path. So this is
a more robust way to identify scenes

This also greatly simplifies scene SceneDrawer
