### PR TITLE
feat: Improve weaver error messages

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -120,13 +120,13 @@ namespace Mirror.Weaver
         {
             if (!md.Name.StartsWith("Cmd"))
             {
-                Weaver.Error($"{md} must start with Cmd.  Consider renaming it to Cmd{md.Name}");
+                Weaver.Error($"{md.Name} must start with Cmd.  Consider renaming it to Cmd{md.Name}", md);
                 return false;
             }
 
             if (md.IsStatic)
             {
-                Weaver.Error($"{md} cannot be static");
+                Weaver.Error($"{md.Name} cannot be static", md);
                 return false;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/GenericArgumentResolver.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/GenericArgumentResolver.cs
@@ -21,7 +21,7 @@ namespace Mirror.Weaver
                 TypeReference arg = parent.GenericArguments[genericArgument];
                 if (arg.IsGenericParameter)
                 {
-                    itemType = FindParameterInStack(genericArgument);
+                    itemType = FindParameterInStack(td, genericArgument);
                 }
                 else
                 {
@@ -32,7 +32,7 @@ namespace Mirror.Weaver
             return itemType != null;
         }
 
-        TypeReference FindParameterInStack(int genericArgument)
+        TypeReference FindParameterInStack(TypeDefinition td, int genericArgument)
         {
             while (stack.Count > 0)
             {
@@ -54,6 +54,7 @@ namespace Mirror.Weaver
                 {
                     // if greater than `genericArgument` it is hard to know which generic arg we want
                     // See SyncListGenericInheritanceWithMultipleGeneric test
+                    Weaver.Error($"Type {td.Name} has too many generic arguments in base class {next}", td);
                     return null;
                 }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/GenericArgumentResolver.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/GenericArgumentResolver.cs
@@ -54,7 +54,6 @@ namespace Mirror.Weaver
                 {
                     // if greater than `genericArgument` it is hard to know which generic arg we want
                     // See SyncListGenericInheritanceWithMultipleGeneric test
-                    Weaver.Error($"Too many generic argument for {next}");
                     return null;
                 }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -47,7 +47,7 @@ namespace Mirror.Weaver
             {
                 if (field.FieldType.FullName == td.FullName)
                 {
-                    Weaver.Error($"{td} has field ${field} that references itself");
+                    Weaver.Error($"{td.Name} has field {field.Name} that references itself", field);
                     return;
                 }
             }
@@ -103,7 +103,7 @@ namespace Mirror.Weaver
             }
             else
             {
-                Weaver.Error($"{field} has unsupported type");
+                Weaver.Error($"{field.Name} has unsupported type", field);
             }
         }
 
@@ -184,7 +184,7 @@ namespace Mirror.Weaver
             }
             else
             {
-                Weaver.Error($"{field} has unsupported type");
+                Weaver.Error($"{field.Name} has unsupported type", field);
             }
         }
     }

--- a/Assets/Mirror/Editor/Weaver/Processors/MonoBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MonoBehaviourProcessor.cs
@@ -17,11 +17,11 @@ namespace Mirror.Weaver
             foreach (FieldDefinition fd in td.Fields)
             {
                 if (fd.HasCustomAttribute(Weaver.SyncVarType))
-                    Weaver.Error($"[SyncVar] {fd} must be inside a NetworkBehaviour.  {td} is not a NetworkBehaviour");
+                    Weaver.Error($"SyncVar {fd.Name} must be inside a NetworkBehaviour.  {td.Name} is not a NetworkBehaviour", fd);
 
                 if (SyncObjectInitializer.ImplementsSyncObject(fd.FieldType))
                 {
-                    Weaver.Error($"{fd} is a SyncObject and must be inside a NetworkBehaviour.  {td} is not a NetworkBehaviour");
+                    Weaver.Error($"{fd.Name} is a SyncObject and must be inside a NetworkBehaviour.  {td.Name} is not a NetworkBehaviour", fd);
                 }
             }
         }
@@ -35,17 +35,17 @@ namespace Mirror.Weaver
                 {
                     if (ca.AttributeType.FullName == Weaver.CommandType.FullName)
                     {
-                        Weaver.Error($"[Command] {md} must be declared inside a NetworkBehaviour");
+                        Weaver.Error($"Command {md.Name} must be declared inside a NetworkBehaviour", md);
                     }
 
                     if (ca.AttributeType.FullName == Weaver.ClientRpcType.FullName)
                     {
-                        Weaver.Error($"[ClientRpc] {md} must be declared inside a NetworkBehaviour");
+                        Weaver.Error($"ClientRpc {md.Name} must be declared inside a NetworkBehaviour", md);
                     }
 
                     if (ca.AttributeType.FullName == Weaver.TargetRpcType.FullName)
                     {
-                        Weaver.Error($"[TargetRpc] {md} must be declared inside a NetworkBehaviour");
+                        Weaver.Error($"TargetRpc {md.Name} must be declared inside a NetworkBehaviour", md);
                     }
 
                     string attributeName = ca.Constructor.DeclaringType.ToString();
@@ -53,16 +53,16 @@ namespace Mirror.Weaver
                     switch (attributeName)
                     {
                         case "Mirror.ServerAttribute":
-                            Weaver.Error($"[Server] {md} must be declared inside a NetworkBehaviour");
+                            Weaver.Error($"Server method {md.Name} must be declared inside a NetworkBehaviour", md);
                             break;
                         case "Mirror.ServerCallbackAttribute":
-                            Weaver.Error($"[ServerCallback] {md} must be declared inside a NetworkBehaviour");
+                            Weaver.Error($"ServerCallback method {md.Name} must be declared inside a NetworkBehaviour", md);
                             break;
                         case "Mirror.ClientAttribute":
-                            Weaver.Error($"[Client] {md} must be declared inside a NetworkBehaviour");
+                            Weaver.Error($"Client method {md.Name} must be declared inside a NetworkBehaviour", md);
                             break;
                         case "Mirror.ClientCallbackAttribute":
-                            Weaver.Error($"[ClientCallback] {md} must be declared inside a NetworkBehaviour");
+                            Weaver.Error($"ClientCallback method {md.Name} must be declared inside a NetworkBehaviour", md);
                             break;
                     }
                 }

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -32,7 +32,7 @@ namespace Mirror.Weaver
         {
             if (netBehaviourSubclass.HasGenericParameters)
             {
-                Weaver.Error($"{netBehaviourSubclass} cannot have generic parameters");
+                Weaver.Error($"{netBehaviourSubclass.Name} cannot have generic parameters", netBehaviourSubclass);
                 return;
             }
             Weaver.DLog(netBehaviourSubclass, "Process Start");
@@ -128,7 +128,7 @@ namespace Mirror.Weaver
                 MethodReference writeFunc = Writers.GetWriteFunc(pd.ParameterType);
                 if (writeFunc == null)
                 {
-                    Weaver.Error($"{md} has invalid parameter {pd}");
+                    Weaver.Error($"{md.Name} has invalid parameter {pd}", md);
                     return false;
                 }
                 // use built-in writer func on writer object
@@ -184,7 +184,7 @@ namespace Mirror.Weaver
                     }
                     else
                     {
-                        Weaver.Error($"{netBehaviourSubclass} has invalid class constructor");
+                        Weaver.Error($"{netBehaviourSubclass.Name} has invalid class constructor", cctor);
                         return;
                     }
                 }
@@ -205,7 +205,7 @@ namespace Mirror.Weaver
 
             if (ctor == null)
             {
-                Weaver.Error($"{netBehaviourSubclass} has invalid constructor");
+                Weaver.Error($"{netBehaviourSubclass.Name} has invalid constructor", netBehaviourSubclass);
                 return;
             }
 
@@ -216,7 +216,7 @@ namespace Mirror.Weaver
             }
             else
             {
-                Weaver.Error($"{netBehaviourSubclass} has invalid constructor");
+                Weaver.Error($"{netBehaviourSubclass.Name} has invalid constructor", ctor);
                 return;
             }
 
@@ -340,7 +340,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.Error($"{syncVar} has unsupported type. Use a supported Mirror type instead");
+                    Weaver.Error($"{syncVar.Name} has unsupported type. Use a supported Mirror type instead", syncVar);
                     return;
                 }
             }
@@ -394,7 +394,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.Error($"{syncVar} has unsupported type. Use a supported Mirror type instead");
+                    Weaver.Error($"{syncVar.Name} has unsupported type. Use a supported Mirror type instead", syncVar);
                     return;
                 }
 
@@ -546,7 +546,7 @@ namespace Mirror.Weaver
                 MethodReference readFunc = Readers.GetReadFunc(syncVar.FieldType);
                 if (readFunc == null)
                 {
-                    Weaver.Error($"{syncVar} has unsupported type. Use a supported Mirror type instead");
+                    Weaver.Error($"{syncVar.Name} has unsupported type. Use a supported Mirror type instead", syncVar);
                     return;
                 }
 
@@ -735,7 +735,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.Error($"{md} has invalid parameter {arg}.  Unsupported type {arg.ParameterType},  use a supported Mirror type instead");
+                    Weaver.Error($"{md.Name} has invalid parameter {arg}.  Unsupported type {arg.ParameterType},  use a supported Mirror type instead", md);
                     return false;
                 }
             }
@@ -752,17 +752,17 @@ namespace Mirror.Weaver
         {
             if (md.ReturnType.FullName == Weaver.IEnumeratorType.FullName)
             {
-                Weaver.Error($"{md} cannot be a coroutine");
+                Weaver.Error($"{md.Name} cannot be a coroutine", md);
                 return false;
             }
             if (md.ReturnType.FullName != Weaver.voidType.FullName)
             {
-                Weaver.Error($"{md} cannot return a value.  Make it void instead");
+                Weaver.Error($"{md.Name} cannot return a value.  Make it void instead", md);
                 return false;
             }
             if (md.HasGenericParameters)
             {
-                Weaver.Error($"{md} cannot have generic parameters");
+                Weaver.Error($"{md.Name} cannot have generic parameters", md);
                 return false;
             }
             return true;
@@ -775,19 +775,19 @@ namespace Mirror.Weaver
                 ParameterDefinition p = md.Parameters[i];
                 if (p.IsOut)
                 {
-                    Weaver.Error($"{md} cannot have out parameters");
+                    Weaver.Error($"{md.Name} cannot have out parameters", md);
                     return false;
                 }
                 if (p.IsOptional)
                 {
-                    Weaver.Error($"{md} cannot have optional parameters");
+                    Weaver.Error($"{md.Name} cannot have optional parameters", md);
                     return false;
                 }
                 // TargetRPC is an exception to this rule and can have a NetworkConnection as first parameter
                 if (p.ParameterType.FullName == Weaver.NetworkConnectionType.FullName &&
                     !(ca.AttributeType.FullName == Weaver.TargetRpcType.FullName && i == 0))
                 {
-                    Weaver.Error($"{md} has invalid parameer {p}. Cannot pass NeworkConnections");
+                    Weaver.Error($"{md.Name} has invalid parameer {p}. Cannot pass NeworkConnections", md);
                     return false;
                 }
             }
