### PR TITLE
feat: logging api

### DIFF
--- a/Assets/Mirror/Runtime/LogFactory.cs
+++ b/Assets/Mirror/Runtime/LogFactory.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mirror
+{
+    // hold a reference to the class logger
+    internal static class Loggers<T>
+    {
+        // note that Loggers<X>.Logger
+        // would have a separate value than Loggers<Y>.Logger
+        // this way we can always get teh same logger back and change it's log level
+        public static ILogger Logger = new Logger(Debug.unityLogger)
+        {
+            // by default, log warnings and up
+            filterLogType = LogType.Warning
+        };
+    }
+
+    public static class LogFactory
+    {
+        public static ILogger GetLogger<T>()
+        {
+            return Loggers<T>.Logger;
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/LogFactory.cs.meta
+++ b/Assets/Mirror/Runtime/LogFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d06522432d5a44e1587967a4731cd279
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/LogFactoryTests.cs
+++ b/Assets/Mirror/Tests/Editor/LogFactoryTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Mirror.Tests
+{
+
+    public class LogFactoryTests
+    {
+        // A Test behaves as an ordinary method
+        [Test]
+        public void SameClassSameLogger()
+        {
+            ILogger logger1 = LogFactory.GetLogger<LogFactoryTests>();
+            ILogger logger2 = LogFactory.GetLogger<LogFactoryTests>();
+            Assert.That(logger1, Is.SameAs(logger2));
+        }
+
+        [Test]
+        public void DifferentClassDifferentLogger()
+        {
+            ILogger logger1 = LogFactory.GetLogger<LogFactoryTests>();
+            ILogger logger2 = LogFactory.GetLogger<NetworkManager>();
+            Assert.That(logger1, Is.Not.SameAs(logger2));
+        }
+
+        [Test]
+        public void LogDebugIgnore()
+        {
+            ILogger logger = LogFactory.GetLogger<LogFactoryTests>();
+            logger.filterLogType = LogType.Warning;
+
+            logger.Log("This message should not be logged");
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void LogWarnOnly()
+        {
+            ILogger logger = LogFactory.GetLogger<LogFactoryTests>();
+            logger.filterLogType = LogType.Warning;
+
+            LogAssert.Expect(LogType.Warning, "LogFactoryTests: This message should be logged");
+            logger.LogWarning(nameof(LogFactoryTests), "This message should be logged");
+            LogAssert.NoUnexpectedReceived();
+        }
+
+    }
+}

--- a/Assets/Mirror/Tests/Editor/LogFactoryTests.cs.meta
+++ b/Assets/Mirror/Tests/Editor/LogFactoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b978d8a846ffa48109a9e4c5e9e2c0c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Provide a ILogger (from unity framework) per class
it can track loggers per class and use  Debug.unityLogger by default

This is how you would use it:

```cs
class NetworkClient
{
       private static ILogger logger = LogFactory.GetLogger<LogFactoryTests>();

       public void DoSomething()
       {
             // do something

            logger.Log("Something just happened");
       }
}
```

By default, the logger only displays warnings and above,  but let's say you want to see debug messages on a class,   then you can change it at runtime:

```cs
        GetLogger<NetworkClient>.filterLogType = LogType.Log;
```

Later we can provide a editor screen screen where we can change the log levels for all loggers at runtime.
