### PR TITLE
Performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Created by performance test
+Assets/StreamingAssets/
+Assets/StreamingAssets.meta
+
 # =============== #
 # Unity generated #
 # =============== #

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -2,3 +2,5 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Mirror.Tests")]
 [assembly: InternalsVisibleTo("Mirror.Tests.Runtime")]
+[assembly: InternalsVisibleTo("Mirror.Tests.Performance")]
+[assembly: InternalsVisibleTo("Mirror.Tests.Performance.Runtime")]

--- a/Assets/Mirror/Tests/Performance.meta
+++ b/Assets/Mirror/Tests/Performance.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0b34ea3c905e3c42aaf95c1572edb1a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Common.meta
+++ b/Assets/Mirror/Tests/Performance/Common.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25df2a7c138a9744f8cf632fb450be13
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Common/Mirror.Tests.Performance.Common.asmdef
+++ b/Assets/Mirror/Tests/Performance/Common/Mirror.Tests.Performance.Common.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Mirror.Tests.Performance.Common",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/Assets/Mirror/Tests/Performance/Common/Mirror.Tests.Performance.Common.asmdef.meta
+++ b/Assets/Mirror/Tests/Performance/Common/Mirror.Tests.Performance.Common.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 384b31cc48ba1b34486b02afed6eeea2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Common/PerformanceTestsWindow.cs
+++ b/Assets/Mirror/Tests/Performance/Common/PerformanceTestsWindow.cs
@@ -100,9 +100,12 @@ namespace Mirror.Tests.WindowScripts
                 }
             }
 
-            if (GUILayout.Button("Build and Open Report"))
+            if (GUILayout.Button("Build Report"))
             {
                 BuildReport();
+            }
+            if (GUILayout.Button("Open Report folder"))
+            {
                 OpenReport();
             }
 
@@ -154,7 +157,7 @@ namespace Mirror.Tests.WindowScripts
 
         private void OpenReport()
         {
-            //throw new NotImplementedException();
+            System.Diagnostics.Process.Start(string.Format("{0}/UnityPerformanceBenchmark", settings.output));
         }
 
         private void DrawResultsLine(SerializedProperty prop)

