### PR TITLE
Moving weaver tests 2

### DIFF
--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests.cs
@@ -2,7 +2,7 @@
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverClientRpcTests : WeaverTests
+    public class WeaverClientRpcTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void ClientRpcValid()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverClientServerAttributeTests : WeaverTests
+    public class WeaverClientServerAttributeTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void NetworkBehaviourServer()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
@@ -2,7 +2,7 @@
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverCommandTests : WeaverTests
+    public class WeaverCommandTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void CommandValid()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverGeneralTests : WeaverTests
+    public class WeaverGeneralTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void RecursionCount()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests.cs
@@ -2,7 +2,7 @@
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverMessageTests : WeaverTests
+    public class WeaverMessageTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void MessageValid()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests.cs
@@ -2,7 +2,7 @@
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverMonoBehaviourTests : WeaverTests
+    public class WeaverMonoBehaviourTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void MonoBehaviourValid()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
@@ -2,7 +2,7 @@
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverNetworkBehaviourTests : WeaverTests
+    public class WeaverNetworkBehaviourTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void NetworkBehaviourValid()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
@@ -2,7 +2,7 @@
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverSyncListTests : WeaverTests
+    public class WeaverSyncListTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void SyncListValid()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
@@ -2,7 +2,7 @@
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverSyncVarTests : WeaverTests
+    public class WeaverSyncVarTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void SyncVarsValid()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests.cs
@@ -2,7 +2,7 @@
 
 namespace Mirror.Weaver.Tests
 {
-    public class WeaverTargetRpcTests : WeaverTests
+    public class WeaverTargetRpcTests : WeaverTestsBuildFromTestName
     {
         [Test]
         public void TargetRpcValid()

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTests.cs
@@ -62,6 +62,8 @@ namespace Mirror.Weaver.Tests
         [OneTimeTearDown]
         public void FixtureCleanup()
         {
+            CompilationFinishedHook.OnWeaverError -= HandleWeaverError;
+            CompilationFinishedHook.OnWeaverWarning -= HandleWeaverWarning;
             CompilationFinishedHook.UnityLogEnabled = true;
         }
 

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTests.cs
@@ -5,6 +5,14 @@ using NUnit.Framework;
 
 namespace Mirror.Weaver.Tests
 {
+    public abstract class WeaverTestsBuildFromTestName : WeaverTests
+    {
+        [SetUp]
+        public void TestSetup()
+        {
+            BuildAndWeaveTestAssembly(TestContext.CurrentContext.Test.Name);
+        }
+    }
     [TestFixture]
     [Category("Weaver")]
     public abstract class WeaverTests
@@ -40,8 +48,6 @@ namespace Mirror.Weaver.Tests
             }
         }
 
-
-
         [OneTimeSetUp]
         public void FixtureSetup()
         {
@@ -57,12 +63,6 @@ namespace Mirror.Weaver.Tests
         public void FixtureCleanup()
         {
             CompilationFinishedHook.UnityLogEnabled = true;
-        }
-
-        [SetUp]
-        public void TestSetup()
-        {
-            BuildAndWeaveTestAssembly(TestContext.CurrentContext.Test.Name);
         }
 
         [TearDown]


### PR DESCRIPTION
Requires https://github.com/vis2k/Mirror/pull/1704 , This PR is just for last commit: f887a2c

Creating a different base class for tests that want to automatically build test Assembly from test name
`BuildAndWeaveTestAssembly(TestContext.CurrentContext.Test.Name);`