### PR TITLE
fix: Eliminate NetworkAnimator SetTrigger double firing on Host

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -519,12 +519,16 @@ namespace Mirror
         [ClientRpc]
         void RpcOnAnimationTriggerClientMessage(int hash)
         {
+            if (isServer) return;
+
             HandleAnimTriggerMsg(hash);
         }
 
         [ClientRpc]
         void RpcOnAnimationResetTriggerClientMessage(int hash)
         {
+            if (isServer) return;
+
             HandleAnimResetTriggerMsg(hash);
         }
 


### PR DESCRIPTION
Added `isServer` checks to the Rpc's.

Fixes #1508 