### PR TITLE
Move comments to previous line

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -37,7 +37,8 @@ namespace Mirror
         bool[] lastBoolParameters;
         AnimatorControllerParameter[] parameters;
 
-        int[] animationHash; // multiple layers
+        // multiple layers
+        int[] animationHash;
         int[] transitionHash;
         float sendTimer;
 

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -233,7 +233,6 @@ namespace Mirror
                 // position if we aren't too far away
                 //
                 // local position/rotation for VR support
-                //
                 if (Vector3.Distance(targetComponent.transform.localPosition, start.localPosition) < oldDistance + newDistance)
                 {
                     start.localPosition = targetComponent.transform.localPosition;

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -50,7 +50,8 @@ namespace Mirror
         [Header("Compression")]
         [Tooltip("Compresses 16 Byte Quaternion into None=12, Much=3, Lots=2 Byte")]
         [SerializeField] Compression compressRotation = Compression.Much;
-        public enum Compression { None, Much, Lots, NoRotation }; // easily understandable and funny
+        // easily understandable and funny
+        public enum Compression { None, Much, Lots, NoRotation };
 
         // target transform to sync. can be on a child.
         protected abstract Transform targetComponent { get; }
@@ -78,7 +79,8 @@ namespace Mirror
         float lastClientSendTime;
 
         // serialization is needed by OnSerialize and by manual sending from authority
-        [EditorBrowsable(EditorBrowsableState.Never)] // public only for tests
+        // public only for tests
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void SerializeIntoWriter(NetworkWriter writer, Vector3 position, Quaternion rotation, Compression compressRotation, Vector3 scale)
         {
             // serialize position
@@ -130,7 +132,8 @@ namespace Mirror
         {
             Vector3 delta = to.localPosition - (from != null ? from.localPosition : transform.localPosition);
             float elapsed = from != null ? to.timeStamp - from.timeStamp : sendInterval;
-            return elapsed > 0 ? delta.magnitude / elapsed : 0; // avoid NaN
+            // avoid NaN
+            return elapsed > 0 ? delta.magnitude / elapsed : 0;
         }
 
         // serialization is needed by OnSerialize and by manual sending from authority
@@ -229,7 +232,8 @@ namespace Mirror
                 // teleport / lag / obstacle detection: only continue at current
                 // position if we aren't too far away
                 //
-                // // local position/rotation for VR support
+                // local position/rotation for VR support
+                //
                 if (Vector3.Distance(targetComponent.transform.localPosition, start.localPosition) < oldDistance + newDistance)
                 {
                     start.localPosition = targetComponent.transform.localPosition;
@@ -279,7 +283,8 @@ namespace Mirror
                 // the moment we get 'goal', 'start' is supposed to
                 // start, so elapsed time is based on:
                 float elapsed = Time.time - goal.timeStamp;
-                return difference > 0 ? elapsed / difference : 0; // avoid NaN
+                // avoid NaN
+                return difference > 0 ? elapsed / difference : 0;
             }
             return 0;
         }
@@ -451,10 +456,12 @@ namespace Mirror
             Gizmos.DrawSphere(data.localPosition + offset, 0.5f);
 
             // draw forward and up
-            Gizmos.color = Color.blue; // like unity move tool
+            // like unity move tool
+            Gizmos.color = Color.blue;
             Gizmos.DrawRay(data.localPosition + offset, data.localRotation * Vector3.forward);
 
-            Gizmos.color = Color.green; // like unity move tool
+            // like unity move tool
+            Gizmos.color = Color.green;
             Gizmos.DrawRay(data.localPosition + offset, data.localRotation * Vector3.up);
         }
 

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -133,7 +133,8 @@ namespace Mirror
                 Rect behaviourRect = new Rect(initialX, labelRect.y + 10, maxBehaviourLabelSize.x, maxBehaviourLabelSize.y);
 
                 GUI.Label(behaviourRect, new GUIContent("Network Behaviours"), styles.labelStyle);
-                behaviourRect.x += 20; // indent names
+                // indent names
+                behaviourRect.x += 20;
                 behaviourRect.y += behaviourRect.height;
 
                 foreach (NetworkBehaviourInfo info in behavioursInfo)
@@ -154,7 +155,8 @@ namespace Mirror
                     Rect observerRect = new Rect(initialX, lastY + 10, 200, 20);
 
                     GUI.Label(observerRect, new GUIContent("Network observers"), styles.labelStyle);
-                    observerRect.x += 20; // indent names
+                    // indent names
+                    observerRect.x += 20;
                     observerRect.y += observerRect.height;
 
                     foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)

--- a/Assets/Mirror/Editor/NetworkManagerEditor.cs
+++ b/Assets/Mirror/Editor/NetworkManagerEditor.cs
@@ -31,7 +31,8 @@ namespace Mirror
                     onRemoveCallback = RemoveButton,
                     onChangedCallback = Changed,
                     onAddCallback = AddButton,
-                    elementHeight = 16 // this uses a 16x16 icon. other sizes make it stretch.
+                    // this uses a 16x16 icon. other sizes make it stretch.
+                    elementHeight = 16
                 };
             }
         }

--- a/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
+++ b/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
@@ -14,12 +14,17 @@ namespace Mirror.Weaver
         const string MirrorRuntimeAssemblyName = "Mirror";
         const string MirrorWeaverAssemblyName = "Mirror.Weaver";
 
-        public static Action<string> OnWeaverMessage; // delegate for subscription to Weaver debug messages
-        public static Action<string> OnWeaverWarning; // delegate for subscription to Weaver warning messages
-        public static Action<string> OnWeaverError; // delete for subscription to Weaver error messages
+        // delegate for subscription to Weaver debug messages
+        public static Action<string> OnWeaverMessage;
+        // delegate for subscription to Weaver warning messages
+        public static Action<string> OnWeaverWarning;
+        // delete for subscription to Weaver error messages
+        public static Action<string> OnWeaverError;
 
-        public static bool WeaverEnabled { get; set; } // controls whether we weave any assemblies when CompilationPipeline delegates are invoked
-        public static bool UnityLogEnabled = true; // controls weather Weaver errors are reported direct to the Unity console (tests enable this)
+        // controls whether we weave any assemblies when CompilationPipeline delegates are invoked
+        public static bool WeaverEnabled { get; set; }
+        // controls weather Weaver errors are reported direct to the Unity console (tests enable this)
+        public static bool UnityLogEnabled = true;
 
         // holds the result status of our latest Weave operation
         // NOTE: WeaveFailed is critical to unit tests, but isn't used for anything else. 

--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -80,8 +80,10 @@ namespace Mirror.Weaver
 
         public static bool IsArrayType(this TypeReference tr)
         {
-            if ((tr.IsArray && ((ArrayType)tr).ElementType.IsArray) || // jagged array
-                (tr.IsArray && ((ArrayType)tr).Rank > 1)) // multidimensional array
+            // jagged array
+            if ((tr.IsArray && ((ArrayType)tr).ElementType.IsArray) ||
+                // multidimensional array
+                (tr.IsArray && ((ArrayType)tr).Rank > 1))
                 return false;
             return true;
         }

--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -60,11 +60,14 @@ namespace Mirror.Weaver
             }
 
             // invoke internal send and return
-            cmdWorker.Append(cmdWorker.Create(OpCodes.Ldarg_0)); // load 'base.' to call the SendCommand function with
+            // load 'base.' to call the SendCommand function with
+            cmdWorker.Append(cmdWorker.Create(OpCodes.Ldarg_0));
             cmdWorker.Append(cmdWorker.Create(OpCodes.Ldtoken, td));
-            cmdWorker.Append(cmdWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference)); // invokerClass
+            // invokerClass
+            cmdWorker.Append(cmdWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference));
             cmdWorker.Append(cmdWorker.Create(OpCodes.Ldstr, cmdName));
-            cmdWorker.Append(cmdWorker.Create(OpCodes.Ldloc_0)); // writer
+            // writer
+            cmdWorker.Append(cmdWorker.Create(OpCodes.Ldloc_0));
             cmdWorker.Append(cmdWorker.Create(OpCodes.Ldc_I4, NetworkBehaviourProcessor.GetChannelId(ca)));
             cmdWorker.Append(cmdWorker.Create(OpCodes.Call, Weaver.sendCommandInternal));
 

--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -56,24 +56,29 @@ namespace Mirror.Weaver
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.voidType);
 
-            if (existingMethod == null) //only add to new method
+            //only add to new method
+            if (existingMethod == null)
             {
                 serializeFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkWriterType)));
             }
             ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
             if (existingMethod != null)
             {
-                serWorker.Body.Instructions.Clear(); //remove default nop&ret from existing empty interface method
+                //remove default nop&ret from existing empty interface method
+                serWorker.Body.Instructions.Clear();
             }
 
-            if (!td.IsValueType) //if not struct(IMessageBase), likely same as using else {} here in all cases
+            //if not struct(IMessageBase), likely same as using else {} here in all cases
+            if (!td.IsValueType)
             {
                 // call base
                 MethodReference baseSerialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Serialize");
                 if (baseSerialize != null)
                 {
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
+                    // base
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                    // writer
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
                     serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
                 }
             }
@@ -99,7 +104,8 @@ namespace Mirror.Weaver
             }
             serWorker.Append(serWorker.Create(OpCodes.Ret));
 
-            if (existingMethod == null) //only add if not just replaced body
+            //only add if not just replaced body
+            if (existingMethod == null)
             {
                 td.Methods.Add(serializeFunc);
             }
@@ -123,24 +129,29 @@ namespace Mirror.Weaver
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.voidType);
 
-            if (existingMethod == null) //only add to new method
+            //only add to new method
+            if (existingMethod == null)
             {
                 serializeFunc.Parameters.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkReaderType)));
             }
             ILProcessor serWorker = serializeFunc.Body.GetILProcessor();
             if (existingMethod != null)
             {
-                serWorker.Body.Instructions.Clear(); //remove default nop&ret from existing empty interface method
+                //remove default nop&ret from existing empty interface method
+                serWorker.Body.Instructions.Clear();
             }
 
-            if (!td.IsValueType) //if not struct(IMessageBase), likely same as using else {} here in all cases
+            //if not struct(IMessageBase), likely same as using else {} here in all cases
+            if (!td.IsValueType)
             {
                 // call base
                 MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, "Deserialize");
                 if (baseDeserialize != null)
                 {
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
+                    // base
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                    // writer
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
                     serWorker.Append(serWorker.Create(OpCodes.Call, baseDeserialize));
                 }
             }
@@ -166,7 +177,8 @@ namespace Mirror.Weaver
             }
             serWorker.Append(serWorker.Create(OpCodes.Ret));
 
-            if (existingMethod == null) //only add if not just replaced body
+            //only add if not just replaced body
+            if (existingMethod == null)
             {
                 td.Methods.Add(serializeFunc);
             }

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -10,7 +10,8 @@ namespace Mirror.Weaver
     {
         readonly List<FieldDefinition> syncVars = new List<FieldDefinition>();
         readonly List<FieldDefinition> syncObjects = new List<FieldDefinition>();
-        readonly Dictionary<FieldDefinition, FieldDefinition> syncVarNetIds = new Dictionary<FieldDefinition, FieldDefinition>(); // <SyncVarField,NetIdField>
+        // <SyncVarField,NetIdField>
+        readonly Dictionary<FieldDefinition, FieldDefinition> syncVarNetIds = new Dictionary<FieldDefinition, FieldDefinition>();
         readonly List<MethodDefinition> commands = new List<MethodDefinition>();
         readonly List<MethodDefinition> clientRpcs = new List<MethodDefinition>();
         readonly List<MethodDefinition> targetRpcs = new List<MethodDefinition>();
@@ -138,7 +139,8 @@ namespace Mirror.Weaver
                 // use built-in writer func on writer object
                 worker.Append(worker.Create(OpCodes.Ldloc_0));         // writer object
                 worker.Append(worker.Create(OpCodes.Ldarg, argNum));   // argument
-                worker.Append(worker.Create(OpCodes.Call, writeFunc)); // call writer func on writer object
+                // call writer func on writer object
+                worker.Append(worker.Create(OpCodes.Call, writeFunc));
                 argNum += 1;
             }
             return true;
