### PR TITLE
fix: NetworkTransform / NetworkAnimator Default Client Authority True

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -21,7 +21,7 @@ namespace Mirror
     {
         [Header("Authority")]
         [Tooltip("Set to true if animations come from owner client,  set to false if animations always come from server")]
-        public bool clientAuthority;
+        public bool clientAuthority = true;
 
         /// <summary>
         /// The animator component to synchronize.

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -25,7 +25,7 @@ namespace Mirror
     {
         [Header("Authority")]
         [Tooltip("Set to true if moves come from owner client, set to false if moves always come from server")]
-        public bool clientAuthority;
+        public bool clientAuthority = true;
 
         // Is this a client with authority over this transform?
         // This component could be on the player object or any object that has been assigned authority to this client.


### PR DESCRIPTION
While server authoritative may be desirable, the reality that's borne out in the support activity in Discord makes it clear that users are not coming in the door with server authoritative character controllers.  They're either making up something simple or adapting something from a single player game or one of Unity's controllers, none of which are suitable for server authority.  When they try to get started, and slap on a Network Transform, and movement sync doesn't work as they expect, they're frustrated and have no idea where to look.  It's not until they get much more knowledgeable about Mirror and networking in general that they start looking at the server moving anything.

Additionally, before these components had this checkbox, they were client authoritative by default, and were in UNet too, so even those migrating from UNet are baffled as to what's broken.

We don't have a proper controller to offer them either.  The ones in the examples are client authoritative as well.  This change won't alter existing components already attached...only new usage of them.

So here it is, changing them back to client auth.  We tried it, and it's just not delivering on "ease of use" in this case.