### PR TITLE
Default log level option

### DIFF
--- a/Assets/Mirror/Runtime/LogFactory.cs
+++ b/Assets/Mirror/Runtime/LogFactory.cs
@@ -7,19 +7,19 @@ namespace Mirror
     {
         internal static readonly Dictionary<string, ILogger> loggers = new Dictionary<string, ILogger>();
 
-        public static ILogger GetLogger<T>()
+        public static ILogger GetLogger<T>(LogType defaultLogLevel = LogType.Warning)
         {
-            return GetLogger(typeof(T).Name);
+            return GetLogger(typeof(T).Name, defaultLogLevel);
         }
 
-        public static ILogger GetLogger(System.Type type)
+        public static ILogger GetLogger(System.Type type, LogType defaultLogLevel = LogType.Warning)
         {
-            return GetLogger(type.Name);
+            return GetLogger(type.Name, defaultLogLevel);
         }
 
-        public static ILogger GetLogger(string loggerName)
+        public static ILogger GetLogger(string loggerName, LogType defaultLogLevel = LogType.Warning)
         {
-            if (loggers.TryGetValue(loggerName, out ILogger logger ))
+            if (loggers.TryGetValue(loggerName, out ILogger logger))
             {
                 return logger;
             }
@@ -27,7 +27,7 @@ namespace Mirror
             logger = new Logger(Debug.unityLogger)
             {
                 // by default, log warnings and up
-                filterLogType = LogType.Warning
+                filterLogType = defaultLogLevel
             };
 
             loggers[loggerName] = logger;

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTests.cs
@@ -20,19 +20,19 @@ namespace Mirror.Weaver.Tests
     [Category("Weaver")]
     public abstract class WeaverTests
     {
-        public static readonly ILogger logger = LogFactory.GetLogger<WeaverTests>();
+        public static readonly ILogger logger = LogFactory.GetLogger<WeaverTests>(LogType.Exception);
 
         protected List<string> weaverErrors = new List<string>();
         void HandleWeaverError(string msg)
         {
-            logger.Log(msg);
+            logger.LogError(msg);
             weaverErrors.Add(msg);
         }
 
         protected List<string> weaverWarnings = new List<string>();
         void HandleWeaverWarning(string msg)
         {
-            logger.Log(msg);
+            logger.LogWarning(msg);
             weaverWarnings.Add(msg);
         }
 


### PR DESCRIPTION
This allows us to set the log function in weaver tests back to LogError/LogWarning