--- a/Assets/Mirror/Tests/Performance/Common/PerformanceTestsWindow.cs
+++ b/Assets/Mirror/Tests/Performance/Common/PerformanceTestsWindow.cs
@@ -7,7 +7,11 @@ namespace Mirror.Tests.WindowScripts
 {
     public class PerformanceTestsWindow : EditorWindow
     {
+#if UNITY_2019_2_OR_NEWER
         static string resultPath => Path.Combine(Application.persistentDataPath, "TestResults.xml");
+#else
+        static string resultPath => Path.Combine(Application.streamingAssetsPath, "TestResults.xml");
+#endif
         static string settingsPath => Path.Combine(Application.persistentDataPath, "PerformanceTestsWindowSettings.json");
 
         [SerializeField] RunSettings settings;

--- a/Assets/Mirror/Tests/Performance/Common/PerformanceTestsWindow.cs
+++ b/Assets/Mirror/Tests/Performance/Common/PerformanceTestsWindow.cs
@@ -1,0 +1,191 @@
+using System.IO;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+namespace Mirror.Tests.WindowScripts
+{
+    public class PerformanceTestsWindow : EditorWindow
+    {
+        static string resultPath => Path.Combine(Application.persistentDataPath, "TestResults.xml");
+        static string settingsPath => Path.Combine(Application.persistentDataPath, "PerformanceTestsWindowSettings.json");
+
+        [SerializeField] RunSettings settings;
+        private SerializedObject so;
+        private SerializedProperty dotnetProp;
+        private SerializedProperty reporterProp;
+        private SerializedProperty outputProp;
+        private SerializedProperty baselineProp;
+        private SerializedProperty resultsProp;
+
+        private void OnEnable()
+        {
+            load();
+        }
+        private void OnDisable()
+        {
+            save();
+        }
+        private void load()
+        {
+            try
+            {
+                string json = File.ReadAllText(settingsPath);
+                settings = JsonUtility.FromJson<RunSettings>(json);
+                so = new SerializedObject(this);
+                SerializedProperty settingProp = so.FindProperty(nameof(settings));
+
+                dotnetProp = settingProp.FindPropertyRelative(nameof(RunSettings.dotnet));
+                reporterProp = settingProp.FindPropertyRelative(nameof(RunSettings.reporter));
+                outputProp = settingProp.FindPropertyRelative(nameof(RunSettings.output));
+                baselineProp = settingProp.FindPropertyRelative(nameof(RunSettings.baseLine));
+                resultsProp = settingProp.FindPropertyRelative(nameof(RunSettings.results));
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogException(e);
+            }
+        }
+
+
+
+        private void save()
+        {
+            try
+            {
+                string json = JsonUtility.ToJson(settings);
+                File.WriteAllText(settingsPath, json);
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogException(e);
+            }
+        }
+
+        public void OnGUI()
+        {
+            if (so == null)
+            {
+                GUILayout.Label("Failed to load");
+                return;
+            }
+            so.Update();
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                if (GUILayout.Button("Save Settings"))
+                {
+                    save();
+                }
+                if (GUILayout.Button("Load Settings"))
+                {
+                    load();
+                }
+            }
+            EditorGUILayout.Space();
+            EditorGUILayout.PropertyField(dotnetProp);
+            EditorGUILayout.PropertyField(reporterProp);
+            EditorGUILayout.PropertyField(outputProp);
+
+            DrawResultsLine(baselineProp);
+            using (new EditorGUI.IndentLevelScope())
+            {
+                resultsProp.arraySize = EditorGUILayout.IntField(new GUIContent("results array size"), resultsProp.arraySize);
+                for (int i = 0; i < resultsProp.arraySize; i++)
+                {
+                    DrawResultsLine(resultsProp.GetArrayElementAtIndex(i));
+                }
+            }
+
+            if (GUILayout.Button("Build and Open Report"))
+            {
+                BuildReport();
+                OpenReport();
+            }
+
+            so.ApplyModifiedProperties();
+        }
+
+        private void BuildReport()
+        {
+            System.Threading.Tasks.Task.Run(() =>
+            {
+                Debug.Log("Build report started");
+                StringBuilder argBuilder = new StringBuilder();
+                argBuilder.Append(settings.reporter);
+                argBuilder.Append(" --baseline=");
+                argBuilder.Append(settings.baseLine);
+                argBuilder.Append(" --reportdirpath=");
+                argBuilder.Append(settings.output);
+
+                foreach (string result in settings.results)
+                {
+                    argBuilder.Append(" --results=");
+                    argBuilder.Append(result);
+                }
+
+                System.Diagnostics.Process process = new System.Diagnostics.Process();
+                process.StartInfo.FileName = settings.dotnet;
+                process.StartInfo.Arguments = argBuilder.ToString();
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.OutputDataReceived += new System.Diagnostics.DataReceivedEventHandler((sender, e) =>
+                {
+                    // Prepend line numbers to each line of the output.
+                    if (!string.IsNullOrEmpty(e.Data))
+                    {
+                        Debug.Log(e.Data);
+                    }
+                });
+
+                process.Start();
+
+                process.BeginOutputReadLine();
+
+                Debug.Log("Build report Finished");
+
+                process.WaitForExit();
+                process.Close();
+            });
+        }
+
+        private void OpenReport()
+        {
+            //throw new NotImplementedException();
+        }
+
+        private void DrawResultsLine(SerializedProperty prop)
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.PropertyField(prop);
+                if (GUILayout.Button("move"))
+                {
+                    MoveResults(prop.stringValue);
+                }
+            }
+        }
+
+        private void MoveResults(string path)
+        {
+            File.Copy(resultPath, path, true);
+        }
+
+        [MenuItem("Window/Tools/Performance Benchmark Report Builder")]
+        public static void ShowWindow()
+        {
+            PerformanceTestsWindow window = GetWindow<PerformanceTestsWindow>();
+            window.titleContent = new GUIContent("Performance Benchmark Report Builder");
+            window.Show();
+        }
+
+        [System.Serializable]
+        public class RunSettings
+        {
+            public string dotnet;
+            public string reporter;
+            public string output;
+            public string baseLine;
+            public string[] results;
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Performance/Common/PerformanceTestsWindow.cs.meta
+++ b/Assets/Mirror/Tests/Performance/Common/PerformanceTestsWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b5f4966791ae874ea66032b217edd90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Editor.meta
+++ b/Assets/Mirror/Tests/Performance/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c40e1b4653f9ca4b928a0ff52f33c60
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Editor/Mirror.Tests.Performance.asmdef
+++ b/Assets/Mirror/Tests/Performance/Editor/Mirror.Tests.Performance.asmdef
@@ -8,6 +8,9 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner"
     ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
     "includePlatforms": [
         "Editor"
     ],
@@ -20,6 +23,5 @@
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
-    ],
-    "versionDefines": []
+    ]
 }