@@ -835,7 +835,7 @@ namespace Mirror.Weaver
 
             if (names.Contains(md.Name))
             {
-                Weaver.Error("Duplicate ClientRpc name [" + netBehaviourSubclass.FullName + ":" + md.Name + "]");
+                Weaver.Error($"Duplicate ClientRpc name {md.Name}", md);
                 return;
             }
             names.Add(md.Name);
@@ -857,7 +857,7 @@ namespace Mirror.Weaver
 
             if (names.Contains(md.Name))
             {
-                Weaver.Error("Duplicate Target Rpc name [" + netBehaviourSubclass.FullName + ":" + md.Name + "]");
+                Weaver.Error($"Duplicate Target Rpc name {md.Name}", md);
                 return;
             }
             names.Add(md.Name);
@@ -879,7 +879,7 @@ namespace Mirror.Weaver
 
             if (names.Contains(md.Name))
             {
-                Weaver.Error("Duplicate Command name [" + netBehaviourSubclass.FullName + ":" + md.Name + "]");
+                Weaver.Error($"Duplicate Command name {md.Name}", md);
                 return;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -101,13 +101,13 @@ namespace Mirror.Weaver
         {
             if (!md.Name.StartsWith("Rpc"))
             {
-                Weaver.Error($"{md} must start with Rpc.  Consider renaming it to Rpc{md.Name}");
+                Weaver.Error($"{md.Name} must start with Rpc.  Consider renaming it to Rpc{md.Name}", md);
                 return false;
             }
 
             if (md.IsStatic)
             {
-                Weaver.Error($"{md} must not be static");
+                Weaver.Error($"{md.Name} must not be static", md);
                 return false;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
@@ -35,7 +35,7 @@ namespace Mirror.Weaver
         {
             if (!Weaver.IsNetworkBehaviour(td))
             {
-                Weaver.Error($"[Server] {md} must be declared in a NetworkBehaviour");
+                Weaver.Error($"Server method {md.Name} must be declared in a NetworkBehaviour", md);
                 return;
             }
             ILProcessor worker = md.Body.GetILProcessor();
@@ -57,7 +57,7 @@ namespace Mirror.Weaver
         {
             if (!Weaver.IsNetworkBehaviour(td))
             {
-                Weaver.Error($"[Client] {md} must be declared in a NetworkBehaviour");
+                Weaver.Error($"Client method {md.Name} must be declared in a NetworkBehaviour", md);
                 return;
             }
             ILProcessor worker = md.Body.GetILProcessor();

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncDictionaryProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncDictionaryProcessor.cs
@@ -19,7 +19,7 @@ namespace Mirror.Weaver
             }
             else
             {
-                Weaver.Error($"Could not find generic arguments for {Weaver.SyncDictionaryType} using {td}");
+                Weaver.Error($"Could not find generic arguments for SyncDictionary in {td.Name}", td);
                 return;
             }
 
@@ -29,7 +29,7 @@ namespace Mirror.Weaver
             }
             else
             {
-                Weaver.Error($"Could not find generic arguments for {Weaver.SyncDictionaryType} using {td}");
+                Weaver.Error($"Could not find generic arguments for SyncDictionary in {td.Name}", td);
             }
         }
     }

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncEventProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncEventProcessor.cs
@@ -21,7 +21,7 @@ namespace Mirror.Weaver
             }
             if (eventField == null)
             {
-                Weaver.Error($"{td} not found. Did you declare the event?");
+                Weaver.Error($"event field not found for {ed.Name}. Did you declare it as an event?", ed);
                 return null;
             }
 
@@ -118,13 +118,13 @@ namespace Mirror.Weaver
                 {
                     if (!ed.Name.StartsWith("Event"))
                     {
-                        Weaver.Error($"{ed} must start with Event.  Consider renaming it to Event{ed.Name}");
+                        Weaver.Error($"{ed.Name} must start with Event.  Consider renaming it to Event{ed.Name}", ed);
                         return;
                     }
 
                     if (ed.EventType.Resolve().HasGenericParameters)
                     {
-                        Weaver.Error($"{ed} must not have generic parameters.  Consider creating a new class that inherits from {ed.EventType} instead");
+                        Weaver.Error($"{ed.Name} must not have generic parameters.  Consider creating a new class that inherits from {ed.EventType} instead", ed);
                         return;
                     }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncListProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncListProcessor.cs
@@ -20,7 +20,7 @@ namespace Mirror.Weaver
             }
             else
             {
-                Weaver.Error($"Could not find generic arguments for {mirrorBaseType} using {td}");
+                Weaver.Error($"Could not find generic arguments for {mirrorBaseType.Name} in {td}", td);
             }
         }
     }

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
@@ -41,7 +41,7 @@ namespace Mirror.Weaver
             MethodDefinition ctor = fieldType.Methods.FirstOrDefault(x => x.Name == ".ctor" && !x.HasParameters);
             if (ctor == null)
             {
-                Weaver.Error($"{fd} Can not intialize field because no default constructor was found. Manually intialize the field (call the constructor) or add constructor without Parameter");
+                Weaver.Error($"Can not intialize field {fd.Name} because no default constructor was found. Manually intialize the field (call the constructor) or add constructor without Parameter", fd);
                 return;
             }
             MethodReference objectConstructor = Weaver.CurrentAssembly.MainModule.ImportReference(ctor);

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
@@ -42,7 +42,7 @@ namespace Mirror.Weaver
             // we need to check if user has made custom function above
             if (itemType.IsGenericInstance)
             {
-                Weaver.Error($"{td} Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use {itemType} in SyncList");
+                Weaver.Error($"Can not create Serialize or Deserialize for generic element in {td.Name}. Override virtual methods with custom Serialize and Deserialize to use {itemType} in SyncList", td);
                 return false;
             }
 
@@ -65,7 +65,7 @@ namespace Mirror.Weaver
             }
             else
             {
-                Weaver.Error($"{td} cannot have item of type {itemType}.  Use a type supported by mirror instead");
+                Weaver.Error($"{td.Name} has sync object generic type {itemType.Name}.  Use a type supported by mirror instead", td);
                 return false;
             }
             serWorker.Append(serWorker.Create(OpCodes.Ret));
@@ -85,7 +85,7 @@ namespace Mirror.Weaver
             // we need to check if user has made custom function above
             if (itemType.IsGenericInstance)
             {
-                Weaver.Error($"{td} Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use {itemType} in SyncList");
+                Weaver.Error($"Can not create Serialize or Deserialize for generic element in {td.Name}. Override virtual methods with custom Serialize and Deserialize to use {itemType.Name} in SyncList", td);
                 return false;
             }
 
@@ -108,7 +108,7 @@ namespace Mirror.Weaver
             }
             else
             {
-                Weaver.Error($"{td} cannot have item of type {itemType}.  Use a type supported by mirror instead");
+                Weaver.Error($"{td.Name} has sync object generic type {itemType.Name}.  Use a type supported by mirror instead", td);
                 return false;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -36,16 +36,16 @@ namespace Mirror.Weaver
                     if (m.Parameters[0].ParameterType != syncVar.FieldType ||
                         m.Parameters[1].ParameterType != syncVar.FieldType)
                     {
-                        Weaver.Error($"{m} should have signature:\npublic void {hookFunctionName}({syncVar.FieldType} oldValue, {syncVar.FieldType} newValue) {{ }}");
+                        Weaver.Error($"{m.Name} should have signature: public void {hookFunctionName}({syncVar.FieldType} oldValue, {syncVar.FieldType} newValue) {{ }}", m);
                         return null;
                     }
                     return m;
                 }
-                Weaver.Error($"{m} should have signature:\npublic void {hookFunctionName}({syncVar.FieldType} oldValue, {syncVar.FieldType} newValue) {{ }}");
+                Weaver.Error($"{m.Name} should have signature: public void {hookFunctionName}({syncVar.FieldType} oldValue, {syncVar.FieldType} newValue) {{ }}", m);
                 return null;
             }
 
-            Weaver.Error($"No hook implementation found for {syncVar}. Add this method to your class:\npublic void {hookFunctionName}({syncVar.FieldType} oldValue, {syncVar.FieldType} newValue) {{ }}");
+            Weaver.Error($"No hook implementation found for {syncVar.Name}. Add this method to your class: public void {hookFunctionName}({syncVar.FieldType} oldValue, {syncVar.FieldType} newValue) {{ }}", syncVar);
             return null;
         }
 
