### PR TITLE
fix: Fixing SyncVar hooks with static methods

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -216,7 +216,11 @@ namespace Mirror.Weaver
                 setWorker.Append(setWorker.Create(OpCodes.Call, Weaver.setSyncVarHookGuard));
 
                 // call hook (oldValue, newValue)
-                setWorker.Append(setWorker.Create(OpCodes.Ldarg_0));
+                // dont add this (Ldarg_0) if method is static
+                if (!hookFunctionMethod.IsStatic)
+                {
+                    setWorker.Append(setWorker.Create(OpCodes.Ldarg_0));
+                }
                 setWorker.Append(setWorker.Create(OpCodes.Ldloc, oldValue));
                 setWorker.Append(setWorker.Create(OpCodes.Ldarg_1));
                 setWorker.Append(setWorker.Create(OpCodes.Callvirt, hookFunctionMethod));


### PR DESCRIPTION
Weave creates code that will throw this execption at run time 

![image](https://user-images.githubusercontent.com/23101891/78613751-8617f080-7864-11ea-837b-9001646fbc09.png)

