### PR TITLE
Moving write length to functions

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -729,9 +729,7 @@ namespace Mirror
             // write placeholder length bytes
             // (jumping back later is WAY faster than allocating a temporary
             //  writer for the payload, then writing payload.size, payload)
-            int headerPosition = writer.Position;
-            writer.WriteInt32(0);
-            int contentPosition = writer.Position;
+            int headerPosition = writer.StartMessageLength();
 
             // write payload
             bool result = false;
@@ -744,14 +742,11 @@ namespace Mirror
                 // show a detailed error and let the user know what went wrong
                 Debug.LogError("OnSerialize failed for: object=" + name + " component=" + comp.GetType() + " sceneId=" + sceneId.ToString("X") + "\n\n" + e);
             }
-            int endPosition = writer.Position;
 
-            // fill in length now
-            writer.Position = headerPosition;
-            writer.WriteInt32(endPosition - contentPosition);
-            writer.Position = endPosition;
+            writer.EndMessageLength(headerPosition);
 
-            if (LogFilter.Debug) Debug.Log("OnSerializeSafely written for object=" + comp.name + " component=" + comp.GetType() + " sceneId=" + sceneId.ToString("X") + "header@" + headerPosition + " content@" + contentPosition + " end@" + endPosition + " contentSize=" + (endPosition - contentPosition));
+            if (LogFilter.Debug) Debug.Log($"OnSerializeSafely written for object={comp.name} component={comp.GetType()} sceneId={sceneId.ToString("X")} header@{headerPosition} content@{headerPosition + 4} end@{writer.Position} contentSize={writer.Position - (headerPosition + 4)}");
+
 
             return result;
         }

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -124,8 +124,38 @@ namespace Mirror
         }
 
         public void WriteInt64(long value) => WriteUInt64((ulong)value);
-    }
 
+
+        /// <summary>
+        /// Returns current position and writes placeholder length
+        /// </summary>
+        /// <returns>headerPosition</returns>
+        public int StartMessageLength()
+        {
+            // write placeholder length bytes
+            // (jumping back later is WAY faster than allocating a temporary
+            //  writer for the payload, then writing payload.size, payload)
+            int headerPosition = Position;
+            WriteInt32(0);
+
+            return headerPosition;
+        }
+
+        /// <summary>
+        /// Writes length to placeholder at headerPosition
+        /// </summary>
+        public void EndMessageLength(int headerPosition)
+        {
+            int contentEnd = Position;
+            int contentStart = headerPosition + 4;
+            int contentLength = contentEnd - contentStart;
+
+            // fill in length now
+            Position = headerPosition;
+            WriteInt32(contentLength);
+            Position = contentEnd;
+        }
+    }
 
     // Mirror's Weaver automatically detects all NetworkWriter function types,
     // but they do all need to be extensions.


### PR DESCRIPTION
Adding functions that `OnSerializeSafely` can use to write length of message