### PR TITLE
NetworkManager.StopHost stops client, then server. Seems more consistent this way.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -556,8 +556,8 @@ namespace Mirror
             // fixes: https://github.com/vis2k/Mirror/issues/1515
             NetworkClient.DisconnectLocalServer();
 
-            StopServer();
             StopClient();
+            StopServer();
         }
 
         /// <summary>


### PR DESCRIPTION
We definitely should stop client first, then stop server.
There is a risk that we silently break something somewhere though.

Tests all pass so far.