### PR TITLE
fix: Allow sync objects to be re-used

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -814,6 +814,14 @@ namespace Mirror
             }
         }
 
+        internal void ResetSyncObjects()
+        {
+            for (int i = 0; i < syncObjects.Count; i++)
+            {
+                syncObjects[i].Reset();
+            }
+        }
+
         // Deprecated 04/20/2020
         /// <summary>
         /// Obsolete: Use <see cref="OnStopClient()"/> instead

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -816,9 +816,9 @@ namespace Mirror
 
         internal void ResetSyncObjects()
         {
-            for (int i = 0; i < syncObjects.Count; i++)
+            foreach (SyncObject syncObject in syncObjects)
             {
-                syncObjects[i].Reset();
+                syncObject.Reset();
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -600,6 +600,7 @@ namespace Mirror
                 try
                 {
                     comp.OnStopServer();
+                    comp.ResetSyncObjects();
                 }
                 catch (Exception e)
                 {
@@ -759,6 +760,7 @@ namespace Mirror
                 try
                 {
                     comp.OnStopClient();
+                    comp.ResetSyncObjects();
                 }
                 catch (Exception e)
                 {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -600,7 +600,6 @@ namespace Mirror
                 try
                 {
                     comp.OnStopServer();
-                    comp.ResetSyncObjects();
                 }
                 catch (Exception e)
                 {
@@ -760,7 +759,6 @@ namespace Mirror
                 try
                 {
                     comp.OnStopClient();
-                    comp.ResetSyncObjects();
                 }
                 catch (Exception e)
                 {
@@ -1279,6 +1277,7 @@ namespace Mirror
             networkBehavioursCache = null;
 
             ClearObservers();
+            ResetSyncObjects();
         }
 
         // invoked by NetworkServer during Update()
@@ -1368,6 +1367,14 @@ namespace Mirror
                 {
                     comp.ClearAllDirtyBits();
                 }
+            }
+        }
+
+        internal void ResetSyncObjects()
+        {
+            foreach (NetworkBehaviour comp in NetworkBehaviours)
+            {
+                comp.ResetSyncObjects();
             }
         }
     }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1267,6 +1267,9 @@ namespace Mirror
         // of invoking reset after OnDestroy is called.
         internal void Reset()
         {
+            // make sure to call this before networkBehavioursCache is cleared below
+            ResetSyncObjects();
+
             clientStarted = false;
             isClient = false;
             isServer = false;
@@ -1277,7 +1280,6 @@ namespace Mirror
             networkBehavioursCache = null;
 
             ClearObservers();
-            ResetSyncObjects();
         }
 
         // invoked by NetworkServer during Update()

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1372,7 +1372,7 @@ namespace Mirror
             }
         }
 
-        internal void ResetSyncObjects()
+        void ResetSyncObjects()
         {
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {

--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -38,6 +38,14 @@ namespace Mirror
         // so we need to skip them
         int changesAhead;
 
+        public void Reset()
+        {
+            IsReadOnly = false;
+            changes.Clear();
+            changesAhead = 0;
+            objects.Clear();
+        }
+
         protected virtual void SerializeKey(NetworkWriter writer, TKey item) { }
         protected virtual void SerializeItem(NetworkWriter writer, TValue item) { }
         protected virtual TKey DeserializeKey(NetworkReader reader) => default;

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -91,6 +91,14 @@ namespace Mirror
         // this should be called after a successfull sync
         public void Flush() => changes.Clear();
 
+        public void Reset()
+        {
+            IsReadOnly = false;
+            changes.Clear();
+            changesAhead = 0;
+            objects.Clear();
+        }
+
         void AddOperation(Operation op, int itemIndex, T oldItem, T newItem)
         {
             if (IsReadOnly)

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -22,5 +22,10 @@ namespace Mirror
 
         // deserialize changes since last sync
         void OnDeserializeDelta(NetworkReader reader);
+
+        /// <summary>
+        /// Resets the SyncObject so that it can be re-used
+        /// </summary>
+        void Reset();
     }
 }

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -41,6 +41,14 @@ namespace Mirror
             this.objects = objects;
         }
 
