### PR TITLE
fix: Adding warning when adding handler with RegisterSpawnHandler if assetid already exists

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -460,6 +460,11 @@ namespace Mirror
 
             if (logger.LogEnabled()) logger.Log("RegisterSpawnHandler asset '" + assetId + "' " + spawnHandler.GetMethodName() + "/" + unspawnHandler.GetMethodName());
 
+            if (spawnHandlers.ContainsKey(assetId) || unspawnHandlers.ContainsKey(assetId))
+            {
+                logger.LogWarning($"Replacing existing spawnHandlers for {assetId}");
+            }
+
             spawnHandlers[assetId] = spawnHandler;
             unspawnHandlers[assetId] = unspawnHandler;
         }

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -465,6 +465,12 @@ namespace Mirror
                 logger.LogWarning($"Replacing existing spawnHandlers for {assetId}");
             }
 
+            if (prefabs.ContainsKey(assetId))
+            {
+                // this is error because SpawnPrefab checks prefabs before handler
+                logger.LogError($"assetId '{assetId}' is already used by prefab '{prefabs[assetId].name}'");
+            }
+
             spawnHandlers[assetId] = spawnHandler;
             unspawnHandlers[assetId] = unspawnHandler;
         }

--- a/Assets/Mirror/Tests/Editor/ClientSceneTests.cs
+++ b/Assets/Mirror/Tests/Editor/ClientSceneTests.cs
@@ -246,7 +246,7 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void RegisterSpawnHandler_SpawnDelegate_WarningWhenHandlerForGuidAlreadyExists()
+        public void RegisterSpawnHandler_SpawnDelegate_WarningWhenHandlerForGuidAlreadyExistsInHandlerDictionary()
         {
             Guid guid = Guid.NewGuid();
             SpawnDelegate spawnHandler = new SpawnDelegate((x, y) => null);
@@ -259,6 +259,19 @@ namespace Mirror.Tests
 
             LogAssert.Expect(LogType.Warning, $"Replacing existing spawnHandlers for {guid}");
             ClientScene.RegisterSpawnHandler(guid, spawnHandler2, unspawnHandler2);
+        }
+
+        [Test]
+        public void RegisterSpawnHandler_SpawnDelegate_ErrorWhenHandlerForGuidAlreadyExistsInPrefabDictionary()
+        {
+            Guid guid = Guid.NewGuid();
+            prefabs.Add(guid, validPrefab);
+
+            SpawnDelegate spawnHandler = new SpawnDelegate((x, y) => null);
+            UnSpawnDelegate unspawnHandler = new UnSpawnDelegate(x => { });
+
+            LogAssert.Expect(LogType.Error, $"assetId '{guid}' is already used by prefab '{validPrefab.name}'");
+            ClientScene.RegisterSpawnHandler(guid, spawnHandler, unspawnHandler);
         }
 
 
@@ -322,7 +335,7 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void RegisterSpawnHandler_SpawnHandlerDelegate_WarningWhenHandlerForGuidAlreadyExists()
+        public void RegisterSpawnHandler_SpawnHandlerDelegate_WarningWhenHandlerForGuidAlreadyExistsInHandlerDictionary()
         {
             Guid guid = Guid.NewGuid();
             SpawnHandlerDelegate spawnHandler = new SpawnHandlerDelegate(x => null);
@@ -335,6 +348,19 @@ namespace Mirror.Tests
 
             LogAssert.Expect(LogType.Warning, $"Replacing existing spawnHandlers for {guid}");
             ClientScene.RegisterSpawnHandler(guid, spawnHandler2, unspawnHandler2);
+        }
+
+        [Test]
+        public void RegisterSpawnHandler_SpawnHandlerDelegate_ErrorWhenHandlerForGuidAlreadyExistsInPrefabDictionary()
+        {
+            Guid guid = Guid.NewGuid();
+            prefabs.Add(guid, validPrefab);
+
+            SpawnHandlerDelegate spawnHandler = new SpawnHandlerDelegate(x => new GameObject());
+            UnSpawnDelegate unspawnHandler = new UnSpawnDelegate(x => UnityEngine.Object.Destroy(x));
+
+            LogAssert.Expect(LogType.Error, $"assetId '{guid}' is already used by prefab '{validPrefab.name}'");
+            ClientScene.RegisterSpawnHandler(guid, spawnHandler, unspawnHandler);
         }
 
 

--- a/Assets/Mirror/Tests/Editor/ClientSceneTests.cs
+++ b/Assets/Mirror/Tests/Editor/ClientSceneTests.cs
@@ -245,6 +245,22 @@ namespace Mirror.Tests
             ClientScene.RegisterSpawnHandler(guid, spawnHandler, unspawnHandler);
         }
 
+        [Test]
+        public void RegisterSpawnHandler_SpawnDelegate_WarningWhenHandlerForGuidAlreadyExists()
+        {
+            Guid guid = Guid.NewGuid();
+            SpawnDelegate spawnHandler = new SpawnDelegate((x, y) => null);
+            UnSpawnDelegate unspawnHandler = new UnSpawnDelegate(x => { });
+
+            ClientScene.RegisterSpawnHandler(guid, spawnHandler, unspawnHandler);
+
+            SpawnDelegate spawnHandler2 = new SpawnDelegate((x, y) => new GameObject());
+            UnSpawnDelegate unspawnHandler2 = new UnSpawnDelegate(x => UnityEngine.Object.Destroy(x));
+
+            LogAssert.Expect(LogType.Warning, $"Replacing existing spawnHandlers for {guid}");
+            ClientScene.RegisterSpawnHandler(guid, spawnHandler2, unspawnHandler2);
+        }
+
 
         [Test]
         public void RegisterSpawnHandler_SpawnHandlerDelegate_AddsHandlerToSpawnHandlers()
@@ -303,6 +319,22 @@ namespace Mirror.Tests
 
             LogAssert.Expect(LogType.Error, "Can not Register SpawnHandler for empty Guid");
             ClientScene.RegisterSpawnHandler(guid, spawnHandler, unspawnHandler);
+        }
+
+        [Test]
+        public void RegisterSpawnHandler_SpawnHandlerDelegate_WarningWhenHandlerForGuidAlreadyExists()
+        {
+            Guid guid = Guid.NewGuid();
+            SpawnHandlerDelegate spawnHandler = new SpawnHandlerDelegate(x => null);
+            UnSpawnDelegate unspawnHandler = new UnSpawnDelegate(x => { });
+
+            ClientScene.RegisterSpawnHandler(guid, spawnHandler, unspawnHandler);
+
+            SpawnHandlerDelegate spawnHandler2 = new SpawnHandlerDelegate(x => new GameObject());
+            UnSpawnDelegate unspawnHandler2 = new UnSpawnDelegate(x => UnityEngine.Object.Destroy(x));
+
+            LogAssert.Expect(LogType.Warning, $"Replacing existing spawnHandlers for {guid}");
+            ClientScene.RegisterSpawnHandler(guid, spawnHandler2, unspawnHandler2);
         }
 
 


### PR DESCRIPTION
Replacing a handler by mistake will lead to code not running when it is expected to.