### PR TITLE
fix: fixing showDebugMessages with new logger

### DIFF
--- a/Assets/Mirror/Runtime/LogFactory.cs
+++ b/Assets/Mirror/Runtime/LogFactory.cs
@@ -27,11 +27,26 @@ namespace Mirror
             logger = new Logger(Debug.unityLogger)
             {
                 // by default, log warnings and up
-                filterLogType = defaultLogLevel
+                filterLogType = debugMode ? LogType.Log : defaultLogLevel
             };
 
             loggers[loggerName] = logger;
             return logger;
+        }
+
+
+        static bool debugMode = false;
+        /// <summary>
+        /// Makes all log levels LogType.Log, this is so that NetworkManger.showDebugMessages can still be used
+        /// </summary>
+        internal static void EnableDebugMode()
+        {
+            debugMode = true;
+
+            foreach (KeyValuePair<string, ILogger> kvp in loggers)
+            {
+                kvp.Value.filterLogType = LogType.Log;
+            }
         }
     }
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -695,6 +695,10 @@ namespace Mirror
 
             // do this early
             LogFilter.Debug = showDebugMessages;
+            if (LogFilter.Debug)
+            {
+                LogFactory.EnableDebugMode();
+            }
 
             if (dontDestroyOnLoad)
             {


### PR DESCRIPTION
In built games, there is currently no way to show debug logs for classes that are using the new logger.


This PR also allows us to keep support for `showDebugMessages` for a few versions.