### PR TITLE
fixing error message

### DIFF
--- a/Assets/Mirror/Runtime/LogFactory.cs
+++ b/Assets/Mirror/Runtime/LogFactory.cs
@@ -40,12 +40,12 @@ namespace Mirror
     {
         public static void LogError(this ILogger logger, object message)
         {
-            logger.LogError(null, message);
+            logger.Log(LogType.Error, message);
         }
 
         public static void LogWarning(this ILogger logger, object message)
         {
-            logger.LogWarning(null, message);
+            logger.Log(LogType.Warning, message);
         }
 
         public static bool LogEnabled(this ILogger logger) => logger.IsLogTypeAllowed(LogType.Log);


### PR DESCRIPTION
Logger.LogError tries to add tag to message causes `:` to be added to the front of error messages

![image](https://user-images.githubusercontent.com/23101891/80754623-407ada80-8b27-11ea-9d3c-46f1db7cf700.png)


See 
```csharp 
private const string kTagFormat = "{0}: {1}";
public void LogError(string tag, object message)
{
    if (IsLogTypeAllowed(LogType.Error))
        logHandler.LogFormat(LogType.Error, null, kTagFormat, new object[] {tag, GetString(message)});
}
```
https://github.com/Unity-Technologies/UnityCsReference/blob/master/Runtime/Export/Logging/Logger.cs#L13

https://github.com/Unity-Technologies/UnityCsReference/blob/master/Runtime/Export/Logging/Logger.cs#L118
