### PR TITLE
perf: faster NetworkWriter pooling

### DIFF
--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -4,7 +4,10 @@ using UnityEngine;
 
 namespace Mirror
 {
-    // Binary stream Writer. Supports simple types, buffers, arrays, structs, and nested types
+    /// <summary>
+    /// Binary stream Writer. Supports simple types, buffers, arrays, structs, and nested types
+    /// <para>Use <see cref="NetworkWriterPool.GetWriter">NetworkWriter.GetWriter</see> to reduce memory allocation</para>
+    /// </summary>
     public class NetworkWriter
     {
         public const int MaxStringLength = 1024 * 32;

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -1,9 +1,10 @@
 using System;
-using System.Collections.Generic;
 
 namespace Mirror
 {
-    // a NetworkWriter that will recycle itself when disposed
+    /// <summary>
+    /// NetworkWriter to be used with <see cref="NetworkWriterPool">NetworkWriterPool</see>
+    /// </summary>
     public class PooledNetworkWriter : NetworkWriter, IDisposable
     {
         public void Dispose()
@@ -12,26 +13,72 @@ namespace Mirror
         }
     }
 
+    /// <summary>
+    /// Pool of NetworkWriters
+    /// <para>Use this pool instead of <see cref="NetworkWriter">NetworkWriter</see> to reduce memory allocation</para>
+    /// <para>Use <see cref="ResizePool">ResizePool</see> to change size of pool</para>
+    /// </summary>
     public static class NetworkWriterPool
     {
-        static readonly Stack<PooledNetworkWriter> pool = new Stack<PooledNetworkWriter>();
+        /// <summary>
+        /// Mirror only uses 4 writers at a time,
+        /// 100 is a good margin for edge cases when
+        /// users need a lot writers at the same time.
+        ///
+        /// <para>keep in mind, most entries of the pool will be null in most cases</para>
+        /// </summary>
+        const int PoolStartSize = 100;
 
-        public static PooledNetworkWriter GetWriter()
+        /// <summary>
+        /// Current Size of Pool
+        /// </summary>
+        public static int PoolSize => pool.Length;
+
+        /// <summary>
+        /// Change size of pool
+        /// <para>If pool is too small getting writers will causes memory allocation</para>
+        /// </summary>
+        /// <param name="newSize"></param>
+        public static void ResizePool(int newSize)
         {
-            if (pool.Count != 0)
-            {
-                PooledNetworkWriter writer = pool.Pop();
-                // reset cached writer length and position
-                writer.SetLength(0);
-                return writer;
-            }
-
-            return new PooledNetworkWriter();
+            Array.Resize(ref pool, newSize);
         }
 
+        static PooledNetworkWriter[] pool = new PooledNetworkWriter[PoolStartSize];
+
+        static int next = -1;
+
+        /// <summary>
+        /// Get the next writer in the pool
+        /// <para>If pool is empty, creates a new Writer</para>
+        /// </summary>
+        public static PooledNetworkWriter GetWriter()
+        {
+            if (next == -1)
+            {
+                return new PooledNetworkWriter();
+            }
+
+            PooledNetworkWriter writer = pool[next];
+            pool[next] = null;
+            next--;
+
+            // reset cached writer length and position
+            writer.SetLength(0);
+            return writer;
+        }
+
+        /// <summary>
+        /// Puts writer back into pool
+        /// <para>If pool is full, the writer is left for the GC</para>
+        /// </summary>
         public static void Recycle(PooledNetworkWriter writer)
         {
-            pool.Push(writer);
+            if ((next + 1) < pool.Length)
+            {
+                next++;
+                pool[next] = writer;
+            }
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkWriterPoolTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterPoolTest.cs
@@ -1,10 +1,10 @@
-﻿using NUnit.Framework;
+using System.Linq;
+using NUnit.Framework;
 
 namespace Mirror.Tests
 {
     public class NetworkWriterPoolTest
     {
-        // A Test behaves as an ordinary method
         [Test]
         public void TestPoolRecycling()
         {
@@ -19,6 +19,72 @@ namespace Mirror.Tests
             {
                 Assert.That(writer, Is.SameAs(firstWriter), "Pool should reuse the writer");
             }
+        }
+
+
+        [Test]
+        public void PoolCanGetMoreWritersThanPoolSize()
+        {
+            NetworkWriterPool.Capacity = 5;
+
+            const int testWriterCount = 10;
+            PooledNetworkWriter[] writers = new PooledNetworkWriter[testWriterCount];
+
+            for (int i = 0; i < testWriterCount; i++)
+            {
+                writers[i] = NetworkWriterPool.GetWriter();
+            }
+
+            // Make sure all writers are different
+            Assert.That(writers.Distinct().Count(), Is.EqualTo(testWriterCount));
+
+            NetworkWriterPool.ResetCapacity();
+        }
+
+        [Test]
+        [Ignore("WIP")]
+        public void PoolReUsesWritersUpToSizeLimit()
+        {
+            //NetworkWriterPool.ResizePool(5);
+
+            //const int testWriterCount = 5;
+            //PooledNetworkWriter[] writers1 = new PooledNetworkWriter[testWriterCount];
+            //PooledNetworkWriter[] writers2 = new PooledNetworkWriter[testWriterCount];
+            //PooledNetworkWriter extra1;
+            //PooledNetworkWriter extra2;
+
+            //// simulate first update
+            //for (int i = 0; i < testWriterCount; i++)
+            //{
+            //    writers1[i] = NetworkWriterPool.GetWriter();
+            //}
+            //extra1 = NetworkWriterPool.GetWriter();
+
+            //for (int i = 0; i < testWriterCount; i++)
+            //{
+            //    writers1[i].Dispose();
+            //}
+            //extra1.Dispose();
+
+
+            //// simulate second update
+            //for (int i = 0; i < testWriterCount; i++)
+            //{
+            //    writers2[i] = NetworkWriterPool.GetWriter();
+            //}
+            //extra2 = NetworkWriterPool.GetWriter();
+
+            //for (int i = 0; i < testWriterCount; i++)
+            //{
+            //    writers2[i].Dispose();
+            //}
+            //extra2.Dispose();
+
+
+            //Assert
+
+
+            //NetworkWriterPool.ResetPoolSize();
         }
     }
 }


### PR DESCRIPTION
Using an array is ~50% faster than Stack/Queue/List