@@ -331,23 +333,30 @@ namespace Mirror.Weaver
             MethodReference baseSerialize = Resolvers.ResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, "OnSerialize");
             if (baseSerialize != null)
             {
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_2)); // forceAll
+                // base
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                // writer
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
+                // forceAll
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_2));
                 serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
-                serWorker.Append(serWorker.Create(OpCodes.Stloc_0)); // set dirtyLocal to result of base.OnSerialize()
+                // set dirtyLocal to result of base.OnSerialize()
+                serWorker.Append(serWorker.Create(OpCodes.Stloc_0));
             }
 
             // Generates: if (forceAll);
             Instruction initialStateLabel = serWorker.Create(OpCodes.Nop);
-            serWorker.Append(serWorker.Create(OpCodes.Ldarg_2)); // forceAll
+            // forceAll
+            serWorker.Append(serWorker.Create(OpCodes.Ldarg_2));
             serWorker.Append(serWorker.Create(OpCodes.Brfalse, initialStateLabel));
 
             foreach (FieldDefinition syncVar in syncVars)
             {
                 // Generates a writer call for each sync variable
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // this
+                // writer
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
+                // this
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
                 serWorker.Append(serWorker.Create(OpCodes.Ldfld, syncVar));
                 MethodReference writeFunc = Writers.GetWriteFunc(syncVar.FieldType);
                 if (writeFunc != null)
@@ -372,8 +381,10 @@ namespace Mirror.Weaver
 
             // write dirty bits before the data fields
             // Generates: writer.WritePackedUInt64 (base.get_syncVarDirtyBits ());
-            serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-            serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+            // writer
+            serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
+            // base
+            serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
             serWorker.Append(serWorker.Create(OpCodes.Call, Weaver.NetworkBehaviourDirtyBitsReference));
             serWorker.Append(serWorker.Create(OpCodes.Call, Writers.GetWriteFunc(Weaver.uint64Type)));
 
@@ -386,15 +397,19 @@ namespace Mirror.Weaver
                 Instruction varLabel = serWorker.Create(OpCodes.Nop);
 
                 // Generates: if ((base.get_syncVarDirtyBits() & 1uL) != 0uL)
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+                // base
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
                 serWorker.Append(serWorker.Create(OpCodes.Call, Weaver.NetworkBehaviourDirtyBitsReference));
-                serWorker.Append(serWorker.Create(OpCodes.Ldc_I8, 1L << dirtyBit)); // 8 bytes = long
+                // 8 bytes = long
+                serWorker.Append(serWorker.Create(OpCodes.Ldc_I8, 1L << dirtyBit));
                 serWorker.Append(serWorker.Create(OpCodes.And));
                 serWorker.Append(serWorker.Create(OpCodes.Brfalse, varLabel));
 
                 // Generates a call to the writer for that field
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
+                // writer
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
+                // base
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
                 serWorker.Append(serWorker.Create(OpCodes.Ldfld, syncVar));
 
                 MethodReference writeFunc = Writers.GetWriteFunc(syncVar.FieldType);
@@ -410,7 +425,8 @@ namespace Mirror.Weaver
 
                 // something was dirty
                 serWorker.Append(serWorker.Create(OpCodes.Ldc_I4_1));
-                serWorker.Append(serWorker.Create(OpCodes.Stloc_0)); // set dirtyLocal to true
+                // set dirtyLocal to true
+                serWorker.Append(serWorker.Create(OpCodes.Stloc_0));
 
                 serWorker.Append(varLabel);
                 dirtyBit += 1;
@@ -453,11 +469,13 @@ namespace Mirror.Weaver
             /*
              Generates code like:
                 uint oldNetId = ___qNetId;
-                GameObject oldSyncVar = syncvar.getter; // returns GetSyncVarGameObject(___qNetId)
+                // returns GetSyncVarGameObject(___qNetId)
+                GameObject oldSyncVar = syncvar.getter;
                 ___qNetId = reader.ReadPackedUInt32();
                 if (!SyncVarEqual(oldNetId, ref ___goNetId))
                 {
-                    OnSetQ(oldSyncVar, syncvar.getter); // getter returns GetSyncVarGameObject(___qNetId)
+                    // getter returns GetSyncVarGameObject(___qNetId)
+                    OnSetQ(oldSyncVar, syncvar.getter);
                 }
              */
             if (syncVar.FieldType.FullName == Weaver.gameObjectType.FullName ||
@@ -493,10 +511,14 @@ namespace Mirror.Weaver
                 //    the host server, and they would all happen and compare
                 //    values BEFORE the hook even returned and hence BEFORE the
                 //    actual value was even set.
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // put 'this.' onto stack for 'this.netId' below
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // reader. for 'reader.Read()' below
-                serWorker.Append(serWorker.Create(OpCodes.Call, Readers.GetReadFunc(Weaver.uint32Type))); // Read()
-                serWorker.Append(serWorker.Create(OpCodes.Stfld, netIdField)); // netId
+                // put 'this.' onto stack for 'this.netId' below
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                // reader. for 'reader.Read()' below
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
+                // Read()
+                serWorker.Append(serWorker.Create(OpCodes.Call, Readers.GetReadFunc(Weaver.uint32Type)));
+                // netId
+                serWorker.Append(serWorker.Create(OpCodes.Stfld, netIdField));
 
                 if (foundMethod != null)
                 {
@@ -535,10 +557,14 @@ namespace Mirror.Weaver
                     serWorker.Append(serWorker.Create(OpCodes.Brtrue, syncVarEqualLabel));
 
                     // call the hook
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // this.
-                    serWorker.Append(serWorker.Create(OpCodes.Ldloc, oldSyncVar)); // oldSyncVar GO/NI
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // this.
-                    serWorker.Append(serWorker.Create(OpCodes.Ldfld, syncVar)); // syncvar.get (finds current GO/NI from netId)
+                    // this.
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                    // oldSyncVar GO/NI
+                    serWorker.Append(serWorker.Create(OpCodes.Ldloc, oldSyncVar));
+                    // this.
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                    // syncvar.get (finds current GO/NI from netId)
+                    serWorker.Append(serWorker.Create(OpCodes.Ldfld, syncVar));
                     serWorker.Append(serWorker.Create(OpCodes.Call, foundMethod));
 
                     // Generates: end if (!SyncVarEqual);
@@ -548,7 +574,8 @@ namespace Mirror.Weaver
             // [SyncVar] int/float/struct/etc.?
             /*
              Generates code like:
-                int oldValue = a; // for hook
+                // for hook
+                int oldValue = a;
                 Networka = reader.ReadPackedInt32();
                 if (!SyncVarEqual(oldValue, ref a))
                 {
@@ -580,10 +607,14 @@ namespace Mirror.Weaver
                 //    the host server, and they would all happen and compare
                 //    values BEFORE the hook even returned and hence BEFORE the
                 //    actual value was even set.
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // put 'this.' onto stack for 'this.syncvar' below
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // reader. for 'reader.Read()' below
-                serWorker.Append(serWorker.Create(OpCodes.Call, readFunc)); // reader.Read()
-                serWorker.Append(serWorker.Create(OpCodes.Stfld, syncVar)); // syncvar
+                // put 'this.' onto stack for 'this.syncvar' below
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                // reader. for 'reader.Read()' below
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
+                // reader.Read()
+                serWorker.Append(serWorker.Create(OpCodes.Call, readFunc));
+                // syncvar
+                serWorker.Append(serWorker.Create(OpCodes.Stfld, syncVar));
 
                 if (foundMethod != null)
                 {
@@ -610,10 +641,14 @@ namespace Mirror.Weaver
                     serWorker.Append(serWorker.Create(OpCodes.Brtrue, syncVarEqualLabel));
 
                     // call the hook
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // this.
-                    serWorker.Append(serWorker.Create(OpCodes.Ldloc, oldValue)); // oldvalue
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // this.
-                    serWorker.Append(serWorker.Create(OpCodes.Ldfld, syncVar)); // syncvar.get
+                    // this.
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                    // oldvalue
+                    serWorker.Append(serWorker.Create(OpCodes.Ldloc, oldValue));
+                    // this.
+                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                    // syncvar.get
+                    serWorker.Append(serWorker.Create(OpCodes.Ldfld, syncVar));
                     serWorker.Append(serWorker.Create(OpCodes.Call, foundMethod));
 
                     // Generates: end if (!SyncVarEqual);
@@ -653,9 +688,12 @@ namespace Mirror.Weaver
             MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, "OnDeserialize");
             if (baseDeserialize != null)
             {
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // reader
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_2)); // initialState
+                // base
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
+                // reader
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
+                // initialState
+                serWorker.Append(serWorker.Create(OpCodes.Ldarg_2));
                 serWorker.Append(serWorker.Create(OpCodes.Call, baseDeserialize));
             }
 
@@ -681,7 +719,8 @@ namespace Mirror.Weaver
             serWorker.Append(serWorker.Create(OpCodes.Stloc_0));
 
             // conditionally read each syncvar
-            int dirtyBit = Weaver.GetSyncVarStart(netBehaviourSubclass.BaseType.FullName); // start at number of syncvars in parent
+            // start at number of syncvars in parent
+            int dirtyBit = Weaver.GetSyncVarStart(netBehaviourSubclass.BaseType.FullName);
             foreach (FieldDefinition syncVar in syncVars)
             {
                 Instruction varLabel = serWorker.Create(OpCodes.Nop);
@@ -719,7 +758,8 @@ namespace Mirror.Weaver
                 {
                     continue;
                 }
-                MethodReference readFunc = Readers.GetReadFunc(arg.ParameterType); //?
+                //?
+                MethodReference readFunc = Readers.GetReadFunc(arg.ParameterType);
 
                 if (readFunc != null)
                 {

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -79,11 +79,14 @@ namespace Mirror.Weaver
             }
 
             // invoke SendInternal and return
-            rpcWorker.Append(rpcWorker.Create(OpCodes.Ldarg_0)); // this
+            // this
+            rpcWorker.Append(rpcWorker.Create(OpCodes.Ldarg_0));
             rpcWorker.Append(rpcWorker.Create(OpCodes.Ldtoken, td));
-            rpcWorker.Append(rpcWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference)); // invokerClass
+            // invokerClass
+            rpcWorker.Append(rpcWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference));
             rpcWorker.Append(rpcWorker.Create(OpCodes.Ldstr, rpcName));
-            rpcWorker.Append(rpcWorker.Create(OpCodes.Ldloc_0)); // writer
+            // writer
+            rpcWorker.Append(rpcWorker.Create(OpCodes.Ldloc_0));
             rpcWorker.Append(rpcWorker.Create(OpCodes.Ldc_I4, NetworkBehaviourProcessor.GetChannelId(ca)));
             rpcWorker.Append(rpcWorker.Create(OpCodes.Callvirt, Weaver.sendRpcInternal));
 

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncEventProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncEventProcessor.cs
@@ -89,11 +89,14 @@ namespace Mirror.Weaver
                 return null;
 
             // invoke interal send and return
-            evtWorker.Append(evtWorker.Create(OpCodes.Ldarg_0)); // this
+            // this
+            evtWorker.Append(evtWorker.Create(OpCodes.Ldarg_0));
             evtWorker.Append(evtWorker.Create(OpCodes.Ldtoken, td));
-            evtWorker.Append(evtWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference)); // invokerClass
+            // invokerClass
+            evtWorker.Append(evtWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference));
             evtWorker.Append(evtWorker.Create(OpCodes.Ldstr, ed.Name));
-            evtWorker.Append(evtWorker.Create(OpCodes.Ldloc_0)); // writer
+            // writer
+            evtWorker.Append(evtWorker.Create(OpCodes.Ldloc_0));
             evtWorker.Append(evtWorker.Create(OpCodes.Ldc_I4, NetworkBehaviourProcessor.GetChannelId(ca)));
             evtWorker.Append(evtWorker.Create(OpCodes.Call, Weaver.sendEventInternal));
 
@@ -140,7 +143,8 @@ namespace Mirror.Weaver
                         MethodDefinition eventCallFunc = ProcessEventCall(td, ed, ca);
                         td.Methods.Add(eventCallFunc);
 
-                        Weaver.WeaveLists.replaceEvents[ed.Name] = eventCallFunc; // original weaver compares .Name, not EventDefinition.
+                        // original weaver compares .Name, not EventDefinition.
+                        Weaver.WeaveLists.replaceEvents[ed.Name] = eventCallFunc;
 
                         Weaver.DLog(td, "  Event: " + ed.Name);
                         break;

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -7,7 +7,8 @@ namespace Mirror.Weaver
 {
     public static class SyncVarProcessor
     {
-        const int SyncVarLimit = 64; // ulong = 64 bytes
+        // ulong = 64 bytes
+        const int SyncVarLimit = 64;
 
         // returns false for error, not for no-hook-exists
         public static bool CheckForHookFunction(TypeDefinition td, FieldDefinition syncVar, out MethodDefinition foundMethod)
@@ -66,7 +67,8 @@ namespace Mirror.Weaver
             if (fd.FieldType.FullName == Weaver.gameObjectType.FullName)
             {
                 // return this.GetSyncVarGameObject(ref field, uint netId);
-                getWorker.Append(getWorker.Create(OpCodes.Ldarg_0)); // this.
+                // this.
+                getWorker.Append(getWorker.Create(OpCodes.Ldarg_0));
                 getWorker.Append(getWorker.Create(OpCodes.Ldarg_0));
                 getWorker.Append(getWorker.Create(OpCodes.Ldfld, netFieldId));
                 getWorker.Append(getWorker.Create(OpCodes.Ldarg_0));
@@ -78,7 +80,8 @@ namespace Mirror.Weaver
             else if (fd.FieldType.FullName == Weaver.NetworkIdentityType.FullName)
             {
                 // return this.GetSyncVarNetworkIdentity(ref field, uint netId);
-                getWorker.Append(getWorker.Create(OpCodes.Ldarg_0)); // this.
+                // this.
+                getWorker.Append(getWorker.Create(OpCodes.Ldarg_0));
                 getWorker.Append(getWorker.Create(OpCodes.Ldarg_0));
                 getWorker.Append(getWorker.Create(OpCodes.Ldfld, netFieldId));
                 getWorker.Append(getWorker.Create(OpCodes.Ldarg_0));
@@ -167,7 +170,8 @@ namespace Mirror.Weaver
             setWorker.Append(setWorker.Create(OpCodes.Ldflda, fd));
 
             // dirty bit
-            setWorker.Append(setWorker.Create(OpCodes.Ldc_I8, dirtyBit)); // 8 byte integer aka long
+            // 8 byte integer aka long
+            setWorker.Append(setWorker.Create(OpCodes.Ldc_I8, dirtyBit));
 
             if (fd.FieldType.FullName == Weaver.gameObjectType.FullName)
             {

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -111,19 +111,24 @@ namespace Mirror.Weaver
             }
 
             // invoke SendInternal and return
-            rpcWorker.Append(rpcWorker.Create(OpCodes.Ldarg_0)); // this
+            // this
+            rpcWorker.Append(rpcWorker.Create(OpCodes.Ldarg_0));
             if (HasNetworkConnectionParameter(md))
             {
-                rpcWorker.Append(rpcWorker.Create(OpCodes.Ldarg_1)); // connection
+                // connection
+                rpcWorker.Append(rpcWorker.Create(OpCodes.Ldarg_1));
             }
             else
             {
-                rpcWorker.Append(rpcWorker.Create(OpCodes.Ldnull)); // null
+                // null
+                rpcWorker.Append(rpcWorker.Create(OpCodes.Ldnull));
             }
             rpcWorker.Append(rpcWorker.Create(OpCodes.Ldtoken, td));
-            rpcWorker.Append(rpcWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference)); // invokerClass
+            // invokerClass
+            rpcWorker.Append(rpcWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference));
             rpcWorker.Append(rpcWorker.Create(OpCodes.Ldstr, rpcName));
-            rpcWorker.Append(rpcWorker.Create(OpCodes.Ldloc_0)); // writer
+            // writer
+            rpcWorker.Append(rpcWorker.Create(OpCodes.Ldloc_0));
             rpcWorker.Append(rpcWorker.Create(OpCodes.Ldc_I4, NetworkBehaviourProcessor.GetChannelId(ca)));
             rpcWorker.Append(rpcWorker.Create(OpCodes.Callvirt, Weaver.sendTargetRpcInternal));
 

--- a/Assets/Mirror/Examples/ListServer/ListServer.cs
+++ b/Assets/Mirror/Examples/ListServer/ListServer.cs
@@ -12,7 +12,7 @@ namespace Mirror.Examples.ListServer
     public class ServerStatus
     {
         public string ip;
-        // <- not all transports use a port. assume default port. feel free to also send a port if needed.
+        // not all transports use a port. assume default port. feel free to also send a port if needed.
         //public ushort port;
         public string title;
         public ushort players;

--- a/Assets/Mirror/Examples/ListServer/ListServer.cs
+++ b/Assets/Mirror/Examples/ListServer/ListServer.cs
@@ -12,13 +12,15 @@ namespace Mirror.Examples.ListServer
     public class ServerStatus
     {
         public string ip;
-        //public ushort port; // <- not all transports use a port. assume default port. feel free to also send a port if needed.
+        // <- not all transports use a port. assume default port. feel free to also send a port if needed.
+        //public ushort port;
         public string title;
         public ushort players;
         public ushort capacity;
 
         public int lastLatency = -1;
-#if !UNITY_WEBGL // Ping isn't known in WebGL builds
+#if !UNITY_WEBGL
+        // Ping isn't known in WebGL builds
         public Ping ping;
 #endif
         public ServerStatus(string ip, /*ushort port,*/ string title, ushort players, ushort capacity)
@@ -28,7 +30,8 @@ namespace Mirror.Examples.ListServer
             this.title = title;
             this.players = players;
             this.capacity = capacity;
-#if !UNITY_WEBGL // Ping isn't known in WebGL builds
+#if !UNITY_WEBGL
+            // Ping isn't known in WebGL builds
             ping = new Ping(ip);
 #endif
         }
@@ -204,7 +207,8 @@ namespace Mirror.Examples.ListServer
                             Debug.Log("[List Server] Client disconnected.");
                     }
 
