### PR TITLE
Remove MarkForReset

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -442,7 +442,7 @@ namespace Mirror
                         }
                         else
                         {
-                            identity.MarkForReset();
+                            identity.Reset();
                             identity.gameObject.SetActive(false);
                         }
                     }
@@ -453,8 +453,6 @@ namespace Mirror
 
         static void ApplySpawnPayload(NetworkIdentity identity, SpawnMessage msg)
         {
-            identity.Reset();
-
             if (msg.assetId != Guid.Empty)
                 identity.assetId = msg.assetId;
 
@@ -628,7 +626,7 @@ namespace Mirror
                     }
                 }
                 NetworkIdentity.spawned.Remove(netId);
-                localObject.MarkForReset();
+                localObject.Reset();
             }
             else
             {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -523,7 +523,7 @@ namespace Mirror
             sceneIds.Remove(sceneId);
             sceneIds.Remove(sceneId & 0x00000000FFFFFFFF);
 
-            // If the object has been unspawned,  then isServer will be false
+            // If false the object has already been unspawned
             // if it is still true, then we need to unspawn it
             if (isServer)
             {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -50,10 +50,6 @@ namespace Mirror
         // configuration
         NetworkBehaviour[] networkBehavioursCache;
 
-        // member used to mark a identity for future reset
-        // check MarkForReset for more information.
-        bool reset;
-
         /// <summary>
         /// Returns true if running as a client and this object was spawned by a server.
         /// </summary>
@@ -527,15 +523,9 @@ namespace Mirror
             sceneIds.Remove(sceneId);
             sceneIds.Remove(sceneId & 0x00000000FFFFFFFF);
 
-            // Only call NetworkServer.Destroy on server and only if reset is false
-            // reset will be false from incorrect use of Destroy instead of NetworkServer.Destroy
-            // reset will be true if NetworkServer.Destroy was correctly invoked to begin with
-            // Users are supposed to call NetworkServer.Destroy instead of just regular Destroy for networked objects.
-            // This is a safeguard in case users accidentally call regular Destroy instead.
-            // We cover their mistake by calling NetworkServer.Destroy for them.
-            // If, however, they call NetworkServer.Destroy correctly, which leads to NetworkIdentity.MarkForReset,
-            // then we don't need to call it again, so the check for reset is needed to prevent the doubling.
-            if (isServer && !reset)
+            // If the object has been unspawned,  then isServer will be false
+            // if it is still true, then we need to unspawn it
+            if (isServer)
             {
                 // Do not add logging to this (see above)
                 NetworkServer.Destroy(gameObject);
@@ -1275,21 +1265,11 @@ namespace Mirror
         // marks the identity for future reset, this is because we cant reset the identity during destroy
         // as people might want to be able to read the members inside OnDestroy(), and we have no way
         // of invoking reset after OnDestroy is called.
-        internal void MarkForReset() => reset = true;
-
-        // check if it was marked for reset
-        internal bool IsMarkedForReset() => reset;
-
-        // if we have marked an identity for reset we do the actual reset.
         internal void Reset()
         {
-            if (!reset)
-                return;
-
             clientStarted = false;
             isClient = false;
             isServer = false;
-            reset = false;
 
             netId = 0;
             connectionToServer = null;

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -737,7 +737,7 @@ namespace Mirror
         {
             foreach (NetworkIdentity identity in Resources.FindObjectsOfTypeAll<NetworkIdentity>())
             {
-                identity.MarkForReset();
+                identity.Reset();
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -676,7 +676,6 @@ namespace Mirror
                 Debug.Log("AddPlayer: playerGameObject has no NetworkIdentity. Please add a NetworkIdentity to " + player);
                 return false;
             }
-            identity.Reset();
 
             // cannot have a player object in "Add" version
             if (conn.identity != null)
@@ -904,7 +903,6 @@ namespace Mirror
                 Debug.LogError("SpawnObject " + obj + " has no NetworkIdentity. Please add a NetworkIdentity to " + obj);
                 return;
             }
-            identity.Reset();
             identity.connectionToClient = (NetworkConnectionToClient)ownerConnection;
 
             // special case to make sure hasAuthority is set
@@ -1101,7 +1099,7 @@ namespace Mirror
             {
                 UnityEngine.Object.Destroy(identity.gameObject);
             }
-            identity.MarkForReset();
+            identity.Reset();
         }
 
         /// <summary>
@@ -1175,7 +1173,6 @@ namespace Mirror
                 if (ValidateSceneObject(identity))
                 {
                     if (LogFilter.Debug) Debug.Log("SpawnObjects sceneId:" + identity.sceneId.ToString("X") + " name:" + identity.gameObject.name);
-                    identity.Reset();
                     identity.gameObject.SetActive(true);
                 }
             }

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -1215,15 +1215,7 @@ namespace Mirror.Tests
             identity.connectionToServer = new NetworkConnectionToServer();
             identity.observers[43] = new NetworkConnectionToClient(2);
 
-            // calling reset shouldn't do anything unless it was marked for reset
-            identity.Reset();
-            Assert.That(identity.isClient, Is.True);
-            Assert.That(identity.netId, Is.EqualTo(netId));
-            Assert.That(identity.connectionToClient, !Is.Null);
-            Assert.That(identity.connectionToServer, !Is.Null);
-
             // mark for reset and reset
-            identity.MarkForReset();
             identity.Reset();
             Assert.That(identity.isClient, Is.False);
             Assert.That(identity.netId, Is.EqualTo(0));

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -1036,13 +1036,13 @@ namespace Mirror.Tests
             identity.sceneId = 42;
             // spawned objects are active
             go.SetActive(true);
-            Assert.That(identity.IsMarkedForReset(), Is.False);
+            identity.netId = 123;
 
             // unspawn
             NetworkServer.UnSpawn(go);
 
             // it should have been marked for reset now
-            Assert.That(identity.IsMarkedForReset(), Is.True);
+            Assert.That(identity.netId, Is.Zero);
 
             // clean up
             GameObject.DestroyImmediate(go);

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -1041,7 +1041,7 @@ namespace Mirror.Tests
             // unspawn
             NetworkServer.UnSpawn(go);
 
-            // it should have been marked for reset now
+            // it should have been reset now
             Assert.That(identity.netId, Is.Zero);
 
             // clean up


### PR DESCRIPTION
MarkForReset was useful to preserve network information during destroy (see #1484),  and yet allow scene objects to be reset if we reconnect.

To address #1484, override OnStopServer instead (see #1743).

This PR simplifies the whole thing by getting rid of MarkForReset and simply resetting objects when they are unspawned.  
