### PR TITLE
fix: Remove leftover AddPlayer methods now that extraData is gone

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -87,27 +87,12 @@ namespace Mirror
         }
 
         /// <summary>
-        /// This adds a player GameObject for this client.
-        /// <para>This causes an AddPlayer message to be sent to the server, and NetworkManager.OnServerAddPlayer is called.</para>
-        /// </summary>
-        /// <returns>True if player was added.</returns>
-        public static bool AddPlayer() => AddPlayer(null);
-
-        /// <summary>
-        /// This adds a player GameObject for this client. This causes an AddPlayer message to be sent to the server, and NetworkManager.OnServerAddPlayer is called. If an extra message was passed to AddPlayer, then OnServerAddPlayer will be called with a NetworkReader that contains the contents of the message.
-        /// </summary>
-        /// <param name="readyConn">The connection to become ready for this client.</param>
-        /// <returns>True if player was added.</returns>
-        public static bool AddPlayer(NetworkConnection readyConn) => AddPlayer(readyConn, null);
-
-        /// <summary>
         /// This adds a player GameObject for this client. This causes an AddPlayer message to be sent to the server, and NetworkManager.OnServerAddPlayer is called. If an extra message was passed to AddPlayer, then OnServerAddPlayer will be called with a NetworkReader that contains the contents of the message.
         /// <para>extraMessage can contain character selection, etc.</para>
         /// </summary>
         /// <param name="readyConn">The connection to become ready for this client.</param>
-        /// <param name="extraData">An extra message object that can be passed to the server for this player.</param>
         /// <returns>True if player was added.</returns>
-        public static bool AddPlayer(NetworkConnection readyConn, byte[] extraData)
+        public static bool AddPlayer(NetworkConnection readyConn)
         {
             // ensure valid ready connection
             if (readyConn != null)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1380,7 +1380,7 @@ namespace Mirror
                 if (!ClientScene.ready) ClientScene.Ready(conn);
                 if (autoCreatePlayer)
                 {
-                    ClientScene.AddPlayer();
+                    ClientScene.AddPlayer(conn);
                 }
             }
         }
@@ -1442,7 +1442,7 @@ namespace Mirror
             if (clientSceneOperation == SceneOperation.Normal && autoCreatePlayer && ClientScene.localPlayer == null)
             {
                 // add player if existing one is null
-                ClientScene.AddPlayer();
+                ClientScene.AddPlayer(conn);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -61,7 +61,7 @@ namespace Mirror
 
                     if (ClientScene.localPlayer == null)
                     {
-                        ClientScene.AddPlayer();
+                        ClientScene.AddPlayer(NetworkClient.connection);
                     }
                 }
             }


### PR DESCRIPTION
This is dead code since extraData was removed last month.  Since the AddPlayerMessage doesn't contain the `byte[] extraData` property this code, despite being public, is effectively unreachable.

The only handler we have is
`void OnServerAddPlayerInternal(NetworkConnection conn, AddPlayerMessage msg)`.