### PR TITLE
Each test file in a separate namespace

### DIFF
--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CanUseCustomReadWriteForInterfaces.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CanUseCustomReadWriteForInterfaces.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CanUseCustomReadWriteForInterfaces
 {
     public class CanUseCustomReadWriteForInterfaces : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CanUseCustomReadWriteForTypesFromDifferentAssemblies.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CanUseCustomReadWriteForTypesFromDifferentAssemblies.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CanUseCustomReadWriteForTypesFromDifferentAssemblies
 {
     public class CanUseCustomReadWriteForTypesFromDifferentAssemblies : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClass.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClass.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CreatesForClass
 {
     public class CreatesForClass : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClassFromDifferentAssemblies.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClassFromDifferentAssemblies.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CreatesForClassFromDifferentAssemblies
 {
     public class CreatesForClassFromDifferentAssemblies : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClassFromDifferentAssembliesWithValidConstructor.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClassFromDifferentAssembliesWithValidConstructor.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CreatesForClassFromDifferentAssembliesWithValidConstructor
 {
     public class CreatesForClassFromDifferentAssembliesWithValidConstructor : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClassWithValidConstructor.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClassWithValidConstructor.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CreatesForClassWithValidConstructor
 {
     public class CreatesForClassWithValidConstructor : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForEnums.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForEnums.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CreatesForEnums
 {
     class CreatesForEnums : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForInheritedFromScriptableObject.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForInheritedFromScriptableObject.cs
@@ -2,7 +2,7 @@ using Mirror;
 using Mirror.Weaver.Tests.Extra;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CreatesForInheritedFromScriptableObject
 {
     public class CreatesForInheritedFromScriptableObject : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForStructFromDifferentAssemblies.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForStructFromDifferentAssemblies.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CreatesForStructFromDifferentAssemblies
 {
     public class CreatesForStructFromDifferentAssemblies : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForStructs.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForStructs.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CreatesForStructs
 {
     public class CreatesForStructs : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/ExcludesNonSerializedFields.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/ExcludesNonSerializedFields.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.ExcludesNonSerializedFields
 {
     public class ExcludesNonSerializedFields : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorForClassWithNoValidConstructor.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorForClassWithNoValidConstructor.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using Mirror.Weaver.Tests.Extra;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.GivesErrorForClassWithNoValidConstructor
 {
     public class GivesErrorForClassWithNoValidConstructor : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingInterface.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingInterface.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.GivesErrorWhenUsingInterface
 {
     public class GivesErrorWhenUsingInterface : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingMonoBehaviour.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingMonoBehaviour.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.GivesErrorWhenUsingMonoBehaviour
 {
     public class GivesErrorWhenUsingMonoBehaviour : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingObject.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingObject.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.GivesErrorWhenUsingObject
 {
     public class GivesErrorWhenUsingObject : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingScriptableObject.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingScriptableObject.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.GivesErrorWhenUsingScriptableObject
 {
     public class GivesErrorWhenUsingScriptableObject : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingTypeInheritedFromMonoBehaviour.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingTypeInheritedFromMonoBehaviour.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.GivesErrorWhenUsingTypeInheritedFromMonoBehaviour
 {
     public class GivesErrorWhenUsingTypeInheritedFromMonoBehaviour : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingUnityAsset.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/GivesErrorWhenUsingUnityAsset.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.GivesErrorWhenUsingUnityAsset
 {
     public class GivesErrorForClassWithNoValidConstructor : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests~/ClientRpcCantBeStatic.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests~/ClientRpcCantBeStatic.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.ClientRpcCantBeStatic
 {
     class ClientRpcCantBeStatic : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests~/ClientRpcStartsWithRpc.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests~/ClientRpcStartsWithRpc.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.ClientRpcStartsWithRpc
 {
     class ClientRpcStartsWithRpc : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests~/ClientRpcValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientRpcTests~/ClientRpcValid.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.ClientRpcValid
 {
     class ClientRpcValid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/NetworkBehaviourClient.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/NetworkBehaviourClient.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClient
 {
     class NetworkBehaviourClient : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/NetworkBehaviourServer.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/NetworkBehaviourServer.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourServer
 {
     class NetworkBehaviourServer : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandCantBeStatic.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandCantBeStatic.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CommandCantBeStatic
 {
     class CommandCantBeStatic : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandStartsWithCmd.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandStartsWithCmd.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CommandStartsWithCmd
 {
     class CommandStartsWithCmd : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandValid.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.CommandValid
 {
     class CommandValid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests~/RecursionCount.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests~/RecursionCount.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.RecursionCount
 {
     class RecursionCount : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests~/TestingScriptableObjectArraySerialization.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests~/TestingScriptableObjectArraySerialization.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.TestingScriptableObjectArraySerialization
 {
     public static class CustomSerializer
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests~/MessageMemberGeneric.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests~/MessageMemberGeneric.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MessageMemberGeneric
 {
     class HasGeneric<T> {}
 

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests~/MessageMemberInterface.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests~/MessageMemberInterface.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MessageMemberInterface
 {
     interface SuperCoolInterface {}
 

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests~/MessageSelfReferencing.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests~/MessageSelfReferencing.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MessageSelfReferencing
 {
     class MessageSelfReferencing : MessageBase
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests~/MessageValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMessageTests~/MessageValid.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MessageValid
 {
     class MessageValid : MessageBase
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourClient.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourClient.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourClient
 {
     class MonoBehaviourClient : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourClientCallback.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourClientCallback.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourClientCallback
 {
     class MonoBehaviourClientCallback : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourClientRpc.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourClientRpc.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourClientRpc
 {
     class MonoBehaviourClientRpc : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourCommand.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourCommand.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourCommand
 {
     class MonoBehaviourCommand : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourServer.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourServer.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourServer
 {
     class MonoBehaviourServer : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourServerCallback.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourServerCallback.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourServerCallback
 {
     class MonoBehaviourServerCallback : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourSyncList.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourSyncList
 {
     class MonoBehaviourSyncList : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourSyncVar.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourSyncVar.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourSyncVar
 {
     class MonoBehaviourSyncVar : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourTargetRpc.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourTargetRpc.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourTargetRpc
 {
     class MonoBehaviourTargetRpc : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourValid.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.MonoBehaviourValid
 {
     class MonoBehaviourValid : MonoBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourAbstractBaseValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourAbstractBaseValid.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourAbstractBaseValid
 {
     public abstract class EntityBase : NetworkBehaviour {}
 

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcCoroutine.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcCoroutine.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcCoroutine
 {
     class NetworkBehaviourClientRpcCoroutine : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcDuplicateName.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcDuplicateName.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcDuplicateName
 {
     class NetworkBehaviourClientRpcDuplicateName : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcGenericParam.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcGenericParam.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcGenericParam
 {
     class NetworkBehaviourClientRpcGenericParam : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamAbstract.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamAbstract.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcParamAbstract
 {
     class NetworkBehaviourClientRpcParamAbstract : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamComponent.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamComponent.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcParamComponent
 {
     class NetworkBehaviourClientRpcParamComponent : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamNetworkConnection.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcParamNetworkConnection
 {
     class NetworkBehaviourClientRpcParamNetworkConnection : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamOptional.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamOptional.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcParamOptional
 {
     class NetworkBehaviourClientRpcParamOptional : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamOut.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamOut.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcParamOut
 {
     class NetworkBehaviourClientRpcParamOut : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamRef.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcParamRef.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcParamRef
 {
     class NetworkBehaviourClientRpcParamRef : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcVoidReturn.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourClientRpcVoidReturn.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourClientRpcVoidReturn
 {
     class NetworkBehaviourClientRpcVoidReturn : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdCoroutine.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdCoroutine.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdCoroutine
 {
     class NetworkBehaviourCmdCoroutine : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdDuplicateName.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdDuplicateName.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdDuplicateName
 {
     class NetworkBehaviourCmdDuplicateName : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdGenericParam.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdGenericParam.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdGenericParam
 {
     class NetworkBehaviourCmdGenericParam : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamAbstract.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamAbstract.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdParamAbstract
 {
     class NetworkBehaviourCmdParamAbstract : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamComponent.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamComponent.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdParamComponent
 {
     class NetworkBehaviourCmdParamComponent : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamNetworkConnection.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdParamNetworkConnection
 {
     class NetworkBehaviourCmdParamNetworkConnection : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamOptional.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamOptional.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdParamOptional
 {
     class NetworkBehaviourCmdParamOptional : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamOut.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamOut.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdParamOut
 {
     class NetworkBehaviourCmdParamOut : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamRef.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdParamRef.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdParamRef
 {
     class NetworkBehaviourCmdParamRef : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdVoidReturn.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourCmdVoidReturn.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourCmdVoidReturn
 {
     class NetworkBehaviourCmdVoidReturn : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourGeneric.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourGeneric.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourGeneric
 {
     class NetworkBehaviourGeneric<T> : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcCoroutine.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcCoroutine.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcCoroutine
 {
     class NetworkBehaviourTargetRpcCoroutine : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcDuplicateName.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcDuplicateName.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcDuplicateName
 {
     class NetworkBehaviourTargetRpcDuplicateName : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcGenericParam.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcGenericParam.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcGenericParam
 {
     class NetworkBehaviourTargetRpcGenericParam : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamAbstract.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamAbstract.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcParamAbstract
 {
     class NetworkBehaviourTargetRpcParamAbstract : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamComponent.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamComponent.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcParamComponent
 {
     class NetworkBehaviourTargetRpcParamComponent : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamNetworkConnection.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcParamNetworkConnection
 {
     class NetworkBehaviourTargetRpcParamNetworkConnection : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamNetworkConnectionNotFirst.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamNetworkConnectionNotFirst.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcParamNetworkConnectionNotFirst
 {
     class NetworkBehaviourTargetRpcParamNetworkConnectionNotFirst : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamOptional.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamOptional.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcParamOptional
 {
     class NetworkBehaviourTargetRpcParamOptional : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamOut.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamOut.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcParamOut
 {
     class NetworkBehaviourTargetRpcParamOut : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamRef.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcParamRef.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcParamRef
 {
     class NetworkBehaviourTargetRpcParamRef : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcVoidReturn.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourTargetRpcVoidReturn.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourTargetRpcVoidReturn
 {
     class NetworkBehaviourTargetRpcVoidReturn : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourValid.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.NetworkBehaviourValid
 {
     class MirrorTestPlayer : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionary.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionary.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionary
 {
     class SyncDictionaryValid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructItem.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructItem.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryErrorForGenericStructItem
 {
     class SyncDictionaryErrorForGenericStructItem : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly
 {
     class SyncDictionaryErrorForGenericStructItemWithCustomDeserializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructItemWithCustomSerializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructItemWithCustomSerializeOnly.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryErrorForGenericStructItemWithCustomSerializeOnly
 {
     class SyncDictionaryErrorForGenericStructItemWithCustomSerializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructKey.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructKey.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryErrorForGenericStructKey
 {
     class SyncDictionaryErrorForGenericStructKey : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly
 {
     class SyncDictionaryErrorForGenericStructKeyWithCustomDeserializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructKeyWithCustomSerializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorForGenericStructKeyWithCustomSerializeOnly.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryErrorForGenericStructKeyWithCustomSerializeOnly
 {
     class SyncDictionaryErrorForGenericStructKeyWithCustomSerializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour
 {
     class SyncDictionaryErrorWhenUsingGenericInNetworkBehaviour : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericAbstractInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericAbstractInheritance.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryGenericAbstractInheritance
 {
     class SyncDictionaryGenericAbstractInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericInheritance.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryGenericInheritance
 {
     class SyncDictionaryGenericInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericStructItemWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericStructItemWithCustomMethods.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryGenericStructItemWithCustomMethods
 {
     class SyncDictionaryGenericStructItemWithCustomMethods : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericStructKeyWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericStructKeyWithCustomMethods.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryGenericStructKeyWithCustomMethods
 {
     class SyncDictionaryGenericStructKeyWithCustomMethods : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryInheritance.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryInheritance
 {
     class SyncDictionaryInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructItem.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructItem.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryStructItem
 {
     class SyncDictionaryStructItem : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructItemWithCustomDeserializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructItemWithCustomDeserializeOnly.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryStructItemWithCustomDeserializeOnly
 {
     class SyncDictionaryStructItemWithCustomDeserializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructItemWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructItemWithCustomMethods.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryStructItemWithCustomMethods
 {
     class SyncDictionaryItemStructWithCustomMethods : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructItemWithCustomSerializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructItemWithCustomSerializeOnly.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryStructItemWithCustomSerializeOnly
 {
     class SyncDictionaryStructItemWithCustomSerializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructKey.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructKey.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryStructKey
 {
     class SyncDictionaryStructKey : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructKeyWithCustomDeserializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructKeyWithCustomDeserializeOnly.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryStructKeyWithCustomDeserializeOnly
 {
     class SyncDictionaryStructKeyWithCustomDeserializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructKeyWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructKeyWithCustomMethods.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryStructKeyWithCustomMethods
 {
     class SyncDictionaryKeyStructWithCustomMethods : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructKeyWithCustomSerializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryStructKeyWithCustomSerializeOnly.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncDictionaryStructKeyWithCustomSerializeOnly
 {
     class SyncDictionaryStructKeyWithCustomSerializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncList.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncList
 {
     class SyncList : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListByteValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListByteValid.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListByteValid
 {
     class SyncListByteValid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorForGenericStruct.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorForGenericStruct.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListErrorForGenericStruct
 {
     class SyncListErrorForGenericStruct : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorForGenericStructWithCustomDeserializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorForGenericStructWithCustomDeserializeOnly.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListErrorForGenericStructWithCustomDeserializeOnly
 {
     class SyncListErrorForGenericStructWithCustomDeserializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorForGenericStructWithCustomSerializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorForGenericStructWithCustomSerializeOnly.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListErrorForGenericStructWithCustomSerializeOnly
 {
     class SyncListErrorForGenericStructWithCustomSerializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorForInterface.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorForInterface.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListErrorForInterface
 {
     class SyncListErrorForInterface : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorWhenUsingGenericListInNetworkBehaviour.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListErrorWhenUsingGenericListInNetworkBehaviour.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListErrorWhenUsingGenericListInNetworkBehaviour
 {
     class SyncListErrorWhenUsingGenericListInNetworkBehaviour : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericAbstractInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericAbstractInheritance.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListGenericAbstractInheritance
 {
     class SyncListGenericAbstractInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericInheritance.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListGenericInheritance
 {
     class SyncListGenericInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericInheritanceWithMultipleGeneric.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericInheritanceWithMultipleGeneric.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListGenericInheritanceWithMultipleGeneric
 {
     /*
     This test will fail

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericStructWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericStructWithCustomMethods.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListGenericStructWithCustomMethods
 {
     class SyncListGenericStructWithCustomMethods : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInheritance.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListInheritance
 {
     class SyncListInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInheritanceWithOverrides.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInheritanceWithOverrides.cs
@@ -1,7 +1,7 @@
 using Mirror;
 using UnityEngine;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListInheritanceWithOverrides
 {
     class SyncListInheritanceWithOverrides : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInterfaceWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInterfaceWithCustomMethods.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListInterfaceWithCustomMethods
 {
     class SyncListInterfaceWithCustomMethods : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListMissingParamlessCtor.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListMissingParamlessCtor.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListMissingParamlessCtor
 {
     class SyncListMissingParamlessCtor : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListMissingParamlessCtorManuallyInitialized.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListMissingParamlessCtorManuallyInitialized.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListMissingParamlessCtorManuallyInitialized
 {
     class SyncListMissingParamlessCtorManuallyInitialized : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedInAbstractClass.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedInAbstractClass.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListNestedInAbstractClass
 {
     class SyncListNestedStruct : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedInAbstractClassWithInvalid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedInAbstractClassWithInvalid.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListNestedInAbstractClassWithInvalid
 {
     class SyncListNestedStructWithInvalid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedInStruct.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedInStruct.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListNestedInStruct
 {
     class SyncListNestedStruct : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedInStructWithInvalid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedInStructWithInvalid.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListNestedInStructWithInvalid
 {
     class SyncListNestedInStructWithInvalid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedStruct.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListNestedStruct.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListNestedStruct
 {
     class SyncListNestedStruct : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListStruct.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListStruct.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListStruct
 {
     class SyncListStruct : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListStructWithCustomDeserializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListStructWithCustomDeserializeOnly.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListStructWithCustomDeserializeOnly
 {
     class SyncListStructWithCustomDeserializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListStructWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListStructWithCustomMethods.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListStructWithCustomMethods
 {
     class SyncListStructWithCustomMethods : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListStructWithCustomSerializeOnly.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListStructWithCustomSerializeOnly.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncListStructWithCustomSerializeOnly
 {
     class SyncListStructWithCustomSerializeOnly : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSet.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSet.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncSet
 {
     class SyncSet : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetByteValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetByteValid.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncSetByteValid
 {
     class SyncSetByteValid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetGenericAbstractInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetGenericAbstractInheritance.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncSetGenericAbstractInheritance
 {
     class SyncSetGenericAbstractInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetGenericInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetGenericInheritance.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncSetGenericInheritance
 {
     class SyncSetGenericInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetInheritance.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncSetInheritance
 {
     class SyncSetInheritance : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetStruct.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSetStruct.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncSetStruct
 {
     class SyncSetStruct : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsCantBeArray.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsCantBeArray.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 using Mirror;
 using System.Collections.Generic;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsCantBeArray
 {
     class SyncVarsCantBeArray : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsDerivedNetworkBehaviour.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsDerivedNetworkBehaviour.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsDerivedNetworkBehaviour
 {
     class SyncVarsDerivedNetworkBehaviour : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsDifferentModule.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsDifferentModule.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsDifferentModule
 {
     class SyncVarsDifferentModule : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsGenericParam.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsGenericParam.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsGenericParam
 {
     class SyncVarsGenericParam : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsInterface.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsInterface.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsInterface
 {
     class SyncVarsInterface : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsMoreThan63.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsMoreThan63.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsMoreThan63
 {
     class SyncVarsMoreThan63 : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsNoHook.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsNoHook.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsNoHook
 {
     class SyncVarsNoHook : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsNoHookParams.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsNoHookParams.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsNoHookParams
 {
     class SyncVarsNoHookParams : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsStatic.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsStatic.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsStatic
 {
     class SyncVarsStatic : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsSyncList.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsSyncList
 {
 
     class SyncVarsSyncList : NetworkBehaviour

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsTooManyHookParams.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsTooManyHookParams.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsTooManyHookParams
 {
     class SyncVarsTooManyHookParams : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsValid.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsValid
 {
     class SyncVarsValid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsWrongHookType.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsWrongHookType.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncVarsWrongHookType
 {
     class SyncVarsWrongHookType : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/SyncEventParamGeneric.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/SyncEventParamGeneric.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncEventParamGeneric
 {
     class SyncEventParamGeneric : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/SyncEventStartsWithEvent.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/SyncEventStartsWithEvent.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncEventStartsWithEvent
 {
     class SyncEventStartsWithEvent : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/SyncEventValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/SyncEventValid.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.SyncEventValid
 {
     class SyncEventValid : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcCantBeStatic.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcCantBeStatic.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.TargetRpcCantBeStatic
 {
     class TargetRpcCantBeStatic : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcNetworkConnectionMissing.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcNetworkConnectionMissing.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.TargetRpcNetworkConnectionMissing
 {
     class TargetRpcNetworkConnectionMissing : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcNetworkConnectionNotFirst.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcNetworkConnectionNotFirst.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.TargetRpcNetworkConnectionNotFirst
 {
     class TargetRpcNetworkConnectionNotFirst : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcStartsWithTarget.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcStartsWithTarget.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.TargetRpcStartsWithTarget
 {
     class TargetRpcStartsWithTarget : NetworkBehaviour
     {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverTargetRpcTests~/TargetRpcValid.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using UnityEngine;
 using Mirror;
 
-namespace MirrorTest
+namespace Mirror.Weaver.Tests.TargetRpcValid
 {
     class TargetRpcValid : NetworkBehaviour
     {


### PR DESCRIPTION
avoids naming conflicts when we do batching