### PR TITLE
adding namespace to runtime tests

### DIFF
--- a/Assets/Mirror/Tests/Performance/Runtime/BenchmarkPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Runtime/BenchmarkPerformance.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 
-namespace Mirror.Tests.Performance
+namespace Mirror.Tests.Performance.Runtime
 {
     [Category("Performance")]
     [Category("Benchmark")]

--- a/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
+++ b/Assets/Mirror/Tests/Performance/Runtime/ULocalConnectionPerformance.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 
 
-namespace Mirror.Tests.Performance
+namespace Mirror.Tests.Performance.Runtime
 {
     class NetworkManagerTest : NetworkManager
     {

--- a/Assets/Mirror/Tests/Runtime/HostSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/HostSetup.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Mirror.Tests
+namespace Mirror.Tests.Runtime
 {
     public class HostSetup
     {

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Mirror.Tests
+namespace Mirror.Tests.Runtime
 {
     public class NetworkIdentityTests
     {

--- a/Assets/Mirror/Tests/Runtime/NetworkManagerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkManagerTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 
-namespace Mirror.Tests
+namespace Mirror.Tests.Runtime
 {
     public class NetworkManagerTests : HostSetup
     {

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Mirror.Tests
+namespace Mirror.Tests.Runtime
 {
     [TestFixture]
     public class NetworkServerRuntimeTest : HostSetup


### PR DESCRIPTION
**HOLD until #1724 is merged**

Adding different namespace to make sure we dont have problem with test classes with the same name in the editmode tests