@@ -306,19 +306,19 @@ namespace Mirror.Weaver
                 {
                     if ((fd.Attributes & FieldAttributes.Static) != 0)
                     {
-                        Weaver.Error($"{fd} cannot be static");
+                        Weaver.Error($"{fd.Name} cannot be static", fd);
                         return;
                     }
 
                     if (fd.FieldType.IsArray)
                     {
-                        Weaver.Error($"{fd} has invalid type. Use SyncLists instead of arrays");
+                        Weaver.Error($"{fd.Name} has invalid type. Use SyncLists instead of arrays", fd);
                         return;
                     }
 
                     if (SyncObjectInitializer.ImplementsSyncObject(fd.FieldType))
                     {
-                        Log.Warning($"{fd} has [SyncVar] attribute. SyncLists should not be marked with SyncVar");
+                        Weaver.Warning($"{fd.Name} has [SyncVar] attribute. SyncLists should not be marked with SyncVar", fd);
                     }
                     else
                     {
@@ -330,7 +330,7 @@ namespace Mirror.Weaver
 
                         if (dirtyBitCounter == SyncVarLimit)
                         {
-                            Weaver.Error($"{td} has too many SyncVars. Consider refactoring your class into multiple components");
+                            Weaver.Error($"{td.Name} has too many SyncVars. Consider refactoring your class into multiple components", td);
                             return;
                         }
                     }
@@ -340,13 +340,13 @@ namespace Mirror.Weaver
                 {
                     if (fd.IsStatic)
                     {
-                        Weaver.Error($"{fd} cannot be static");
+                        Weaver.Error($"{fd.Name} cannot be static", fd);
                         return;
                     }
 
                     if (fd.FieldType.Resolve().HasGenericParameters)
                     {
-                        Weaver.Error($"{fd} Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead.");
+                        Weaver.Error($"{fd.Name} Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead", fd);
                         return;
                     }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -346,7 +346,7 @@ namespace Mirror.Weaver
 
                     if (fd.FieldType.Resolve().HasGenericParameters)
                     {
-                        Weaver.Error($"{fd.Name} Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead", fd);
+                        Weaver.Error($"Cannot use generic SyncObject {fd.Name} directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead", fd);
                         return;
                     }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -143,13 +143,13 @@ namespace Mirror.Weaver
         {
             if (!md.Name.StartsWith("Target"))
             {
-                Weaver.Error($"{md} must start with Target.  Consider renaming it to Target{md.Name}");
+                Weaver.Error($"{md.Name} must start with Target.  Consider renaming it to Target{md.Name}", md);
                 return false;
             }
 
             if (md.IsStatic)
             {
-                Weaver.Error($"{md} must not be static");
+                Weaver.Error($"{md.Name} must not be static", md);
                 return false;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Program.cs
+++ b/Assets/Mirror/Editor/Weaver/Program.cs
@@ -11,12 +11,12 @@ namespace Mirror.Weaver
 
         public static void Warning(string msg)
         {
-            WarningMethod("Mirror.Weaver warning: " + msg);
+            WarningMethod(msg);
         }
 
         public static void Error(string msg)
         {
-            ErrorMethod("Mirror.Weaver error: " + msg);
+            ErrorMethod(msg);
         }
     }
 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -43,38 +43,38 @@ namespace Mirror.Weaver
             TypeDefinition td = variable.Resolve();
             if (td == null)
             {
-                Weaver.Error($"{variable} is not a supported type");
+                Weaver.Error($"{variable.Name} is not a supported type", variable);
                 return null;
             }
             if (td.IsDerivedFrom(Weaver.ComponentType))
             {
-                Weaver.Error($"Cannot generate reader for component type {variable}. Use a supported type or provide a custom reader");
+                Weaver.Error($"Cannot generate reader for component type {variable.Name}. Use a supported type or provide a custom reader", variable);
                 return null;
             }
             if (variable.FullName == Weaver.ObjectType.FullName)
             {
-                Weaver.Error($"Cannot generate reader for {variable}. Use a supported type or provide a custom reader");
+                Weaver.Error($"Cannot generate reader for {variable.Name}. Use a supported type or provide a custom reader", variable);
                 return null;
             }
             if (variable.FullName == Weaver.ScriptableObjectType.FullName)
             {
-                Weaver.Error($"Cannot generate reader for {variable}. Use a supported type or provide a custom reader");
+                Weaver.Error($"Cannot generate reader for {variable.Name}. Use a supported type or provide a custom reader", variable);
                 return null;
             }
             if (variable.IsByReference)
             {
                 // error??
-                Weaver.Error($"Cannot pass type {variable} by reference");
+                Weaver.Error($"Cannot pass type {variable.Name} by reference", variable);
                 return null;
             }
             if (td.HasGenericParameters && !td.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
             {
-                Weaver.Error($"Cannot generate reader for generic variable {variable}. Use a supported type or provide a custom reader");
+                Weaver.Error($"Cannot generate reader for generic variable {variable.Name}. Use a supported type or provide a custom reader", variable);
                 return null;
             }
             if (td.IsInterface)
             {
-                Weaver.Error($"Cannot generate reader for interface {variable}. Use a supported type or provide a custom reader");
+                Weaver.Error($"Cannot generate reader for interface {variable.Name}. Use a supported type or provide a custom reader", variable);
                 return null;
             }
 
@@ -84,7 +84,7 @@ namespace Mirror.Weaver
             }
             else if (variable.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
             {
-                newReaderFunc = GenerateArraySegmentReadFunc(variable, recursionCount);
+                newReaderFunc = GenerateArraySegmentReadFunc(variable, variable, recursionCount);
             }
             else
             {
@@ -93,7 +93,7 @@ namespace Mirror.Weaver
 
             if (newReaderFunc == null)
             {
-                Weaver.Error($"{variable} is not a supported type");
+                Weaver.Error($"{variable.Name} is not a supported type", variable);
                 return null;
             }
             RegisterReadFunc(variable.FullName, newReaderFunc);
@@ -109,11 +109,11 @@ namespace Mirror.Weaver
             Weaver.WeaveLists.generateContainerClass.Methods.Add(newReaderFunc);
         }
 
-        static MethodDefinition GenerateArrayReadFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArrayReadFunc( TypeReference variable, int recursionCount)
         {
             if (!variable.IsArrayType())
             {
-                Weaver.Error($"{variable} is an unsupported type. Jagged and multidimensional arrays are not supported");
+                Weaver.Error($"{variable.Name} is an unsupported type. Jagged and multidimensional arrays are not supported", variable);
                 return null;
             }
 
@@ -206,7 +206,7 @@ namespace Mirror.Weaver
             return readerFunc;
         }
 
-        static MethodDefinition GenerateArraySegmentReadFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArraySegmentReadFunc(MemberReference member, TypeReference variable, int recursionCount)
         {
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
@@ -300,7 +300,7 @@ namespace Mirror.Weaver
         {
             if (recursionCount > MaxRecursionCount)
             {
-                Weaver.Error($"{variable} can't be deserialized because it references itself");
+                Weaver.Error($"{variable.Name} can't be deserialized because it references itself", variable);
                 return null;
             }
 
@@ -362,7 +362,7 @@ namespace Mirror.Weaver
                 MethodDefinition ctor = Resolvers.ResolveDefaultPublicCtor(variable);
                 if (ctor == null)
                 {
-                    Weaver.Error($"{variable} can't be deserialized because it has no default constructor");
+                    Weaver.Error($"{variable.Name} can't be deserialized because it has no default constructor", variable);
                     return;
                 }
 
@@ -396,7 +396,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.Error($"{field} has an unsupported type");
+                    Weaver.Error($"{field.Name} has an unsupported type", field);
                 }
                 FieldReference fieldRef = Weaver.CurrentAssembly.MainModule.ImportReference(field);
 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -84,7 +84,7 @@ namespace Mirror.Weaver
             }
             else if (variable.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
             {
-                newReaderFunc = GenerateArraySegmentReadFunc(variable, variable, recursionCount);
+                newReaderFunc = GenerateArraySegmentReadFunc(variable, recursionCount);
             }
             else
             {
@@ -206,7 +206,7 @@ namespace Mirror.Weaver
             return readerFunc;
         }
 
-        static MethodDefinition GenerateArraySegmentReadFunc(MemberReference member, TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArraySegmentReadFunc(TypeReference variable, int recursionCount)
         {
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];

--- a/Assets/Mirror/Editor/Weaver/Resolvers.cs
+++ b/Assets/Mirror/Editor/Weaver/Resolvers.cs
@@ -12,10 +12,9 @@ namespace Mirror.Weaver
     {
         public static MethodReference ResolveMethod(TypeReference tr, AssemblyDefinition scriptDef, string name)
         {
-            //Console.WriteLine("ResolveMethod " + t.ToString () + " " + name);
             if (tr == null)
             {
-                Weaver.Error("Type missing for " + name);
+                Weaver.Error($"Cannot resolve method {name} without a class");
                 return null;
             }
             return ResolveMethod(tr, scriptDef, method => method.Name == name);
@@ -31,7 +30,7 @@ namespace Mirror.Weaver
                 }
             }
 
-            Weaver.Error($"Method not found");
+            Weaver.Error($"Method not found in type {t.Name}", t);
             return null;
         }
 
@@ -39,7 +38,7 @@ namespace Mirror.Weaver
         {
             if (tr == null)
             {
-                Weaver.Error("Type missing for " + name);
+                Weaver.Error($"Cannot resolve method {name} without a type");
                 return null;
             }
             foreach (MethodDefinition methodRef in tr.Resolve().Methods)
@@ -100,7 +99,7 @@ namespace Mirror.Weaver
                 }
             }
 
-            Weaver.Error($"{t}.{name}<{genericType}>() not found");
+            Weaver.Error($"Method {name} not found in {t.Name}", t);
             return null;
         }
 

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -150,6 +150,17 @@ namespace Mirror.Weaver
             WeavingFailed = true;
         }
 
+        public static void Error(string message, MemberReference mr)
+        {    
+            Log.Error($"{message} (at {mr})");
+            WeavingFailed = true;
+        }
+
+        public static void Warning(string message, MemberReference mr)
+        {
+            Log.Warning($"{message} (at {mr})");
+        }
+
         public static int GetSyncVarStart(string className)
         {
             return WeaveLists.numSyncVars.ContainsKey(className)

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -44,38 +44,38 @@ namespace Mirror.Weaver
             if (variable.IsByReference)
             {
                 // error??
-                Weaver.Error($"Cannot pass {variable} by reference");
+                Weaver.Error($"Cannot pass {variable.Name} by reference", variable);
                 return null;
             }
             TypeDefinition td = variable.Resolve();
             if (td == null)
             {
-                Weaver.Error($"{variable} is not a supported type. Use a supported type or provide a custom writer");
+                Weaver.Error($"{variable.Name} is not a supported type. Use a supported type or provide a custom writer", variable);
                 return null;
             }
             if (td.IsDerivedFrom(Weaver.ComponentType))
             {
-                Weaver.Error($"Cannot generate writer for component type {variable}. Use a supported type or provide a custom writer");
+                Weaver.Error($"Cannot generate writer for component type {variable.Name}. Use a supported type or provide a custom writer", variable);
                 return null;
             }
             if (variable.FullName == Weaver.ObjectType.FullName)
             {
-                Weaver.Error($"Cannot generate writer for {variable}. Use a supported type or provide a custom writer");
+                Weaver.Error($"Cannot generate writer for {variable.Name}. Use a supported type or provide a custom writer", variable);
                 return null;
             }
             if (variable.FullName == Weaver.ScriptableObjectType.FullName)
             {
-                Weaver.Error($"Cannot generate writer for {variable}. Use a supported type or provide a custom writer");
+                Weaver.Error($"Cannot generate writer for {variable.Name}. Use a supported type or provide a custom writer", variable);
                 return null;
             }
             if (td.HasGenericParameters && !td.FullName.StartsWith("System.ArraySegment`1", System.StringComparison.Ordinal))
             {
-                Weaver.Error($"Cannot generate writer for generic type {variable}. Use a supported type or provide a custom writer");
+                Weaver.Error($"Cannot generate writer for generic type {variable.Name}. Use a supported type or provide a custom writer", variable);
                 return null;
             }
             if (td.IsInterface)
             {
-                Weaver.Error($"Cannot generate writer for interface {variable}. Use a supported type or provide a custom writer");
+                Weaver.Error($"Cannot generate writer for interface {variable.Name}. Use a supported type or provide a custom writer", variable);
                 return null;
             }
 
@@ -114,7 +114,7 @@ namespace Mirror.Weaver
         {
             if (recursionCount > MaxRecursionCount)
             {
-                Weaver.Error($"{variable} can't be serialized because it references itself");
+                Weaver.Error($"{variable.Name} can't be serialized because it references itself", variable);
                 return null;
             }
 
@@ -161,7 +161,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    Weaver.Error($"{field} has unsupported type. Use a type supported by Mirror instead");
+                    Weaver.Error($"{field.Name} has unsupported type. Use a type supported by Mirror instead", field);
                     return null;
                 }
             }
@@ -178,7 +178,7 @@ namespace Mirror.Weaver
 
             if (!variable.IsArrayType())
             {
-                Weaver.Error($"{variable} is an unsupported type. Jagged and multidimensional arrays are not supported");
+                Weaver.Error($"{variable.Name} is an unsupported type. Jagged and multidimensional arrays are not supported", variable);
                 return null;
             }
 

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests.cs
@@ -15,14 +15,14 @@ namespace Mirror.Weaver.Tests
         public void ClientRpcStartsWithRpc()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.ClientRpcStartsWithRpc::DoesntStartWithRpc() must start with Rpc.  Consider renaming it to RpcDoesntStartWithRpc"));
+            Assert.That(weaverErrors, Contains.Item("DoesntStartWithRpc must start with Rpc.  Consider renaming it to RpcDoesntStartWithRpc (at System.Void MirrorTest.ClientRpcStartsWithRpc::DoesntStartWithRpc())"));
         }
 
         [Test]
         public void ClientRpcCantBeStatic()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.ClientRpcCantBeStatic::RpcCantBeStatic() must not be static"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantBeStatic must not be static (at System.Void MirrorTest.ClientRpcCantBeStatic::RpcCantBeStatic())"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
@@ -15,14 +15,14 @@ namespace Mirror.Weaver.Tests
         public void CommandStartsWithCmd()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.CommandStartsWithCmd::DoesntStartWithCmd() must start with Cmd.  Consider renaming it to CmdDoesntStartWithCmd"));
+            Assert.That(weaverErrors, Contains.Item("DoesntStartWithCmd must start with Cmd.  Consider renaming it to CmdDoesntStartWithCmd (at System.Void MirrorTest.CommandStartsWithCmd::DoesntStartWithCmd())"));
         }
 
         [Test]
         public void CommandCantBeStatic()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.CommandCantBeStatic::CmdCantBeStatic() cannot be static"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantBeStatic cannot be static (at System.Void MirrorTest.CommandCantBeStatic::CmdCantBeStatic())"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests.cs
