### PR TITLE
fix: Don't destroy the player twice

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -967,14 +967,9 @@ namespace Mirror
         /// <param name="conn">The connections object to clean up for.</param>
         public static void DestroyPlayerForConnection(NetworkConnection conn)
         {
-            // destroy all objects owned by this connection
+            // destroy all objects owned by this connection, including the player object
             conn.DestroyOwnedObjects();
-
-            if (conn.identity != null)
-            {
-                DestroyObject(conn.identity, true);
-                conn.identity = null;
-            }
+            conn.identity = null;
         }
 
         /// <summary>

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Mirror.Tests
+{
+    [TestFixture]
+    public class NetworkServerRuntimeTest
+    {
+        private GameObject transportGameObject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            transportGameObject = new GameObject("Transport");
+            Transport.activeTransport = transportGameObject.AddComponent<MemoryTransport>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // reset all state
+            NetworkServer.Shutdown();
+
+            Transport.activeTransport = null;
+            Object.Destroy(transportGameObject);
+        }
+
+
+        [UnityTest]
+        public IEnumerator DestroyPlayerForConnectionTest()
+        {
+            NetworkServer.Listen(1);
+
+            GameObject player = new GameObject("testPlayer", typeof(NetworkIdentity));
+            NetworkConnectionToClient conn = new NetworkConnectionToClient(1);
+
+            NetworkServer.AddPlayerForConnection(conn, player);
+
+            NetworkServer.DestroyPlayerForConnection(conn);
+
+            // takes 1 frame for unity to destroy object
+            yield return null;
+
+            Assert.That(player == null, "Player should be destroyed with DestroyPlayerForConnection");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs.meta
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a94e088c9596a284cb2cb960746ef2ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`conn.DestroyOwnedObjects();` already destroys the player object...once is enough.