+        public void Reset()
+        {
+            IsReadOnly = false;
+            changes.Clear();
+            changesAhead = 0;
+            objects.Clear();
+        }
+
         protected virtual void SerializeItem(NetworkWriter writer, T item) { }
         protected virtual T DeserializeItem(NetworkReader reader) => default;
 

--- a/Assets/Mirror/Tests/Editor/SyncDictionaryTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncDictionaryTest.cs
@@ -303,45 +303,48 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void ResetShouldSetReadOnlyToFalse()
+        public void ObjectCanBeReusedAfterReset()
         {
             SyncDictionaryIntString serverList = new SyncDictionaryIntString();
             SyncDictionaryIntString clientList = new SyncDictionaryIntString();
-
-            // data has been flushed,  should go back to clear
-            Assert.That(clientList.IsReadOnly, Is.False);
 
             serverList.Add(20, "yay");
             serverList.Add(30, "hello");
             serverList.Add(35, "world");
             SerializeDeltaTo(serverList, clientList);
 
-            // client list should now lock itself,  trying to modify it
-            // should produce an InvalidOperationException
-            Assert.That(clientList.IsReadOnly, Is.True);
-            Assert.Throws<InvalidOperationException>(() => clientList.Add(50, "fail"));
-
             clientList.Reset();
 
             // make old client the host
-
             SyncDictionaryIntString hostList = clientList;
             SyncDictionaryIntString clientList2 = new SyncDictionaryIntString();
 
-
             Assert.That(hostList.IsReadOnly, Is.False);
-            Assert.That(clientList2.IsReadOnly, Is.False);
 
             hostList.Add(20, "yay");
             hostList.Add(30, "hello");
             hostList.Add(35, "world");
             SerializeDeltaTo(hostList, clientList2);
 
-            // client list should now lock itself,  trying to modify it
-            // should produce an InvalidOperationException
-            Assert.That(clientList2.IsReadOnly, Is.True);
             Assert.That(hostList.IsReadOnly, Is.False);
-            Assert.Throws<InvalidOperationException>(() => clientList2.Add(50, "fail"));
+        }
+
+        [Test]
+        public void ResetShouldSetReadOnlyToFalse()
+        {
+            SyncDictionaryIntString serverList = new SyncDictionaryIntString();
+            SyncDictionaryIntString clientList = new SyncDictionaryIntString();
+
+            serverList.Add(20, "yay");
+            serverList.Add(30, "hello");
+            serverList.Add(35, "world");
+            SerializeDeltaTo(serverList, clientList);
+
+            Assert.That(clientList.IsReadOnly, Is.True);
+
+            clientList.Reset();
+
+            Assert.That(clientList.IsReadOnly, Is.False);
         }
 
         [Test]
@@ -373,7 +376,7 @@ namespace Mirror.Tests
 
             serverList.Reset();
 
-            Assert.That(serverList.Count, Is.Zero);
+            Assert.That(serverList, Is.Empty);
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SyncDictionaryTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncDictionaryTest.cs
@@ -301,5 +301,79 @@ namespace Mirror.Tests
             Assert.That(clientList.IsReadOnly, Is.True);
             Assert.Throws<InvalidOperationException>(() => clientList.Add(50, "fail"));
         }