@@ -8,8 +8,9 @@ namespace Mirror.Weaver.Tests
         public void RecursionCount()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.RecursionCount/Potato1 can't be serialized because it references itself"));
+            Assert.That(weaverErrors, Contains.Item("Potato1 can't be serialized because it references itself (at MirrorTest.RecursionCount/Potato1)"));
         }
+
         [Test]
         public void TestingScriptableObjectArraySerialization()
         {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
@@ -95,9 +95,7 @@ namespace Mirror.Weaver.Tests
             // would only want to be send as an arg as a base type for an Inherited object
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Contains.Item("Cannot generate writer for Object. Use a supported type or provide a custom writer (at UnityEngine.Object)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter obj (at System.Void MirrorTest.GivesErrorWhenUsingObject::RpcDoSomething(UnityEngine.Object))"));
             Assert.That(weaverErrors, Contains.Item("Cannot generate reader for Object. Use a supported type or provide a custom reader (at UnityEngine.Object)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter obj.  Unsupported type UnityEngine.Object,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingObject::RpcDoSomething(UnityEngine.Object))"));
         }
 
         [Test]
@@ -107,9 +105,7 @@ namespace Mirror.Weaver.Tests
             // would only want to be send as an arg as a base type for an Inherited object
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Contains.Item("Cannot generate writer for ScriptableObject. Use a supported type or provide a custom writer (at UnityEngine.ScriptableObject)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter obj (at System.Void MirrorTest.GivesErrorWhenUsingScriptableObject::RpcDoSomething(UnityEngine.ScriptableObject))"));
             Assert.That(weaverErrors, Contains.Item("Cannot generate reader for ScriptableObject. Use a supported type or provide a custom reader (at UnityEngine.ScriptableObject)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter obj.  Unsupported type UnityEngine.ScriptableObject,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingScriptableObject::RpcDoSomething(UnityEngine.ScriptableObject))"));
         }
 
         [Test]
@@ -117,9 +113,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type MonoBehaviour. Use a supported type or provide a custom writer (at UnityEngine.MonoBehaviour)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter behaviour (at System.Void MirrorTest.GivesErrorWhenUsingMonoBehaviour::RpcDoSomething(UnityEngine.MonoBehaviour))"));
             Assert.That(weaverErrors, Contains.Item("Cannot generate reader for component type MonoBehaviour. Use a supported type or provide a custom reader (at UnityEngine.MonoBehaviour)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter behaviour.  Unsupported type UnityEngine.MonoBehaviour,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingMonoBehaviour::RpcDoSomething(UnityEngine.MonoBehaviour))"));
         }
 
         [Test]
@@ -127,9 +121,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type MyBehaviour. Use a supported type or provide a custom writer (at MirrorTest.MyBehaviour)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter behaviour (at System.Void MirrorTest.GivesErrorWhenUsingTypeInheritedFromMonoBehaviour::RpcDoSomething(MirrorTest.MyBehaviour))"));
             Assert.That(weaverErrors, Contains.Item("Cannot generate reader for component type MyBehaviour. Use a supported type or provide a custom reader (at MirrorTest.MyBehaviour)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter behaviour.  Unsupported type MirrorTest.MyBehaviour,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingTypeInheritedFromMonoBehaviour::RpcDoSomething(MirrorTest.MyBehaviour))"));
         }
 
         [Test]
@@ -145,9 +137,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
             Assert.That(weaverErrors, Contains.Item("Cannot generate writer for interface IData. Use a supported type or provide a custom writer (at MirrorTest.IData)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter data (at System.Void MirrorTest.GivesErrorWhenUsingInterface::RpcDoSomething(MirrorTest.IData))"));
             Assert.That(weaverErrors, Contains.Item("Cannot generate reader for interface IData. Use a supported type or provide a custom reader (at MirrorTest.IData)"));
-            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter data.  Unsupported type MirrorTest.IData,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingInterface::RpcDoSomething(MirrorTest.IData))"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
@@ -43,7 +43,7 @@ namespace Mirror.Weaver.Tests
         public void GivesErrorForClassWithNoValidConstructor()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Has.Some.Match(@"Mirror\.Weaver error: MirrorTest\.SomeOtherData can't be deserialized because it has no default constructor"));
+            Assert.That(weaverErrors, Contains.Item("SomeOtherData can't be deserialized because it has no default constructor (at MirrorTest.SomeOtherData)"));
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace Mirror.Weaver.Tests
         public void GivesErrorWhenUsingUnityAsset()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Has.Some.Match(@"Mirror\.Weaver error: UnityEngine\.Material can't be deserialized because it has no default constructor"));
+            Assert.That(weaverErrors, Contains.Item("Material can't be deserialized because it has no default constructor (at UnityEngine.Material)"));
         }
 
         [Test]
@@ -94,8 +94,10 @@ namespace Mirror.Weaver.Tests
             // TODO: decide if we want to block sending of Object
             // would only want to be send as an arg as a base type for an Inherited object
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for UnityEngine\.Object\. Use a supported type or provide a custom writer"));
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for UnityEngine\.Object\. Use a supported type or provide a custom reader"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for Object. Use a supported type or provide a custom writer (at UnityEngine.Object)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter obj (at System.Void MirrorTest.GivesErrorWhenUsingObject::RpcDoSomething(UnityEngine.Object))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate reader for Object. Use a supported type or provide a custom reader (at UnityEngine.Object)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter obj.  Unsupported type UnityEngine.Object,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingObject::RpcDoSomething(UnityEngine.Object))"));
         }
 
         [Test]
@@ -104,24 +106,30 @@ namespace Mirror.Weaver.Tests
             // TODO: decide if we want to block sending of ScripableObject
             // would only want to be send as an arg as a base type for an Inherited object
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for UnityEngine\.ScriptableObject\. Use a supported type or provide a custom writer"));
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for UnityEngine\.ScriptableObject\. Use a supported type or provide a custom reader"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for ScriptableObject. Use a supported type or provide a custom writer (at UnityEngine.ScriptableObject)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter obj (at System.Void MirrorTest.GivesErrorWhenUsingScriptableObject::RpcDoSomething(UnityEngine.ScriptableObject))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate reader for ScriptableObject. Use a supported type or provide a custom reader (at UnityEngine.ScriptableObject)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter obj.  Unsupported type UnityEngine.ScriptableObject,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingScriptableObject::RpcDoSomething(UnityEngine.ScriptableObject))"));
         }
 
         [Test]
         public void GivesErrorWhenUsingMonoBehaviour()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for component type UnityEngine\.MonoBehaviour\. Use a supported type or provide a custom writer"));
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for component type UnityEngine\.MonoBehaviour\. Use a supported type or provide a custom reader"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type MonoBehaviour. Use a supported type or provide a custom writer (at UnityEngine.MonoBehaviour)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter behaviour (at System.Void MirrorTest.GivesErrorWhenUsingMonoBehaviour::RpcDoSomething(UnityEngine.MonoBehaviour))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate reader for component type MonoBehaviour. Use a supported type or provide a custom reader (at UnityEngine.MonoBehaviour)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter behaviour.  Unsupported type UnityEngine.MonoBehaviour,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingMonoBehaviour::RpcDoSomething(UnityEngine.MonoBehaviour))"));
         }
 
         [Test]
         public void GivesErrorWhenUsingTypeInheritedFromMonoBehaviour()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for component type MirrorTest\.MyBehaviour\. Use a supported type or provide a custom writer"));
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for component type MirrorTest\.MyBehaviour\. Use a supported type or provide a custom reader"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type MyBehaviour. Use a supported type or provide a custom writer (at MirrorTest.MyBehaviour)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter behaviour (at System.Void MirrorTest.GivesErrorWhenUsingTypeInheritedFromMonoBehaviour::RpcDoSomething(MirrorTest.MyBehaviour))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate reader for component type MyBehaviour. Use a supported type or provide a custom reader (at MirrorTest.MyBehaviour)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter behaviour.  Unsupported type MirrorTest.MyBehaviour,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingTypeInheritedFromMonoBehaviour::RpcDoSomething(MirrorTest.MyBehaviour))"));
         }
 
         [Test]
