### PR TITLE
feat: Make OnSetHostVisibility virtual with default functionality

### DIFF
--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -156,18 +156,5 @@ namespace Mirror
                 }
             }
         }
-
-        /// <summary>
-        /// Callback used by the visibility system for objects on a host.
-        /// <para>Objects on a host (with a local client) cannot be disabled or destroyed when they are not visible to the local client. So this function is called to allow custom code to hide these objects. A typical implementation will disable renderer components on the object. This is only called on local clients on a host.</para>
-        /// </summary>
-        /// <param name="visible">New visibility state.</param>
-        public override void OnSetHostVisibility(bool visible)
-        {
-            foreach (Renderer rend in GetComponentsInChildren<Renderer>())
-            {
-                rend.enabled = visible;
-            }
-        }
     }
 }

--- a/Assets/Mirror/Components/NetworkSceneChecker.cs
+++ b/Assets/Mirror/Components/NetworkSceneChecker.cs
@@ -108,16 +108,5 @@ namespace Mirror
                 if (networkIdentity != null && networkIdentity.connectionToClient != null)
                     observers.Add(networkIdentity.connectionToClient);
         }
-
-        /// <summary>
-        /// Callback used by the visibility system for objects on a host.
-        /// <para>Objects on a host (with a local client) cannot be disabled or destroyed when they are not visible to the local client. So this function is called to allow custom code to hide these objects. A typical implementation will disable renderer components on the object. This is only called on local clients on a host.</para>
-        /// </summary>
-        /// <param name="visible">New visibility state.</param>
-        public override void OnSetHostVisibility(bool visible)
-        {
-            foreach (Renderer rend in GetComponentsInChildren<Renderer>())
-                rend.enabled = visible;
-        }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkVisibility.cs
+++ b/Assets/Mirror/Runtime/NetworkVisibility.cs
@@ -33,6 +33,10 @@ namespace Mirror
         /// <para>Objects on a host (with a local client) cannot be disabled or destroyed when they are not visible to the local client. So this function is called to allow custom code to hide these objects. A typical implementation will disable renderer components on the object. This is only called on local clients on a host.</para>
         /// </summary>
         /// <param name="visible">New visibility state.</param>
-        public abstract void OnSetHostVisibility(bool visible);
+        public virtual void OnSetHostVisibility(bool visible)
+        {
+            foreach (Renderer rend in GetComponentsInChildren<Renderer>())
+                rend.enabled = visible;
+        }
     }
 }


### PR DESCRIPTION
Upon reviewing all 4 custom observers, they all have the exact same code for `OnSetHostVisibility`.

This PR makes that method a virtual with the default code in it, and removes the overrides from the other 2 that are currently in Mirror.

NetworkGridProximityChecker in uMMORPG can also have its override removed.

NetworkMatchChecker #1688  will have its override removed after this is merged.