### PR TITLE
test for #1499 OnClientDisconnect is never fired

### DIFF
--- a/Assets/Mirror/Tests/Editor/NetworkManagerStopClientOnClientDisconnectTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerStopClientOnClientDisconnectTest.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+
+namespace Mirror.Tests
+{
+    class NetworkManagerOnClientDisconnect : NetworkManager
+    {
+        public int called;
+        public override void OnClientDisconnect(NetworkConnection conn) { ++called; }
+    }
+
+    [TestFixture]
+    public class NetworkManagerStopHostOnClientDisconnectedTest
+    {
+        GameObject gameObject;
+        NetworkManagerOnClientDisconnect manager;
+        MemoryTransport transport;
+
+        [SetUp]
+        public void SetUp()
+        {
+            gameObject = new GameObject();
+            // add transport first, so networkmanager doesn't add telepathy
+            Transport.activeTransport = transport = gameObject.AddComponent<MemoryTransport>();
+            manager = gameObject.AddComponent<NetworkManagerOnClientDisconnect>();
+            // shouldn't automatically create a player. we don't have one.
+            manager.autoCreatePlayer = false;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Transport.activeTransport = null;
+            GameObject.DestroyImmediate(gameObject);
+        }
+
+        // test to prevent https://github.com/vis2k/Mirror/issues/1515
+        [Test]
+        public void StopHostCallsOnClientDisconnectForHostClient()
+        {
+            // OnServerDisconnect is always called when a client disconnects.
+            // it should also be called for the host client when we stop the host
+            Assert.That(manager.called, Is.EqualTo(0));
+            manager.StartServer();
+            manager.StartClient();
+            transport.LateUpdate();
+            Assert.That(NetworkClient.isConnected, Is.True);
+            manager.StopClient();
+            Assert.That(manager.called, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkManagerStopClientOnClientDisconnectTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerStopClientOnClientDisconnectTest.cs
@@ -34,7 +34,7 @@ namespace Mirror.Tests
             GameObject.DestroyImmediate(gameObject);
         }
 
-        // test to prevent https://github.com/vis2k/Mirror/issues/1515
+        // test to prevent https://github.com/vis2k/Mirror/issues/1499
         [Test]
         public void StopHostCallsOnClientDisconnectForHostClient()
         {

--- a/Assets/Mirror/Tests/Editor/NetworkManagerStopClientOnClientDisconnectTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerStopClientOnClientDisconnectTest.cs
@@ -46,6 +46,7 @@ namespace Mirror.Tests
             transport.LateUpdate();
             Assert.That(NetworkClient.isConnected, Is.True);
             manager.StopClient();
+            transport.LateUpdate(); // let transport process the disconnect
             Assert.That(manager.called, Is.EqualTo(1));
         }
     }

--- a/Assets/Mirror/Tests/Editor/NetworkManagerStopClientOnClientDisconnectTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerStopClientOnClientDisconnectTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48c6397c2925841f084879122b7dac00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ok the bug is actually related to what we just discussed in discord 5 minutes ago.

StopClient calls connection.disconnect->transport.disconnect and IMMEDIATELY shuts down networkclient and handlers.

transport disconnects client.
transport adds disconnected event.
...
a bit later the event would have been processed, but client is already fully shut down.

paul is currently rewriting how we do disconnects, which will fix this bug.
will leave this open because we can use the tests to verify that it worked.