### PR TITLE
Tests for SyncLists that use structs

### DIFF
--- a/Assets/Mirror/Tests/Editor/SyncListStructTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListStructTest.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    public class SyncListStructTest
+    {
+        [Test]
+        public void ListIsDirtyWhenModifingAndSettingStruct()
+        {
+            SyncListTestPlayer serverList = new SyncListTestPlayer();
+            SyncListTestPlayer clientList = new SyncListTestPlayer();
+            SyncListTest.SerializeAllTo(serverList, clientList);
+            serverList.Add(new TestPlayer { item = new TestItem { price = 10 } });
+            SyncListTest.SerializeDeltaTo(serverList, clientList);
+            Assert.That(serverList.IsDirty, Is.False);
+
+            TestPlayer player = serverList[0];
+            player.item.price = 15;
+            serverList[0] = player;
+
+            Assert.That(serverList.IsDirty, Is.True);
+        }
+
+
+        [Test]
+        public void OldValueShouldNotBeNewValue()
+        {
+            SyncListTestPlayer serverList = new SyncListTestPlayer();
+            SyncListTestPlayer clientList = new SyncListTestPlayer();
+            SyncListTest.SerializeAllTo(serverList, clientList);
+            serverList.Add(new TestPlayer { item = new TestItem { price = 10 } });
+            SyncListTest.SerializeDeltaTo(serverList, clientList);
+
+            TestPlayer player = serverList[0];
+            player.item.price = 15;
+            serverList[0] = player;
+
+            bool callbackCalled = false;
+            clientList.Callback += (SyncList<TestPlayer>.Operation op, int itemIndex, TestPlayer oldItem, TestPlayer newItem) =>
+            {
+                Assert.That(op == SyncList<TestPlayer>.Operation.OP_SET, Is.True);
+                Assert.That(itemIndex, Is.EqualTo(0));
+                Assert.That(oldItem.item.price, Is.EqualTo(10));
+                Assert.That(newItem.item.price, Is.EqualTo(15));
+                callbackCalled = true;
+            };
+
+            SyncListTest.SerializeDeltaTo(serverList, clientList);
+            Assert.IsTrue(callbackCalled);
+        }
+    }
+
+
+    public class SyncListTestPlayer : SyncList<TestPlayer>
+    {
+
+    }
+    public struct TestPlayer
+    {
+        public TestItem item;
+    }
+    public struct TestItem
+    {
+        public float price;
+    }
+}

--- a/Assets/Mirror/Tests/Editor/SyncListStructTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/SyncListStructTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1cad81f2aee838a4ababa9c8ee23a700
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -9,7 +9,7 @@ namespace Mirror.Tests
         SyncListString serverSyncList;
         SyncListString clientSyncList;
 
-        void SerializeAllTo<T>(T fromList, T toList) where T : SyncObject
+        public static void SerializeAllTo<T>(T fromList, T toList) where T : SyncObject
         {
             NetworkWriter writer = new NetworkWriter();
             fromList.OnSerializeAll(writer);
@@ -17,7 +17,7 @@ namespace Mirror.Tests
             toList.OnDeserializeAll(reader);
         }
 
-        void SerializeDeltaTo<T>(T fromList, T toList) where T : SyncObject
+        public static void SerializeDeltaTo<T>(T fromList, T toList) where T : SyncObject
         {
             NetworkWriter writer = new NetworkWriter();
             fromList.OnSerializeDelta(writer);


### PR DESCRIPTION
Tests to make sure structs sync when their fields are updated

We should probably update the docs to say that this is the correct way to update a struct field when using SyncLists

```csharp
TestPlayer player = serverList[index];
player.item.price = 15;
serverList[index] = player;
```