### PR TITLE
Hot path micro-optimization: NetworkTransform's HasMovedRotatedScaled

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -289,29 +289,21 @@ namespace Mirror
         {
             // moved or rotated or scaled?
             // local position/rotation/scale for VR support
-            Transform targetComponentTransform = targetComponent.transform;
-
-            bool Moved() =>
-                DistanceGreaterThan(lastPosition, targetComponentTransform.localPosition, localPositionSensitivity);
-
-            bool Scaled() =>
-                DistanceGreaterThan(lastScale, targetComponentTransform.localScale, localScaleSensitivity);
-
-            bool Rotated() =>
-                Quaternion.Angle(lastRotation, targetComponentTransform.localRotation) > localRotationSensitivity;
+            bool moved = DistanceGreaterThan(lastPosition, targetComponent.transform.localPosition, localPositionSensitivity);
+            bool scaled = DistanceGreaterThan(lastScale, targetComponent.transform.localScale, localScaleSensitivity);
+            bool rotated = Quaternion.Angle(lastRotation, targetComponent.transform.localRotation) > localRotationSensitivity;
 
             // save last for next frame to compare
             // (only if change was detected. otherwise slow moving objects might
             //  never sync because of C#'s float comparison tolerance. see also:
             //  https://github.com/vis2k/Mirror/pull/428 )
-            // Micro-optimization to lazily evaluate other performance-heavy conditions
-            bool change = Moved() || Rotated() || Scaled();
+            bool change = moved || rotated || scaled;
             if (change)
             {
                 // local position/rotation for VR support
-                lastPosition = targetComponentTransform.localPosition;
-                lastRotation = targetComponentTransform.localRotation;
-                lastScale = targetComponentTransform.localScale;
+                lastPosition = targetComponent.transform.localPosition;
+                lastRotation = targetComponent.transform.localRotation;
+                lastScale = targetComponent.transform.localScale;
             }
 
             return change;
@@ -321,8 +313,8 @@ namespace Mirror
         static bool DistanceGreaterThan(in Vector3 first, in Vector3 second, in float greaterThan)
         {
             // SqrMagnitude provides better performance than Distance, as it avoids an expensive square root function,
-            // which is generally not an issue on modern PC CPUs based on benchmarks, but it hurts mobile performance
-            //return SqrMagnitude(first - second) > greaterThan * greaterThan;
+            // which is generally not an issue on modern PC CPUs based on benchmarks, but it hurts mobile performance.
+            // Following code is the equivalent of: return SqrMagnitude(first - second) > greaterThan * greaterThan;
             // Further micro-optimizations: 1. Avoid a Vector3 constructor call for "operator -"
             // 2. Use "in" function parameters to avoid copying structs (Or instead copy its content to prevent a call)
             float x = first.x - second.x;


### PR DESCRIPTION
This is a micro-optimization for a hot path, which scales linearly with the number of **NetworkTransform** components and generally seems to provide at least **20% performance gain of its Update()**. Simply using "||" operator often avoids unnecessary calculation, which was supposedly done for the reason of improving code readability by using variables instead of comments, as advised in the [Contribution Guide](https://github.com/vis2k/Mirror/blob/master/CONTRIBUTING.md), which I don't really agree with, but I've found a user-friendly alternative of writing short-hand lambda syntax for local functions, which can promote similar approach when a similar opportunity appears in the future.

Furthermore, I've re-introduced the same **Vector3.Distance -> Vector3.SqrMagnitude** optimization as in rejected https://github.com/vis2k/Mirror/pull/1514, which contained discussion about accidental misunderstanding of the square operation in the right side of the equation, and this being less intuitive in spite of Unity documentation being very explicit about it. To prevent any such mistakes, I don't see any harm in extracting this to a private DistanceGreaterThan function, which could be easily stored in a Util class as well. I'm only replacing contents of HasEitherMovedRotatedScaled(), so it's up to you if you want to take a similar approach elsewhere. I've taken the opportunity for further straight-forward micro-optimization within this function. For example, I've realized that making an "in" method parameter for a struct like Vector3 reduces the function call overhead by 10%-50% based on Unity Profiler, but I have no idea if there are any intelligent compilers such that it's unnecessary.

* ^ Note that this improvement was already integrated by https://github.com/vis2k/Mirror/pull/1810 where there were no similar steps taken to prevent misunderstanding the code as criticized in https://github.com/vis2k/Mirror/pull/1514, such as extracting it into a custom function, so I'd like someone to provide a feedback about which solution is more user-friendly. That PR is an experimental WIP, so my intention is to get this integrated sooner.

However, the simplest optimization seems to have the largest effect of them all: **caching targetComponent.transform** by replacing its occurrence in 5 places by a variable seems to practically increase the performance by 20% on its own. For example, the JetBrains Rider IDE already suggests this optimization automatically by always underlining them. If this issue is really as severe as my tests show, then some caching via private class fields may be worth considering.

I've also tried to set up a test scenario using [BenchmarkPerformance](https://github.com/vis2k/Mirror/blob/e346885ff5d1230310497d4aaa8cebe3babeaad7/Assets/Mirror/Tests/Performance/Runtime/BenchmarkPerformance.cs) in both the situations of all objects moving in every frame, and not moving at all. The Average values returned the following values:

- Before optimization
- - Moving objects: 14.86 37.42
- - Idle objects: 14.92 34.82
- After optimization
- - Moving objects: 3.498 15.264
- - Idle objects: 9.53 20.53

I'm looking forward to any feedback, and I hope that we can establish some guidelines for development in a way that prevents similar unnecessary performance leaks (to make it easier for new contributors to clean up the code), without taking precious time from leading project contributors who focus on major improvements. After all, new C# versions already provide plenty of user-friendly syntax alternatives :)

---

**More details:**

The HasEitherMovedRotatedScaled is called in every Update for every object of NetworkTransformBase on Server, and after every syncInterval on Client, causing unnecessary calculation, which can be lazily evaluated under some circumstances, specifically when the position was already moved, or when it was rotated. To enable the lazy evaluation, local functions were chosen instead of expensive Func<bool> lambdas or Lazy<bool> variables, because either of them would negate all of the performance gains. Used a short syntax of local functions to improve readability.

During a simulation of 10_000 moving objects, this had an impact on NetworkTransformBase.Update() of approximately 20% performance increase, from above 15ms down to 11.6 ms on i7-8700K 4.7GHz, as Moved() returning true short-circuits both Rotated() and Scaled(). (Some of these gains were due to transform caching mentioned later.)

As a further optimization, a simple usage of Vector3.Distance was replaced by Vector3.SqrMagnitude after extracting it to a strictly defined static function to prevent developers' mistakes in a future. In this function, 3 other micro-optimizations were used:

1. in parameters to prevent copying structs
2. avoiding Vector3 constructor of "operator -"
3. avoiding a function call

During the same simulation of 10_000 objects executing 3 conditions, the impact was around 5% (e.g. 14.4ms to 13.6ms, 13 ms to 12.2 ms).

Next optimization, which was way simpler and has a visible impact, was caching targetComponent.transform instead of duplicate calls. Executing 3 functions [Moved() Rotated() Scaled()] having replaced their calls by a single one had an impact of 7% (13.6ms to 12.2 ms). Replacing 3 more calls under "if (change)" reduced it down to 10.6ms, causing at least 20% relative improvement.

After enabling the "Moved() || Rotated() || Scaled()" short-circuit optimization, 10_000 moving objects caused the Update() to further drop to around 9.4ms. Non-moving objects were measured around 10.7ms, compared to 11ms when removing other optimizations except transform, so the DistanceGreaterThan accounts only for around 3-5%, but based on Unity specification for square root and other benchmarks, this may vary depending on available CPU instructions, causing better results.