-#if !UNITY_WEBGL // Ping isn't known in WebGL builds
+#if !UNITY_WEBGL
+                    // Ping isn't known in WebGL builds
                     // ping again if previous ping finished
                     foreach (ServerStatus server in list.Values)
                     {

--- a/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
@@ -29,7 +29,8 @@ namespace Mirror.Examples.Pong
             return (ballPos.y - racketPos.y) / racketHeight;
         }
 
-        [ServerCallback] // only call this on server
+        // only call this on server
+        [ServerCallback]
         void OnCollisionEnter2D(Collision2D col)
         {
             // Note: 'col' holds the collision information. If the

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -20,7 +20,8 @@ namespace Mirror
     [AttributeUsage(AttributeTargets.Method)]
     public class CommandAttribute : Attribute
     {
-        public int channel = Channels.DefaultReliable; // this is zero
+        // this is zero
+        public int channel = Channels.DefaultReliable;
     }
 
     /// <summary>
@@ -29,7 +30,8 @@ namespace Mirror
     [AttributeUsage(AttributeTargets.Method)]
     public class ClientRpcAttribute : Attribute
     {
-        public int channel = Channels.DefaultReliable; // this is zero
+        // this is zero
+        public int channel = Channels.DefaultReliable;
     }
 
     /// <summary>
@@ -38,7 +40,8 @@ namespace Mirror
     [AttributeUsage(AttributeTargets.Method)]
     public class TargetRpcAttribute : Attribute
     {
-        public int channel = Channels.DefaultReliable; // this is zero
+        // this is zero
+        public int channel = Channels.DefaultReliable;
     }
 
     /// <summary>
@@ -47,7 +50,8 @@ namespace Mirror
     [AttributeUsage(AttributeTargets.Event)]
     public class SyncEventAttribute : Attribute
     {
-        public int channel = Channels.DefaultReliable; // this is zero
+        // this is zero
+        public int channel = Channels.DefaultReliable;
     }
 
     /// <summary>

--- a/Assets/Mirror/Runtime/FloatBytePacker.cs
+++ b/Assets/Mirror/Runtime/FloatBytePacker.cs
@@ -11,7 +11,8 @@ namespace Mirror
         public static byte ScaleFloatToByte(float value, float minValue, float maxValue, byte minTarget, byte maxTarget)
         {
             // note: C# byte - byte => int, hence so many casts
-            int targetRange = maxTarget - minTarget; // max byte - min byte only fits into something bigger
+            // max byte - min byte only fits into something bigger
+            int targetRange = maxTarget - minTarget;
             float valueRange = maxValue - minValue;
             float valueRelative = value - minValue;
             return (byte)(minTarget + (byte)(valueRelative / valueRange * targetRange));
@@ -48,7 +49,8 @@ namespace Mirror
         {
             byte lower = (byte)(combined & 0x1F);
             byte middle = (byte)((combined >> 5) & 0x1F);
-            byte upper = (byte)(combined >> 10); // nothing on the left, no & needed
+            // nothing on the left, no & needed
+            byte upper = (byte)(combined >> 10);
 
             // note: we have to use 4 bits per float, so between 0x00 and 0x0F
             float u = ScaleByteToFloat(lower, 0x00, 0x1F, minTarget, maxTarget);

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -85,7 +85,8 @@ namespace Mirror
     public struct SceneMessage : IMessageBase
     {
         public string sceneName;
-        public SceneOperation sceneOperation; // Normal = 0, LoadAdditive = 1, UnloadAdditive = 2
+        // Normal = 0, LoadAdditive = 1, UnloadAdditive = 2
+        public SceneOperation sceneOperation;
         public bool customHandling;
 
         public void Deserialize(NetworkReader reader)
@@ -126,7 +127,8 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             componentIndex = (int)reader.ReadPackedUInt32();
-            functionHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
+            // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
+            functionHash = reader.ReadInt32();
             payload = reader.ReadBytesAndSizeSegment();
         }
 
@@ -152,7 +154,8 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             componentIndex = (int)reader.ReadPackedUInt32();
-            functionHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
+            // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
+            functionHash = reader.ReadInt32();
             payload = reader.ReadBytesAndSizeSegment();
         }
 
@@ -178,7 +181,8 @@ namespace Mirror
         {
             netId = reader.ReadPackedUInt32();
             componentIndex = (int)reader.ReadPackedUInt32();
-            functionHash = reader.ReadInt32(); // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
+            // hash is always 4 full bytes, WritePackedInt would send 1 extra byte here
+            functionHash = reader.ReadInt32();
             payload = reader.ReadBytesAndSizeSegment();
         }
 

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -36,7 +36,8 @@ namespace Mirror
         /// sync interval for OnSerialize (in seconds)
         /// </summary>
         [Tooltip("Time in seconds until next change is synchronized to the client. '0' means send immediately if changed. '0.5' means only send changes every 500ms.\n(This is for state synchronization like SyncVars, SyncLists, OnSerialize. Not for Cmds, Rpcs, etc.)")]
-        [Range(0, 2)] // [0,2] should be enough. anything >2s is too laggy anyway.
+        // [0,2] should be enough. anything >2s is too laggy anyway.
+        [Range(0, 2)]
         [HideInInspector] public float syncInterval = 0.1f;
 
         /// <summary>
@@ -205,8 +206,10 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = GetMethodHash(invokeClass, cmdName), // type+func so Inventory.RpcUse != Equipment.RpcUse
-                payload = writer.ToArraySegment() // segment to avoid reader allocations
+                // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = GetMethodHash(invokeClass, cmdName),
+                // segment to avoid reader allocations
+                payload = writer.ToArraySegment()
             };
 
             ClientScene.readyConnection.Send(message, channelId);
@@ -247,8 +250,10 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = GetMethodHash(invokeClass, rpcName), // type+func so Inventory.RpcUse != Equipment.RpcUse
-                payload = writer.ToArraySegment() // segment to avoid reader allocations
+                // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = GetMethodHash(invokeClass, rpcName),
+                // segment to avoid reader allocations
+                payload = writer.ToArraySegment()
             };
 
             NetworkServer.SendToReady(netIdentity, message, channelId);
