### PR TITLE
NetworkIdentity.isServer simplified via one flag instead of helper variable + netId check. When isServer is set in OnStartServer, netId is set to != 0 in any case, so the previous check was unnecessary.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -65,7 +65,6 @@ namespace Mirror
         // => fixes https://github.com/vis2k/Mirror/issues/1475
         public bool isClient { get; internal set; }
 
-        bool m_IsServer;
         /// <summary>
         /// Returns true if NetworkServer.active and server is not stopped.
         /// </summary>
@@ -75,11 +74,7 @@ namespace Mirror
         // but we need it in OnDestroy, e.g. when saving players on quit. this
         // works fine if we keep the UNET way of setting isServer manually.
         // => fixes https://github.com/vis2k/Mirror/issues/1484
-        public bool isServer
-        {
-            get => m_IsServer && netId != 0;
-            internal set => m_IsServer = value;
-        }
+        public bool isServer { get; internal set; }
 
         /// <summary>
         /// This returns true if this object is the one that represents the player on the local machine.
@@ -512,11 +507,14 @@ namespace Mirror
         internal void OnStartServer()
         {
             // do nothing if already spawned
-            if (m_IsServer)
-            {
+            if (isServer)
                 return;
-            }
-            m_IsServer = true;
+
+            // set isServer flag.
+            // note that UNET previously had a netId != 0 check for isServer to
+            // be true. but if we get here, then netId will be set to != 0 no
+            // matter what. so the check is not necessary, this is fine.
+            isServer = true;
 
             // If the instance/net ID is invalid here then this is an object instantiated from a prefab and the server should assign a valid ID
             // NOTE: this might not be necessary because the above m_IsServer
@@ -718,7 +716,7 @@ namespace Mirror
                 {
                     Debug.LogError("Exception in OnNetworkDestroy:" + e.Message + " " + e.StackTrace);
                 }
-                m_IsServer = false;
+                isServer = false;
             }
         }
 
@@ -1225,7 +1223,7 @@ namespace Mirror
 
             clientStarted = false;
             isClient = false;
-            m_IsServer = false;
+            isServer = false;
             reset = false;
 
             netId = 0;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -510,10 +510,7 @@ namespace Mirror
             if (isServer)
                 return;
 
-            // set isServer flag.
-            // note that UNET previously had a netId != 0 check for isServer to
-            // be true. but if we get here, then netId will be set to != 0 no
-            // matter what. so the check is not necessary, this is fine.
+            // set isServer flag
             isServer = true;
 
             // If the instance/net ID is invalid here then this is an object instantiated from a prefab and the server should assign a valid ID

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -235,10 +235,9 @@ namespace Mirror.Tests
         [TearDown]
         public void TearDown()
         {
-            // reset netId so that isServer is false. otherwise Destroy instead
-            // of DestroyImmediate is called internally, giving an error in
-            // Editor tests
-            identity.netId = 0;
+            // set isServer is false. otherwise Destroy instead of
+            // DestroyImmediate is called internally, giving an error in Editor
+            identity.isServer = false;
             GameObject.DestroyImmediate(gameObject);
             NetworkServer.RemoveLocalConnection();
         }

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -488,8 +488,6 @@ namespace Mirror.Tests
             identity.OnStartServer();
             identity.observers[connectionToServer.connectionToClient.connectionId] = connectionToServer.connectionToClient;
 
-            identity.netId = 42;
-
             // isServer needs to be true, otherwise we can't call rpcs
             Assert.That(comp.isServer, Is.True);
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -642,7 +642,7 @@ namespace Mirror.Tests
 
             // removing authority while not isServer shouldn't work.
             // only allow it on server.
-            identity.netId = 0;
+            identity.isServer = false;
 
             // error log is expected
             LogAssert.ignoreFailingMessages = true;
@@ -652,7 +652,7 @@ namespace Mirror.Tests
             Assert.That(callbackCalled, Is.EqualTo(1));
 
             // enable isServer again
-            identity.netId = 42;
+            identity.isServer = true;
 
             // removing authority for the main player object shouldn't work
             // set connection's player object

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -305,10 +305,9 @@ namespace Mirror.Tests
         [TearDown]
         public void TearDown()
         {
-            // reset netId so that isServer is false. otherwise Destroy instead
-            // of DestroyImmediate is called internally, giving an error in
-            // Editor tests
-            identity.netId = 0;
+            // set isServer is false. otherwise Destroy instead of
+            // DestroyImmediate is called internally, giving an error in Editor
+            identity.isServer = false;
             GameObject.DestroyImmediate(gameObject);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -1066,10 +1066,10 @@ namespace Mirror.Tests
             Assert.That(go2.activeSelf, Is.False);
 
             // clean up
-            // reset isServer otherwise Destory instead of DestroyImmediate is
+            // reset isServer otherwise Destroy instead of DestroyImmediate is
             // called
-            identity.netId = 0;
-            identity2.netId = 0;
+            identity.isServer = false;
+            identity2.isServer = false;
             NetworkServer.Shutdown();
             GameObject.DestroyImmediate(go);
             GameObject.DestroyImmediate(go2);


### PR DESCRIPTION
WIP