### PR TITLE
feat: Quaternion Compression and tests

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -298,7 +298,6 @@ namespace Mirror
         public static Vector3Int ReadVector3Int(this NetworkReader reader) => new Vector3Int(reader.ReadPackedInt32(), reader.ReadPackedInt32(), reader.ReadPackedInt32());
         public static Color ReadColor(this NetworkReader reader) => new Color(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
         public static Color32 ReadColor32(this NetworkReader reader) => new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
-        public static Quaternion ReadQuaternion(this NetworkReader reader) => new Quaternion(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
         public static Rect ReadRect(this NetworkReader reader) => new Rect(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
         public static Plane ReadPlane(this NetworkReader reader) => new Plane(reader.ReadVector3(), reader.ReadSingle());
         public static Ray ReadRay(this NetworkReader reader) => new Ray(reader.ReadVector3(), reader.ReadVector3());

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -298,6 +298,7 @@ namespace Mirror
         public static Vector3Int ReadVector3Int(this NetworkReader reader) => new Vector3Int(reader.ReadPackedInt32(), reader.ReadPackedInt32(), reader.ReadPackedInt32());
         public static Color ReadColor(this NetworkReader reader) => new Color(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
         public static Color32 ReadColor32(this NetworkReader reader) => new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
+        public static Quaternion ReadQuaternion(this NetworkReader reader) => new Quaternion(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
         public static Rect ReadRect(this NetworkReader reader) => new Rect(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
         public static Plane ReadPlane(this NetworkReader reader) => new Plane(reader.ReadVector3(), reader.ReadSingle());
         public static Ray ReadRay(this NetworkReader reader) => new Ray(reader.ReadVector3(), reader.ReadVector3());

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -356,6 +356,13 @@ namespace Mirror
             writer.WriteByte(value.b);
             writer.WriteByte(value.a);
         }
+        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value)
+        {
+            writer.WriteSingle(value.x);
+            writer.WriteSingle(value.y);
+            writer.WriteSingle(value.z);
+            writer.WriteSingle(value.w);
+        }
 
         public static void WriteRect(this NetworkWriter writer, Rect value)
         {

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -357,14 +357,6 @@ namespace Mirror
             writer.WriteByte(value.a);
         }
 
-        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value)
-        {
-            writer.WriteSingle(value.x);
-            writer.WriteSingle(value.y);
-            writer.WriteSingle(value.z);
-            writer.WriteSingle(value.w);
-        }
-
         public static void WriteRect(this NetworkWriter writer, Rect value)
         {
             writer.WriteSingle(value.xMin);

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -64,7 +64,9 @@ namespace Mirror
         const float MaxValue = 1f / 1.414214f;
         const float ValueRange = MaxValue - MinValue;
 
-       
+        /// <summary>
+        /// Used to Compress Quaternion into [Highest 9 bytes, Medium 4 bytes, Low 3 bytes, NoRotation 0 bytes]
+        /// </summary>
         public static void WriteQuaternion(this NetworkWriter writer, Quaternion value, RotationPrecision precision)
         {
             value = value.normalized;
@@ -87,7 +89,10 @@ namespace Mirror
             }
         }
 
-
+        /// <summary>
+        /// Used to read a Compressed Quaternion [Highest 9 bytes, Medium 4 bytes, Low 3 bytes, NoRotation 0 bytes]
+        /// <para>Quaternion is normalised</para>
+        /// </summary>
         public static Quaternion ReadQuaternion(this NetworkReader reader, RotationPrecision precision)
         {
             if (precision == RotationPrecision.Highest)

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -267,7 +267,7 @@ namespace Mirror
                     c = z;
                     break;
                 default:
-                    throw new System.ArgumentException("LargestIndex did not have value between 0 and 3");
+                    return Vector3.zero;
             }
             // largest needs to be positive to be calculated by reader 
             // if largest is negative flip sign of others
@@ -309,7 +309,7 @@ namespace Mirror
                     w = largest;
                     break;
                 default:
-                    throw new System.ArgumentException("LargestIndex did not have value between 0 and 3");
+                    return Quaternion.identity;
             }
             // 0.999999f is tolerance for Unity's Dot function
             Debug.Assert(x * x + y * y + z * z + w * w < (2 - 0.999999f), "larger than 1");

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -39,7 +39,6 @@ namespace Mirror
         https://gafferongames.com/post/snapshot_compression/
          */
 
-
     public enum RotationPrecision
     {
         /// <summary>
@@ -73,6 +72,7 @@ namespace Mirror
         {
             WriteQuaternion(writer, value, DefaultPrecision);
         }
+
         public static void WriteQuaternion(this NetworkWriter writer, Quaternion value, RotationPrecision precision)
         {
             value = value.normalized;
@@ -95,6 +95,7 @@ namespace Mirror
             }
         }
 
+
         /// <summary>
         /// Writes Quaternion using QuaternionReadWrite.DefaultPrecision
         /// </summary>
@@ -102,6 +103,7 @@ namespace Mirror
         {
             return ReadQuaternion(reader, DefaultPrecision);
         }
+
         public static Quaternion ReadQuaternion(this NetworkReader reader, RotationPrecision precision)
         {
             if (precision == RotationPrecision.Highest)
@@ -121,6 +123,7 @@ namespace Mirror
                 return Quaternion.identity;
             }
         }
+
 
         static void WriteQuaternionFull(NetworkWriter writer, int largestIndex, Vector3 small)
         {
@@ -146,6 +149,7 @@ namespace Mirror
             writer.WriteByte((byte)(c >> 8));
             writer.WriteByte((byte)(c >> 16));
         }
+
         static Quaternion ReadQuaternionFull(NetworkReader reader)
         {
             Quaternion result;
@@ -182,6 +186,7 @@ namespace Mirror
             return result;
         }
 
+
         static void WriteQuaternionHalf(NetworkWriter writer, int largestIndex, Vector3 small)
         {
             const int bitLength = 10;
@@ -206,6 +211,7 @@ namespace Mirror
             writer.WriteByte((byte)c1);
             writer.WriteByte((byte)extra);
         }
+
         static Quaternion ReadQuaternionHalf(NetworkReader reader)
         {
             Quaternion result;
@@ -237,6 +243,7 @@ namespace Mirror
             return result;
         }
 
+
         static void WriteQuaternionLow(NetworkWriter writer, int largestIndex, Vector3 small)
         {
             const int bitLength = 7;
@@ -258,6 +265,7 @@ namespace Mirror
             writer.WriteByte((byte)b1);
             writer.WriteByte((byte)c1);
         }
+
         static Quaternion ReadQuaternionLow(NetworkReader reader)
         {
             Quaternion result;
@@ -285,6 +293,8 @@ namespace Mirror
             result = FromSmallerDimensions(largestIndex, small);
             return result;
         }
+
+
         internal static int FindLargestIndex(Quaternion q)
         {
             int index = 0;
@@ -303,6 +313,7 @@ namespace Mirror
             return index;
         }
 
+        
         static Vector3 GetSmallerDimensions(int largestIndex, Quaternion value)
         {
             float x = value.x;
@@ -341,6 +352,7 @@ namespace Mirror
             float largestSign = Mathf.Sign(value[largestIndex]);
             return new Vector3(a, b, c) * largestSign;
         }
+
         static Quaternion FromSmallerDimensions(uint largestIndex, Vector3 smallest)
         {
             float a = smallest.x;
@@ -397,6 +409,7 @@ namespace Mirror
 
             return (uint)outValue;
         }
+
         static float ScaleFromUInt(uint source, int sourceBitLength)
         {
             // same as Mathf.Pow(2, targetBitLength) - 1

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -64,11 +64,7 @@ namespace Mirror
         }
         public static void WriteQuaternion(this NetworkWriter writer, Quaternion value, RotationPrecision precision)
         {
-            // use Equals because Quaternion overrides ==
-            if (Equals(value, default(Quaternion)))
-            {
-                throw new System.ArgumentException("Quaternion must be normalized, Use 'Quaternion.identity' instead of 'default'");
-            }
+            value = value.normalized;
 
             int largestIndex = findLargestIndex(value);
             Vector3 small = getSmallerDimensions(largestIndex, value);

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -66,8 +66,8 @@ namespace Mirror
         {
             value = value.normalized;
 
-            int largestIndex = findLargestIndex(value);
-            Vector3 small = getSmallerDimensions(largestIndex, value);
+            int largestIndex = FindLargestIndex(value);
+            Vector3 small = GetSmallerDimensions(largestIndex, value);
 
 
             if (precision == RotationPrecision.Full)
@@ -107,9 +107,9 @@ namespace Mirror
         {
             // 22 bits
             int bitLength = 22;
-            uint a = scaleToUInt(small.x, bitLength);
-            uint b = scaleToUInt(small.y, bitLength);
-            uint c = scaleToUInt(small.z, bitLength);
+            uint a = ScaleToUInt(small.x, bitLength);
+            uint b = ScaleToUInt(small.y, bitLength);
+            uint c = ScaleToUInt(small.z, bitLength);
 
             // pack largestIndex info a
             a |= ((uint)largestIndex) << 22;
@@ -151,9 +151,9 @@ namespace Mirror
 
             const int bitLength = 22;
 
-            float x = scaleFromUInt(a, bitLength);
-            float y = scaleFromUInt(b, bitLength);
-            float z = scaleFromUInt(c, bitLength);
+            float x = ScaleFromUInt(a, bitLength);
+            float y = ScaleFromUInt(b, bitLength);
+            float z = ScaleFromUInt(c, bitLength);
 
             Vector3 small = new Vector3(x, y, z);
             result = FromSmallerDimensions(largestIndex, small);
@@ -164,9 +164,9 @@ namespace Mirror
         {
             // 22 bits
             int bitLength = 9;
-            uint a = scaleToUInt(small.x, bitLength);
-            uint b = scaleToUInt(small.y, bitLength);
-            uint c = scaleToUInt(small.z, bitLength);
+            uint a = ScaleToUInt(small.x, bitLength);
+            uint b = ScaleToUInt(small.y, bitLength);
+            uint c = ScaleToUInt(small.z, bitLength);
 
             // split abc into 8+1 bits, pack extra 1 bit with largestIndex
             uint a1 = byte.MaxValue & a;
@@ -207,9 +207,9 @@ namespace Mirror
 
             const int bitLength = 9;
 
-            float x = scaleFromUInt(a, bitLength);
-            float y = scaleFromUInt(b, bitLength);
-            float z = scaleFromUInt(c, bitLength);
+            float x = ScaleFromUInt(a, bitLength);
+            float y = ScaleFromUInt(b, bitLength);
+            float z = ScaleFromUInt(c, bitLength);
 
             Vector3 small = new Vector3(x, y, z);
             result = FromSmallerDimensions(largestIndex, small);
@@ -217,7 +217,7 @@ namespace Mirror
         }
 
 
-        internal static int findLargestIndex(Quaternion q)
+        internal static int FindLargestIndex(Quaternion q)
         {
             int index = 0;
             float current = Mathf.Abs(q.x);
@@ -236,7 +236,7 @@ namespace Mirror
         }
 
 
-        static Vector3 getSmallerDimensions(int largestIndex, Quaternion value)
+        static Vector3 GetSmallerDimensions(int largestIndex, Quaternion value)
         {
             float x = value.x;
             float y = value.y;
@@ -317,7 +317,7 @@ namespace Mirror
         }
 
 
-        static uint scaleToUInt(float value, int targetBitLength)
+        static uint ScaleToUInt(float value, int targetBitLength)
         {
             // same as Mathf.Pow(2, targetBitLength) - 1
             int targetRange = (1 << targetBitLength) - 1;
@@ -330,7 +330,7 @@ namespace Mirror
 
             return (uint)outValue;
         }
-        static float scaleFromUInt(uint source, int sourceBitLength)
+        static float ScaleFromUInt(uint source, int sourceBitLength)
         {
             // same as Mathf.Pow(2, targetBitLength) - 1
             int sourceRange = (1 << sourceBitLength) - 1;

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -36,13 +36,13 @@ namespace Mirror
     public enum RotationPrecision
     {
         /// <summary>
-        /// Send 9 bytes, smallest rotation 0.000000334
+        /// Send 9 bytes, smallest rotation 0.000000169 in range [-1,+1]
         /// </summary>
-        Full,
+        Highest,
         /// <summary>
-        /// Send 4 bytes, smallest rotation 0.00276
+        /// Send 4 bytes, smallest rotation 0.00138 in range [-1,+1]
         /// </summary>
-        Half,
+        Medium,
         /// <summary>
         /// Dont send rotation
         /// </summary>
@@ -50,7 +50,7 @@ namespace Mirror
     };
     public static class QuaternionReadWrite
     {
-        public static RotationPrecision DefaultPrecision => RotationPrecision.Half;
+        public static RotationPrecision DefaultPrecision => RotationPrecision.Medium;
         const float MinValue = -1f / 1.414214f; // 1/ sqrt(2)
         const float MaxValue = 1f / 1.414214f;
         const float ValueRange = MaxValue - MinValue;
@@ -70,11 +70,11 @@ namespace Mirror
             Vector3 small = GetSmallerDimensions(largestIndex, value);
 
 
-            if (precision == RotationPrecision.Full)
+            if (precision == RotationPrecision.Highest)
             {
                 WriteQuaternionFull(writer, largestIndex, small);
             }
-            else if (precision == RotationPrecision.Half)
+            else if (precision == RotationPrecision.Medium)
             {
                 WriteQuaternionHalf(writer, largestIndex, small);
             }
@@ -89,11 +89,11 @@ namespace Mirror
         }
         public static Quaternion ReadQuaternion(this NetworkReader reader, RotationPrecision precision)
         {
-            if (precision == RotationPrecision.Full)
+            if (precision == RotationPrecision.Highest)
             {
                 return ReadQuaternionFull(reader);
             }
-            else if (precision == RotationPrecision.Half)
+            else if (precision == RotationPrecision.Medium)
             {
                 return ReadQuaternionHalf(reader);
             }

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -1,0 +1,348 @@
+using UnityEngine;
+
+namespace Mirror
+{
+
+    /*
+        uncompressed Quaternion = 32 * 4 = 128 bits => send 16 bytes
+
+        Quaternion Always normalized
+        x^2 + y^2 + z^2 + w^2 = 1
+        can drop largest value and re-calculate it
+        encode which is largest using 2 bits
+
+        2nd largest value has max size of 1/sqrt(2)
+        c^2 + c^2 + 0 + 0 = 1
+        can encode the smallest three components in [-0.707107,+0.707107] instead of [-1,+1]
+
+
+        Sign of largest value doesnt matter
+        Q * vec3 == (-Q) * vec3
+
+
+        With no precision loss 
+
+        22 bits per value (32 * 0.707)
+        2 + 22 * 3 = 70 bits => send 9 bytes
+
+        9 bits per value
+        2 + 9 * 3 = 29 bits => send 4 bytes
+
+        Links for more info
+        https://youtu.be/Z9X4lysFr64
+        https://gafferongames.com/post/snapshot_compression/
+         */
+
+    public enum RotationPrecision
+    {
+        /// <summary>
+        /// Send 9 bytes, smallest rotation 0.000000334
+        /// </summary>
+        Full,
+        /// <summary>
+        /// Send 4 bytes, smallest rotation 0.00276
+        /// </summary>
+        Half,
+        /// <summary>
+        /// Dont send rotation
+        /// </summary>
+        NoRotation,
+    };
+    public static class QuaternionReadWrite
+    {
+        public static RotationPrecision DefaultPrecision => RotationPrecision.Half;
+        const float MinValue = -1f / 1.414214f; // 1/ sqrt(2)
+        const float MaxValue = 1f / 1.414214f;
+        const float ValueRange = MaxValue - MinValue;
+
+        /// <summary>
+        /// Writes Quaternion using QuaternionReadWrite.DefaultPrecision
+        /// </summary>
+        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value)
+        {
+            WriteQuaternion(writer, value, DefaultPrecision);
+        }
+        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value, RotationPrecision precision)
+        {
+            // use Equals because Quaternion overrides ==
+            if (Equals(value, default(Quaternion)))
+            {
+                throw new System.ArgumentException("Quaternion must be normalized, Use 'Quaternion.identity' instead of 'default'");
+            }
+
+            int largestIndex = findLargestIndex(value);
+            Vector3 small = getSmallerDimensions(largestIndex, value);
+
+
+            if (precision == RotationPrecision.Full)
+            {
+                WriteQuaternionFull(writer, largestIndex, small);
+            }
+            else if (precision == RotationPrecision.Half)
+            {
+                WriteQuaternionHalf(writer, largestIndex, small);
+            }
+        }
+
+        /// <summary>
+        /// Writes Quaternion using QuaternionReadWrite.DefaultPrecision
+        /// </summary>
+        public static Quaternion ReadQuaternion(this NetworkReader reader)
+        {
+            return ReadQuaternion(reader, DefaultPrecision);
+        }
+        public static Quaternion ReadQuaternion(this NetworkReader reader, RotationPrecision precision)
+        {
+            if (precision == RotationPrecision.Full)
+            {
+                return ReadQuaternionFull(reader);
+            }
+            else if (precision == RotationPrecision.Half)
+            {
+                return ReadQuaternionHalf(reader);
+            }
+            else
+            {
+                return Quaternion.identity;
+            }
+        }
+
+        static void WriteQuaternionFull(NetworkWriter writer, int largestIndex, Vector3 small)
+        {
+            // 22 bits
+            int bitLength = 22;
+            uint a = scaleToUInt(small.x, bitLength);
+            uint b = scaleToUInt(small.y, bitLength);
+            uint c = scaleToUInt(small.z, bitLength);
+
+            // pack largestIndex info a
+            a |= ((uint)largestIndex) << 22;
+
+            writer.WriteByte((byte)a);
+            writer.WriteByte((byte)(a >> 8));
+            writer.WriteByte((byte)(a >> 16));
+
+            writer.WriteByte((byte)b);
+            writer.WriteByte((byte)(b >> 8));
+            writer.WriteByte((byte)(b >> 16));
+
+            writer.WriteByte((byte)c);
+            writer.WriteByte((byte)(c >> 8));
+            writer.WriteByte((byte)(c >> 16));
+        }
+        static Quaternion ReadQuaternionFull(NetworkReader reader)
+        {
+            Quaternion result;
+            uint a1 = reader.ReadByte();
+            uint a2 = reader.ReadByte();
+            uint a3 = reader.ReadByte();
+
+            uint b1 = reader.ReadByte();
+            uint b2 = reader.ReadByte();
+            uint b3 = reader.ReadByte();
+
+            uint c1 = reader.ReadByte();
+            uint c2 = reader.ReadByte();
+            uint c3 = reader.ReadByte();
+
+            uint a = a1 | (a2 << 8) | (a3 << 16);
+            uint b = b1 | (b2 << 8) | (b3 << 16);
+            uint c = c1 | (c2 << 8) | (c3 << 16);
+
+            uint largestIndex = a >> 22;
+            // removes largestIndex from a 
+            a &= ~(3u << 22);
+
+            const int bitLength = 22;
+
+            float x = scaleFromUInt(a, bitLength);
+            float y = scaleFromUInt(b, bitLength);
+            float z = scaleFromUInt(c, bitLength);
+
+            Vector3 small = new Vector3(x, y, z);
+            result = FromSmallerDimensions(largestIndex, small);
+            return result;
+        }
+
+        static void WriteQuaternionHalf(NetworkWriter writer, int largestIndex, Vector3 small)
+        {
+            // 22 bits
+            int bitLength = 9;
+            uint a = scaleToUInt(small.x, bitLength);
+            uint b = scaleToUInt(small.y, bitLength);
+            uint c = scaleToUInt(small.z, bitLength);
+
+            // split abc into 8+1 bits, pack extra 1 bit with largestIndex
+            uint a1 = byte.MaxValue & a;
+            uint a2 = byte.MaxValue & (a >> 8);
+
+            uint b1 = byte.MaxValue & b;
+            uint b2 = byte.MaxValue & (b >> 8);
+
+            uint c1 = byte.MaxValue & c;
+            uint c2 = byte.MaxValue & (c >> 8);
+
+            uint extra = ((uint)largestIndex) + (a2 << 2) + (b2 << 3) + (c2 << 4);
+
+            writer.WriteByte((byte)a1);
+            writer.WriteByte((byte)b1);
+            writer.WriteByte((byte)c1);
+            writer.WriteByte((byte)extra);
+        }
+        static Quaternion ReadQuaternionHalf(NetworkReader reader)
+        {
+            Quaternion result;
+            uint a1 = reader.ReadByte();
+            uint b1 = reader.ReadByte();
+            uint c1 = reader.ReadByte();
+            byte extra = reader.ReadByte();
+
+            // first 2 bytes
+            uint largestIndex = (uint)(extra & 3);
+
+            // get nth bit, then move to start
+            uint a2 = (uint)((extra & (1 << 2)) >> 2);
+            uint b2 = (uint)((extra & (1 << 3)) >> 3);
+            uint c2 = (uint)((extra & (1 << 4)) >> 4);
+
+            uint a = a1 | (a2 << 8);
+            uint b = b1 | (b2 << 8);
+            uint c = c1 | (c2 << 8);
+
+            const int bitLength = 9;
+
+            float x = scaleFromUInt(a, bitLength);
+            float y = scaleFromUInt(b, bitLength);
+            float z = scaleFromUInt(c, bitLength);
+
+            Vector3 small = new Vector3(x, y, z);
+            result = FromSmallerDimensions(largestIndex, small);
+            return result;
+        }
+
+
+        internal static int findLargestIndex(Quaternion q)
+        {
+            int index = 0;
+            float current = Mathf.Abs(q.x);
+
+            for (int i = 1; i < 4; i++)
+            {
+                float next = Mathf.Abs(q[i]);
+                if (next > current)
+                {
+                    index = i;
+                    current = next;
+                }
+            }
+
+            return index;
+        }
+
+
+        static Vector3 getSmallerDimensions(int largestIndex, Quaternion value)
+        {
+            float x = value.x;
+            float y = value.y;
+            float z = value.z;
+            float w = value.w;
+
+            float a, b, c;
+            switch (largestIndex)
+            {
+                case 0:
+                    a = y;
+                    b = z;
+                    c = w;
+                    break;
+                case 1:
+                    a = x;
+                    b = z;
+                    c = w;
+                    break;
+                case 2:
+                    a = x;
+                    b = y;
+                    c = w;
+                    break;
+                case 3:
+                    a = x;
+                    b = y;
+                    c = z;
+                    break;
+                default:
+                    throw new System.ArgumentException("LargestIndex did not have value between 0 and 3");
+            }
+            // largest needs to be positive to be calculated by reader 
+            // if largest is negative flip sign of others
+            float largestSign = Mathf.Sign(value[largestIndex]);
+            return new Vector3(a, b, c) * largestSign;
+        }
+        static Quaternion FromSmallerDimensions(uint largestIndex, Vector3 smallest)
+        {
+            float a = smallest.x;
+            float b = smallest.y;
+            float c = smallest.z;
+
+            float x, y, z, w;
+            float largest = Mathf.Sqrt(1 - a * a - b * b - c * c);
+            switch (largestIndex)
+            {
+                case 0:
+                    x = largest;
+                    y = a;
+                    z = b;
+                    w = c;
+                    break;
+                case 1:
+                    x = a;
+                    y = largest;
+                    z = b;
+                    w = c;
+                    break;
+                case 2:
+                    x = a;
+                    y = b;
+                    z = largest;
+                    w = c;
+                    break;
+                case 3:
+                    x = a;
+                    y = b;
+                    z = c;
+                    w = largest;
+                    break;
+                default:
+                    throw new System.ArgumentException("LargestIndex did not have value between 0 and 3");
+            }
+            // 0.999999f is tolerance for Unity's Dot function
+            Debug.Assert(x * x + y * y + z * z + w * w < (2 - 0.999999f), "larger than 1");
+            return new Quaternion(x, y, z, w).normalized;
+        }
+
+
+        static uint scaleToUInt(float value, int targetBitLength)
+        {
+            // same as Mathf.Pow(2, targetBitLength) - 1
+            int targetRange = (1 << targetBitLength) - 1;
+
+            if (value > MaxValue) { return (uint)targetRange; }
+            if (value < MinValue) { return 0; }
+
+            float valueRetive = (value - MinValue) / ValueRange;
+            float outValue = valueRetive * targetRange;
+
+            return (uint)outValue;
+        }
+        static float scaleFromUInt(uint source, int sourceBitLength)
+        {
+            // same as Mathf.Pow(2, targetBitLength) - 1
+            int sourceRange = (1 << sourceBitLength) - 1;
+
+
+            float valueRetive = ((float)source) / sourceRange;
+            float value = valueRetive * ValueRange + MinValue;
+            return value;
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -60,19 +60,11 @@ namespace Mirror
     };
     public static class QuaternionReadWrite
     {
-        public static RotationPrecision DefaultPrecision => RotationPrecision.Medium;
         const float MinValue = -1f / 1.414214f; // 1/ sqrt(2)
         const float MaxValue = 1f / 1.414214f;
         const float ValueRange = MaxValue - MinValue;
 
-        /// <summary>
-        /// Writes Quaternion using QuaternionReadWrite.DefaultPrecision
-        /// </summary>
-        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value)
-        {
-            WriteQuaternion(writer, value, DefaultPrecision);
-        }
-
+       
         public static void WriteQuaternion(this NetworkWriter writer, Quaternion value, RotationPrecision precision)
         {
             value = value.normalized;
@@ -95,14 +87,6 @@ namespace Mirror
             }
         }
 
-
-        /// <summary>
-        /// Writes Quaternion using QuaternionReadWrite.DefaultPrecision
-        /// </summary>
-        public static Quaternion ReadQuaternion(this NetworkReader reader)
-        {
-            return ReadQuaternion(reader, DefaultPrecision);
-        }
 
         public static Quaternion ReadQuaternion(this NetworkReader reader, RotationPrecision precision)
         {

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs
@@ -20,18 +20,25 @@ namespace Mirror
         Q * vec3 == (-Q) * vec3
 
 
-        With no precision loss 
+        smallest rotation = 2/sqrt(2) / (2^bitCount - 1)
 
-        22 bits per value (32 * 0.707)
-        2 + 22 * 3 = 70 bits => send 9 bytes
+        23 bits per value (32 * 0.707)
+        2 + 23 * 3 = 71 bits => send 9 bytes
+        smallest rotation +-0.000000169 in range [-1,+1]
 
-        9 bits per value
-        2 + 9 * 3 = 29 bits => send 4 bytes
+        10 bits per value
+        2 + 10 * 3 = 32 bits => send 4 bytes
+        smallest rotation +-0.00138 in range [-1,+1]
+
+        7 bits per value
+        2 + 7 * 3 = 23 bits => send 3 bytes
+        smallest rotation +-0.0110 in range [-1,+1]
 
         Links for more info
         https://youtu.be/Z9X4lysFr64
         https://gafferongames.com/post/snapshot_compression/
          */
+
 
     public enum RotationPrecision
     {

--- a/Assets/Mirror/Runtime/QuaternionReadWrite.cs.meta
+++ b/Assets/Mirror/Runtime/QuaternionReadWrite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6c7ce55f95325547919283b4052b2e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -416,24 +416,6 @@ namespace Mirror.Tests
             }
         }
 
-        [Test]
-        public void TestQuaternion()
-        {
-            Quaternion[] inputs = {
-                Quaternion.identity,
-                default,
-                Quaternion.LookRotation(new Vector3(0.3f,0.4f,0.5f)),
-                Quaternion.Euler(45f,56f,Mathf.PI)
-            };
-            foreach (Quaternion input in inputs)
-            {
-                NetworkWriter writer = new NetworkWriter();
-                writer.WriteQuaternion(input);
-                NetworkReader reader = new NetworkReader(writer.ToArray());
-                Quaternion output = reader.ReadQuaternion();
-                Assert.That(output, Is.EqualTo(input));
-            }
-        }
 
         [Test]
         public void TestRect()

--- a/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
+++ b/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
@@ -105,8 +105,8 @@ namespace Mirror.Tests
             object[] cases = new object[count * 2];
             for (int i = 0; i < count; i++)
             {
-                cases[i] = new object[] { list[i], RotationPrecision.Full, FullPercision };
-                cases[i + count] = new object[] { list[i], RotationPrecision.Half, HalfPercision };
+                cases[i] = new object[] { list[i], RotationPrecision.Highest, FullPercision };
+                cases[i + count] = new object[] { list[i], RotationPrecision.Medium, HalfPercision };
             }
 
 
@@ -118,7 +118,7 @@ namespace Mirror.Tests
         public void WriteQuaternionCorrectLengthForFull()
         {
             NetworkWriter writer = new NetworkWriter();
-            writer.WriteQuaternion(Quaternion.identity, RotationPrecision.Full);
+            writer.WriteQuaternion(Quaternion.identity, RotationPrecision.Highest);
 
             Assert.That(writer.ToArray().Length, Is.EqualTo(9));
         }
@@ -126,7 +126,7 @@ namespace Mirror.Tests
         public void WriteQuaternionCorrectLengthForHalf()
         {
             NetworkWriter writer = new NetworkWriter();
-            writer.WriteQuaternion(Quaternion.identity, RotationPrecision.Half);
+            writer.WriteQuaternion(Quaternion.identity, RotationPrecision.Medium);
 
             Assert.That(writer.ToArray().Length, Is.EqualTo(4));
         }

--- a/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
+++ b/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
@@ -43,7 +43,7 @@ namespace Mirror.Tests
 
         internal static void AssertPrecision(Quaternion inRot, Quaternion outRot, float percision)
         {
-            int largest = QuaternionReadWrite.findLargestIndex(inRot);
+            int largest = QuaternionReadWrite.FindLargestIndex(inRot);
             float sign = Mathf.Sign(inRot[largest]);
             // flip sign of A if largest is is negative
             // Q == (-Q)
@@ -143,7 +143,7 @@ namespace Mirror.Tests
         [TestCaseSource(nameof(GetLargestIndeTestCases))]
         public void findLargestIndexWork(Quaternion quaternion, int expected)
         {
-            int largest = QuaternionReadWrite.findLargestIndex(quaternion);
+            int largest = QuaternionReadWrite.FindLargestIndex(quaternion);
 
             Assert.That(largest, Is.EqualTo(expected));
         }

--- a/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
+++ b/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
@@ -140,19 +140,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void QuaternionCompressShouldNotAcceptDefault()
-        {
-            NetworkWriter writer = new NetworkWriter();
-
-            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
-            {
-                writer.WriteQuaternion(default, RotationPrecision.Full);
-            });
-
-            Assert.That(exception.Message, Is.EqualTo("Quaternion must be normalized, Use 'Quaternion.identity' instead of 'default'"));
-        }
-
-        [Test]
         [TestCaseSource(nameof(GetLargestIndeTestCases))]
         public void findLargestIndexWork(Quaternion quaternion, int expected)
         {

--- a/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
+++ b/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
@@ -7,13 +6,30 @@ namespace Mirror.Tests
 {
     public class QuaternionReadWriteTest
     {
-        internal const float FullPercision = 0.000000334f;
-        internal const float HalfPercision = 0.00276f;
+        internal const float HighestPercision = 0.000000169f;
+        internal const float MediumPercision = 0.00138f;
         internal const float LowPercision = 0.0110f;
 
         [Test]
         [TestCaseSource(nameof(GetTestCases))]
-        public void QuaternionCompressWithinPrecision(Quaternion rotationIn, RotationPrecision precision, float allowedPercision)
+        public void QuaternionCompressAtFullPrecision(Quaternion rotationIn)
+        {
+            QuaternionCompressWithinPrecision(rotationIn, RotationPrecision.Highest, HighestPercision);
+        }
+        [Test]
+        [TestCaseSource(nameof(GetTestCases))]
+        public void QuaternionCompressAtHalfPrecision(Quaternion rotationIn)
+        {
+            QuaternionCompressWithinPrecision(rotationIn, RotationPrecision.Medium, MediumPercision);
+        }
+        [Test]
+        [TestCaseSource(nameof(GetTestCases))]
+        public void QuaternionCompressAtLowPrecision(Quaternion rotationIn)
+        {
+            QuaternionCompressWithinPrecision(rotationIn, RotationPrecision.Low, LowPercision);
+        }
+
+        static void QuaternionCompressWithinPrecision(Quaternion rotationIn, RotationPrecision precision, float allowedPercision)
         {
             NetworkWriter writer = new NetworkWriter();
             writer.WriteQuaternion(rotationIn, precision);
@@ -49,10 +65,10 @@ namespace Mirror.Tests
             // flip sign of A if largest is is negative
             // Q == (-Q)
 
-            Assert.AreEqual(sign * inRot.x, outRot.x, percision);
-            Assert.AreEqual(sign * inRot.y, outRot.y, percision);
-            Assert.AreEqual(sign * inRot.z, outRot.z, percision);
-            Assert.AreEqual(sign * inRot.w, outRot.w, percision);
+            Assert.AreEqual(sign * inRot.x, outRot.x, percision, $"x off by {Mathf.Abs(sign * inRot.x - outRot.x)}");
+            Assert.AreEqual(sign * inRot.y, outRot.y, percision, $"y off by {Mathf.Abs(sign * inRot.y - outRot.y)}");
+            Assert.AreEqual(sign * inRot.z, outRot.z, percision, $"z off by {Mathf.Abs(sign * inRot.z - outRot.z)}");
+            Assert.AreEqual(sign * inRot.w, outRot.w, percision, $"w off by {Mathf.Abs(sign * inRot.w - outRot.w)}");
         }
 
         static object[] GetTestCases()
@@ -103,14 +119,11 @@ namespace Mirror.Tests
             };
 
             int count = list.Count;
-            object[] cases = new object[count * 3];
+            object[] cases = new object[count];
             for (int i = 0; i < count; i++)
             {
-                cases[i] = new object[] { list[i], RotationPrecision.Highest, FullPercision };
-                cases[i + count] = new object[] { list[i], RotationPrecision.Medium, HalfPercision };
-                cases[i + count*2] = new object[] { list[i], RotationPrecision.Low, HalfPercision };
+                cases[i] = new object[] { list[i] };
             }
-
 
             return cases;
         }

--- a/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
+++ b/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
@@ -9,6 +9,7 @@ namespace Mirror.Tests
     {
         internal const float FullPercision = 0.000000334f;
         internal const float HalfPercision = 0.00276f;
+        internal const float LowPercision = 0.0110f;
 
         [Test]
         [TestCaseSource(nameof(GetTestCases))]
@@ -102,11 +103,12 @@ namespace Mirror.Tests
             };
 
             int count = list.Count;
-            object[] cases = new object[count * 2];
+            object[] cases = new object[count * 3];
             for (int i = 0; i < count; i++)
             {
                 cases[i] = new object[] { list[i], RotationPrecision.Highest, FullPercision };
                 cases[i + count] = new object[] { list[i], RotationPrecision.Medium, HalfPercision };
+                cases[i + count*2] = new object[] { list[i], RotationPrecision.Low, HalfPercision };
             }
 
 

--- a/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
+++ b/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
@@ -159,14 +159,14 @@ namespace Mirror.Tests
         }
 
         [Test]
-        [TestCaseSource(nameof(GetLargestIndeTestCases))]
-        public void findLargestIndexWork(Quaternion quaternion, int expected)
+        [TestCaseSource(nameof(GetLargestIndexTestCases))]
+        public void FindLargestIndexWork(Quaternion quaternion, int expected)
         {
             int largest = QuaternionReadWrite.FindLargestIndex(quaternion);
 
             Assert.That(largest, Is.EqualTo(expected));
         }
-        static object[] GetLargestIndeTestCases()
+        static object[] GetLargestIndexTestCases()
         {
             return new object[]
             {

--- a/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
+++ b/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs
@@ -6,9 +6,13 @@ namespace Mirror.Tests
 {
     public class QuaternionReadWriteTest
     {
-        internal const float HighestPercision = 0.000000169f;
+        // worse case where xyzw all equal error in largest is ~1.732 times greater than error in smallest 3
+        // High/Low Percision fails when xyzw all equal,
+        // *1.8f is enough to allow extra error in largest,
+        internal const float HighestPercision = 0.000000169f * 1.8f;
         internal const float MediumPercision = 0.00138f;
-        internal const float LowPercision = 0.0110f;
+        // *1.2f is enough to allow extra error in largest
+        internal const float LowPercision = 0.0110f * 1.2f; 
 
         [Test]
         [TestCaseSource(nameof(GetTestCases))]

--- a/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/QuaternionReadWriteTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25f2db0af9b69e04da757aaa4bc41740
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Maths for Quaternion Compression 

Uncompressed Quaternion = 32 * 4 = 128 bits => send 16 bytes

Quaternion Always normalized
`x^2 + y^2 + z^2 + w^2 = 1`

Can drop largest value and re-calculate it
Encode which is largest using 2 bits

2nd largest value has max size of 1/sqrt(2)
`c^2 + c^2 + 0 + 0 = 1`
Can encode the smallest three components in [-0.707,+0.707] instead of [-1,+1]

Sign of largest value doesn't matter
`Q * vec3 == (-Q) * vec3`

With almost no precision loss 
22 bits per value (32 * 0.707)
2 + 22 * 3 = 70 bits => send 9 bytes

With acceptable precision loss 
9 bits per value
2 + 9 * 3 = 29 bits => send 4 bytes


Links for more info
https://youtu.be/Z9X4lysFr64
https://gafferongames.com/post/snapshot_compression/