### PR TITLE
feat: NetworkServer.SendToReady

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -318,6 +318,7 @@ namespace Mirror
 
         /// <summary>
         /// Send a message to only clients which are ready.
+        /// <para>See <see cref="NetworkConnection.isReady"/></para>
         /// </summary>
         /// <typeparam name="T">Message type.</typeparam>
         /// <param name="msg">Message</param>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -392,7 +392,7 @@ namespace Mirror
         /// <param name="msg">Message</param>
         /// <param name="channelId">Transport channel to use</param>
         /// <returns></returns>
-        public static bool SendToReady<T>(T msg, int channelId) where T : IMessageBase
+        public static bool SendToReady<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             // get writer from pool
             using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
@@ -409,14 +409,17 @@ namespace Mirror
                 int count = 0;
                 foreach (KeyValuePair<int, NetworkConnectionToClient> kvp in connections)
                 {
-                    count++;
+                    if (kvp.Value.isReady)
+                    {
+                        count++;
 
-                    // use local connection directly because it doesn't send via transport
-                    if (kvp.Value is ULocalConnectionToClient)
-                        result &= kvp.Value.Send(segment);
-                    // gather all internet connections
-                    else
-                        connectionIdsCache.Add(kvp.Key);
+                        // use local connection directly because it doesn't send via transport
+                        if (kvp.Value is ULocalConnectionToClient)
+                            result &= kvp.Value.Send(segment);
+                        // gather all internet connections
+                        else
+                            connectionIdsCache.Add(kvp.Key);
+                    }
                 }
 
                 // send to all internet connections at once

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -375,13 +375,60 @@ namespace Mirror
         /// <para>See <see cref="ClientScene.ready"/></para>
         /// </summary>
         /// <typeparam name="T">Message type</typeparam>
-        /// <param name="identity"></param>
+        /// <param name="identity">identity of the object</param>
         /// <param name="msg">Message</param>
         /// <param name="channelId">Transport channel to use</param>
         /// <returns></returns>
         public static bool SendToReady<T>(NetworkIdentity identity, T msg, int channelId) where T : IMessageBase
         {
             return SendToReady(identity, msg, true, channelId);
+        }
+
+        /// <summary>
+        /// Send a message to only clients which are ready
+        /// <para>See <see cref="ClientScene.ready"/></para>
+        /// </summary>
+        /// <typeparam name="T">Message type</typeparam>
+        /// <param name="msg">Message</param>
+        /// <param name="channelId">Transport channel to use</param>
+        /// <returns></returns>
+        public static bool SendToReady<T>(T msg, int channelId) where T : IMessageBase
+        {
+            // get writer from pool
+            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            {
+                // pack message only once
+                MessagePacker.Pack(msg, writer);
+                ArraySegment<byte> segment = writer.ToArraySegment();
+
+                // filter and then send to all internet connections at once
+                // -> makes code more complicated, but is HIGHLY worth it to
+                //    avoid allocations, allow for multicast, etc.
+                connectionIdsCache.Clear();
+                bool result = true;
+                int count = 0;
+                foreach (KeyValuePair<int, NetworkConnectionToClient> kvp in connections)
+                {
+                    count++;
+
+                    // use local connection directly because it doesn't send via transport
+                    if (kvp.Value is ULocalConnectionToClient)
+                        result &= kvp.Value.Send(segment);
+                    // gather all internet connections
+                    else
+                        connectionIdsCache.Add(kvp.Key);
+                }
+
+                // send to all internet connections at once
+                if (connectionIdsCache.Count > 0)
+                {
+                    result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
+                }
+
+                NetworkDiagnostics.OnSend(msg, channelId, segment.Count, count);
+
+                return result;
+            }
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -317,6 +317,18 @@ namespace Mirror
         }
 
         /// <summary>
+        /// Send a message to only clients which are ready.
+        /// </summary>
+        /// <typeparam name="T">Message type.</typeparam>
+        /// <param name="msg">Message</param>
+        /// <param name="channelId">Transport channel to use</param>
+        /// <returns></returns>
+        public static bool SendToReady<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
+        {
+            return SendToAll(msg, channelId, true);
+        }
+
+        /// <summary>
         /// Send a message to only clients which are ready with option to include the owner of the object identity.
         /// <para>See <see cref="NetworkConnection.isReady"/></para>
         /// </summary>


### PR DESCRIPTION
This adds an optional sendToReadyOnly parameter to SendToAll and a shorthand SendToReady method for server-wide messages to all **ready** clients without needing a NetworkIdentity for observers / owner checks.