### PR TITLE
adding Category to weaver and Telepathy tests

### DIFF
--- a/Assets/Mirror/Tests/Editor/Telepathy/TransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/Telepathy/TransportTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Threading;
 using NUnit.Framework;
 using UnityEngine.TestTools;
@@ -6,6 +6,7 @@ using UnityEngine.TestTools;
 namespace Telepathy.Tests
 {
     [TestFixture]
+    [Category("Telepathy")]
     [Ignore("Telepathy tests are flaky")]
     public class TransportTest
     {

--- a/Assets/Mirror/Tests/Editor/WeaverTest.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTest.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace Mirror.Tests
 {
     [TestFixture]
+    [Category("Weaver")]
     public class WeaverTest
     {
         #region Private


### PR DESCRIPTION
Allows us to filter tests, and "Run All" only on a subset of test.

Works as a flag allowing us to run multiple Categories at once

![image](https://user-images.githubusercontent.com/23101891/78270525-d6a8ea00-7502-11ea-91dc-0c29218c03b0.png)