--- a/Assets/Mirror/Tests/Performance/Editor/Mirror.Tests.Performance.asmdef
+++ b/Assets/Mirror/Tests/Performance/Editor/Mirror.Tests.Performance.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "Mirror.Tests.Performance",
+    "references": [
+        "Unity.PerformanceTesting",
+        "Mirror",
+        "Mirror.Components",
+        "Mirror.Tests.Common",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": []
+}

--- a/Assets/Mirror/Tests/Performance/Editor/Mirror.Tests.Performance.asmdef.meta
+++ b/Assets/Mirror/Tests/Performance/Editor/Mirror.Tests.Performance.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ac82bd0f79158140826224aad56b5e3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Editor/NetworkWriterPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Editor/NetworkWriterPerformance.cs
@@ -1,0 +1,35 @@
+#if UNITY_2019_2_OR_NEWER
+using Mirror;
+using NUnit.Framework;
+using Unity.PerformanceTesting;
+
+namespace Tests
+{
+    public class NetworkWriterPerformance
+    {
+        // A Test behaves as an ordinary method
+        [Test]
+        [Performance]
+        public void WritePackedInt32()
+        {
+            Measure.Method(WriteInt32)
+                .WarmupCount(10)
+                .MeasurementCount(100)
+                .IterationsPerMeasurement(10000)
+                .GC()
+                .Run();
+        }
+
+        void WriteInt32()
+        {
+            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    writer.WritePackedInt32(i * 1000);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Assets/Mirror/Tests/Performance/Editor/NetworkWriterPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Editor/NetworkWriterPerformance.cs
@@ -1,4 +1,3 @@
-#if UNITY_2019_2_OR_NEWER
 using Mirror;
 using NUnit.Framework;
 using Unity.PerformanceTesting;
@@ -9,27 +8,33 @@ namespace Tests
     {
         // A Test behaves as an ordinary method
         [Test]
+#if UNITY_2019_2_OR_NEWER
         [Performance]
+#else
+        [PerformanceTest]
+#endif
+        [Version("2")]
         public void WritePackedInt32()
         {
             Measure.Method(WriteInt32)
                 .WarmupCount(10)
                 .MeasurementCount(100)
-                .IterationsPerMeasurement(10000)
                 .GC()
                 .Run();
         }
 
         void WriteInt32()
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            for (int j = 0; j < 1000; j++)
             {
-                for (int i = 0; i < 10; i++)
+                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
                 {
-                    writer.WritePackedInt32(i * 1000);
+                    for (int i = 0; i < 10; i++)
+                    {
+                        writer.WritePackedInt32(i * 1000);
+                    }
                 }
             }
         }
     }
 }
-#endif

--- a/Assets/Mirror/Tests/Performance/Editor/NetworkWriterPerformance.cs.meta
+++ b/Assets/Mirror/Tests/Performance/Editor/NetworkWriterPerformance.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3c833c30b262be45860a01b933a3220
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Runtime.meta
+++ b/Assets/Mirror/Tests/Performance/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f902e7dc9ebba44fa9ed637a824ddb8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Runtime/Mirror.Tests.Performance.Runtime.asmdef
+++ b/Assets/Mirror/Tests/Performance/Runtime/Mirror.Tests.Performance.Runtime.asmdef
@@ -8,6 +8,9 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner"
     ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
@@ -18,6 +21,5 @@
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
-    ],
-    "versionDefines": []
+    ]
 }

