### PR TITLE
fix: Check SceneManager GetSceneByName and GetSceneByPath

### DIFF
--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/AdditiveNetworkManager.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/AdditiveNetworkManager.cs
@@ -45,7 +45,7 @@ namespace Mirror.Examples.Additive
             if (LogFilter.Debug) Debug.Log("Unloading Subscenes");
 
             foreach (string sceneName in subScenes)
-                if (SceneManager.GetSceneByName(sceneName).IsValid())
+                if (SceneManager.GetSceneByName(sceneName).IsValid() || SceneManager.GetSceneByPath(sceneName).IsValid())
                 {
                     yield return SceneManager.UnloadSceneAsync(sceneName);
                     if (LogFilter.Debug) Debug.Log($"Unloaded {sceneName}");

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -850,25 +850,28 @@ namespace Mirror
                     loadingSceneAsync = SceneManager.LoadSceneAsync(newSceneName);
                     break;
                 case SceneOperation.LoadAdditive:
-                    if (!SceneManager.GetSceneByName(newSceneName).IsValid())
+                    // Ensure additive scene is not already loaded on client by name or path
+                    // since we don't know which was passed in the Scene message
+                    if (!SceneManager.GetSceneByName(newSceneName).IsValid() && !SceneManager.GetSceneByPath(newSceneName).IsValid())
                         loadingSceneAsync = SceneManager.LoadSceneAsync(newSceneName, LoadSceneMode.Additive);
                     else
                     {
-                        Debug.LogWarningFormat("Scene {0} is already loaded", newSceneName);
+                        Debug.LogWarning($"Scene {newSceneName} is already loaded");
+
+                        // Re-enable the transport that we disabled before entering this switch
                         Transport.activeTransport.enabled = true;
                     }
                     break;
                 case SceneOperation.UnloadAdditive:
-                    if (SceneManager.GetSceneByName(newSceneName).IsValid())
-                    {
-                        if (SceneManager.GetSceneByName(newSceneName) != null)
-                            loadingSceneAsync = SceneManager.UnloadSceneAsync(newSceneName, UnloadSceneOptions.UnloadAllEmbeddedSceneObjects);
-                        else
-                            Transport.activeTransport.enabled = true;
-                    }
+                    // Ensure additive scene is actually loaded on client by name or path
+                    // since we don't know which was passed in the Scene message
+                    if (SceneManager.GetSceneByName(newSceneName).IsValid() || SceneManager.GetSceneByPath(newSceneName).IsValid())
+                        loadingSceneAsync = SceneManager.UnloadSceneAsync(newSceneName, UnloadSceneOptions.UnloadAllEmbeddedSceneObjects);
                     else
                     {
-                        Debug.LogWarning("Cannot unload the active scene with UnloadAdditive operation");
+                        Debug.LogWarning($"Cannot unload {newSceneName} with UnloadAdditive operation");
+
+                        // Re-enable the transport that we disabled before entering this switch
                         Transport.activeTransport.enabled = true;
                     }
                     break;


### PR DESCRIPTION
Now that we store full path in scene fields, we need to check for both name and path in additive loading and unloading.