### PR TITLE
using MemoryTransport for ULocalConnectionPerformance test

### DIFF
--- a/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
@@ -12,7 +12,7 @@ namespace Mirror.Tests.Performance
     {
         public override void Awake()
         {
-            transport = gameObject.AddComponent<TelepathyTransport>();
+            transport = gameObject.AddComponent<MemoryTransport>();
             playerPrefab = new GameObject("testPlayerPrefab", typeof(NetworkIdentity));
             base.Awake();
         }


### PR DESCRIPTION
Telepathy sometimes causes errors for tests, adding fake transport class to use instead.