### PR TITLE
fix: Fixing SyncVars not serializing when OnSerialize is overridden

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -281,7 +281,8 @@ namespace Mirror.Weaver
         {
             Weaver.DLog(netBehaviourSubclass, "  GenerateSerialization");
 
-            if (netBehaviourSubclass.GetMethod("OnSerialize") != null)
+            const string SerializeMethodName = "SerializeSyncVars";
+            if (netBehaviourSubclass.GetMethod(SerializeMethodName) != null)
                 return;
 
             if (syncVars.Count == 0)
@@ -290,7 +291,7 @@ namespace Mirror.Weaver
                 return;
             }
 
-            MethodDefinition serialize = new MethodDefinition("OnSerialize",
+            MethodDefinition serialize = new MethodDefinition(SerializeMethodName,
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.boolType);
 
@@ -304,7 +305,7 @@ namespace Mirror.Weaver
             VariableDefinition dirtyLocal = new VariableDefinition(Weaver.boolType);
             serialize.Body.Variables.Add(dirtyLocal);
 
-            MethodReference baseSerialize = Resolvers.ResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, "OnSerialize");
+            MethodReference baseSerialize = Resolvers.ResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, SerializeMethodName);
             if (baseSerialize != null)
             {
                 // base
@@ -619,7 +620,8 @@ namespace Mirror.Weaver
         {
             Weaver.DLog(netBehaviourSubclass, "  GenerateDeSerialization");
 
-            if (netBehaviourSubclass.GetMethod("OnDeserialize") != null)
+            const string DeserializeMethodName = "DeserializeSyncVars";
+            if (netBehaviourSubclass.GetMethod(DeserializeMethodName) != null)
                 return;
 
             if (syncVars.Count == 0)
@@ -628,7 +630,7 @@ namespace Mirror.Weaver
                 return;
             }
 
-            MethodDefinition serialize = new MethodDefinition("OnDeserialize",
+            MethodDefinition serialize = new MethodDefinition(DeserializeMethodName,
                     MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
                     Weaver.voidType);
 
@@ -640,7 +642,7 @@ namespace Mirror.Weaver
             VariableDefinition dirtyBitsLocal = new VariableDefinition(Weaver.int64Type);
             serialize.Body.Variables.Add(dirtyBitsLocal);
 
-            MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, "OnDeserialize");
+            MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, DeserializeMethodName);
             if (baseDeserialize != null)
             {
                 // base

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -735,6 +735,8 @@ namespace Mirror
             //   write syncVarDirtyBits
             //   write dirty SyncVars
         }
