### PR TITLE
fix: clear all message handlers on Shutdown

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -113,6 +113,7 @@ namespace Mirror
             }
             dontListen = false;
             active = false;
+            handlers.Clear();
 
             NetworkIdentity.ResetNextNetworkId();
         }


### PR DESCRIPTION
Handlers should be cleared when NetworkServer is shut down.