### PR TITLE
removing cached field

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1233,10 +1233,6 @@ namespace Mirror
             ClearObservers();
         }
 
-        // MirrorUpdate is a hot path. Caching the vars msg is really worth it to
-        // avoid large amounts of allocations.
-        static UpdateVarsMessage varsMessage = new UpdateVarsMessage();
-
         // invoked by NetworkServer during Update()
         internal void ServerUpdate()
         {
@@ -1249,8 +1245,10 @@ namespace Mirror
                     OnSerializeAllSafely(false, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
                     if (ownerWritten > 0 || observersWritten > 0)
                     {
-                        // populate cached UpdateVarsMessage and send
-                        varsMessage.netId = netId;
+                        UpdateVarsMessage varsMessage = new UpdateVarsMessage
+                        {
+                            netId = netId
+                        };
 
                         // send ownerWriter to owner
                         // (only if we serialized anything for owner)


### PR DESCRIPTION
UpdateVarsMessage is currently a struct so field no longer needs to be cached