--- a/Assets/Mirror/Tests/Performance/Runtime/Mirror.Tests.Performance.Runtime.asmdef
+++ b/Assets/Mirror/Tests/Performance/Runtime/Mirror.Tests.Performance.Runtime.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Mirror.Tests.Performance.Runtime",
+    "references": [
+        "Unity.PerformanceTesting",
+        "Mirror",
+        "Mirror.Components",
+        "Mirror.Tests.Common",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": []
+}

--- a/Assets/Mirror/Tests/Performance/Runtime/Mirror.Tests.Performance.Runtime.asmdef.meta
+++ b/Assets/Mirror/Tests/Performance/Runtime/Mirror.Tests.Performance.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 98f4e20eb641b974bab6c080624bb1ae
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_2_OR_NEWER
+//#if UNITY_2019_2_OR_NEWER
 using System;
 using System.Collections;
 using Mirror;
@@ -47,7 +47,11 @@ namespace Tests
             yield return Disconnect();
         }
         [UnityTest]
+#if UNITY_2019_2_OR_NEWER
         [Performance]
+#else
+        [PerformanceUnityTest]
+#endif
         [Version("11.4.1")]
         public IEnumerator ULocalConnectionPerformanceWithEnumeratorPasses()
         {
@@ -104,4 +108,4 @@ namespace Tests
         }
     }
 }
-#endif
+//#endif

