### PR TITLE
fix #1484: isServer state in NetworkIdentity is not dependent on NetworkServer.active anymore. Fixes a bug where isServer was already false in OnDestroy, but we sometimes still need it there to save a player etc. Also added a test to prevent it in the future.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -72,7 +72,7 @@ namespace Mirror
         //
         // IMPORTANT: checking NetworkServer.active means that isServer is false in OnDestroy:
         //   public bool isServer => NetworkServer.active && netId != 0;
-        // but we need it in OnDestroy, e.g. when saving skillbars on quit. this
+        // but we need it in OnDestroy, e.g. when saving players on quit. this
         // works fine if we keep the UNET way of setting isServer manually.
         // => fixes https://github.com/vis2k/Mirror/issues/1484
         public bool isServer

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -65,10 +65,21 @@ namespace Mirror
         // => fixes https://github.com/vis2k/Mirror/issues/1475
         public bool isClient { get; internal set; }
 
+        bool m_IsServer;
         /// <summary>
         /// Returns true if NetworkServer.active and server is not stopped.
         /// </summary>
-        public bool isServer => NetworkServer.active && netId != 0;
+        //
+        // IMPORTANT: checking NetworkServer.active means that isServer is false in OnDestroy:
+        //   public bool isServer => NetworkServer.active && netId != 0;
+        // but we need it in OnDestroy, e.g. when saving skillbars on quit. this
+        // works fine if we keep the UNET way of setting isServer manually.
+        // => fixes https://github.com/vis2k/Mirror/issues/1484
+        public bool isServer
+        {
+            get => m_IsServer && netId != 0;
+            internal set => m_IsServer = value;
+        }
 
         /// <summary>
         /// This returns true if this object is the one that represents the player on the local machine.
@@ -500,7 +511,18 @@ namespace Mirror
 
         internal void OnStartServer()
         {
+            // do nothing if already spawned
+            if (m_IsServer)
+            {
+                return;
+            }
+            m_IsServer = true;
+
             // If the instance/net ID is invalid here then this is an object instantiated from a prefab and the server should assign a valid ID
+            // NOTE: this might not be necessary because the above m_IsServer
+            //       check already checks netId. BUT this case here checks only
+            //       netId, so it would still check cases where isServer=false
+            //       but netId!=0.
             if (netId != 0)
             {
                 // This object has already been spawned, this method might be called again
@@ -696,6 +718,7 @@ namespace Mirror
                 {
                     Debug.LogError("Exception in OnNetworkDestroy:" + e.Message + " " + e.StackTrace);
                 }
+                m_IsServer = false;
             }
         }
 
@@ -1202,6 +1225,7 @@ namespace Mirror
 
             clientStarted = false;
             isClient = false;
+            m_IsServer = false;
             reset = false;
 
             netId = 0;

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -1066,6 +1066,10 @@ namespace Mirror.Tests
             Assert.That(go2.activeSelf, Is.False);
 
             // clean up
+            // reset isServer otherwise Destory instead of DestroyImmediate is
+            // called
+            identity.netId = 0;
+            identity2.netId = 0;
             NetworkServer.Shutdown();
             GameObject.DestroyImmediate(go);
             GameObject.DestroyImmediate(go2);

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using Mirror;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class NetworkIdentityTests
+    {
+        GameObject gameObject;
+        NetworkIdentity identity;
+
+        [SetUp]
+        public void SetUp()
+        {
+            gameObject = new GameObject();
+            identity = gameObject.AddComponent<NetworkIdentity>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GameObject.Destroy(gameObject);
+        }
+
+        // prevents https://github.com/vis2k/Mirror/issues/1484
+        [Test]
+        public void OnDestroyIsServerTrue()
+        {
+            // call OnStartServer so that isServer is true
+            identity.OnStartServer();
+            Assert.That(identity.isServer, Is.True);
+
+            // destroy it
+            // note: we need runtime .Destroy instead of edit mode .DestroyImmediate
+            //       because we can't check isServer after DestroyImmediate
+            GameObject.Destroy(gameObject);
+
+            // make sure that isServer is still true so we can save players etc.
+            Assert.That(identity.isServer, Is.EqualTo(true));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs.meta
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef23592667dfe46948980606ccbe1860
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
will test in a few hours