### PR TITLE
fix: NetworkManager doesn't reset networkSceneName after client/server disconnect

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -585,9 +585,12 @@ namespace Mirror
             {
                 ServerChangeScene(offlineScene);
             }
+
             CleanupNetworkIdentities();
 
             startPositionIndex = 0;
+
+            networkSceneName = "";
         }
 
         /// <summary>
@@ -619,6 +622,8 @@ namespace Mirror
             }
 
             CleanupNetworkIdentities();
+
+            networkSceneName = "";
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes a problem where a client that starts hosting after previously disconnecting from a game ends up forcing new clients to change scenes to the previously disconnected game's scene.

This should allow the NetworkManager to be a bit more re-usable between sessions without having to destroy and recreate it.