--- a/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
@@ -1,0 +1,107 @@
+#if UNITY_2019_2_OR_NEWER
+using System;
+using System.Collections;
+using Mirror;
+using Unity.PerformanceTesting;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+
+namespace Tests
+{
+    class NetworkManagerTest : NetworkManager
+    {
+        public override void Awake()
+        {
+            transport = gameObject.AddComponent<TelepathyTransport>();
+            playerPrefab = new GameObject("testPlayerPrefab", typeof(NetworkIdentity));
+            base.Awake();
+        }
+    }
+    public class ULocalConnectionPerformance
+    {
+        NetworkManager manager;
+
+        IEnumerator SetUpConnections()
+        {
+            GameObject go = new GameObject();
+            manager = go.AddComponent<NetworkManagerTest>();
+            yield return null;
+
+            manager.StartHost();
+
+            yield return null;
+        }
+        IEnumerator Disconnect()
+        {
+            manager.StopHost();
+            yield return null;
+            GameObject.Destroy(manager.gameObject);
+        }
+
+        [UnityTest]
+        public IEnumerator ConnectAndDisconnectWorks()
+        {
+            yield return SetUpConnections();
+
+            yield return Disconnect();
+        }
+        [UnityTest]
+        [Performance]
+        [Version("11.4.1")]
+        public IEnumerator ULocalConnectionPerformanceWithEnumeratorPasses()
+        {
+            yield return SetUpConnections();
+
+            using (Measure.Frames()
+                .WarmupCount(10)
+                .MeasurementCount(100)
+                .Scope())
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    sendSomeMessages();
+                    yield return null;
+                }
+            }
+
+            yield return Disconnect();
+        }
+
+        static void sendSomeMessages()
+        {
+            for (uint i = 0; i < 10000u; i++)
+            {
+                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                {
+                    // write mask
+                    writer.WritePackedUInt64(1);
+                    // behaviour length
+                    writer.WriteInt32(1);
+
+                    // behaviour delta
+
+                    //  sync object mask
+                    writer.WritePackedUInt64(0);
+                    // sync object delta
+                    //      assume no sync objects for this test
+
+                    // sync var mask
+                    writer.WritePackedUInt64(1);
+                    // sync var delta
+                    //      assume sync var has changed its value to 10
+                    writer.WritePackedInt32(10);
+
+
+                    // send message
+                    NetworkServer.localConnection.Send(new UpdateVarsMessage()
+                    {
+                        netId = i,
+                        payload = writer.ToArraySegment()
+                    });
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs.meta
+++ b/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82f7edc4e79efb74db284b02dab6704d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/README.md
+++ b/Assets/Mirror/Tests/README.md
@@ -1,3 +1,42 @@
+To use Performance Benchmark Reporter you must have:
+- Unity Performance Testing Extension
+- [.NET core SDK](https://dotnet.microsoft.com/download)
+- [Performance Benchmark Reporter DLL](https://github.com/Unity-Technologies/PerformanceBenchmarkReporter/releases)
+
+#### Install Unity Performance Testing Extension
+- Open  `manifest.json`
+- Add 
+```json
+{
+    "dependencies": {
+        "com.unity.test-framework": "0.0.4-preview",
+        "com.unity.test-framework.performance": "0.1.49-preview",
+        /// other dependencies
+        },
+    "testables": [
+        "com.unity.test-framework.performance"
+    ]
+}
+```
+
+
+# Create a Performance Benchmark Report
+
+0. Set up the `Performance Benchmark Report Builder` window by adding the path to the required files. Window can be found at `Window/Tools/Performance Benchmark Report Builder`
+
+1. Run the performance tests using the test runner to create a `TestResults.xml`
+2. Press "move" in the Builder window to copy the result to the path
+3. Change branches and run performance tests again
+4. Once all results are collected press "Build Report"
+5. Open the "UnityPerformanceBenchmark" html file that is created to view the report
+    
+
+![image of window](https://user-images.githubusercontent.com/23101891/78310942-52c52100-7547-11ea-969a-662c0d8e8df7.png)
+
+
+### Performance Benchmark Report Builder Window
+
+The window stores its settings in `Application.persistentDataPath`, Use Save/Load settings buttons at top to manauly save/load. Settings should automatically load/save when window is opened/closed.
 
 
 # Links
@@ -9,10 +48,8 @@ https://blogs.unity3d.com/2018/09/25/performance-benchmarking-in-unity-how-to-ge
 https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/index.html
 https://docs.unity3d.com/Packages/com.unity.test-framework.performance@2.0/manual/index.html
 
-Have to manually add `"com.unity.test-framework.performance": "2.0.9-preview",` to `manifest.json`
 
 
 #### Performance Benchmark Reporter
 
-creates html page to compare 2 test results
 https://github.com/Unity-Technologies/PerformanceBenchmarkReporter/wiki

--- a/Assets/Mirror/Tests/README.md
+++ b/Assets/Mirror/Tests/README.md
@@ -1,0 +1,18 @@
+
+
+# Links
+
+#### Blog post
+https://blogs.unity3d.com/2018/09/25/performance-benchmarking-in-unity-how-to-get-started/
+
+#### Unity packages
+https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/index.html
+https://docs.unity3d.com/Packages/com.unity.test-framework.performance@2.0/manual/index.html
+
+Have to manually add `"com.unity.test-framework.performance": "2.0.9-preview",` to `manifest.json`
+
+
+#### Performance Benchmark Reporter
+
+creates html page to compare 2 test results
+https://github.com/Unity-Technologies/PerformanceBenchmarkReporter/wiki

--- a/Assets/Mirror/Tests/README.md.meta
+++ b/Assets/Mirror/Tests/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a322196416f669044b8d2fa186a6f80c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Would be useful to have these in master if we want to test performance of different branches

Test classes are in `#if UNITY_2019_2_OR_NEWER` block so should not cause compile errors with 2018. 
2019 projects will need to add `"com.unity.test-framework.performance": "1.2.6-preview",` to the `package/manifest/json`