@@ -136,8 +144,10 @@ namespace Mirror.Weaver.Tests
         public void GivesErrorWhenUsingInterface()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate writer for interface MirrorTest\.IData\. Use a supported type or provide a custom writer"));
-            Assert.That(weaverErrors, Has.Some.Match(@"Cannot generate reader for interface MirrorTest\.IData\. Use a supported type or provide a custom reader"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for interface IData. Use a supported type or provide a custom writer (at MirrorTest.IData)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter data (at System.Void MirrorTest.GivesErrorWhenUsingInterface::RpcDoSomething(MirrorTest.IData))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate reader for interface IData. Use a supported type or provide a custom reader (at MirrorTest.IData)"));
+            Assert.That(weaverErrors, Contains.Item("RpcDoSomething has invalid parameter data.  Unsupported type MirrorTest.IData,  use a supported Mirror type instead (at System.Void MirrorTest.GivesErrorWhenUsingInterface::RpcDoSomething(MirrorTest.IData))"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests.cs
@@ -15,21 +15,22 @@ namespace Mirror.Weaver.Tests
         public void MessageSelfReferencing()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.MessageSelfReferencing has field $MirrorTest.MessageSelfReferencing MirrorTest.MessageSelfReferencing::selfReference that references itself"));
-        }
+            Assert.That(weaverErrors, Contains.Item("MessageSelfReferencing has field selfReference that references itself (at MirrorTest.MessageSelfReferencing MirrorTest.MessageSelfReferencing::selfReference)"));        }
 
         [Test]
         public void MessageMemberGeneric()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for generic type MirrorTest.HasGeneric`1<System.Int32>. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for generic type HasGeneric`1. Use a supported type or provide a custom writer (at MirrorTest.HasGeneric`1<System.Int32>)"));
+            Assert.That(weaverErrors, Contains.Item("invalidField has unsupported type (at MirrorTest.HasGeneric`1<System.Int32> MirrorTest.MessageMemberGeneric::invalidField)"));
         }
 
         [Test]
         public void MessageMemberInterface()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for interface MirrorTest.SuperCoolInterface. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for interface SuperCoolInterface. Use a supported type or provide a custom writer (at MirrorTest.SuperCoolInterface)"));
+            Assert.That(weaverErrors, Contains.Item("invalidField has unsupported type (at MirrorTest.SuperCoolInterface MirrorTest.MessageMemberInterface::invalidField)"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests.cs
@@ -15,63 +15,63 @@ namespace Mirror.Weaver.Tests
         public void MonoBehaviourSyncVar()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: [SyncVar] System.Int32 MirrorTest.MonoBehaviourSyncVar::potato must be inside a NetworkBehaviour.  MirrorTest.MonoBehaviourSyncVar is not a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("SyncVar potato must be inside a NetworkBehaviour.  MonoBehaviourSyncVar is not a NetworkBehaviour (at System.Int32 MirrorTest.MonoBehaviourSyncVar::potato)"));
         }
 
         [Test]
         public void MonoBehaviourSyncList()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Mirror.SyncListInt MirrorTest.MonoBehaviourSyncList::potato is a SyncObject and must be inside a NetworkBehaviour.  MirrorTest.MonoBehaviourSyncList is not a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("potato is a SyncObject and must be inside a NetworkBehaviour.  MonoBehaviourSyncList is not a NetworkBehaviour (at Mirror.SyncListInt MirrorTest.MonoBehaviourSyncList::potato)"));
         }
 
         [Test]
         public void MonoBehaviourCommand()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: [Command] System.Void MirrorTest.MonoBehaviourCommand::CmdThisCantBeOutsideNetworkBehaviour() must be declared inside a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("Command CmdThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void MirrorTest.MonoBehaviourCommand::CmdThisCantBeOutsideNetworkBehaviour())"));
         }
 
         [Test]
         public void MonoBehaviourClientRpc()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: [ClientRpc] System.Void MirrorTest.MonoBehaviourClientRpc::RpcThisCantBeOutsideNetworkBehaviour() must be declared inside a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("ClientRpc RpcThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void MirrorTest.MonoBehaviourClientRpc::RpcThisCantBeOutsideNetworkBehaviour())"));
         }
 
         [Test]
         public void MonoBehaviourTargetRpc()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: [TargetRpc] System.Void MirrorTest.MonoBehaviourTargetRpc::TargetThisCantBeOutsideNetworkBehaviour(Mirror.NetworkConnection) must be declared inside a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpc TargetThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void MirrorTest.MonoBehaviourTargetRpc::TargetThisCantBeOutsideNetworkBehaviour(Mirror.NetworkConnection))"));
         }
 
         [Test]
         public void MonoBehaviourServer()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: [Server] System.Void MirrorTest.MonoBehaviourServer::ThisCantBeOutsideNetworkBehaviour() must be declared inside a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("Server method ThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void MirrorTest.MonoBehaviourServer::ThisCantBeOutsideNetworkBehaviour())"));
         }
 
         [Test]
         public void MonoBehaviourServerCallback()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: [ServerCallback] System.Void MirrorTest.MonoBehaviourServerCallback::ThisCantBeOutsideNetworkBehaviour() must be declared inside a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("ServerCallback method ThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void MirrorTest.MonoBehaviourServerCallback::ThisCantBeOutsideNetworkBehaviour())"));
         }
 
         [Test]
         public void MonoBehaviourClient()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: [Client] System.Void MirrorTest.MonoBehaviourClient::ThisCantBeOutsideNetworkBehaviour() must be declared inside a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("Client method ThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void MirrorTest.MonoBehaviourClient::ThisCantBeOutsideNetworkBehaviour())"));
         }
 
         [Test]
         public void MonoBehaviourClientCallback()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: [ClientCallback] System.Void MirrorTest.MonoBehaviourClientCallback::ThisCantBeOutsideNetworkBehaviour() must be declared inside a NetworkBehaviour"));