@@ -286,8 +291,10 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = GetMethodHash(invokeClass, rpcName), // type+func so Inventory.RpcUse != Equipment.RpcUse
-                payload = writer.ToArraySegment() // segment to avoid reader allocations
+                // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = GetMethodHash(invokeClass, rpcName),
+                // segment to avoid reader allocations
+                payload = writer.ToArraySegment()
             };
 
             conn.Send(message, channelId);
@@ -321,8 +328,10 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = ComponentIndex,
-                functionHash = GetMethodHash(invokeClass, eventName), // type+func so Inventory.RpcUse != Equipment.RpcUse
-                payload = writer.ToArraySegment() // segment to avoid reader allocations
+                // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = GetMethodHash(invokeClass, eventName),
+                // segment to avoid reader allocations
+                payload = writer.ToArraySegment()
             };
 
             NetworkServer.SendToReady(netIdentity, message, channelId);
@@ -362,7 +371,8 @@ namespace Mirror
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected static void RegisterDelegate(Type invokeClass, string cmdName, MirrorInvokeType invokerType, CmdDelegate func)
         {
-            int cmdHash = GetMethodHash(invokeClass, cmdName); // type+func so Inventory.RpcUse != Equipment.RpcUse
+            // type+func so Inventory.RpcUse != Equipment.RpcUse
+            int cmdHash = GetMethodHash(invokeClass, cmdName);
 
             if (cmdHandlerDelegates.ContainsKey(cmdHash))
             {
@@ -509,7 +519,8 @@ namespace Mirror
 
             if (LogFilter.Debug) Debug.Log("SetSyncVar GameObject " + GetType().Name + " bit [" + dirtyBit + "] netfieldId:" + netIdField + "->" + newNetId);
             SetDirtyBit(dirtyBit);
-            gameObjectField = newGameObject; // assign new one on the server, and in case we ever need it on client too
+            // assign new one on the server, and in case we ever need it on client too
+            gameObjectField = newGameObject;
             netIdField = newNetId;
         }
 
@@ -571,7 +582,8 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("SetSyncVarNetworkIdentity NetworkIdentity " + GetType().Name + " bit [" + dirtyBit + "] netIdField:" + netIdField + "->" + newNetId);
             SetDirtyBit(dirtyBit);
             netIdField = newNetId;
-            identityField = newIdentity; // assign new one on the server, and in case we ever need it on client too
+            // assign new one on the server, and in case we ever need it on client too
+            identityField = newIdentity;
         }
 
         // helper function for [SyncVar] NetworkIdentities.

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -263,8 +263,10 @@ namespace Mirror
                 RegisterHandler<ObjectHideMessage>(ClientScene.OnHostClientObjectHide);
                 RegisterHandler<NetworkPongMessage>((conn, msg) => { }, false);
                 RegisterHandler<SpawnMessage>(ClientScene.OnHostClientSpawn);