+
+        [Test]
+        public void ResetShouldSetReadOnlyToFalse()
+        {
+            SyncDictionaryIntString serverList = new SyncDictionaryIntString();
+            SyncDictionaryIntString clientList = new SyncDictionaryIntString();
+
+            // data has been flushed,  should go back to clear
+            Assert.That(clientList.IsReadOnly, Is.False);
+
+            serverList.Add(20, "yay");
+            serverList.Add(30, "hello");
+            serverList.Add(35, "world");
+            SerializeDeltaTo(serverList, clientList);
+
+            // client list should now lock itself,  trying to modify it
+            // should produce an InvalidOperationException
+            Assert.That(clientList.IsReadOnly, Is.True);
+            Assert.Throws<InvalidOperationException>(() => clientList.Add(50, "fail"));
+
+            clientList.Reset();
+
+            // make old client the host
+
+            SyncDictionaryIntString hostList = clientList;
+            SyncDictionaryIntString clientList2 = new SyncDictionaryIntString();
+
+
+            Assert.That(hostList.IsReadOnly, Is.False);
+            Assert.That(clientList2.IsReadOnly, Is.False);
+
+            hostList.Add(20, "yay");
+            hostList.Add(30, "hello");
+            hostList.Add(35, "world");
+            SerializeDeltaTo(hostList, clientList2);
+
+            // client list should now lock itself,  trying to modify it
+            // should produce an InvalidOperationException
+            Assert.That(clientList2.IsReadOnly, Is.True);
+            Assert.That(hostList.IsReadOnly, Is.False);
+            Assert.Throws<InvalidOperationException>(() => clientList2.Add(50, "fail"));
+        }
+
+        [Test]
+        public void ResetShouldClearChanges()
+        {
+            SyncDictionaryIntString serverList = new SyncDictionaryIntString();
+
+            serverList.Add(20, "yay");
+            serverList.Add(30, "hello");
+            serverList.Add(35, "world");
+
+            Assert.That(serverList.GetChangeCount(), Is.GreaterThan(0));
+
+            serverList.Reset();
+
+            Assert.That(serverList.GetChangeCount(), Is.Zero);
+        }
+
+        [Test]
+        public void ResetShouldClearItems()
+        {
+            SyncDictionaryIntString serverList = new SyncDictionaryIntString();
+
+            serverList.Add(20, "yay");
+            serverList.Add(30, "hello");
+            serverList.Add(35, "world");
+
+            Assert.That(serverList.Count, Is.GreaterThan(0));
+
+            serverList.Reset();
+
+            Assert.That(serverList.Count, Is.Zero);
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -321,44 +321,48 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void ResetTest()
+        public void ObjectCanBeReusedAfterReset()
         {
             SyncListUInt serverList = new SyncListUInt();
             SyncListUInt clientList = new SyncListUInt();
-
-            // data has been flushed,  should go back to clear
-            Assert.That(clientList.IsReadOnly, Is.False);
 
             serverList.Add(1U);
             serverList.Add(2U);
             serverList.Add(3U);
             SerializeDeltaTo(serverList, clientList);
 
-            // client list should now lock itself,  trying to modify it
-            // should produce an InvalidOperationException
-            Assert.That(clientList.IsReadOnly, Is.True);
-            Assert.Throws<InvalidOperationException>(() => { clientList.Add(5U); });
-
             clientList.Reset();
 
             // make old client the host
-
             SyncListUInt hostList = clientList;
             SyncListUInt clientList2 = new SyncListUInt();
 
             Assert.That(hostList.IsReadOnly, Is.False);
-            Assert.That(clientList2.IsReadOnly, Is.False);
 
             hostList.Add(1U);
             hostList.Add(2U);
             hostList.Add(3U);
             SerializeDeltaTo(hostList, clientList2);
 
-            // client list should now lock itself,  trying to modify it
-            // should produce an InvalidOperationException
-            Assert.That(clientList2.IsReadOnly, Is.True);
             Assert.That(hostList.IsReadOnly, Is.False);
-            Assert.Throws<InvalidOperationException>(() => { clientList2.Add(5U); });
+        }
+
+        [Test]
+        public void ResetShouldSetReadOnlyToFalse()
+        {
+            SyncListUInt serverList = new SyncListUInt();
+            SyncListUInt clientList = new SyncListUInt();
+
+            serverList.Add(1U);
+            serverList.Add(2U);
+            serverList.Add(3U);
+            SerializeDeltaTo(serverList, clientList);
+
+            Assert.That(clientList.IsReadOnly, Is.True);
+
+            clientList.Reset();
+
+            Assert.That(clientList.IsReadOnly, Is.False);
         }
 
         [Test]
@@ -390,7 +394,7 @@ namespace Mirror.Tests
 
             serverList.Reset();
 
-            Assert.That(serverList.Count, Is.Zero);
+            Assert.That(serverList, Is.Empty);
         }
     }
 

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -120,7 +120,7 @@ namespace Mirror.Tests
             string element = serverSyncList.Find(entry => entry == "World");
             Assert.That(element, Is.EqualTo("World"));
         }
