### PR TITLE
Adding defines to performance tests

### DIFF
--- a/Assets/Mirror/Tests/Performance/Editor/Mirror.Tests.Performance.asmdef
+++ b/Assets/Mirror/Tests/Performance/Editor/Mirror.Tests.Performance.asmdef
@@ -19,5 +19,12 @@
     "autoReferenced": true,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.test-framework.performance",
+            "expression": "(,2.0)",
+            "define": "UNITY_PERFORMANCE_TESTS_1_OR_OLDER"
+        }
     ]
 }

--- a/Assets/Mirror/Tests/Performance/Editor/NetworkWriterPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Editor/NetworkWriterPerformance.cs
@@ -1,3 +1,4 @@
+#if !UNITY_2019_2_OR_NEWER || UNITY_PERFORMANCE_TESTS_1_OR_OLDER
 using NUnit.Framework;
 using Unity.PerformanceTesting;
 
@@ -36,3 +37,4 @@ namespace Mirror.Tests.Performance
         }
     }
 }
+#endif

--- a/Assets/Mirror/Tests/Performance/Runtime/BenchmarkPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Runtime/BenchmarkPerformance.cs
@@ -1,3 +1,4 @@
+#if !UNITY_2019_2_OR_NEWER || UNITY_PERFORMANCE_TESTS_1_OR_OLDER
 using System.Collections;
 using System.Diagnostics;
 using Mirror.Examples;
@@ -140,3 +141,4 @@ namespace Mirror.Tests.Performance
         }
     }
 }
+#endif

--- a/Assets/Mirror/Tests/Performance/Runtime/Mirror.Tests.Performance.Runtime.asmdef
+++ b/Assets/Mirror/Tests/Performance/Runtime/Mirror.Tests.Performance.Runtime.asmdef
@@ -18,5 +18,12 @@
     "autoReferenced": true,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.test-framework.performance",
+            "expression": "(,2.0)",
+            "define": "UNITY_PERFORMANCE_TESTS_1_OR_OLDER"
+        }
     ]
 }

--- a/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
@@ -1,4 +1,4 @@
-//#if UNITY_2019_2_OR_NEWER
+#if !UNITY_2019_2_OR_NEWER || UNITY_PERFORMANCE_TESTS_1_OR_OLDER
 using System.Collections;
 using NUnit.Framework;
 using Unity.PerformanceTesting;
@@ -107,4 +107,4 @@ namespace Mirror.Tests.Performance
         }
     }
 }
-//#endif
+#endif


### PR DESCRIPTION
Adding `versionDefines` so that tests dont break in 2019.3 with wrong package version.

versionDefines do not work in earlier versions of unity so we also need to check if we are on an earlier version of unity.

The version define is only needed for unity 2019.3 because that is the only version of Performance test that can use  > 2.0.0 (which breaks our scripts.