### PR TITLE
fix: fixing syncmode not showing up in Inspector

### DIFF
--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -21,6 +21,12 @@ namespace Mirror
         // does this type sync anything? otherwise we don't need to show syncInterval
         bool SyncsAnything(Type scriptClass)
         {
+            // syncVarNames should be set because SyncsAnything is called
+            if (syncVarNames.Count > 0)
+            {
+                return true;
+            }
+
             // has OnSerialize that is not in NetworkBehaviour?
             // then it either has a syncvar or custom OnSerialize. either way
             // this means we have something to sync.


### PR DESCRIPTION
syncMode and syncInterval now show up in Inspector when only sync vars are used