-        
+
         [Test]
         public void TestNoFind()
         {
@@ -132,9 +132,9 @@ namespace Mirror.Tests
         public void TestFindAll()
         {
             List<string> results = serverSyncList.FindAll(entry => entry.Contains("l"));
-            Assert.That(results, Is.EquivalentTo( new [] {"Hello", "World"}));
+            Assert.That(results, Is.EquivalentTo(new[] { "Hello", "World" }));
         }
-        
+
         [Test]
         public void TestFindAllNonExistent()
         {
@@ -318,7 +318,97 @@ namespace Mirror.Tests
             // should produce an InvalidOperationException
             Assert.That(clientList.IsReadOnly, Is.True);
             Assert.Throws<InvalidOperationException>(() => { clientList.Add(5U); });
+        }
 
+        [Test]
+        public void ResetTest()
+        {
+            SyncListUInt serverList = new SyncListUInt();
+            SyncListUInt clientList = new SyncListUInt();
+
+            // data has been flushed,  should go back to clear
+            Assert.That(clientList.IsReadOnly, Is.False);
+
+            serverList.Add(1U);
+            serverList.Add(2U);
+            serverList.Add(3U);
+            SerializeDeltaTo(serverList, clientList);
+
+            // client list should now lock itself,  trying to modify it
+            // should produce an InvalidOperationException
+            Assert.That(clientList.IsReadOnly, Is.True);
+            Assert.Throws<InvalidOperationException>(() => { clientList.Add(5U); });
+
+            clientList.Reset();
+
+            // make old client the host
+
+            SyncListUInt hostList = clientList;
+            SyncListUInt clientList2 = new SyncListUInt();
+
+            Assert.That(hostList.IsReadOnly, Is.False);
+            Assert.That(clientList2.IsReadOnly, Is.False);
+
+            hostList.Add(1U);
+            hostList.Add(2U);
+            hostList.Add(3U);
+            SerializeDeltaTo(hostList, clientList2);
+
+            // client list should now lock itself,  trying to modify it
+            // should produce an InvalidOperationException
+            Assert.That(clientList2.IsReadOnly, Is.True);
+            Assert.That(hostList.IsReadOnly, Is.False);
+            Assert.Throws<InvalidOperationException>(() => { clientList2.Add(5U); });
+        }
+
+        [Test]
+        public void ResetShouldClearChanges()
+        {
+            SyncListUInt serverList = new SyncListUInt();
+
+            serverList.Add(1U);
+            serverList.Add(2U);
+            serverList.Add(3U);
+
+            Assert.That(serverList.GetChangeCount(), Is.GreaterThan(0));
+
+            serverList.Reset();
+
+            Assert.That(serverList.GetChangeCount(), Is.Zero);
+        }
+
+        [Test]
+        public void ResetShouldClearItems()
+        {
+            SyncListUInt serverList = new SyncListUInt();
+
+            serverList.Add(1U);
+            serverList.Add(2U);
+            serverList.Add(3U);
+
+            Assert.That(serverList.Count, Is.GreaterThan(0));
+
+            serverList.Reset();
+
+            Assert.That(serverList.Count, Is.Zero);
+        }
+    }
+
+    public static class SyncObjectTestMethods
+    {
+        public static uint GetChangeCount(this SyncObject syncObject)
+        {
+            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            {
+                syncObject.OnSerializeDelta(writer);
+
+                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                {
+                    uint count = reader.ReadPackedUInt32();
+
+                    return count;
+                }
+            }
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsSyncList.cs
@@ -11,6 +11,7 @@ namespace MirrorTest
         public void OnSerializeDelta(NetworkWriter writer) {}
         public void OnDeserializeAll(NetworkReader reader) {}
         public void OnDeserializeDelta(NetworkReader reader) {}
+        public void Reset() {}
     }
 
     class MirrorTestPlayer : NetworkBehaviour


### PR DESCRIPTION
feature: https://github.com/vis2k/Mirror/issues/1714

Not sure sure if this is classed as a breaking change. Anyone who implements `SyncObject` interface will need to add  `void Reset();`