+            Assert.That(weaverErrors, Contains.Item("ClientCallback method ThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void MirrorTest.MonoBehaviourClientCallback::ThisCantBeOutsideNetworkBehaviour())"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
@@ -22,84 +22,90 @@ namespace Mirror.Weaver.Tests
         public void NetworkBehaviourGeneric()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.NetworkBehaviourGeneric`1 cannot have generic parameters"));
+            Assert.That(weaverErrors, Contains.Item("NetworkBehaviourGeneric`1 cannot have generic parameters (at MirrorTest.NetworkBehaviourGeneric`1)" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdGenericParam()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourCmdGenericParam::CmdCantHaveGeneric() cannot have generic parameters"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveGeneric cannot have generic parameters (at System.Void MirrorTest.NetworkBehaviourCmdGenericParam::CmdCantHaveGeneric())" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdCoroutine()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Collections.IEnumerator MirrorTest.NetworkBehaviourCmdCoroutine::CmdCantHaveCoroutine() cannot be a coroutine"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveCoroutine cannot be a coroutine (at System.Collections.IEnumerator MirrorTest.NetworkBehaviourCmdCoroutine::CmdCantHaveCoroutine())" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdVoidReturn()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Int32 MirrorTest.NetworkBehaviourCmdVoidReturn::CmdCantHaveNonVoidReturn() cannot return a value.  Make it void instead"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveNonVoidReturn cannot return a value.  Make it void instead (at System.Int32 MirrorTest.NetworkBehaviourCmdVoidReturn::CmdCantHaveNonVoidReturn())" ));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcGenericParam()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourTargetRpcGenericParam::TargetRpcCantHaveGeneric() cannot have generic parameters"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveGeneric cannot have generic parameters (at System.Void MirrorTest.NetworkBehaviourTargetRpcGenericParam::TargetRpcCantHaveGeneric())" ));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcCoroutine()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Collections.IEnumerator MirrorTest.NetworkBehaviourTargetRpcCoroutine::TargetRpcCantHaveCoroutine() cannot be a coroutine"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveCoroutine cannot be a coroutine (at System.Collections.IEnumerator MirrorTest.NetworkBehaviourTargetRpcCoroutine::TargetRpcCantHaveCoroutine())" ));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcVoidReturn()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Int32 MirrorTest.NetworkBehaviourTargetRpcVoidReturn::TargetRpcCantHaveNonVoidReturn() cannot return a value.  Make it void instead"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveNonVoidReturn cannot return a value.  Make it void instead (at System.Int32 MirrorTest.NetworkBehaviourTargetRpcVoidReturn::TargetRpcCantHaveNonVoidReturn())" ));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcParamOut()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourTargetRpcParamOut::TargetRpcCantHaveParamOut(Mirror.NetworkConnection,System.Int32&) cannot have out parameters"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveParamOut cannot have out parameters (at System.Void MirrorTest.NetworkBehaviourTargetRpcParamOut::TargetRpcCantHaveParamOut(Mirror.NetworkConnection,System.Int32&))" ));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcParamOptional()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourTargetRpcParamOptional::TargetRpcCantHaveParamOptional(Mirror.NetworkConnection,System.Int32) cannot have optional parameters"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveParamOptional cannot have optional parameters (at System.Void MirrorTest.NetworkBehaviourTargetRpcParamOptional::TargetRpcCantHaveParamOptional(Mirror.NetworkConnection,System.Int32))" ));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcParamRef()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot pass System.Int32& by reference"));
+            Assert.That(weaverErrors, Contains.Item("Cannot pass Int32& by reference (at System.Int32&)"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveParamRef has invalid parameter monkeys (at System.Void MirrorTest.NetworkBehaviourTargetRpcParamRef::TargetRpcCantHaveParamRef(Mirror.NetworkConnection,System.Int32&))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot pass type Int32& by reference (at System.Int32&)"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveParamRef has invalid parameter monkeys.  Unsupported type System.Int32&,  use a supported Mirror type instead (at System.Void MirrorTest.NetworkBehaviourTargetRpcParamRef::TargetRpcCantHaveParamRef(Mirror.NetworkConnection,System.Int32&))" ));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcParamAbstract()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.NetworkBehaviourTargetRpcParamAbstract/AbstractClass can't be deserialized because it has no default constructor"));
+            Assert.That(weaverErrors, Contains.Item("AbstractClass can't be deserialized because it has no default constructor (at MirrorTest.NetworkBehaviourTargetRpcParamAbstract/AbstractClass)" ));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcParamComponent()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for component type MirrorTest.NetworkBehaviourTargetRpcParamComponent/ComponentClass. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type ComponentClass. Use a supported type or provide a custom writer (at MirrorTest.NetworkBehaviourTargetRpcParamComponent/ComponentClass)"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveParamComponent has invalid parameter monkeyComp (at System.Void MirrorTest.NetworkBehaviourTargetRpcParamComponent::TargetRpcCantHaveParamComponent(Mirror.NetworkConnection,MirrorTest.NetworkBehaviourTargetRpcParamComponent/ComponentClass))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate reader for component type ComponentClass. Use a supported type or provide a custom reader (at MirrorTest.NetworkBehaviourTargetRpcParamComponent/ComponentClass)"));
+            Assert.That(weaverErrors, Contains.Item("TargetRpcCantHaveParamComponent has invalid parameter monkeyComp.  Unsupported type MirrorTest.NetworkBehaviourTargetRpcParamComponent/ComponentClass,  use a supported Mirror type instead (at System.Void MirrorTest.NetworkBehaviourTargetRpcParamComponent::TargetRpcCantHaveParamComponent(Mirror.NetworkConnection,MirrorTest.NetworkBehaviourTargetRpcParamComponent/ComponentClass))" ));
         }
 
         [Test]
@@ -113,126 +119,138 @@ namespace Mirror.Weaver.Tests
         public void NetworkBehaviourTargetRpcDuplicateName()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Duplicate Target Rpc name [MirrorTest.NetworkBehaviourTargetRpcDuplicateName:TargetRpcCantHaveSameName]"));
+            Assert.That(weaverErrors, Contains.Item("Duplicate Target Rpc name TargetRpcCantHaveSameName (at System.Void MirrorTest.NetworkBehaviourTargetRpcDuplicateName::TargetRpcCantHaveSameName(Mirror.NetworkConnection,System.Int32,System.Int32))" ));
         }
 
         [Test]
         public void NetworkBehaviourClientRpcGenericParam()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourClientRpcGenericParam::RpcCantHaveGeneric() cannot have generic parameters"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveGeneric cannot have generic parameters (at System.Void MirrorTest.NetworkBehaviourClientRpcGenericParam::RpcCantHaveGeneric())"));
         }
 
         [Test]
         public void NetworkBehaviourClientRpcCoroutine()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Collections.IEnumerator MirrorTest.NetworkBehaviourClientRpcCoroutine::RpcCantHaveCoroutine() cannot be a coroutine"));
-        }
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveCoroutine cannot be a coroutine (at System.Collections.IEnumerator MirrorTest.NetworkBehaviourClientRpcCoroutine::RpcCantHaveCoroutine())"));        }
 
         [Test]
         public void NetworkBehaviourClientRpcVoidReturn()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Int32 MirrorTest.NetworkBehaviourClientRpcVoidReturn::RpcCantHaveNonVoidReturn() cannot return a value.  Make it void instead"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveNonVoidReturn cannot return a value.  Make it void instead (at System.Int32 MirrorTest.NetworkBehaviourClientRpcVoidReturn::RpcCantHaveNonVoidReturn())" ));
         }
 
         [Test]
         public void NetworkBehaviourClientRpcParamOut()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourClientRpcParamOut::RpcCantHaveParamOut(System.Int32&) cannot have out parameters"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveParamOut cannot have out parameters (at System.Void MirrorTest.NetworkBehaviourClientRpcParamOut::RpcCantHaveParamOut(System.Int32&))"));
         }
 
         [Test]
         public void NetworkBehaviourClientRpcParamOptional()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourClientRpcParamOptional::RpcCantHaveParamOptional(System.Int32) cannot have optional parameters"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveParamOptional cannot have optional parameters (at System.Void MirrorTest.NetworkBehaviourClientRpcParamOptional::RpcCantHaveParamOptional(System.Int32))"));
         }
 
         [Test]
         public void NetworkBehaviourClientRpcParamRef()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot pass System.Int32& by reference"));
+            Assert.That(weaverErrors, Contains.Item("Cannot pass Int32& by reference (at System.Int32&)"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveParamRef has invalid parameter monkeys (at System.Void MirrorTest.NetworkBehaviourClientRpcParamRef::RpcCantHaveParamRef(System.Int32&))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot pass type Int32& by reference (at System.Int32&)"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveParamRef has invalid parameter monkeys.  Unsupported type System.Int32&,  use a supported Mirror type instead (at System.Void MirrorTest.NetworkBehaviourClientRpcParamRef::RpcCantHaveParamRef(System.Int32&))"));
+            ;
         }
 
         [Test]
         public void NetworkBehaviourClientRpcParamAbstract()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.NetworkBehaviourClientRpcParamAbstract/AbstractClass can't be deserialized because it has no default constructor"));
+            Assert.That(weaverErrors, Contains.Item("AbstractClass can't be deserialized because it has no default constructor (at MirrorTest.NetworkBehaviourClientRpcParamAbstract/AbstractClass)"));
         }
 
         [Test]
         public void NetworkBehaviourClientRpcParamComponent()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for component type MirrorTest.NetworkBehaviourClientRpcParamComponent/ComponentClass. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type ComponentClass. Use a supported type or provide a custom writer (at MirrorTest.NetworkBehaviourClientRpcParamComponent/ComponentClass)"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveParamComponent has invalid parameter monkeyComp (at System.Void MirrorTest.NetworkBehaviourClientRpcParamComponent::RpcCantHaveParamComponent(MirrorTest.NetworkBehaviourClientRpcParamComponent/ComponentClass))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate reader for component type ComponentClass. Use a supported type or provide a custom reader (at MirrorTest.NetworkBehaviourClientRpcParamComponent/ComponentClass)"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveParamComponent has invalid parameter monkeyComp.  Unsupported type MirrorTest.NetworkBehaviourClientRpcParamComponent/ComponentClass,  use a supported Mirror type instead (at System.Void MirrorTest.NetworkBehaviourClientRpcParamComponent::RpcCantHaveParamComponent(MirrorTest.NetworkBehaviourClientRpcParamComponent/ComponentClass))"));
         }
 
         [Test]
         public void NetworkBehaviourClientRpcParamNetworkConnection()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourClientRpcParamNetworkConnection::RpcCantHaveParamOptional(Mirror.NetworkConnection) has invalid parameer monkeyCon. Cannot pass NeworkConnections"));
+            Assert.That(weaverErrors, Contains.Item("RpcCantHaveParamOptional has invalid parameer monkeyCon. Cannot pass NeworkConnections (at System.Void MirrorTest.NetworkBehaviourClientRpcParamNetworkConnection::RpcCantHaveParamOptional(Mirror.NetworkConnection))"));
         }
 
         [Test]
         public void NetworkBehaviourClientRpcDuplicateName()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Duplicate ClientRpc name [MirrorTest.NetworkBehaviourClientRpcDuplicateName:RpcCantHaveSameName]"));
+            Assert.That(weaverErrors, Contains.Item("Duplicate ClientRpc name RpcCantHaveSameName (at System.Void MirrorTest.NetworkBehaviourClientRpcDuplicateName::RpcCantHaveSameName(System.Int32,System.Int32))"));
         }
 
         [Test]
         public void NetworkBehaviourCmdParamOut()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourCmdParamOut::CmdCantHaveParamOut(System.Int32&) cannot have out parameters"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamOut cannot have out parameters (at System.Void MirrorTest.NetworkBehaviourCmdParamOut::CmdCantHaveParamOut(System.Int32&))" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdParamOptional()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourCmdParamOptional::CmdCantHaveParamOptional(System.Int32) cannot have optional parameters"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamOptional cannot have optional parameters (at System.Void MirrorTest.NetworkBehaviourCmdParamOptional::CmdCantHaveParamOptional(System.Int32))" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdParamRef()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot pass System.Int32& by reference"));
+            Assert.That(weaverErrors, Contains.Item("Cannot pass Int32& by reference (at System.Int32&)"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamRef has invalid parameter monkeys (at System.Void MirrorTest.NetworkBehaviourCmdParamRef::CmdCantHaveParamRef(System.Int32&))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot pass type Int32& by reference (at System.Int32&)"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamRef has invalid parameter monkeys.  Unsupported type System.Int32&,  use a supported Mirror type instead (at System.Void MirrorTest.NetworkBehaviourCmdParamRef::CmdCantHaveParamRef(System.Int32&))" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdParamAbstract()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.NetworkBehaviourCmdParamAbstract/AbstractClass can't be deserialized because it has no default constructor"));
+            Assert.That(weaverErrors, Contains.Item("AbstractClass can't be deserialized because it has no default constructor (at MirrorTest.NetworkBehaviourCmdParamAbstract/AbstractClass)" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdParamComponent()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for component type MirrorTest.NetworkBehaviourCmdParamComponent/ComponentClass. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type ComponentClass. Use a supported type or provide a custom writer (at MirrorTest.NetworkBehaviourCmdParamComponent/ComponentClass)"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamComponent has invalid parameter monkeyComp (at System.Void MirrorTest.NetworkBehaviourCmdParamComponent::CmdCantHaveParamComponent(MirrorTest.NetworkBehaviourCmdParamComponent/ComponentClass))"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate reader for component type ComponentClass. Use a supported type or provide a custom reader (at MirrorTest.NetworkBehaviourCmdParamComponent/ComponentClass)"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamComponent has invalid parameter monkeyComp.  Unsupported type MirrorTest.NetworkBehaviourCmdParamComponent/ComponentClass,  use a supported Mirror type instead (at System.Void MirrorTest.NetworkBehaviourCmdParamComponent::CmdCantHaveParamComponent(MirrorTest.NetworkBehaviourCmdParamComponent/ComponentClass))" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdParamNetworkConnection()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.NetworkBehaviourCmdParamNetworkConnection::CmdCantHaveParamOptional(Mirror.NetworkConnection) has invalid parameer monkeyCon. Cannot pass NeworkConnections"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamOptional has invalid parameer monkeyCon. Cannot pass NeworkConnections (at System.Void MirrorTest.NetworkBehaviourCmdParamNetworkConnection::CmdCantHaveParamOptional(Mirror.NetworkConnection))" ));
         }
 
         [Test]
         public void NetworkBehaviourCmdDuplicateName()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Duplicate Command name [MirrorTest.NetworkBehaviourCmdDuplicateName:CmdCantHaveSameName]"));
+            Assert.That(weaverErrors, Contains.Item("Duplicate Command name CmdCantHaveSameName (at System.Void MirrorTest.NetworkBehaviourCmdDuplicateName::CmdCantHaveSameName(System.Int32,System.Int32))" ));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests.cs
@@ -94,42 +94,42 @@ namespace Mirror.Weaver.Tests
         public void SyncDictionaryErrorForGenericStructKey()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncDictionaryErrorForGenericStructKey/MyGenericStructDictionary Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructKey/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructDictionary. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructKey/MyGenericStruct`1<System.Single> in SyncList (at MirrorTest.SyncDictionaryErrorForGenericStructKey/MyGenericStructDictionary)"));
         }
 
         [Test]
         public void SyncDictionaryErrorForGenericStructItem()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncDictionaryErrorForGenericStructItem/MyGenericStructDictionary Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructItem/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructDictionary. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructItem/MyGenericStruct`1<System.Single> in SyncList (at MirrorTest.SyncDictionaryErrorForGenericStructItem/MyGenericStructDictionary)"));
         }
 
         [Test]
         public void SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly/MyGenericStructDictionary Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructDictionary. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly/MyGenericStruct`1<System.Single> in SyncList (at MirrorTest.SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly/MyGenericStructDictionary)"));
         }
 
         [Test]
         public void SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly/MyGenericStructDictionary Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructDictionary. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly/MyGenericStruct`1<System.Single> in SyncList (at MirrorTest.SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly/MyGenericStructDictionary)"));
         }
 
         [Test]
         public void SyncDictionaryErrorForGenericStructKeyWithCustomSerializeOnly()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncDictionaryErrorForGenericStructKeyWithCustomSerializeOnly/MyGenericStructDictionary Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructKeyWithCustomSerializeOnly/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructDictionary. Override virtual methods with custom Serialize and Deserialize to use MyGenericStruct`1 in SyncList (at MirrorTest.SyncDictionaryErrorForGenericStructKeyWithCustomSerializeOnly/MyGenericStructDictionary)"));
         }
 
         [Test]
         public void SyncDictionaryErrorForGenericStructItemWithCustomSerializeOnly()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncDictionaryErrorForGenericStructItemWithCustomSerializeOnly/MyGenericStructDictionary Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncDictionaryErrorForGenericStructItemWithCustomSerializeOnly/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructDictionary. Override virtual methods with custom Serialize and Deserialize to use MyGenericStruct`1 in SyncList (at MirrorTest.SyncDictionaryErrorForGenericStructItemWithCustomSerializeOnly/MyGenericStructDictionary)"));
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace Mirror.Weaver.Tests
         public void SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour/SomeSyncDictionary`2<System.Int32,System.String> MirrorTest.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour::someDictionary Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead."));
