### PR TITLE
Adding changed check to PreprocessorDefine

### DIFF
--- a/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
+++ b/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
@@ -29,6 +29,8 @@ namespace Mirror
                 "MIRROR_12_0_OR_NEWER"
             };
 
+            // only touch PlayerSettings if we actually modified it.
+            // otherwise it shows up as changed in git each time.
             string newDefines = string.Join(";", defines);
             if (newDefines != currentDefines)
             {

--- a/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
+++ b/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
@@ -11,7 +11,8 @@ namespace Mirror
         [InitializeOnLoadMethod]
         public static void AddDefineSymbols()
         {
-            HashSet<string> defines = new HashSet<string>(PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup).Split(';'))
+            string currentDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+            HashSet<string> defines = new HashSet<string>(currentDefines.Split(';'))
             {
                 "MIRROR",
                 "MIRROR_1726_OR_NEWER",
@@ -27,7 +28,12 @@ namespace Mirror
                 "MIRROR_11_0_OR_NEWER",
                 "MIRROR_12_0_OR_NEWER"
             };
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, string.Join(";", defines));
+
+            string newDefines = string.Join(";", defines);
+            if (newDefines != currentDefines)
+            {
+                PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, newDefines);
+            }
         }
     }
 }


### PR DESCRIPTION
this stops ProjectSettings being marked as dirty and showing up in git (with no changes) each time the editor is opened