### PR TITLE
Weaver error messages and tests for using interfaces

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -69,12 +69,12 @@ namespace Mirror.Weaver
             }
             if (td.HasGenericParameters && !td.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
             {
-                Weaver.Error($"Cannot generate reader for generic variable {variable}. Use a concrete type or provide a custom reader");
+                Weaver.Error($"Cannot generate reader for generic variable {variable}. Use a supported type or provide a custom reader");
                 return null;
             }
             if (td.IsInterface)
             {
-                Weaver.Error($"Cannot generate reader for interface variable {variable}. Use a concrete type or provide a custom reader");
+                Weaver.Error($"Cannot generate reader for interface variable {variable}. Use a supported type or provide a custom reader");
                 return null;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -53,12 +53,12 @@ namespace Mirror.Weaver
             }
             if (variable.FullName == Weaver.ObjectType.FullName)
             {
-                Weaver.Error($"Cannot generate reader for {variable}. Use a supported type or provide a custom writer");
+                Weaver.Error($"Cannot generate reader for {variable}. Use a supported type or provide a custom reader");
                 return null;
             }
             if (variable.FullName == Weaver.ScriptableObjectType.FullName)
             {
-                Weaver.Error($"Cannot generate reader for {variable}. Use a supported type or provide a custom writer");
+                Weaver.Error($"Cannot generate reader for {variable}. Use a supported type or provide a custom reader");
                 return null;
             }
             if (variable.IsByReference)
@@ -74,7 +74,7 @@ namespace Mirror.Weaver
             }
             if (td.IsInterface)
             {
-                Weaver.Error($"Cannot generate reader for interface variable {variable}. Use a supported type or provide a custom reader");
+                Weaver.Error($"Cannot generate reader for interface {variable}. Use a supported type or provide a custom reader");
                 return null;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -70,12 +70,12 @@ namespace Mirror.Weaver
             }
             if (td.HasGenericParameters && !td.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
             {
-                Weaver.Error($"Cannot generate writer for generic type {variable}. Use a concrete type or provide a custom writer");
+                Weaver.Error($"Cannot generate writer for generic type {variable}. Use a supported type or provide a custom writer");
                 return null;
             }
             if (td.IsInterface)
             {
-                Weaver.Error($"Cannot generate writer for interface {variable}. Use a concrete type or provide a custom writer");
+                Weaver.Error($"Cannot generate writer for interface {variable}. Use a supported type or provide a custom writer");
                 return null;
             }
 

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CanUseCustomReadWriteForInterfaces.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CanUseCustomReadWriteForInterfaces.cs
@@ -1,0 +1,44 @@
+using Mirror;
+
+namespace MirrorTest
+{
+    public class CanUseCustomReadWriteForInterfaces : NetworkBehaviour
+    {
+        [ClientRpc]
+        public void RpcDoSomething(IData data)
+        {
+            // empty
+        }
+    }
+
+    public interface IData
+    {
+        int id { get; }
+    }
+
+    public class SomeData : IData
+    {
+        public int id => 1;
+    }
+
+    public static class DataReadWrite
+    {
+        public static void WriteData(this NetworkWriter writer, IData data)
+        {
+            writer.WriteInt32(data.id);
+            // write extra stuff depending on id here
+        }
+
+        public static IData ReadData(this NetworkReader reader)
+        {
+            int id = reader.ReadInt32();
+            // do something with id
+
+            SomeData someData = new SomeData();
+            // read extra stuff depending on id here
+
+            return someData;
+        }
+    }
+
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingInterface.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingInterface.cs
@@ -1,0 +1,16 @@
+using Mirror;
+using UnityEngine;
+
+namespace MirrorTest
+{
+    public class GivesErrorWhenUsingInterface : NetworkBehaviour
+    {
+        [ClientRpc]
+        public void RpcDoSomething(IData data)
+        {
+            // empty
+        }
+    }
+
+    public interface IData { }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
@@ -95,6 +95,7 @@ namespace Mirror.Weaver.Tests
             // would only want to be send as an arg as a base type for an Inherited object
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for UnityEngine\.Object\. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for UnityEngine\.Object\. Use a supported type or provide a custom reader"));
         }
 
         [Test]
@@ -104,6 +105,7 @@ namespace Mirror.Weaver.Tests
             // would only want to be send as an arg as a base type for an Inherited object
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for UnityEngine\.ScriptableObject\. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for UnityEngine\.ScriptableObject\. Use a supported type or provide a custom reader"));
         }
 
         [Test]
@@ -111,6 +113,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for component type UnityEngine\.MonoBehaviour\. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for component type UnityEngine\.MonoBehaviour\. Use a supported type or provide a custom reader"));
         }
 
         [Test]
@@ -118,6 +121,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for component type MirrorTest\.MyBehaviour\. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for component type MirrorTest\.MyBehaviour\. Use a supported type or provide a custom reader"));
         }
 
         [Test]
@@ -125,6 +129,21 @@ namespace Mirror.Weaver.Tests
         public void ExcludesNonSerializedFields()
         {
             // we test this by having a not allowed type in the class, but mark it with NonSerialized
+            Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
+            Assert.That(weaverErrors, Is.Empty);
+        }
+
+        [Test]
+        public void GivesErrorWhenUsingInterface()
+        {
+            Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
+            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for interface MirrorTest\.IData\. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for interface MirrorTest\.IData\. Use a supported type or provide a custom reader"));
+        }
+
+        [Test]
+        public void CanUseCustomReadWriteForInterfaces()
+        {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
             Assert.That(weaverErrors, Is.Empty);
         }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests.cs
@@ -22,14 +22,14 @@ namespace Mirror.Weaver.Tests
         public void MessageMemberGeneric()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for generic type MirrorTest.HasGeneric`1<System.Int32>. Use a concrete type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for generic type MirrorTest.HasGeneric`1<System.Int32>. Use a supported type or provide a custom writer"));
         }
 
         [Test]
         public void MessageMemberInterface()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for interface MirrorTest.SuperCoolInterface. Use a concrete type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for interface MirrorTest.SuperCoolInterface. Use a supported type or provide a custom writer"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
@@ -57,14 +57,14 @@ namespace Mirror.Weaver.Tests
         public void SyncVarsGenericParam()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for generic type MirrorTest.MirrorTestPlayer/MySyncVar`1<System.Int32>. Use a concrete type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for generic type MirrorTest.MirrorTestPlayer/MySyncVar`1<System.Int32>. Use a supported type or provide a custom writer"));
         }
 
         [Test]
         public void SyncVarsInterface()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for interface MirrorTest.MirrorTestPlayer/MySyncVar. Use a concrete type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for interface MirrorTest.MirrorTestPlayer/MySyncVar. Use a supported type or provide a custom writer"));
         }
 
         [Test]


### PR DESCRIPTION
- Adding tests `GivesErrorWhenUsingInterface` and `CanUseCustomReadWriteForInterfaces`
- Checking for "Cannot generate reader" error message
- Updating error message to be consistent 
