### PR TITLE
feat: keep log levels when player starts

### DIFF
--- a/Assets/Mirror/Editor/LogLevelWindow.cs
+++ b/Assets/Mirror/Editor/LogLevelWindow.cs
@@ -8,7 +8,7 @@ namespace Mirror
 {
     public class LogLevelWindow : EditorWindow
     {
-
+        #region GUI
         void OnGUI()
         {
             EditorGUILayout.BeginVertical();
@@ -35,15 +35,6 @@ namespace Mirror
             }
         }
 
-        private void SetLoggers(IEnumerable<LogSetting> savedLevels)
-        {
-            foreach (LogSetting setting in savedLevels)
-            {
-                ILogger logger = LogFactory.GetLogger(setting.logger);
-                logger.filterLogType = setting.logType;
-            }
-        }
-
         static void DrawLoggerField(string loggerName, ILogger logger)
         {
             logger.filterLogType = (LogType)EditorGUILayout.EnumPopup(new GUIContent(loggerName), logger.filterLogType);
@@ -56,7 +47,9 @@ namespace Mirror
             window.titleContent = new GUIContent("Mirror Log levels");
             window.Show();
         }
+        #endregion
 
+        #region Log settings persistence
         [Serializable]
         public struct LogSetting
         {
@@ -64,6 +57,14 @@ namespace Mirror
             public LogType logType;
         }
 
+        private void SetLoggers(IEnumerable<LogSetting> savedLevels)
+        {
+            foreach (LogSetting setting in savedLevels)
+            {
+                ILogger logger = LogFactory.GetLogger(setting.logger);
+                logger.filterLogType = setting.logType;
+            }
+        }
         private void LoadSavedLevels()
         {
             string levelsJson = EditorPrefs.GetString("LogLevels");
@@ -107,5 +108,7 @@ namespace Mirror
         {
             public T[] Items;
         }
+
+        #endregion
     }
 }

--- a/Assets/Mirror/Editor/LogLevelWindow.cs
+++ b/Assets/Mirror/Editor/LogLevelWindow.cs
@@ -57,6 +57,7 @@ namespace Mirror
             window.Show();
         }
 
+        [Serializable]
         public struct LogSetting
         {
             public string logger;
@@ -66,25 +67,45 @@ namespace Mirror
         private void LoadSavedLevels()
         {
             string levelsJson = EditorPrefs.GetString("LogLevels");
-            LogSetting[] settings =  JsonUtility.FromJson<LogSetting[]>(levelsJson);
+            LogSetting[] settings =  FromJson<LogSetting>(levelsJson);
             SetLoggers(settings ?? new LogSetting[] { });
         }
 
         private void SaveLevels()
         {
-            List<LogSetting> settings = new List<LogSetting>();
+            LogSetting[] settings = new LogSetting[LogFactory.loggers.Count()];
 
+            int i = 0;
             foreach (KeyValuePair<string, ILogger> item in LogFactory.loggers)
             {
-                settings.Add(new LogSetting
+                settings[i++] = new LogSetting
                 {
                     logger = item.Key,
                     logType = item.Value.filterLogType
-                });
+                };
             }
 
-            string levelsJSon = JsonUtility.ToJson(settings);
+            string levelsJSon = ToJson(settings);
             EditorPrefs.SetString("LogLevels", levelsJSon);
+        }
+
+        public static T[] FromJson<T>(string json)
+        {
+            Wrapper<T> wrapper = JsonUtility.FromJson<Wrapper<T>>(json);
+            return wrapper.Items;
+        }
+
+        public static string ToJson<T>(T[] array)
+        {
+            Wrapper<T> wrapper = new Wrapper<T>();
+            wrapper.Items = array;
+            return JsonUtility.ToJson(wrapper);
+        }
+
+        [Serializable]
+        private class Wrapper<T>
+        {
+            public T[] Items;
         }
     }
 }

--- a/Assets/Mirror/Editor/LogLevelWindow.cs
+++ b/Assets/Mirror/Editor/LogLevelWindow.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
@@ -6,6 +8,7 @@ namespace Mirror
 {
     public class LogLevelWindow : EditorWindow
     {
+
         void OnGUI()
         {
             EditorGUILayout.BeginVertical();
@@ -15,22 +18,36 @@ namespace Mirror
             EditorGUILayout.Space();
             EditorGUILayout.EndVertical();
 
+            EditorGUI.BeginChangeCheck();
+
             EditorGUILayout.BeginVertical(EditorStyles.inspectorDefaultMargins);
+            LoadSavedLevels();
+
             foreach (KeyValuePair<string, ILogger> item in LogFactory.loggers)
             {
-                DrawLoggerField(item);
+                DrawLoggerField(item.Key, item.Value);
             }
             EditorGUILayout.EndVertical();
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                SaveLevels();
+            }
         }
 
-        static void DrawLoggerField(KeyValuePair<string, ILogger> item)
+        private void SetLoggers(IEnumerable<LogSetting> savedLevels)
         {
-            ILogger logger = item.Value;
-            string name = item.Key;
-
-            logger.filterLogType = (LogType)EditorGUILayout.EnumPopup(new GUIContent(name), logger.filterLogType);
+            foreach (LogSetting setting in savedLevels)
+            {
+                ILogger logger = LogFactory.GetLogger(setting.logger);
+                logger.filterLogType = setting.logType;
+            }
         }
 
+        static void DrawLoggerField(string loggerName, ILogger logger)
+        {
+            logger.filterLogType = (LogType)EditorGUILayout.EnumPopup(new GUIContent(loggerName), logger.filterLogType);
+        }
 
         [MenuItem("Window/Analysis/Mirror Log Levels", priority = 20002)]
         public static void ShowWindow()
@@ -38,6 +55,36 @@ namespace Mirror
             LogLevelWindow window = GetWindow<LogLevelWindow>();
             window.titleContent = new GUIContent("Mirror Log levels");
             window.Show();
+        }
+
+        public struct LogSetting
+        {
+            public string logger;
+            public LogType logType;
+        }
+
+        private void LoadSavedLevels()
+        {
+            string levelsJson = EditorPrefs.GetString("LogLevels");
+            LogSetting[] settings =  JsonUtility.FromJson<LogSetting[]>(levelsJson);
+            SetLoggers(settings ?? new LogSetting[] { });
+        }
+
+        private void SaveLevels()
+        {
+            List<LogSetting> settings = new List<LogSetting>();
+
+            foreach (KeyValuePair<string, ILogger> item in LogFactory.loggers)
+            {
+                settings.Add(new LogSetting
+                {
+                    logger = item.Key,
+                    logType = item.Value.filterLogType
+                });
+            }
+
+            string levelsJSon = JsonUtility.ToJson(settings);
+            EditorPrefs.SetString("LogLevels", levelsJSon);
         }
     }
 }


### PR DESCRIPTION
The log window now keeps the log settings when the player starts/stop by saving the logs in editor prefs.

WIP