+            Assert.That(weaverErrors, Contains.Item("someDictionary Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead (at MirrorTest.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour/SomeSyncDictionary`2<System.Int32,System.String> MirrorTest.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour::someDictionary)"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests.cs
@@ -150,7 +150,7 @@ namespace Mirror.Weaver.Tests
         public void SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("someDictionary Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead (at MirrorTest.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour/SomeSyncDictionary`2<System.Int32,System.String> MirrorTest.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour::someDictionary)"));
+            Assert.That(weaverErrors, Contains.Item("Cannot use generic SyncObject someDictionary directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead (at MirrorTest.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour/SomeSyncDictionary`2<System.Int32,System.String> MirrorTest.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour::someDictionary)"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
@@ -183,7 +183,7 @@ namespace Mirror.Weaver.Tests
         public void SyncListErrorWhenUsingGenericListInNetworkBehaviour()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("someList Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead (at MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour/SomeList`1<System.Int32> MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour::someList)"));
+            Assert.That(weaverErrors, Contains.Item("Cannot use generic SyncObjects someList directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead (at MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour/SomeList`1<System.Int32> MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour::someList)"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
@@ -183,7 +183,7 @@ namespace Mirror.Weaver.Tests
         public void SyncListErrorWhenUsingGenericListInNetworkBehaviour()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Cannot use generic SyncObjects someList directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead (at MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour/SomeList`1<System.Int32> MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour::someList)"));
+            Assert.That(weaverErrors, Contains.Item("Cannot use generic SyncObject someList directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead (at MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour/SomeList`1<System.Int32> MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour::someList)"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
@@ -36,8 +36,7 @@ namespace Mirror.Weaver.Tests
         public void SyncListGenericInheritanceWithMultipleGeneric()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Too many generic argument for MirrorTest.SyncListGenericInheritanceWithMultipleGeneric/SomeList`2<System.String,System.Int32>"));
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Could not find generic arguments for Mirror.SyncList`1 using MirrorTest.SyncListGenericInheritanceWithMultipleGeneric/SomeListInt"));
+            Assert.That(weaverErrors, Contains.Item("Could not find generic arguments for SyncList`1 in MirrorTest.SyncListGenericInheritanceWithMultipleGeneric/SomeListInt (at MirrorTest.SyncListGenericInheritanceWithMultipleGeneric/SomeListInt)"));
         }
 
         [Test]
@@ -51,7 +50,7 @@ namespace Mirror.Weaver.Tests
         public void SyncListMissingParamlessCtor()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncListMissingParamlessCtor/SyncListString2 MirrorTest.SyncListMissingParamlessCtor::Foo Can not intialize field because no default constructor was found. Manually intialize the field (call the constructor) or add constructor without Parameter"));
+            Assert.That(weaverErrors, Contains.Item("Can not intialize field Foo because no default constructor was found. Manually intialize the field (call the constructor) or add constructor without Parameter (at MirrorTest.SyncListMissingParamlessCtor/SyncListString2 MirrorTest.SyncListMissingParamlessCtor::Foo)"));
         }
 
         [Test]
@@ -80,9 +79,9 @@ namespace Mirror.Weaver.Tests
         {
             // we need this negative test to make sure that SyncList is being processed 
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for UnityEngine.Object. Use a supported type or provide a custom writer"));
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: UnityEngine.Object MirrorTest.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStruct::target has unsupported type. Use a type supported by Mirror instead"));
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStructList cannot have item of type MirrorTest.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStruct.  Use a type supported by mirror instead"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for Object. Use a supported type or provide a custom writer (at UnityEngine.Object)"));
+            Assert.That(weaverErrors, Contains.Item("target has unsupported type. Use a type supported by Mirror instead (at UnityEngine.Object MirrorTest.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStruct::target)"));
+            Assert.That(weaverErrors, Contains.Item("MyNestedStructList has sync object generic type MyNestedStruct.  Use a type supported by mirror instead (at MirrorTest.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStructList)"));
         }
 
         [Test]
@@ -97,9 +96,9 @@ namespace Mirror.Weaver.Tests
         {
             // we need this negative test to make sure that SyncList is being processed 
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for UnityEngine.Object. Use a supported type or provide a custom writer"));
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: UnityEngine.Object MirrorTest.SyncListNestedInStructWithInvalid/SomeData::target has unsupported type. Use a type supported by Mirror instead"));
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncListNestedInStructWithInvalid/SomeData/SyncList cannot have item of type MirrorTest.SyncListNestedInStructWithInvalid/SomeData.  Use a type supported by mirror instead"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for Object. Use a supported type or provide a custom writer (at UnityEngine.Object)"));
+            Assert.That(weaverErrors, Contains.Item("target has unsupported type. Use a type supported by Mirror instead (at UnityEngine.Object MirrorTest.SyncListNestedInStructWithInvalid/SomeData::target)"));
+            Assert.That(weaverErrors, Contains.Item("SyncList has sync object generic type SomeData.  Use a type supported by mirror instead (at MirrorTest.SyncListNestedInStructWithInvalid/SomeData/SyncList)"));
         }
 
         [Test]
@@ -134,21 +133,21 @@ namespace Mirror.Weaver.Tests
         public void SyncListErrorForGenericStruct()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncListErrorForGenericStruct/MyGenericStructList Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncListErrorForGenericStruct/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructList. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncListErrorForGenericStruct/MyGenericStruct`1<System.Single> in SyncList (at MirrorTest.SyncListErrorForGenericStruct/MyGenericStructList)"));
         }
 
         [Test]
         public void SyncListErrorForGenericStructWithCustomDeserializeOnly()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncListErrorForGenericStructWithCustomDeserializeOnly/MyGenericStructList Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncListErrorForGenericStructWithCustomDeserializeOnly/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructList. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncListErrorForGenericStructWithCustomDeserializeOnly/MyGenericStruct`1<System.Single> in SyncList (at MirrorTest.SyncListErrorForGenericStructWithCustomDeserializeOnly/MyGenericStructList)"));
         }
 
         [Test]
         public void SyncListErrorForGenericStructWithCustomSerializeOnly()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncListErrorForGenericStructWithCustomSerializeOnly/MyGenericStructList Can not create Serialize or Deserialize for generic element. Override virtual methods with custom Serialize and Deserialize to use MirrorTest.SyncListErrorForGenericStructWithCustomSerializeOnly/MyGenericStruct`1<System.Single> in SyncList"));
+            Assert.That(weaverErrors, Contains.Item("Can not create Serialize or Deserialize for generic element in MyGenericStructList. Override virtual methods with custom Serialize and Deserialize to use MyGenericStruct`1 in SyncList (at MirrorTest.SyncListErrorForGenericStructWithCustomSerializeOnly/MyGenericStructList)"));
         }
 
         [Test]
@@ -162,10 +161,8 @@ namespace Mirror.Weaver.Tests
         public void SyncListErrorForInterface()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            string weaverError = @"Mirror\.Weaver error:";
-            string type = @"MirrorTest\.MyInterfaceList";
-            string errorMessage = @"cannot have item of type MirrorTest\.MyInterface\.  Use a type supported by mirror instead";
-            Assert.That(weaverErrors, Has.Some.Match($"{weaverError} {type} {errorMessage}"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for interface MyInterface. Use a supported type or provide a custom writer (at MirrorTest.MyInterface)"));
+            Assert.That(weaverErrors, Contains.Item("MyInterfaceList has sync object generic type MyInterface.  Use a type supported by mirror instead (at MirrorTest.MyInterfaceList)"));
         }
 
         [Test]
@@ -186,7 +183,7 @@ namespace Mirror.Weaver.Tests
         public void SyncListErrorWhenUsingGenericListInNetworkBehaviour()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour/SomeList`1<System.Int32> MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour::someList Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead."));
+            Assert.That(weaverErrors, Contains.Item("someList Can not use generic SyncObjects directly in NetworkBehaviour. Create a class and inherit from the generic SyncObject instead (at MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour/SomeList`1<System.Int32> MirrorTest.SyncListErrorWhenUsingGenericListInNetworkBehaviour::someList)"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
@@ -15,70 +15,74 @@ namespace Mirror.Weaver.Tests
         public void SyncVarsNoHook()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: No hook implementation found for System.Int32 MirrorTest.SyncVarsNoHook::health. Add this method to your class:\npublic void OnChangeHealth(System.Int32 oldValue, System.Int32 newValue) { }"));
