### PR TITLE
feat: Exclude fields from weaver's automatic Read/Write using System.NonSerialized attribute 

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -380,6 +380,9 @@ namespace Mirror.Weaver
                 if (field.IsStatic || field.IsPrivate)
                     continue;
 
+                if (field.IsNotSerialized)
+                    continue;
+
                 // mismatched ldloca/ldloc for struct/class combinations is invalid IL, which causes crash at runtime
                 OpCode opcode = variable.IsValueType ? OpCodes.Ldloca : OpCodes.Ldloc;
                 worker.Append(worker.Create(opcode, 0));

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -145,6 +145,9 @@ namespace Mirror.Weaver
                 if (field.IsStatic || field.IsPrivate)
                     continue;
 
+                if (field.IsNotSerialized)
+                    continue;
+
                 MethodReference writeFunc = GetWriteFunc(field.FieldType, recursionCount + 1);
                 if (writeFunc != null)
                 {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/ExcludesNonSerializedFields.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/ExcludesNonSerializedFields.cs
@@ -1,0 +1,21 @@
+using Mirror;
+using Mirror.Weaver.Tests.Extra;
+
+namespace MirrorTest
+{
+    public class ExcludesNonSerializedFields : NetworkBehaviour
+    {
+        [ClientRpc]
+        public void RpcDoSomething(SomeDataUsingNonSerialized data)
+        {
+            // empty
+        }
+    }
+
+    public struct SomeDataUsingNonSerialized
+    {
+        public int usefulNumber;
+        // Object is a not allowed type
+        [System.NonSerialized] public UnityEngine.Object obj;
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
@@ -121,7 +121,6 @@ namespace Mirror.Weaver.Tests
         }
 
         [Test]
-        [Ignore("Not Implemented")]
         public void ExcludesNonSerializedFields()
         {
             // we test this by having a not allowed type in the class, but mark it with NonSerialized


### PR DESCRIPTION
feature https://github.com/vis2k/Mirror/issues/1229

tldr, if user adds `[System.NonSerialized]` to a field, weaver doesn't try to Serialize it.