### PR TITLE
perf: Removing length field from NetworkWriter

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -71,7 +71,7 @@ namespace Mirror
 
         public void ResetBuffer()
         {
-            writer.SetLength(0);
+            writer.Position = 0;
             reader.Position = 0;
         }
     }

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -72,7 +72,7 @@ namespace Mirror
             next--;
 
             // reset cached writer length and position
-            writer.SetLength(0);
+            writer.Position = 0;
             return writer;
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -109,11 +109,11 @@ namespace Mirror.Tests
             writer.WriteInt64(0xA_FADED_DEAD_EEL);
             writer.WriteString("and ate it");
             int position = writer.Position;
-            writer.SetLength(10);
+            writer.Position = 10;
             // Setting length should set position too
             Assert.That(writer.Position, Is.EqualTo(10));
             // lets grow it back and check there's zeroes now.
-            writer.SetLength(position);
+            writer.Position = position;
             byte[] data = writer.ToArray();
             for (int i = position; i < data.Length; i++)
                 Assert.That(data[i], Is.EqualTo(0), $"index {i} should have value 0");
@@ -123,9 +123,7 @@ namespace Mirror.Tests
         public void TestSetLengthInitialization()
         {
             NetworkWriter writer = new NetworkWriter();
-            writer.SetLength(10);
-            // Setting length should leave position at 0
-            Assert.That(writer.Position, Is.EqualTo(0));
+            writer.Position = 10;
             byte[] data = writer.ToArray();
             for (int i = 0; i < data.Length; i++)
                 Assert.That(data[i], Is.EqualTo(0), $"index {i} should have value 0");
@@ -504,7 +502,7 @@ namespace Mirror.Tests
         {
             NetworkWriter writer = new NetworkWriter();
             writer.WriteString("a string longer than 10 bytes");
-            writer.SetLength(10);
+            writer.Position = 10;
             NetworkReader reader = new NetworkReader(writer.ToArray());
             Assert.Throws<System.IO.EndOfStreamException>(() => reader.ReadString());
         }
@@ -523,8 +521,8 @@ namespace Mirror.Tests
             // set position back by one
             writer.Position = 1;
 
-            // Changing the position should not alter the size of the data
-            Assert.That(writer.ToArray().Length, Is.EqualTo(2));
+            // Changing the position should alter the size of the data
+            Assert.That(writer.ToArray().Length, Is.EqualTo(1));
         }
 
         [Test]


### PR DESCRIPTION
The length field/property was only used inside of NetworkWriter and added a lot of extra code to the hot path

### Performance
Performance of `writer.WritePackedInt32`
Execution time
Master 0.99
Replacing length 0.55

Tested using https://github.com/vis2k/Mirror/pull/1648

![image](https://user-images.githubusercontent.com/23101891/78316822-88263a80-7558-11ea-99c7-90f04cc3d536.png)

I also tested manually inlining the `WritePackedUInt64` code to the `WritePackedUInt32` which seemed to give ~10% performance increase