### PR TITLE
making singleton private set

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -138,7 +138,7 @@ namespace Mirror
         /// <summary>
         /// NetworkManager singleton
         /// </summary>
-        public static NetworkManager singleton;
+        public static NetworkManager singleton { get; private set; }
 
         /// <summary>
         /// Number of active player objects across all connections on the server.


### PR DESCRIPTION
There should be no reason to set singleton outside of networkmanager.

Setting single currently happens inside `InitializeSingleton` setting it outside of this may cause problems.