-                RegisterHandler<ObjectSpawnStartedMessage>((conn, msg) => { }); // host mode doesn't need spawning
-                RegisterHandler<ObjectSpawnFinishedMessage>((conn, msg) => { }); // host mode doesn't need spawning
+                // host mode doesn't need spawning
+                RegisterHandler<ObjectSpawnStartedMessage>((conn, msg) => { });
+                // host mode doesn't need spawning
+                RegisterHandler<ObjectSpawnFinishedMessage>((conn, msg) => { });
                 RegisterHandler<UpdateVarsMessage>((conn, msg) => { });
             }
             else

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -429,7 +429,8 @@ namespace Mirror
         {
             if (ThisIsAPrefab())
             {
-                sceneId = 0; // force 0 for prefabs
+                // force 0 for prefabs
+                sceneId = 0;
                 AssignAssetID(gameObject);
             }
             // are we currently in prefab editing mode? aka prefab stage
@@ -452,7 +453,8 @@ namespace Mirror
                 //   * GetPrefabStage(go) = 'are we editing THIS prefab?'
                 if (PrefabStageUtility.GetPrefabStage(gameObject) != null)
                 {
-                    sceneId = 0; // force 0 for prefabs
+                    // force 0 for prefabs
+                    sceneId = 0;
                     //Debug.Log(name + " @ scene: " + gameObject.scene.name + " sceneid reset to 0 because CurrentPrefabStage=" + PrefabStageUtility.GetCurrentPrefabStage() + " PrefabStage=" + PrefabStageUtility.GetPrefabStage(gameObject));
                     // NOTE: might make sense to use GetPrefabStage for asset
                     //       path, but let's not touch it while it works.
@@ -560,7 +562,8 @@ namespace Mirror
                 //    one exception doesn't stop all the other Start() calls!
                 try
                 {
-                    comp.OnStartClient(); // user implemented startup
+                    // user implemented startup
+                    comp.OnStartClient();
                 }
                 catch (Exception e)
                 {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -197,7 +197,8 @@ namespace Mirror
 #endif
             }
 
-            maxConnections = Mathf.Max(maxConnections, 0); // always >= 0
+            // always >= 0
+            maxConnections = Mathf.Max(maxConnections, 0);
 
             if (playerPrefab != null && playerPrefab.GetComponent<NetworkIdentity>() == null)
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -642,7 +642,8 @@ namespace Mirror
             // internally sends a spawn message for each one to the connection.
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
             {
-                if (identity.gameObject.activeSelf) //TODO this is different // try with far away ones in ummorpg!
+                // try with far away ones in ummorpg!
+                if (identity.gameObject.activeSelf) //TODO this is different
                 {
                     if (LogFilter.Debug) Debug.Log("Sending spawn message for current server objects name='" + identity.name + "' netId=" + identity.netId + " sceneId=" + identity.sceneId);
 
@@ -923,7 +924,8 @@ namespace Mirror
             if (identity.serverOnly)
                 return;
 
-            if (LogFilter.Debug) Debug.Log("Server SendSpawnMessage: name=" + identity.name + " sceneId=" + identity.sceneId.ToString("X") + " netid=" + identity.netId); // for easier debugging
+            // for easier debugging
+            if (LogFilter.Debug) Debug.Log("Server SendSpawnMessage: name=" + identity.name + " sceneId=" + identity.sceneId.ToString("X") + " netid=" + identity.netId);
 
             // one writer for owner, one for observers
             using (PooledNetworkWriter ownerWriter = NetworkWriterPool.GetWriter(), observersWriter = NetworkWriterPool.GetWriter())

--- a/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -67,7 +67,8 @@ namespace Mirror
             MaxTimerTimeout = 12000
         };
 
-        readonly int channelId; // always use first channel
+        // always use first channel
+        readonly int channelId;
         byte error;
 
         int clientId = -1;

--- a/Assets/Mirror/Runtime/Transport/Telepathy/Client.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Client.cs
@@ -133,8 +133,10 @@ namespace Telepathy
             // => the trick is to clear the internal IPv4 socket so that Connect
             //    resolves the hostname and creates either an IPv4 or an IPv6
             //    socket as needed (see TcpClient source)
-            client = new TcpClient(); // creates IPv4 socket
-            client.Client = null; // clear internal IPv4 socket until Connect()
+            // creates IPv4 socket
+            client = new TcpClient();
+            // clear internal IPv4 socket until Connect()
+            client.Client = null;
 
             // clear old messages in queue, just to be sure that the caller
             // doesn't receive data from last time and gets out of sync.
@@ -194,7 +196,8 @@ namespace Telepathy
                     // calling Send here would be blocking (sometimes for long times
                     // if other side lags or wire was disconnected)
                     sendQueue.Enqueue(data);
-                    sendPending.Set(); // interrupt SendThread WaitOne()
+                    // interrupt SendThread WaitOne()
+                    sendPending.Set();
                     return true;
                 }
                 Logger.LogError("Client.Send: message too big: " + data.Length + ". Limit: " + MaxMessageSize);

--- a/Assets/Mirror/Runtime/Transport/Telepathy/Common.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Common.cs
@@ -8,7 +8,8 @@ namespace Telepathy
 {
     public abstract class Common
     {
-        // common code /////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
+        // common code
         // incoming message queue of <connectionId, message>
         // (not a HashSet because one connection can have multiple new messages)
         protected ConcurrentQueue<Message> receiveQueue = new ConcurrentQueue<Message>();
@@ -59,7 +60,8 @@ namespace Telepathy
         // all threads
         [ThreadStatic] static byte[] payload;
 
-        // static helper functions /////////////////////////////////////////////
+        /////////////////////////////////////////////
+        // static helper functions
         // send message (via stream) with the <size,content> message structure
         // this function is blocking sometimes!
         // (e.g. if someone has high latency or wire was cut off)
@@ -73,7 +75,8 @@ namespace Telepathy
                 // packet to avoid TCP overheads and improve performance.
                 int packetSize = 0;
                 for (int i = 0; i < messages.Length; ++i)
-                    packetSize += sizeof(int) + messages[i].Length; // header + content
+                    // header + content
+                    packetSize += sizeof(int) + messages[i].Length;
 
                 // create payload buffer if not created yet or previous one is
                 // too small
@@ -179,7 +182,8 @@ namespace Telepathy
                     // read the next message (blocking) or stop if stream closed
                     byte[] content;
                     if (!ReadMessageBlocking(stream, MaxMessageSize, out content))
-                        break; // break instead of return so stream close still happens!
+                        // break instead of return so stream close still happens!
+                        break;
 
                     // queue it
                     receiveQueue.Enqueue(new Message(connectionId, EventType.Data, content));
@@ -233,7 +237,8 @@ namespace Telepathy
 
             try
             {
-                while (client.Connected) // try this. client will get closed eventually.
+                // try this. client will get closed eventually.
+                while (client.Connected)
                 {
                     // reset ManualResetEvent before we do anything else. this
                     // way there is no race condition. if Send() is called again
@@ -241,7 +246,8 @@ namespace Telepathy
                     // -> otherwise Send might be called right after dequeue but
                     //    before .Reset, which would completely ignore it until
                     //    the next Send call.
-                    sendPending.Reset(); // WaitOne() blocks until .Set() again
+                    // WaitOne() blocks until .Set() again
+                    sendPending.Reset();
 
                     // dequeue all
                     // SafeQueue.TryDequeueAll is twice as fast as
@@ -251,7 +257,8 @@ namespace Telepathy
                     {
                         // send message (blocking) or stop if stream is closed
                         if (!SendMessagesBlocking(stream, messages))
-                            break; // break instead of return so stream close still happens!
+                            // break instead of return so stream close still happens!
+                            break;
                     }
 
                     // don't choke up the CPU: wait until queue not empty anymore

--- a/Assets/Mirror/Runtime/Transport/Telepathy/Server.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Server.cs
@@ -252,7 +252,8 @@ namespace Telepathy
                     // calling Send here would be blocking (sometimes for long times
                     // if other side lags or wire was disconnected)
                     token.sendQueue.Enqueue(data);
-                    token.sendPending.Set(); // interrupt SendThread WaitOne()
+                    // interrupt SendThread WaitOne()
+                    token.sendPending.Set();
                     return true;
                 }
                 // sending to an invalid connectionId is expected sometimes.

--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/HttpHelper.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/HttpHelper.cs
@@ -76,7 +76,8 @@ namespace Ninja.WebSockets
         /// <returns>The HTTP header</returns>
         public static async Task<string> ReadHttpHeaderAsync(Stream stream, CancellationToken token)
         {
-            int length = 1024 * 16; // 16KB buffer more than enough for http header
+            // 16KB buffer more than enough for http header
+            int length = 1024 * 16;
             byte[] buffer = new byte[length];
             int offset = 0;
             int bytesRead = 0;

--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/BinaryReaderWriter.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/BinaryReaderWriter.cs
@@ -72,7 +72,8 @@ namespace Ninja.WebSockets.Internal
 
             if (!isLittleEndian)
             {
-                Array.Reverse(buffer.Array, buffer.Offset, 2); // big endian
+                // big endian
+                Array.Reverse(buffer.Array, buffer.Offset, 2);
             }
 
             return BitConverter.ToUInt16(buffer.Array, buffer.Offset);
@@ -84,7 +85,8 @@ namespace Ninja.WebSockets.Internal
 
             if (!isLittleEndian)
             {
-                Array.Reverse(buffer.Array, buffer.Offset, 8); // big endian
+                // big endian
+                Array.Reverse(buffer.Array, buffer.Offset, 8);
             }
 
             return BitConverter.ToUInt64(buffer.Array, buffer.Offset);
@@ -96,7 +98,8 @@ namespace Ninja.WebSockets.Internal
 
             if (!isLittleEndian)
             {
-                Array.Reverse(buffer.Array, buffer.Offset, 8); // big endian
+                // big endian
+                Array.Reverse(buffer.Array, buffer.Offset, 8);
             }
 
             return BitConverter.ToInt64(buffer.Array, buffer.Offset);

--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketFrameCommon.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketFrameCommon.cs
@@ -53,7 +53,8 @@ namespace Ninja.WebSockets.Internal
             // TODO: make this faster
             for (int i = payloadOffset; i < payloadCount; i++)
             {
-                int payloadIndex = i - payloadOffset; // index should start at zero
+                // index should start at zero
+                int payloadIndex = i - payloadOffset;
                 int maskKeyIndex = maskKeyOffset + (payloadIndex % MaskKeyLength);
                 buffer[i] = (Byte)(buffer[i] ^ maskKeyArray[maskKeyIndex]);
             }

--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketFrameReader.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketFrameReader.cs
@@ -105,7 +105,8 @@ namespace Ninja.WebSockets.Internal
 
             if (count >= 2)
             {
-                Array.Reverse(buffer.Array, buffer.Offset, 2); // network byte order
+                // network byte order
+                Array.Reverse(buffer.Array, buffer.Offset, 2);
                 int closeStatusCode = (int)BitConverter.ToUInt16(buffer.Array, buffer.Offset);
                 if (Enum.IsDefined(typeof(WebSocketCloseStatus), closeStatusCode))
                 {
@@ -153,7 +154,8 @@ namespace Ninja.WebSockets.Internal
             else if (len == 127)
             {
                 len = (uint)await BinaryReaderWriter.ReadULongExactly(fromStream, false, smallBuffer, cancellationToken);
-                const uint maxLen = 2147483648; // 2GB - not part of the spec but just a precaution. Send large volumes of data in smaller frames.
+                // 2GB - not part of the spec but just a precaution. Send large volumes of data in smaller frames.
+                const uint maxLen = 2147483648;
 
                 // protect ourselves against bad data
                 if (len > maxLen || len < 0)

--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketImplementation.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketImplementation.cs
@@ -253,7 +253,8 @@ namespace Ninja.WebSockets.Internal
                 }
 
                 await WriteStreamToNetwork(stream, cancellationToken);
-                _isContinuationFrame = !endOfMessage; // TODO: is this correct??
+                // TODO: is this correct??
+                _isContinuationFrame = !endOfMessage;
             }
         }
 
@@ -318,7 +319,8 @@ namespace Ninja.WebSockets.Internal
         {
             if (_state == WebSocketState.Open)
             {
-                _state = WebSocketState.Closed; // set this before we write to the network because the write may fail
+                // set this before we write to the network because the write may fail
+                _state = WebSocketState.Closed;
 
                 using (MemoryStream stream = _recycledStreamFactory())
                 {
@@ -390,7 +392,8 @@ namespace Ninja.WebSockets.Internal
         ArraySegment<byte> BuildClosePayload(WebSocketCloseStatus closeStatus, string statusDescription)
         {
             byte[] statusBuffer = BitConverter.GetBytes((ushort)closeStatus);
-            Array.Reverse(statusBuffer); // network byte order (big endian)
+            // network byte order (big endian)
+            Array.Reverse(statusBuffer);
 
             if (statusDescription == null)
             {

--- a/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
+++ b/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
@@ -100,7 +100,8 @@ namespace Mirror.Tests
         [Test]
         public void ClientToServerFailTest()
         {
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             bool result = connectionToServer.Send(new ArraySegment<byte>(new byte[0]));
             LogAssert.ignoreFailingMessages = false;
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -219,7 +219,8 @@ namespace Mirror.Tests
     {
         GameObject gameObject;
         NetworkIdentity identity;
-        EmptyBehaviour emptyBehaviour; // useful in most tests, but not necessarily all tests
+        // useful in most tests, but not necessarily all tests
+        EmptyBehaviour emptyBehaviour;
 
         [SetUp]
         public void SetUp()
@@ -339,17 +340,20 @@ namespace Mirror.Tests
             // create a connection from client to server and from server to client
             ULocalConnectionToClient connection = new ULocalConnectionToClient {
                 isReady = true,
-                isAuthenticated = true // commands require authentication
+                // commands require authentication
+                isAuthenticated = true
             };
             connection.connectionToServer = new ULocalConnectionToServer {
                 isReady = true,
-                isAuthenticated = true // commands require authentication
+                // commands require authentication
+                isAuthenticated = true
             };
             connection.connectionToServer.connectionToClient = connection;
             identity.connectionToClient = connection;
 
             // calling command before client is connected shouldn't work
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             comp.CallSendCommandInternal();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp.called, Is.EqualTo(0));
@@ -359,7 +363,8 @@ namespace Mirror.Tests
             Assert.That(NetworkClient.active, Is.True);
 
             // calling command before we have authority should fail
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             comp.CallSendCommandInternal();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp.called, Is.EqualTo(0));
@@ -386,7 +391,8 @@ namespace Mirror.Tests
             NetworkIdentity.spawned[identity.netId] = identity;
 
             // calling command before clientscene has ready connection shouldn't work
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             comp.CallSendCommandInternal();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp.called, Is.EqualTo(0));
@@ -400,7 +406,8 @@ namespace Mirror.Tests
 
             // clean up
             NetworkBehaviour.ClearDelegates();
-            ClientScene.Shutdown(); // clear clientscene.readyconnection
+            // clear clientscene.readyconnection
+            ClientScene.Shutdown();
             NetworkClient.Shutdown();
             NetworkServer.Shutdown();
             Transport.activeTransport = null;
@@ -479,7 +486,8 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(0));
 
             // we need an observer because sendrpc sends to ready observers
-            identity.OnStartServer(); // creates observers
+            // creates observers
+            identity.OnStartServer();
             identity.observers[connectionToServer.connectionToClient.connectionId] = connectionToServer.connectionToClient;
 
             identity.netId = 42;
@@ -507,7 +515,8 @@ namespace Mirror.Tests
 
             // clean up
             NetworkBehaviour.ClearDelegates();
-            ClientScene.Shutdown(); // clear clientscene.readyconnection
+            // clear clientscene.readyconnection
+            ClientScene.Shutdown();
             NetworkServer.RemoveLocalConnection();
             NetworkClient.Shutdown();
             NetworkServer.Shutdown();
@@ -596,7 +605,8 @@ namespace Mirror.Tests
 
             // clean up
             NetworkBehaviour.ClearDelegates();
-            ClientScene.Shutdown(); // clear clientscene.readyconnection
+            // clear clientscene.readyconnection
+            ClientScene.Shutdown();
             NetworkServer.RemoveLocalConnection();
             NetworkClient.Shutdown();
             NetworkServer.Shutdown();
@@ -671,7 +681,8 @@ namespace Mirror.Tests
             connectionToServer.connectionToClient.identity = identity;
 
             // we need an observer because sendevent sends to ready observers
-            identity.OnStartServer(); // creates observers
+            // creates observers
+            identity.OnStartServer();
             identity.observers[connectionToServer.connectionToClient.connectionId] = connectionToServer.connectionToClient;
 
             identity.netId = 42;
@@ -703,7 +714,8 @@ namespace Mirror.Tests
 
             // clean up
             NetworkBehaviour.ClearDelegates();
-            ClientScene.Shutdown(); // clear clientscene.readyconnection
+            // clear clientscene.readyconnection
+            ClientScene.Shutdown();
             NetworkServer.RemoveLocalConnection();
             NetworkClient.Shutdown();
             NetworkServer.Shutdown();
@@ -1027,7 +1039,8 @@ namespace Mirror.Tests
         {
             // add test component
             NetworkBehaviourSetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourSetSyncVarGameObjectComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // create a valid GameObject with networkidentity and netid
             GameObject go = new GameObject();
@@ -1050,7 +1063,8 @@ namespace Mirror.Tests
         {
             // add test component
             NetworkBehaviourSetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourSetSyncVarGameObjectComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // set some existing GO+netId first to check if it is going to be
             // overwritten
@@ -1074,7 +1088,8 @@ namespace Mirror.Tests
         {
             // add test component
             NetworkBehaviourSetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourSetSyncVarGameObjectComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // set some existing GO+netId first to check if it is going to be
             // overwritten
@@ -1110,7 +1125,8 @@ namespace Mirror.Tests
         {
             // add test component
             NetworkBehaviourSetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourSetSyncVarGameObjectComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // set some existing GO+netId first to check if it is going to be
             // overwritten
@@ -1150,12 +1166,14 @@ namespace Mirror.Tests
             // isServer is only true if we have a server running and netId set
             Transport.activeTransport = Substitute.For<Transport>();
             NetworkServer.Listen(1);
-            identity.netId = 42; // otherwise isServer is false
+            // otherwise isServer is false
+            identity.netId = 42;
             Assert.That(identity.isServer, Is.True);
 
             // add test component
             NetworkBehaviourGetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarGameObjectComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // create a syncable GameObject
             GameObject go = new GameObject();
@@ -1183,12 +1201,14 @@ namespace Mirror.Tests
             // isServer is only true if we have a server running and netId set
             Transport.activeTransport = Substitute.For<Transport>();
             NetworkServer.Listen(1);
-            identity.netId = 42; // otherwise isServer is false
+            // otherwise isServer is false
+            identity.netId = 42;
             Assert.That(identity.isServer, Is.True);
 
             // add test component
             NetworkBehaviourGetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarGameObjectComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // get it on the server. null should work fine.
             GameObject result = comp.GetSyncVarGameObjectExposed();
@@ -1208,7 +1228,8 @@ namespace Mirror.Tests
 
             // add test component
             NetworkBehaviourGetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarGameObjectComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // create a syncable GameObject
             GameObject go = new GameObject();
@@ -1245,7 +1266,8 @@ namespace Mirror.Tests
 
             // add test component
             NetworkBehaviourGetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarGameObjectComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // get it on the client. null should be supported.
             GameObject result = comp.GetSyncVarGameObjectExposed();
@@ -1261,7 +1283,8 @@ namespace Mirror.Tests
         {
             // add test component
             NetworkBehaviourSetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourSetSyncVarNetworkIdentityComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // create a valid GameObject with networkidentity and netid
             GameObject go = new GameObject();
@@ -1284,7 +1307,8 @@ namespace Mirror.Tests
         {
             // add test component
             NetworkBehaviourSetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourSetSyncVarNetworkIdentityComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // set some existing NI+netId first to check if it is going to be
             // overwritten
@@ -1309,7 +1333,8 @@ namespace Mirror.Tests
         {
             // add test component
             NetworkBehaviourSetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourSetSyncVarNetworkIdentityComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // set some existing NI+netId first to check if it is going to be
             // overwritten
@@ -1350,12 +1375,14 @@ namespace Mirror.Tests
             // isServer is only true if we have a server running and netId set
             Transport.activeTransport = Substitute.For<Transport>();
             NetworkServer.Listen(1);
-            identity.netId = 42; // otherwise isServer is false
+            // otherwise isServer is false
+            identity.netId = 42;
             Assert.That(identity.isServer, Is.True);
 
             // add test component
             NetworkBehaviourGetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarNetworkIdentityComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // create a syncable GameObject
             GameObject go = new GameObject();
@@ -1383,12 +1410,14 @@ namespace Mirror.Tests
             // isServer is only true if we have a server running and netId set
             Transport.activeTransport = Substitute.For<Transport>();
             NetworkServer.Listen(1);
-            identity.netId = 42; // otherwise isServer is false
+            // otherwise isServer is false
+            identity.netId = 42;
             Assert.That(identity.isServer, Is.True);
 
             // add test component
             NetworkBehaviourGetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarNetworkIdentityComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // get it on the server. null should work fine.
             NetworkIdentity result = comp.GetSyncVarNetworkIdentityExposed();
@@ -1408,7 +1437,8 @@ namespace Mirror.Tests
 
             // add test component
             NetworkBehaviourGetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarNetworkIdentityComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // create a syncable GameObject
             GameObject go = new GameObject();
@@ -1445,7 +1475,8 @@ namespace Mirror.Tests
 
             // add test component
             NetworkBehaviourGetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarNetworkIdentityComponent>();
-            comp.syncInterval = 0; // for isDirty check
+            // for isDirty check
+            comp.syncInterval = 0;
 
             // get it on the client. null should be supported.
             NetworkIdentity result = comp.GetSyncVarNetworkIdentityExposed();

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -196,7 +196,8 @@ namespace Mirror.Tests
             public override bool OnSerialize(NetworkWriter writer, bool initialState)
             {
                 writer.WriteInt32(value);
-                writer.WriteInt32(value); // one too many
+                // one too many
+                writer.WriteInt32(value);
                 return true;
             }
             public override void OnDeserialize(NetworkReader reader, bool initialState)
@@ -407,7 +408,8 @@ namespace Mirror.Tests
 
             // setting it when it's already set shouldn't overwrite the original
             ULocalConnectionToClient overwrite = new ULocalConnectionToClient();
-            LogAssert.ignoreFailingMessages = true; // will log a warning
+            // will log a warning
+            LogAssert.ignoreFailingMessages = true;
             identity.SetClientOwner(overwrite);
             Assert.That(identity.connectionToClient, Is.EqualTo(original));
             LogAssert.ignoreFailingMessages = false;
@@ -491,7 +493,8 @@ namespace Mirror.Tests
             // being initialized
             // (an error log is expected though)
             LogAssert.ignoreFailingMessages = true;
-            identity.OnStartServer(); // should catch the exception internally and not throw it
+            // should catch the exception internally and not throw it
+            identity.OnStartServer();
             Assert.That(comp.called, Is.EqualTo(1));
             LogAssert.ignoreFailingMessages = false;
         }
@@ -509,14 +512,16 @@ namespace Mirror.Tests
             // being initialized
             // (an error log is expected though)
             LogAssert.ignoreFailingMessages = true;
-            identity.OnStartClient(); // should catch the exception internally and not throw it
+            // should catch the exception internally and not throw it
+            identity.OnStartClient();
             Assert.That(comp.called, Is.EqualTo(1));
             LogAssert.ignoreFailingMessages = false;
 
             // we have checks to make sure that it's only called once.
             // let's see if they work.
             identity.OnStartClient();
-            Assert.That(comp.called, Is.EqualTo(1)); // same as before?
+            // same as before?
+            Assert.That(comp.called, Is.EqualTo(1));
         }
 
         [Test]
@@ -532,7 +537,8 @@ namespace Mirror.Tests
             // being initialized
             // (an error log is expected though)
             LogAssert.ignoreFailingMessages = true;
-            identity.OnStartAuthority(); // should catch the exception internally and not throw it
+            // should catch the exception internally and not throw it
+            identity.OnStartAuthority();
             Assert.That(comp.called, Is.EqualTo(1));
             LogAssert.ignoreFailingMessages = false;
         }
@@ -550,7 +556,8 @@ namespace Mirror.Tests
             // being initialized
             // (an error log is expected though)
             LogAssert.ignoreFailingMessages = true;
-            identity.OnStopAuthority(); // should catch the exception internally and not throw it
+            // should catch the exception internally and not throw it
+            identity.OnStopAuthority();
             Assert.That(comp.called, Is.EqualTo(1));
             LogAssert.ignoreFailingMessages = false;
         }
@@ -586,14 +593,16 @@ namespace Mirror.Tests
             // assigning authority should only work on server.
             // if isServer is false because server isn't running yet then it
             // should fail.
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             bool result = identity.AssignClientAuthority(owner);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(result, Is.False);
 
             // we can only handle authority on the server.
             // start the server so that isServer is true.
-            Transport.activeTransport = Substitute.For<Transport>(); // needed in .Listen
+            // needed in .Listen
+            Transport.activeTransport = Substitute.For<Transport>();
             NetworkServer.Listen(1);
             Assert.That(identity.isServer, Is.True);
 
@@ -608,12 +617,14 @@ namespace Mirror.Tests
 
             // assigning authority should respawn the object with proper authority
             // on the client. that's the best way to sync the new state right now.
-            owner.connectionToServer.Update(); // process pending messages
+            // process pending messages
+            owner.connectionToServer.Update();
             Assert.That(spawnCalled, Is.EqualTo(1));
 
             // shouldn't be able to assign authority while already owned by
             // another connection
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             result = identity.AssignClientAuthority(new NetworkConnectionToClient(43));
             LogAssert.ignoreFailingMessages = false;
             Assert.That(result, Is.False);
@@ -622,7 +633,8 @@ namespace Mirror.Tests
 
             // someone might try to remove authority by assigning null.
             // make sure this fails.
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             result = identity.AssignClientAuthority(null);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(result, Is.False);
@@ -630,16 +642,20 @@ namespace Mirror.Tests
             // removing authority while not isServer shouldn't work.
             // only allow it on server.
             NetworkServer.Shutdown();
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.RemoveClientAuthority();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(identity.connectionToClient, Is.EqualTo(owner));
             Assert.That(callbackCalled, Is.EqualTo(1));
-            NetworkServer.Listen(1); // restart it gain
+            // restart it gain
+            NetworkServer.Listen(1);
 
             // removing authority for the main player object shouldn't work
-            owner.identity = identity; // set connection's player object
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // set connection's player object
+            owner.identity = identity;
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.RemoveClientAuthority();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(identity.connectionToClient, Is.EqualTo(owner));
@@ -650,7 +666,8 @@ namespace Mirror.Tests
             identity.RemoveClientAuthority();
             Assert.That(identity.connectionToClient, Is.Null);
             Assert.That(callbackCalled, Is.EqualTo(2));
-            Assert.That(callbackConnection, Is.EqualTo(owner)); // the one that was removed
+            // the one that was removed
+            Assert.That(callbackConnection, Is.EqualTo(owner));
             Assert.That(callbackIdentity, Is.EqualTo(identity));
             Assert.That(callbackState, Is.EqualTo(false));
 
@@ -669,30 +686,42 @@ namespace Mirror.Tests
             // set authority from false to true, which should call OnStartAuthority
             identity.hasAuthority = true;
             identity.NotifyAuthority();
-            Assert.That(identity.hasAuthority, Is.True); // shouldn't be touched
-            Assert.That(compStart.called, Is.EqualTo(1)); // start should be called
-            Assert.That(compStop.called, Is.EqualTo(0)); // stop shouldn't
+            // shouldn't be touched
+            Assert.That(identity.hasAuthority, Is.True);
+            // start should be called
+            Assert.That(compStart.called, Is.EqualTo(1));
+            // stop shouldn't
+            Assert.That(compStop.called, Is.EqualTo(0));
 
             // set it to true again, should do nothing because already true
             identity.hasAuthority = true;
             identity.NotifyAuthority();
-            Assert.That(identity.hasAuthority, Is.True); // shouldn't be touched
-            Assert.That(compStart.called, Is.EqualTo(1)); // same as before
-            Assert.That(compStop.called, Is.EqualTo(0)); // same as before
+            // shouldn't be touched
+            Assert.That(identity.hasAuthority, Is.True);
+            // same as before
+            Assert.That(compStart.called, Is.EqualTo(1));
+            // same as before
+            Assert.That(compStop.called, Is.EqualTo(0));
 
             // set it to false, should call OnStopAuthority
             identity.hasAuthority = false;
             identity.NotifyAuthority();
-            Assert.That(identity.hasAuthority, Is.False); // shouldn't be touched
-            Assert.That(compStart.called, Is.EqualTo(1)); // same as before
-            Assert.That(compStop.called, Is.EqualTo(1)); // stop should be called
+            // shouldn't be touched
+            Assert.That(identity.hasAuthority, Is.False);
+            // same as before
+            Assert.That(compStart.called, Is.EqualTo(1));
+            // stop should be called
+            Assert.That(compStop.called, Is.EqualTo(1));
 
             // set it to false again, should do nothing because already false
             identity.hasAuthority = false;
             identity.NotifyAuthority();
-            Assert.That(identity.hasAuthority, Is.False); // shouldn't be touched
-            Assert.That(compStart.called, Is.EqualTo(1)); // same as before
-            Assert.That(compStop.called, Is.EqualTo(1)); // same as before
+            // shouldn't be touched
+            Assert.That(identity.hasAuthority, Is.False);
+            // same as before
+            Assert.That(compStart.called, Is.EqualTo(1));
+            // same as before
+            Assert.That(compStop.called, Is.EqualTo(1));
         }
 
         [Test]
@@ -709,11 +738,13 @@ namespace Mirror.Tests
             // (an error log is expected though)
             LogAssert.ignoreFailingMessages = true;
 
-            identity.OnSetHostVisibility(true); // should catch the exception internally and not throw it
+            // should catch the exception internally and not throw it
+            identity.OnSetHostVisibility(true);
             Assert.That(comp.called, Is.EqualTo(1));
             Assert.That(comp.valuePassed, Is.True);
 
-            identity.OnSetHostVisibility(false); // should catch the exception internally and not throw it
+            // should catch the exception internally and not throw it
+            identity.OnSetHostVisibility(false);
             Assert.That(comp.called, Is.EqualTo(2));
             Assert.That(comp.valuePassed, Is.False);
 
@@ -771,7 +802,8 @@ namespace Mirror.Tests
             // being checked
             // (an error log is expected though)
             LogAssert.ignoreFailingMessages = true;
-            bool result = identity.OnCheckObserver(connection); // should catch the exception internally and not throw it
+            // should catch the exception internally and not throw it
+            bool result = identity.OnCheckObserver(connection);
             Assert.That(result, Is.True);
             Assert.That(compExc.called, Is.EqualTo(1));
             LogAssert.ignoreFailingMessages = false;
@@ -824,7 +856,8 @@ namespace Mirror.Tests
             // serialize all - should work even if compExc throws an exception
             NetworkWriter ownerWriter = new NetworkWriter();
             NetworkWriter observersWriter = new NetworkWriter();
-            LogAssert.ignoreFailingMessages = true; // error log because of the exception is expected
+            // error log because of the exception is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
             LogAssert.ignoreFailingMessages = false;
 
@@ -840,7 +873,8 @@ namespace Mirror.Tests
 
             // deserialize all for owner - should work even if compExc throws an exception
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            LogAssert.ignoreFailingMessages = true; // error log because of the exception is expected
+            // error log because of the exception is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.OnDeserializeAllSafely(reader, true);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp1.value, Is.EqualTo(12345));
@@ -852,11 +886,14 @@ namespace Mirror.Tests
 
             // deserialize all for observers - should work even if compExc throws an exception
             reader = new NetworkReader(observersWriter.ToArray());
-            LogAssert.ignoreFailingMessages = true; // error log because of the exception is expected
+            // error log because of the exception is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.OnDeserializeAllSafely(reader, true);
             LogAssert.ignoreFailingMessages = false;
-            Assert.That(comp1.value, Is.EqualTo(12345)); // observers mode, should be in data
-            Assert.That(comp2.value, Is.EqualTo(null)); // owner mode, should not be in data
+            // observers mode, should be in data
+            Assert.That(comp1.value, Is.EqualTo(12345));
+            // owner mode, should not be in data
+            Assert.That(comp2.value, Is.EqualTo(null));
         }
 
         // OnSerializeAllSafely supports at max 64 components, because our
@@ -873,7 +910,8 @@ namespace Mirror.Tests
             // try to serialize
             NetworkWriter ownerWriter = new NetworkWriter();
             NetworkWriter observersWriter = new NetworkWriter();
-            LogAssert.ignoreFailingMessages = true; // error log is expected because of too many components
+            // error log is expected because of too many components
+            LogAssert.ignoreFailingMessages = true;
             identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
             LogAssert.ignoreFailingMessages = false;
 
@@ -912,7 +950,8 @@ namespace Mirror.Tests
 
             // deserialize all
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            LogAssert.ignoreFailingMessages = true; // warning log because of serialization mismatch
+            // warning log because of serialization mismatch
+            LogAssert.ignoreFailingMessages = true;
             identity.OnDeserializeAllSafely(reader, true);
             LogAssert.ignoreFailingMessages = false;
 
@@ -936,7 +975,8 @@ namespace Mirror.Tests
             // call OnStartLocalPlayer in identity
             // one component will throw an exception, but that shouldn't stop
             // OnStartLocalPlayer from being called in the second one
-            LogAssert.ignoreFailingMessages = true; // exception will log an error
+            // exception will log an error
+            LogAssert.ignoreFailingMessages = true;
             identity.OnStartLocalPlayer();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(compEx.called, Is.EqualTo(1));
@@ -945,8 +985,10 @@ namespace Mirror.Tests
             // we have checks to make sure that it's only called once.
             // let's see if they work.
             identity.OnStartLocalPlayer();
-            Assert.That(compEx.called, Is.EqualTo(1)); // same as before?
-            Assert.That(comp.called, Is.EqualTo(1)); // same as before?
+            // same as before?
+            Assert.That(compEx.called, Is.EqualTo(1));
+            // same as before?
+            Assert.That(comp.called, Is.EqualTo(1));
         }
 
         [Test]
@@ -963,7 +1005,8 @@ namespace Mirror.Tests
             // call OnNetworkDestroy in identity
             // one component will throw an exception, but that shouldn't stop
             // OnNetworkDestroy from being called in the second one
-            LogAssert.ignoreFailingMessages = true; // exception will log an error
+            // exception will log an error
+            LogAssert.ignoreFailingMessages = true;
             identity.OnNetworkDestroy();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(compEx.called, Is.EqualTo(1));
@@ -980,7 +1023,8 @@ namespace Mirror.Tests
             // AddObserver should return early if called before .observers was
             // created
             Assert.That(identity.observers, Is.Null);
-            LogAssert.ignoreFailingMessages = true; // error log is expected
+            // error log is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.AddObserver(connection1);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(identity.observers, Is.Null);
@@ -1036,13 +1080,17 @@ namespace Mirror.Tests
             // set components dirty bits
             compA.SetDirtyBit(0x0001);
             compB.SetDirtyBit(0x1001);
-            Assert.That(compA.IsDirty(), Is.True); // dirty because interval reached and mask != 0
-            Assert.That(compB.IsDirty(), Is.False); // not dirty because syncinterval not reached
+            // dirty because interval reached and mask != 0
+            Assert.That(compA.IsDirty(), Is.True);
+            // not dirty because syncinterval not reached
+            Assert.That(compB.IsDirty(), Is.False);
 
             // call identity.ClearDirtyComponentsDirtyBits
             identity.ClearDirtyComponentsDirtyBits();
-            Assert.That(compA.IsDirty(), Is.False); // should be cleared now
-            Assert.That(compB.IsDirty(), Is.False); // should be untouched
+            // should be cleared now
+            Assert.That(compA.IsDirty(), Is.False);
+            // should be untouched
+            Assert.That(compB.IsDirty(), Is.False);
 
             // set compB syncinterval to 0 to check if the masks were untouched
             // (if they weren't, then it should be dirty now)
@@ -1064,13 +1112,17 @@ namespace Mirror.Tests
             // set components dirty bits
             compA.SetDirtyBit(0x0001);
             compB.SetDirtyBit(0x1001);
-            Assert.That(compA.IsDirty(), Is.True); // dirty because interval reached and mask != 0
-            Assert.That(compB.IsDirty(), Is.False); // not dirty because syncinterval not reached
+            // dirty because interval reached and mask != 0
+            Assert.That(compA.IsDirty(), Is.True);
+            // not dirty because syncinterval not reached
+            Assert.That(compB.IsDirty(), Is.False);
 
             // call identity.ClearAllComponentsDirtyBits
             identity.ClearAllComponentsDirtyBits();
-            Assert.That(compA.IsDirty(), Is.False); // should be cleared now
-            Assert.That(compB.IsDirty(), Is.False); // should be cleared now
+            // should be cleared now
+            Assert.That(compA.IsDirty(), Is.False);
+            // should be cleared now
+            Assert.That(compB.IsDirty(), Is.False);
 
             // set compB syncinterval to 0 to check if the masks were cleared
             // (if they weren't, then it would still be dirty now)
@@ -1083,7 +1135,8 @@ namespace Mirror.Tests
         {
             // modify it a bit
             identity.isClient = true;
-            identity.OnStartServer(); // creates .observers and generates a netId
+            // creates .observers and generates a netId
+            identity.OnStartServer();
             uint netId = identity.netId;
             identity.connectionToClient = new NetworkConnectionToClient(1);
             identity.connectionToServer = new NetworkConnectionToServer();
@@ -1126,13 +1179,15 @@ namespace Mirror.Tests
             Assert.That(comp0.called, Is.EqualTo(1));
 
             // try wrong component index. command shouldn't be called again.
-            LogAssert.ignoreFailingMessages = true; // warning is expected
+            // warning is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.HandleCommand(1, functionHash, payload);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp0.called, Is.EqualTo(1));
 
             // try wrong function hash. command shouldn't be called again.
-            LogAssert.ignoreFailingMessages = true; // warning is expected
+            // warning is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.HandleCommand(0, functionHash+1, payload);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp0.called, Is.EqualTo(1));
@@ -1164,13 +1219,15 @@ namespace Mirror.Tests
             Assert.That(comp0.called, Is.EqualTo(1));
 
             // try wrong component index. rpc shouldn't be called again.
-            LogAssert.ignoreFailingMessages = true; // warning is expected
+            // warning is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.HandleRPC(1, functionHash, payload);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp0.called, Is.EqualTo(1));
 
             // try wrong function hash. rpc shouldn't be called again.
-            LogAssert.ignoreFailingMessages = true; // warning is expected
+            // warning is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.HandleRPC(0, functionHash+1, payload);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp0.called, Is.EqualTo(1));
@@ -1202,13 +1259,15 @@ namespace Mirror.Tests
             Assert.That(comp0.called, Is.EqualTo(1));
 
             // try wrong component index. syncevent shouldn't be called again.
-            LogAssert.ignoreFailingMessages = true; // warning is expected
+            // warning is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.HandleSyncEvent(1, functionHash, payload);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp0.called, Is.EqualTo(1));
 
             // try wrong function hash. syncevent shouldn't be called again.
-            LogAssert.ignoreFailingMessages = true; // warning is expected
+            // warning is expected
+            LogAssert.ignoreFailingMessages = true;
             identity.HandleSyncEvent(0, functionHash+1, payload);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp0.called, Is.EqualTo(1));
@@ -1223,13 +1282,19 @@ namespace Mirror.Tests
         {
             // add components
             SerializeTest1NetworkBehaviour compA = gameObject.AddComponent<SerializeTest1NetworkBehaviour>();
-            compA.value = 1337; // test value
-            compA.syncInterval = 0; // set syncInterval so IsDirty passes the interval check
-            compA.syncMode = SyncMode.Owner; // one needs to sync to owner
+            // test value
+            compA.value = 1337;
+            // set syncInterval so IsDirty passes the interval check
+            compA.syncInterval = 0;
+            // one needs to sync to owner
+            compA.syncMode = SyncMode.Owner;
             SerializeTest2NetworkBehaviour compB = gameObject.AddComponent<SerializeTest2NetworkBehaviour>();
-            compB.value = "test"; // test value
-            compB.syncInterval = 0; // set syncInterval so IsDirty passes the interval check
-            compB.syncMode = SyncMode.Observers; // one needs to sync to owner
+            // test value
+            compB.value = "test";
+            // set syncInterval so IsDirty passes the interval check
+            compB.syncInterval = 0;
+            // one needs to sync to owner
+            compB.syncMode = SyncMode.Observers;
 
             // call OnStartServer once so observers are created
             identity.OnStartServer();
@@ -1248,7 +1313,8 @@ namespace Mirror.Tests
 
             // add an owner connection that will receive the updates
             ULocalConnectionToClient owner = new ULocalConnectionToClient();
-            owner.isReady = true; // for syncing
+            // for syncing
+            owner.isReady = true;
             // add a client to server connection + handler to receive syncs
             owner.connectionToServer = new ULocalConnectionToServer();
             int ownerCalled = 0;
@@ -1260,7 +1326,8 @@ namespace Mirror.Tests
 
             // add an observer connection that will receive the updates
             ULocalConnectionToClient observer = new ULocalConnectionToClient();
-            observer.isReady = true; // we only sync to ready observers
+            // we only sync to ready observers
+            observer.isReady = true;
             // add a client to server connection + handler to receive syncs
             observer.connectionToServer = new ULocalConnectionToServer();
             int observerCalled = 0;

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -616,7 +616,8 @@ namespace Mirror.Tests
             GameObject go = new GameObject();
             NetworkIdentity identity = go.AddComponent<NetworkIdentity>();
             identity.netId = 42;
-            identity.connectionToClient = connection; // for authority check
+            // for authority check
+            identity.connectionToClient = connection;
             CommandTestNetworkBehaviour comp0 = go.AddComponent<CommandTestNetworkBehaviour>();
             Assert.That(comp0.called, Is.EqualTo(0));
             CommandTestNetworkBehaviour comp1 = go.AddComponent<CommandTestNetworkBehaviour>();
@@ -664,18 +665,22 @@ namespace Mirror.Tests
 
             // sending a command without authority should fail
             // (= if connectionToClient is not what we received the data on)
-            identity.connectionToClient = new ULocalConnectionToClient(); // set wrong authority
+            // set wrong authority
+            identity.connectionToClient = new ULocalConnectionToClient();
             comp0.called = 0;
             comp1.called = 0;
             Transport.activeTransport.OnServerDataReceived.Invoke(0, segment, 0);
             Assert.That(comp0.called, Is.EqualTo(0));
             Assert.That(comp1.called, Is.EqualTo(0));
-            identity.connectionToClient = connection; // restore authority
+            // restore authority
+            identity.connectionToClient = connection;
 
             // sending a component with wrong netId should fail
-            message.netId += 1; // wrong netid
+            // wrong netid
+            message.netId += 1;
             writer = new NetworkWriter();
-            MessagePacker.Pack(message, writer); // need to serialize the message again with wrong netid
+            // need to serialize the message again with wrong netid
+            MessagePacker.Pack(message, writer);
             ArraySegment<byte> segmentWrongNetId = writer.ToArraySegment();
             comp0.called = 0;
             comp1.called = 0;
@@ -702,7 +707,8 @@ namespace Mirror.Tests
             GameObject go = new GameObject();
             NetworkIdentity identity = go.AddComponent<NetworkIdentity>();
             identity.netId = 42;
-            //identity.connectionToClient = connection; // for authority check
+            // for authority check
+            //identity.connectionToClient = connection;
             OnStartClientTestNetworkBehaviour comp = go.AddComponent<OnStartClientTestNetworkBehaviour>();
             Assert.That(comp.called, Is.EqualTo(0));
             //connection.identity = identity;
@@ -810,7 +816,8 @@ namespace Mirror.Tests
             LogAssert.ignoreFailingMessages = true;
             Transport.activeTransport.OnServerDataReceived.Invoke(42, writer.ToArraySegment(), 0);
             LogAssert.ignoreFailingMessages = false;
-            Assert.That(variant1Called, Is.EqualTo(1)); // still 1, not 2
+            // still 1, not 2
+            Assert.That(variant1Called, Is.EqualTo(1));
 
             // unregister second handler via ClearHandlers to test that one too. send, should fail
             NetworkServer.ClearHandlers();
@@ -822,7 +829,8 @@ namespace Mirror.Tests
             LogAssert.ignoreFailingMessages = true;
             Transport.activeTransport.OnServerDataReceived.Invoke(42, writer.ToArraySegment(), 0);
             LogAssert.ignoreFailingMessages = false;
-            Assert.That(variant2Called, Is.EqualTo(1)); // still 1, not 2
+            // still 1, not 2
+            Assert.That(variant2Called, Is.EqualTo(1));
 
             // clean up
             NetworkServer.Shutdown();
@@ -916,7 +924,8 @@ namespace Mirror.Tests
 
             // add connection
             ULocalConnectionToClient connection = new ULocalConnectionToClient();
-            connection.isReady = true; // required for ShowForConnection
+            // required for ShowForConnection
+            connection.isReady = true;
             connection.connectionToServer = new ULocalConnectionToServer();
             // set a client handler
             int called = 0;
@@ -943,7 +952,8 @@ namespace Mirror.Tests
             connection.isReady = false;
             NetworkServer.ShowForConnection(identity, connection);
             connection.connectionToServer.Update();
-            Assert.That(called, Is.EqualTo(1)); // not 2 but 1 like before?
+            // not 2 but 1 like before?
+            Assert.That(called, Is.EqualTo(1));
 
             // clean up
             NetworkServer.Shutdown();
@@ -966,7 +976,8 @@ namespace Mirror.Tests
 
             // add connection
             ULocalConnectionToClient connection = new ULocalConnectionToClient();
-            connection.isReady = true; // required for ShowForConnection
+            // required for ShowForConnection
+            connection.isReady = true;
             connection.connectionToServer = new ULocalConnectionToServer();
             // set a client handler
             int called = 0;
@@ -1028,14 +1039,18 @@ namespace Mirror.Tests
             // create a gameobject and networkidentity that lives in the scene(=has sceneid)
             GameObject go = new GameObject("Test");
             NetworkIdentity identity = go.AddComponent<NetworkIdentity>();
-            identity.sceneId = 42; // lives in the scene from the start
-            go.SetActive(false); // unspawned scene objects are set to inactive before spawning
+            // lives in the scene from the start
+            identity.sceneId = 42;
+            // unspawned scene objects are set to inactive before spawning
+            go.SetActive(false);
 
             // create a gameobject that looks like it was instantiated and doesn't live in the scene
             GameObject go2 = new GameObject("Test2");
             NetworkIdentity identity2 = go2.AddComponent<NetworkIdentity>();
-            identity2.sceneId = 0; // not a scene object
-            go2.SetActive(false); // unspawned scene objects are set to inactive before spawning
+            // not a scene object
+            identity2.sceneId = 0;
+            // unspawned scene objects are set to inactive before spawning
+            go2.SetActive(false);
 
             // calling SpawnObjects while server isn't active should do nothing
             Assert.That(NetworkServer.SpawnObjects(), Is.False);
@@ -1063,8 +1078,10 @@ namespace Mirror.Tests
             GameObject go = new GameObject("Test");
             NetworkIdentity identity = go.AddComponent<NetworkIdentity>();
             OnNetworkDestroyTestNetworkBehaviour comp = go.AddComponent<OnNetworkDestroyTestNetworkBehaviour>();
-            identity.sceneId = 42; // lives in the scene from the start
-            go.SetActive(true); // spawned objects are active
+            // lives in the scene from the start
+            identity.sceneId = 42;
+            // spawned objects are active
+            go.SetActive(true);
             Assert.That(identity.IsMarkedForReset(), Is.False);
 
             // unspawn

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -89,7 +89,8 @@ namespace Mirror.Tests
         public void TestWritingSegmentAndReadingSegment()
         {
             byte[] data = { 1, 2, 3, 4 };
-            ArraySegment<byte> segment = new ArraySegment<byte>(data, 1, 1); // [2, 3]
+            // [2, 3]
+            ArraySegment<byte> segment = new ArraySegment<byte>(data, 1, 1);
             NetworkWriter writer = new NetworkWriter();
             writer.WriteBytesAndSizeSegment(segment);
 
@@ -1117,11 +1118,16 @@ namespace Mirror.Tests
             writer.WriteString((string)null);
             writer.WriteString("");
             writer.WriteString("13");
-            writer.WriteBytes(new byte[] { 14, 15 }, 0, 2); // just the byte array, no size info etc.
-            writer.WriteBytesAndSize((byte[])null); // [SyncVar] struct values can have uninitialized byte arrays, null needs to be supported
-            writer.WriteBytesAndSize(new byte[] { 17, 18 }, 0, 2); // buffer, no-offset, count
-            writer.WriteBytesAndSize(new byte[] { 19, 20, 21 }, 1, 2); // buffer, offset, count
-            writer.WriteBytesAndSize(new byte[] { 22, 23 }, 0, 2); // size, buffer
+            // just the byte array, no size info etc.
+            writer.WriteBytes(new byte[] { 14, 15 }, 0, 2);
+            // [SyncVar] struct values can have uninitialized byte arrays, null needs to be supported
+            writer.WriteBytesAndSize((byte[])null);
+            // buffer, no-offset, count
+            writer.WriteBytesAndSize(new byte[] { 17, 18 }, 0, 2);
+            // buffer, offset, count
+            writer.WriteBytesAndSize(new byte[] { 19, 20, 21 }, 1, 2);
+            // size, buffer
+            writer.WriteBytesAndSize(new byte[] { 22, 23 }, 0, 2);
 
             // read them
             NetworkReader reader = new NetworkReader(writer.ToArray());
@@ -1139,7 +1145,8 @@ namespace Mirror.Tests
             Assert.That(reader.ReadSingle(), Is.EqualTo(10));
             Assert.That(reader.ReadDouble(), Is.EqualTo(11));
             Assert.That(reader.ReadDecimal(), Is.EqualTo(12));
-            Assert.That(reader.ReadString(), Is.Null); // writing null string should write null in Mirror ("" in original HLAPI)
+            // writing null string should write null in Mirror ("" in original HLAPI)
+            Assert.That(reader.ReadString(), Is.Null);
             Assert.That(reader.ReadString(), Is.EqualTo(""));
             Assert.That(reader.ReadString(), Is.EqualTo("13"));
 

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -121,7 +121,8 @@ namespace Mirror.Tests
 
             // serialize all the data as we would for the network
             NetworkWriter ownerWriter = new NetworkWriter();
-            NetworkWriter observersWriter = new NetworkWriter(); // not really used in this Test
+            // not really used in this Test
+            NetworkWriter observersWriter = new NetworkWriter();
             identity1.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
 
             // set up a "client" object

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/TestingScriptableObjectArraySerialization.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/TestingScriptableObjectArraySerialization.cs
@@ -29,7 +29,8 @@ namespace MirrorTest
         [Command]
         public void
             CmdwriteArraydata(
-                Data[] arg) //This gonna give error saying-- Mirror.Weaver error: Cannot generate writer for scriptable object Data[]. Use a supported type or provide a custom writer
+                //This gonna give error saying-- Mirror.Weaver error: Cannot generate writer for scriptable object Data[]. Use a supported type or provide a custom writer
+                Data[] arg)
         {
 
             //some code

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/TestingScriptableObjectArraySerialization.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/TestingScriptableObjectArraySerialization.cs
@@ -28,6 +28,8 @@ namespace MirrorTest
     {
         [Command]
         public void
+             // This gonna give error saying-- Mirror.Weaver error: 
+             // Cannot generate writer for scriptable object Data[]. Use a supported type or provide a custom writer
             CmdwriteArraydata(
                 //This gonna give error saying-- Mirror.Weaver error: Cannot generate writer for scriptable object Data[]. Use a supported type or provide a custom writer
                 Data[] arg)

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/TestingScriptableObjectArraySerialization.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/TestingScriptableObjectArraySerialization.cs
@@ -31,7 +31,6 @@ namespace MirrorTest
              // This gonna give error saying-- Mirror.Weaver error: 
              // Cannot generate writer for scriptable object Data[]. Use a supported type or provide a custom writer
             CmdwriteArraydata(
-                //This gonna give error saying-- Mirror.Weaver error: Cannot generate writer for scriptable object Data[]. Use a supported type or provide a custom writer
                 Data[] arg)
         {
 


### PR DESCRIPTION
We have a mix of comments at on the previous line and at the end of
the line. We need to "pick one way and stick with it".

Per the C# code guidelines, comments go on the previous line. See here:
https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions

This also makes pull requests more readable since comments are less
likely to wrap

There are no code changes here, just a search and replace for all comments, plus a little bit of manual cleanup.

This also makes cloc counts more accurate as it can better determine
how many lines of comments vs code we have