### PR TITLE
Rename OnNetworkDestroy to OnStopClient

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -611,7 +611,7 @@ namespace Mirror
 
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity localObject) && localObject != null)
             {
-                localObject.OnNetworkDestroy();
+                localObject.OnStopClient();
 
                 if (!InvokeUnSpawnHandler(localObject.assetId, localObject.gameObject))
                 {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -815,11 +815,23 @@ namespace Mirror
         }
 
         /// <summary>
+        /// Obsolete, use OnStopClient instead
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use OnStopClient instead")]
+        public virtual void OnNetworkDestroy() { }
+
+        /// <summary>
         /// This is invoked on clients when the server has caused this object to be destroyed.
         /// <para>This can be used as a hook to invoke effects or do client specific cleanup.</para>
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual void OnNetworkDestroy() { }
+        public virtual void OnStopClient()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            // backwards compatibility
+            OnNetworkDestroy();
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
 
         /// <summary>
         /// This is invoked for NetworkBehaviour objects when they become active on the server.

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -737,7 +737,7 @@ namespace Mirror
             return true;
         }
 
-        internal void OnNetworkDestroy()
+        internal void OnStopClient()
         {
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {
@@ -748,7 +748,7 @@ namespace Mirror
                 //    one exception doesn't stop all the other Start() calls!
                 try
                 {
-                    comp.OnNetworkDestroy();
+                    comp.OnStopClient();
                 }
                 catch (Exception e)
                 {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1091,7 +1091,7 @@ namespace Mirror
             identity.ClearObservers();
             if (NetworkClient.active && localClientActive)
             {
-                identity.OnNetworkDestroy();
+                identity.OnStopClient();
             }
 
             // when unspawning, dont destroy the server's object

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -184,7 +184,7 @@ namespace Mirror.Tests
     public class OnNetworkDestroyComponent : NetworkBehaviour
     {
         public int called;
-        public override void OnNetworkDestroy()
+        public override void OnStopClient()
         {
             ++called;
         }
@@ -1595,7 +1595,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(0));
 
             // call identity OnNetworkDestroy
-            identity.OnNetworkDestroy();
+            identity.OnStopClient();
 
             // should have been forwarded to behaviours
             Assert.That(comp.called, Is.EqualTo(1));

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -92,7 +92,7 @@ namespace Mirror.Tests
         class NetworkDestroyExceptionNetworkBehaviour : NetworkBehaviour
         {
             public int called;
-            public override void OnNetworkDestroy()
+            public override void OnStopClient()
             {
                 ++called;
                 throw new Exception("some exception");
@@ -102,7 +102,7 @@ namespace Mirror.Tests
         class NetworkDestroyCalledNetworkBehaviour : NetworkBehaviour
         {
             public int called;
-            public override void OnNetworkDestroy() { ++called; }
+            public override void OnStopClient() { ++called; }
         }
 
         class SetHostVisibilityExceptionNetworkBehaviour : NetworkVisibility
@@ -1032,7 +1032,7 @@ namespace Mirror.Tests
             // OnNetworkDestroy from being called in the second one
             // exception will log an error
             LogAssert.ignoreFailingMessages = true;
-            identity.OnNetworkDestroy();
+            identity.OnStopClient();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(compEx.called, Is.EqualTo(1));
             Assert.That(comp.called, Is.EqualTo(1));

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -54,7 +54,7 @@ namespace Mirror.Tests
     {
         // counter to make sure that it's called exactly once
         public int called;
-        public override void OnNetworkDestroy() { ++called; }
+        public override void OnStopClient() { ++called; }
     }
 
     [TestFixture]


### PR DESCRIPTION
OnNetworkDestroy is not a good name,  is it server? is it client?
you can't tell by the name.

Moreover,  we have OnStartClient,  API should be symetric so we should
have a corresponding OnStopClient.

Note this keeps backwards compatibility with an Obsolete for now