+
+        // Don't rename. Weaver uses this exact function name.
         public virtual void DeserializeSyncVars(NetworkReader reader, bool initialState)
         {
             // SyncVars are read here in subclass

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -685,7 +685,7 @@ namespace Mirror
         /// <returns>True if data was written.</returns>
         public virtual bool OnSerialize(NetworkWriter writer, bool initialState)
         {
-            bool objectWriten = false;
+            bool objectWritten = false;
             if (initialState)
             {
                 objectWriten = SerializeObjectsAll(writer);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -688,7 +688,7 @@ namespace Mirror
             bool objectWritten = false;
             if (initialState)
             {
-                objectWriten = SerializeObjectsAll(writer);
+                objectWritten = SerializeObjectsAll(writer);
             }
             else
             {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -695,7 +695,7 @@ namespace Mirror
                 objectWriten = SerializeObjectsDelta(writer);
             }
 
-            bool syncVarWriten = SerializeSyncVars(writer, initialState);
+            bool syncVarWritten = SerializeSyncVars(writer, initialState);
 
             return objectWriten || syncVarWriten;
         }

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -692,7 +692,7 @@ namespace Mirror
             }
             else
             {
-                objectWriten = SerializeObjectsDelta(writer);
+                objectWritten = SerializeObjectsDelta(writer);
             }
 
             bool syncVarWritten = SerializeSyncVars(writer, initialState);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -687,7 +687,7 @@ namespace Mirror
         {
             bool objectWritten = false;
             // if initialState: write all SyncVars.
-            // otherwise write dirtyBits+dirty SyncVars//
+            // otherwise write dirtyBits+dirty SyncVars
             if (initialState)
             {
                 objectWritten = SerializeObjectsAll(writer);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -686,6 +686,8 @@ namespace Mirror
         public virtual bool OnSerialize(NetworkWriter writer, bool initialState)
         {
             bool objectWritten = false;
+            // if initialState: write all SyncVars.
+            // otherwise write dirtyBits+dirty SyncVars//
             if (initialState)
             {
                 objectWritten = SerializeObjectsAll(writer);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -722,6 +722,7 @@ namespace Mirror
             DeserializeSyncVars(reader, initialState);
         }
 
+        // Don't rename. Weaver uses this exact function name.
         public virtual bool SerializeSyncVars(NetworkWriter writer, bool initialState)
         {
             return false;

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -685,23 +685,21 @@ namespace Mirror
         /// <returns>True if data was written.</returns>
         public virtual bool OnSerialize(NetworkWriter writer, bool initialState)
         {
+            bool objectWriten = false;
             if (initialState)
             {
-                return SerializeObjectsAll(writer);
+                objectWriten = SerializeObjectsAll(writer);
             }
             else
             {
-                return SerializeObjectsDelta(writer);
+                objectWriten = SerializeObjectsDelta(writer);
             }
 
-            // SyncVar are writen here in subclass
+            bool syncVarWriten = SerializeSyncVars(writer, initialState);
 
-            // if initialState
-            //   write all SyncVars
-            // else
-            //   write syncVarDirtyBits
-            //   write dirty SyncVars
+            return objectWriten || syncVarWriten;
         }
+
 
         /// <summary>
         /// Virtual function to override to receive custom serialization data. The corresponding function to send serialization data is OnSerialize().
@@ -719,6 +717,23 @@ namespace Mirror
                 DeSerializeObjectsDelta(reader);
             }
 
+            DeserializeSyncVars(reader, initialState);
+        }
+
+        public virtual bool SerializeSyncVars(NetworkWriter writer, bool initialState)
+        {
+            return false;
+
+            // SyncVar are writen here in subclass
+
+            // if initialState
+            //   write all SyncVars
+            // else
+            //   write syncVarDirtyBits
+            //   write dirty SyncVars
+        }
+        public virtual void DeserializeSyncVars(NetworkReader reader, bool initialState)
+        {
             // SyncVars are read here in subclass
 
             // if initialState

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -697,7 +697,7 @@ namespace Mirror
 
             bool syncVarWritten = SerializeSyncVars(writer, initialState);
 
-            return objectWriten || syncVarWriten;
+            return objectWritten || syncVarWritten;
         }
 
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
@@ -47,6 +47,20 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
         public Vector3 anotherSyncField;
     }
 
+
+    class MiddleClassWithSyncVar : AbstractBehaviour
+    {
+        // class with sync var
+        [SyncVar]
+        public string syncFieldInMiddle;
+    }
+    class SubClassFromSyncVar : MiddleClassWithSyncVar
+    {
+        // class with sync var
+        // this is to make sure that override works correctly if base class doesnt have sync vars
+        [SyncVar]
+        public Vector3 syncFieldInSub;
+    }
     #endregion
 
     #region OnSerialize/OnDeserialize override
@@ -221,7 +235,29 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
             Assert.That(target.anotherSyncField, Is.EqualTo(new Vector3(40, 20, 10)));
         }
 
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SubClassFromSyncVarTest(bool initialState)
+        {
+            SubClassFromSyncVar source = CreateBehaviour<SubClassFromSyncVar>();
+            SubClassFromSyncVar target = CreateBehaviour<SubClassFromSyncVar>();
 
+            source.SyncFieldInAbstract = 10;
+            source.syncListInAbstract.Add(true);
+
+            source.syncFieldInMiddle = "Hello World!";
+            source.syncFieldInSub = new Vector3(40, 20, 10);
+
+            SyncNetworkBehaviour(source, target, initialState);
+
+            Assert.That(target.SyncFieldInAbstract, Is.EqualTo(10));
+            Assert.That(target.syncListInAbstract.Count, Is.EqualTo(1));
+            Assert.That(target.syncListInAbstract[0], Is.True);
+
+            Assert.That(target.syncFieldInMiddle, Is.EqualTo("Hello World!"));
+            Assert.That(target.syncFieldInSub, Is.EqualTo(new Vector3(40, 20, 10)));
+        }
 
 
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
@@ -1,0 +1,308 @@
+using NUnit.Framework;
+using UnityEngine;
+
+// Note: Weaver doesn't run on nested class so so use namespace to group classes instead
+namespace Mirror.Tests.NetworkBehaviourSerialize
+{
+    #region No OnSerialize/OnDeserialize override
+    abstract class AbstractBehaviour : NetworkBehaviour
+    {
+        public readonly SyncListBool syncListInAbstract = new SyncListBool();
+
+        [SyncVar]
+        public int SyncFieldInAbstract;
+    }
+
+    class BehaviourWithSyncVar : NetworkBehaviour
+    {
+        public readonly SyncListBool syncList = new SyncListBool();
+
+        [SyncVar]
+        public int SyncField;
+    }
+
+    class OverrideBehaviourFromSyncVar : AbstractBehaviour
+    {
+
+    }
+
+    class OverrideBehaviourWithSyncVarFromSyncVar : AbstractBehaviour
+    {
+        public readonly SyncListBool syncListInOverride = new SyncListBool();
+
+        [SyncVar]
+        public int SyncFieldInOverride;
+    }
+
+
+    class MiddleClass : AbstractBehaviour
+    {
+        // class with no sync var
+    }
+    class SubClass : MiddleClass
+    {
+        // class with sync var
+        // this is to make sure that override works correctly if base class doesnt have sync vars
+        [SyncVar]
+        public Vector3 anotherSyncField;
+    }
+
+    #endregion
+
+    #region OnSerialize/OnDeserialize override
+
+
+    class BehaviourWithSyncVarWithOnSerialize : NetworkBehaviour
+    {
+        public readonly SyncListBool syncList = new SyncListBool();
+
+        [SyncVar]
+        public int SyncField;
+
+        public float customSerializeField;
+
+        public override bool OnSerialize(NetworkWriter writer, bool initialState)
+        {
+            writer.WriteSingle(customSerializeField);
+            return base.OnSerialize(writer, initialState);
+        }
+        public override void OnDeserialize(NetworkReader reader, bool initialState)
+        {
+            customSerializeField = reader.ReadSingle();
+            base.OnDeserialize(reader, initialState);
+        }
+    }
+
+    class OverrideBehaviourFromSyncVarWithOnSerialize : AbstractBehaviour
+    {
+        public float customSerializeField;
+
+        public override bool OnSerialize(NetworkWriter writer, bool initialState)
+        {
+            writer.WriteSingle(customSerializeField);
+            return base.OnSerialize(writer, initialState);
+        }
+        public override void OnDeserialize(NetworkReader reader, bool initialState)
+        {
+            customSerializeField = reader.ReadSingle();
+            base.OnDeserialize(reader, initialState);
+        }
+    }
+
+    class OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize : AbstractBehaviour
+    {
+        public readonly SyncListBool syncListInOverride = new SyncListBool();
+
+        [SyncVar]
+        public int SyncFieldInOverride;
+
+        public float customSerializeField;
+
+        public override bool OnSerialize(NetworkWriter writer, bool initialState)
+        {
+            writer.WriteSingle(customSerializeField);
+            return base.OnSerialize(writer, initialState);
+        }
+        public override void OnDeserialize(NetworkReader reader, bool initialState)
+        {
+            customSerializeField = reader.ReadSingle();
+            base.OnDeserialize(reader, initialState);
+        }
+    }
+    #endregion
+
+    public class NetworkBehaviourSerializeTest
+    {
+        static T CreateBehaviour<T>() where T : NetworkBehaviour
+        {
+            GameObject go1 = new GameObject();
+            go1.AddComponent<NetworkIdentity>();
+            return go1.AddComponent<T>();
+        }
+        static void SyncNetworkBehaviour(NetworkBehaviour source, NetworkBehaviour target, bool initialState)
+        {
+            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            {
+                source.OnSerialize(writer, initialState);
+
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                {
+                    target.OnDeserialize(reader, initialState);
+                }
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BehaviourWithSyncVarTest(bool initialState)
+        {
+            BehaviourWithSyncVar source = CreateBehaviour<BehaviourWithSyncVar>();
+            BehaviourWithSyncVar target = CreateBehaviour<BehaviourWithSyncVar>();
+
+            source.SyncField = 10;
+            source.syncList.Add(true);
+
+            SyncNetworkBehaviour(source, target, initialState);
+
+            Assert.That(target.SyncField, Is.EqualTo(10));
+            Assert.That(target.syncList.Count, Is.EqualTo(1));
+            Assert.That(target.syncList[0], Is.True);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OverrideBehaviourFromSyncVarTest(bool initialState)
+        {
+            OverrideBehaviourFromSyncVar source = CreateBehaviour<OverrideBehaviourFromSyncVar>();
+            OverrideBehaviourFromSyncVar target = CreateBehaviour<OverrideBehaviourFromSyncVar>();
+
+            source.SyncFieldInAbstract = 12;
+            source.syncListInAbstract.Add(true);
+            source.syncListInAbstract.Add(false);
+
+            SyncNetworkBehaviour(source, target, initialState);
+
+            Assert.That(target.SyncFieldInAbstract, Is.EqualTo(12));
+            Assert.That(target.syncListInAbstract.Count, Is.EqualTo(2));
+            Assert.That(target.syncListInAbstract[0], Is.True);
+            Assert.That(target.syncListInAbstract[1], Is.False);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OverrideBehaviourWithSyncVarFromSyncVarTest(bool initialState)
+        {
+            OverrideBehaviourWithSyncVarFromSyncVar source = CreateBehaviour<OverrideBehaviourWithSyncVarFromSyncVar>();
+            OverrideBehaviourWithSyncVarFromSyncVar target = CreateBehaviour<OverrideBehaviourWithSyncVarFromSyncVar>();
+
+            source.SyncFieldInAbstract = 10;
+            source.syncListInAbstract.Add(true);
+
+            source.SyncFieldInOverride = 52;
+            source.syncListInOverride.Add(false);
+            source.syncListInOverride.Add(true);
+
+            SyncNetworkBehaviour(source, target, initialState);
+
+            Assert.That(target.SyncFieldInAbstract, Is.EqualTo(10));
+            Assert.That(target.syncListInAbstract.Count, Is.EqualTo(1));
+            Assert.That(target.syncListInAbstract[0], Is.True);
+
+
+            Assert.That(target.SyncFieldInOverride, Is.EqualTo(52));
+            Assert.That(target.syncListInOverride.Count, Is.EqualTo(2));
+            Assert.That(target.syncListInOverride[0], Is.False);
+            Assert.That(target.syncListInOverride[1], Is.True);
+        }
+
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SubClassTest(bool initialState)
+        {
+            SubClass source = CreateBehaviour<SubClass>();
+            SubClass target = CreateBehaviour<SubClass>();
+
+            source.SyncFieldInAbstract = 10;
+            source.syncListInAbstract.Add(true);
+
+            source.anotherSyncField = new Vector3(40, 20, 10);
+
+            SyncNetworkBehaviour(source, target, initialState);
+
+            Assert.That(target.SyncFieldInAbstract, Is.EqualTo(10));
+            Assert.That(target.syncListInAbstract.Count, Is.EqualTo(1));
+            Assert.That(target.syncListInAbstract[0], Is.True);
+
+            Assert.That(target.anotherSyncField, Is.EqualTo(new Vector3(40, 20, 10)));
+        }
+
+
+
+
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BehaviourWithSyncVarWithOnSerializeTest(bool initialState)
+        {
+            BehaviourWithSyncVarWithOnSerialize source = CreateBehaviour<BehaviourWithSyncVarWithOnSerialize>();
+            BehaviourWithSyncVarWithOnSerialize target = CreateBehaviour<BehaviourWithSyncVarWithOnSerialize>();
+
+            source.SyncField = 10;
+            source.syncList.Add(true);
+
+            source.customSerializeField = 20.5f;
+
+            SyncNetworkBehaviour(source, target, initialState);
+
+            Assert.That(target.SyncField, Is.EqualTo(10));
+            Assert.That(target.syncList.Count, Is.EqualTo(1));
+            Assert.That(target.syncList[0], Is.True);
+
+            Assert.That(target.customSerializeField, Is.EqualTo(20.5f));
+        }
+
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OverrideBehaviourFromSyncVarWithOnSerializeTest(bool initialState)
+        {
+            OverrideBehaviourFromSyncVarWithOnSerialize source = CreateBehaviour<OverrideBehaviourFromSyncVarWithOnSerialize>();
+            OverrideBehaviourFromSyncVarWithOnSerialize target = CreateBehaviour<OverrideBehaviourFromSyncVarWithOnSerialize>();
+
+            source.SyncFieldInAbstract = 12;
+            source.syncListInAbstract.Add(true);
+            source.syncListInAbstract.Add(false);
+
+            source.customSerializeField = 20.5f;
+
+            SyncNetworkBehaviour(source, target, initialState);
+
+            Assert.That(target.SyncFieldInAbstract, Is.EqualTo(12));
+            Assert.That(target.syncListInAbstract.Count, Is.EqualTo(2));
+            Assert.That(target.syncListInAbstract[0], Is.True);
+            Assert.That(target.syncListInAbstract[1], Is.False);
+
+            Assert.That(target.customSerializeField, Is.EqualTo(20.5f));
+        }
+
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OverrideBehaviourWithSyncVarFromSyncVarWithOnSerializeTest(bool initialState)
+        {
+            OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize source = CreateBehaviour<OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize>();
+            OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize target = CreateBehaviour<OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize>();
+
+            source.SyncFieldInAbstract = 10;
+            source.syncListInAbstract.Add(true);
+
+            source.SyncFieldInOverride = 52;
+            source.syncListInOverride.Add(false);
+            source.syncListInOverride.Add(true);
+
+            source.customSerializeField = 20.5f;
+
+            SyncNetworkBehaviour(source, target, initialState);
+
+            Assert.That(target.SyncFieldInAbstract, Is.EqualTo(10));
+            Assert.That(target.syncListInAbstract.Count, Is.EqualTo(1));
+            Assert.That(target.syncListInAbstract[0], Is.True);
+
+
+            Assert.That(target.SyncFieldInOverride, Is.EqualTo(52));
+            Assert.That(target.syncListInOverride.Count, Is.EqualTo(2));
+            Assert.That(target.syncListInOverride[0], Is.False);
+            Assert.That(target.syncListInOverride[1], Is.True);
+
+            Assert.That(target.customSerializeField, Is.EqualTo(20.5f));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 253d419ce2900134482c3c8b76883c60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
this will allow SyncVars to still work if user overrides OnSerialize as long as they call base.OnSerialize