### PR TITLE
making ULocalConnectionPerformance clean up new objects

### DIFF
--- a/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
@@ -16,6 +16,13 @@ namespace Mirror.Tests.Performance
             playerPrefab = new GameObject("testPlayerPrefab", typeof(NetworkIdentity));
             base.Awake();
         }
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+
+            // clean up new object created in awake
+            Destroy(playerPrefab);
+        }
     }
     [Category("Performance")]
     public class ULocalConnectionPerformance


### PR DESCRIPTION
`testPlayerPrefab` was causing problems with OnPostProcessScene in other runtime tests. Cleaning up object after fixes this.