+            Assert.That(weaverErrors, Contains.Item("No hook implementation found for health. Add this method to your class: public void OnChangeHealth(System.Int32 oldValue, System.Int32 newValue) { } (at System.Int32 MirrorTest.SyncVarsNoHook::health)"));
         }
 
         [Test]
         public void SyncVarsNoHookParams()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.SyncVarsNoHookParams::OnChangeHealth() should have signature:\npublic void OnChangeHealth(System.Int32 oldValue, System.Int32 newValue) { }"));
+            Assert.That(weaverErrors, Contains.Item("OnChangeHealth should have signature: public void OnChangeHealth(System.Int32 oldValue, System.Int32 newValue) { } (at System.Void MirrorTest.SyncVarsNoHookParams::OnChangeHealth())"));
         }
 
         [Test]
         public void SyncVarsTooManyHookParams()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.SyncVarsTooManyHookParams::OnChangeHealth(System.Int32,System.Int32,System.Int32) should have signature:\npublic void OnChangeHealth(System.Int32 oldValue, System.Int32 newValue) { }"));
+            Assert.That(weaverErrors, Contains.Item("OnChangeHealth should have signature: public void OnChangeHealth(System.Int32 oldValue, System.Int32 newValue) { } (at System.Void MirrorTest.SyncVarsTooManyHookParams::OnChangeHealth(System.Int32,System.Int32,System.Int32))"));
         }
 
         [Test]
         public void SyncVarsWrongHookType()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.SyncVarsWrongHookType::OnChangeHealth(System.Boolean,System.Boolean) should have signature:\npublic void OnChangeHealth(System.Int32 oldValue, System.Int32 newValue) { }"));
+            Assert.That(weaverErrors, Contains.Item("OnChangeHealth should have signature: public void OnChangeHealth(System.Int32 oldValue, System.Int32 newValue) { } (at System.Void MirrorTest.SyncVarsWrongHookType::OnChangeHealth(System.Boolean,System.Boolean))"));
         }
 
         [Test]
         public void SyncVarsDerivedNetworkBehaviour()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for component type MirrorTest.SyncVarsDerivedNetworkBehaviour/MySyncVar. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type MySyncVar. Use a supported type or provide a custom writer (at MirrorTest.SyncVarsDerivedNetworkBehaviour/MySyncVar)"));
+            Assert.That(weaverErrors, Contains.Item("invalidVar has unsupported type. Use a supported Mirror type instead (at MirrorTest.SyncVarsDerivedNetworkBehaviour/MySyncVar MirrorTest.SyncVarsDerivedNetworkBehaviour::invalidVar)"));
         }
 
         [Test]
         public void SyncVarsStatic()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Int32 MirrorTest.SyncVarsStatic::invalidVar cannot be static"));
+            Assert.That(weaverErrors, Contains.Item("invalidVar cannot be static (at System.Int32 MirrorTest.SyncVarsStatic::invalidVar)"));
         }
 
         [Test]
         public void SyncVarsGenericParam()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for generic type MirrorTest.SyncVarsGenericParam/MySyncVar`1<System.Int32>. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for generic type MySyncVar`1. Use a supported type or provide a custom writer (at MirrorTest.SyncVarsGenericParam/MySyncVar`1<System.Int32>)"));
+            Assert.That(weaverErrors, Contains.Item("invalidVar has unsupported type. Use a supported Mirror type instead (at MirrorTest.SyncVarsGenericParam/MySyncVar`1<System.Int32> MirrorTest.SyncVarsGenericParam::invalidVar)"));
         }
 
         [Test]
         public void SyncVarsInterface()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for interface MirrorTest.SyncVarsInterface/MySyncVar. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for interface MySyncVar. Use a supported type or provide a custom writer (at MirrorTest.SyncVarsInterface/MySyncVar)"));
+            Assert.That(weaverErrors, Contains.Item("invalidVar has unsupported type. Use a supported Mirror type instead (at MirrorTest.SyncVarsInterface/MySyncVar MirrorTest.SyncVarsInterface::invalidVar)"));
         }
 
         [Test]
         public void SyncVarsDifferentModule()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: Cannot generate writer for component type UnityEngine.TextMesh. Use a supported type or provide a custom writer"));
+            Assert.That(weaverErrors, Contains.Item("Cannot generate writer for component type TextMesh. Use a supported type or provide a custom writer (at UnityEngine.TextMesh)"));
+            Assert.That(weaverErrors, Contains.Item("invalidVar has unsupported type. Use a supported Mirror type instead (at UnityEngine.TextMesh MirrorTest.SyncVarsDifferentModule::invalidVar)"));
         }
 
         [Test]
         public void SyncVarsCantBeArray()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Int32[] MirrorTest.SyncVarsCantBeArray::thisShouldntWork has invalid type. Use SyncLists instead of arrays"));
+            Assert.That(weaverErrors, Contains.Item("thisShouldntWork has invalid type. Use SyncLists instead of arrays (at System.Int32[] MirrorTest.SyncVarsCantBeArray::thisShouldntWork)"));
         }
 
         [Test]
@@ -86,15 +90,15 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
             Assert.That(weaverErrors, Is.Empty);
-            Assert.That(weaverWarnings, Contains.Item("Mirror.Weaver warning: MirrorTest.SyncVarsSyncList/SyncObjImplementer MirrorTest.SyncVarsSyncList::syncobj has [SyncVar] attribute. SyncLists should not be marked with SyncVar"));
-            Assert.That(weaverWarnings, Contains.Item("Mirror.Weaver warning: Mirror.SyncListInt MirrorTest.SyncVarsSyncList::syncints has [SyncVar] attribute. SyncLists should not be marked with SyncVar"));
+            Assert.That(weaverWarnings, Contains.Item("syncobj has [SyncVar] attribute. SyncLists should not be marked with SyncVar (at MirrorTest.SyncVarsSyncList/SyncObjImplementer MirrorTest.SyncVarsSyncList::syncobj)"));
+            Assert.That(weaverWarnings, Contains.Item("syncints has [SyncVar] attribute. SyncLists should not be marked with SyncVar (at Mirror.SyncListInt MirrorTest.SyncVarsSyncList::syncints)"));
         }
 
         [Test]
         public void SyncVarsMoreThan63()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncVarsMoreThan63 has too many SyncVars. Consider refactoring your class into multiple components"));
+            Assert.That(weaverErrors, Contains.Item("SyncVarsMoreThan63 has too many SyncVars. Consider refactoring your class into multiple components (at MirrorTest.SyncVarsMoreThan63)"));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests.cs
@@ -15,14 +15,14 @@ namespace Mirror.Weaver.Tests
         public void TargetRpcStartsWithTarget()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.TargetRpcStartsWithTarget::DoesntStartWithTarget(Mirror.NetworkConnection) must start with Target.  Consider renaming it to TargetDoesntStartWithTarget"));
+            Assert.That(weaverErrors, Contains.Item("DoesntStartWithTarget must start with Target.  Consider renaming it to TargetDoesntStartWithTarget (at System.Void MirrorTest.TargetRpcStartsWithTarget::DoesntStartWithTarget(Mirror.NetworkConnection))"));
         }
 
         [Test]
         public void TargetRpcCantBeStatic()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.TargetRpcCantBeStatic::TargetCantBeStatic(Mirror.NetworkConnection) must not be static"));
+            Assert.That(weaverErrors, Contains.Item("TargetCantBeStatic must not be static (at System.Void MirrorTest.TargetRpcCantBeStatic::TargetCantBeStatic(Mirror.NetworkConnection))"));
         }
 
         [Test]
@@ -36,13 +36,14 @@ namespace Mirror.Weaver.Tests
         public void SyncEventStartsWithEvent()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncEventStartsWithEvent/MySyncEventDelegate MirrorTest.SyncEventStartsWithEvent::DoCoolThingsWithExcitingPeople must start with Event.  Consider renaming it to EventDoCoolThingsWithExcitingPeople"));
+            Assert.That(weaverErrors, Contains.Item("DoCoolThingsWithExcitingPeople must start with Event.  Consider renaming it to EventDoCoolThingsWithExcitingPeople (at MirrorTest.SyncEventStartsWithEvent/MySyncEventDelegate MirrorTest.SyncEventStartsWithEvent::DoCoolThingsWithExcitingPeople)"));
         }
 
         [Test]
         public void SyncEventParamGeneric()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: MirrorTest.SyncEventParamGeneric/MySyncEventDelegate`1<System.Int32> MirrorTest.SyncEventParamGeneric::EventDoCoolThingsWithExcitingPeople must not have generic parameters.  Consider creating a new class that inherits from MirrorTest.SyncEventParamGeneric/MySyncEventDelegate`1<System.Int32> instead"));        }
+            Assert.That(weaverErrors, Contains.Item("EventDoCoolThingsWithExcitingPeople must not have generic parameters.  Consider creating a new class that inherits from MirrorTest.SyncEventParamGeneric/MySyncEventDelegate`1<System.Int32> instead (at MirrorTest.SyncEventParamGeneric/MySyncEventDelegate`1<System.Int32> MirrorTest.SyncEventParamGeneric::EventDoCoolThingsWithExcitingPeople)"));
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTests.cs
@@ -44,9 +44,10 @@ namespace Mirror.Weaver.Tests
             WeaverAssembler.Build();
 
             Assert.That(WeaverAssembler.CompilerErrors, Is.False);
-            if (weaverErrors.Count > 0)
+            foreach (string error in weaverErrors)
             {
-                Assert.That(weaverErrors[0], Does.StartWith("Mirror.Weaver error: "));
+                // ensure all errors have a location
+                Assert.That(error, Does.Match(@"\(at .*\)$"));
             }
         }
 


### PR DESCRIPTION
Weaver error messages should be easier to read and always display
location

This is what weaver errors would look like after this:

<img width="928" alt="Screen Shot 2020-04-25 at 2 08 48 PM" src="https://user-images.githubusercontent.com/466007/80288624-ba156180-86fe-11ea-8525-ed779ab5d3b6.png">

