### PR TITLE
adding StreamingAssets folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Created by performance test
+Assets/StreamingAssets/
+Assets/StreamingAssets.meta
+
 # =============== #
 # Unity generated #
 # =============== #


### PR DESCRIPTION
Unity create `StreamingAssets` folder for performance test in versions 2018.3/4