### PR TITLE
WIP: dirty check for sync var

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -930,9 +930,11 @@ namespace Mirror
             // one writer for owner, one for observers
             using (PooledNetworkWriter ownerWriter = NetworkWriterPool.GetWriter(), observersWriter = NetworkWriterPool.GetWriter())
             {
+                ulong dirtyComponentsMask = identity.GetDirtyMask(true);
+
                 // serialize all components with initialState = true
                 // (can be null if has none)
-                identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+                identity.OnSerializeAllSafely(true, dirtyComponentsMask, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
 
                 // convert to ArraySegment to avoid reader allocations
                 // (need to handle null case too)

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NSubstitute;
 using NUnit.Framework;
@@ -860,7 +860,7 @@ namespace Mirror.Tests
             NetworkWriter observersWriter = new NetworkWriter();
             // error log because of the exception is expected
             LogAssert.ignoreFailingMessages = true;
-            identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            identity.OnSerializeAllSafely(true, identity.GetDirtyMask(true), ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
             LogAssert.ignoreFailingMessages = false;
 
             // owner should have written all components
@@ -914,7 +914,7 @@ namespace Mirror.Tests
             NetworkWriter observersWriter = new NetworkWriter();
             // error log is expected because of too many components
             LogAssert.ignoreFailingMessages = true;
-            identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            identity.OnSerializeAllSafely(true, identity.GetDirtyMask(true), ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
             LogAssert.ignoreFailingMessages = false;
 
             // shouldn't have written anything because too many components
@@ -944,7 +944,7 @@ namespace Mirror.Tests
             // serialize
             NetworkWriter ownerWriter = new NetworkWriter();
             NetworkWriter observersWriter = new NetworkWriter();
-            identity.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            identity.OnSerializeAllSafely(true, identity.GetDirtyMask(true), ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
 
             // reset component values
             comp1.value = 0;

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -123,7 +123,7 @@ namespace Mirror.Tests
             NetworkWriter ownerWriter = new NetworkWriter();
             // not really used in this Test
             NetworkWriter observersWriter = new NetworkWriter();
-            identity1.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            identity1.OnSerializeAllSafely(true, identity1.GetDirtyMask(true), ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
 
             // set up a "client" object
             GameObject gameObject2 = new GameObject();

--- a/Assets/Mirror/Tests/Editor/SyncVarVirtualTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarVirtualTest.cs
@@ -77,7 +77,7 @@ namespace Mirror.Tests
             NetworkWriter ownerWriter = new NetworkWriter();
             // not really used in this Test
             NetworkWriter observersWriter = new NetworkWriter();
-            netIdServer.OnSerializeAllSafely(true, ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
+            netIdServer.OnSerializeAllSafely(true, netIdServer.GetDirtyMask(true), ownerWriter, out int ownerWritten, observersWriter, out int observersWritten);
 
 
             // apply all the data from the server object


### PR DESCRIPTION
We should look into the is dirty check for NetworkIdenity more, I tested it with some rough code and it gets and it cuts frame times for 25% on the 10k benchmark scene


![image](https://user-images.githubusercontent.com/23101891/78513688-5524b680-77a5-11ea-8e0e-c23560161333.png)
