### PR TITLE
breaking: Eliminates RemovePlayerMessage As Security Risk

### DIFF
--- a/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
+++ b/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
@@ -26,7 +26,8 @@ namespace Mirror
                 "MIRROR_9_0_OR_NEWER",
                 "MIRROR_10_0_OR_NEWER",
                 "MIRROR_11_0_OR_NEWER",
-                "MIRROR_12_0_OR_NEWER"
+                "MIRROR_12_0_OR_NEWER",
+                "MIRROR_13_0_OR_NEWER"
             };
 
             // only touch PlayerSettings if we actually modified it.

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using UnityEngine;
 using Guid = System.Guid;
@@ -121,27 +123,13 @@ namespace Mirror
             return true;
         }
 
+        // Deprecated 5/2/2020
         /// <summary>
-        /// Removes the player from the game.
+        /// Obsolete: Removed as a security risk
         /// </summary>
         /// <returns>True if succcessful</returns>
-        public static bool RemovePlayer()
-        {
-            if (logger.LogEnabled()) logger.Log("ClientScene.RemovePlayer() called with connection [" + readyConnection + "]");
-
-            if (readyConnection.identity != null)
-            {
-                readyConnection.Send(new RemovePlayerMessage());
-
-                Object.Destroy(readyConnection.identity.gameObject);
-
-                readyConnection.identity = null;
-                localPlayer = null;
-
-                return true;
-            }
-            return false;
-        }
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk", true)]
+        public static bool RemovePlayer() { return false; }
 
         /// <summary>
         /// Signal that the client connection is ready to enter the game.

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -125,10 +125,9 @@ namespace Mirror
 
         // Deprecated 5/2/2020
         /// <summary>
-        /// Obsolete: Removed as a security risk
+        /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
         /// </summary>
-        /// <returns>True if succcessful</returns>
-        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk", true)]
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk. Use NetworkServer.RemovePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
         public static bool RemovePlayer() { return false; }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -65,7 +65,7 @@ namespace Mirror
     /// <summary>
     /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
     /// </summary>
-    [Obsolete("Removed as a security risk. Use NetworkServer.RemovePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
+    [Obsolete("Removed as a security risk. Use NetworkServer.RemovePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead")]
     public struct RemovePlayerMessage : IMessageBase
     {
         public void Deserialize(NetworkReader reader) { }

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -61,6 +61,11 @@ namespace Mirror
         public void Serialize(NetworkWriter writer) { }
     }
 
+    // Deprecated 5/2/2020
+    /// <summary>
+    /// Obsolete: Removed as a security risk
+    /// </summary>
+    [Obsolete("Removed as a security risk")]
     public struct RemovePlayerMessage : IMessageBase
     {
         public void Deserialize(NetworkReader reader) { }

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -65,7 +65,7 @@ namespace Mirror
     /// <summary>
     /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
     /// </summary>
-    [Obsolete("Removed as a security risk. Use NetworkServer.ReplacePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead")]
+    [Obsolete("Removed as a security risk. Use NetworkServer.RemovePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
     public struct RemovePlayerMessage : IMessageBase
     {
         public void Deserialize(NetworkReader reader) { }

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -63,9 +63,9 @@ namespace Mirror
 
     // Deprecated 5/2/2020
     /// <summary>
-    /// Obsolete: Removed as a security risk
+    /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
     /// </summary>
-    [Obsolete("Removed as a security risk")]
+    [Obsolete("Removed as a security risk. Use NetworkServer.ReplacePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead")]
     public struct RemovePlayerMessage : IMessageBase
     {
         public void Deserialize(NetworkReader reader) { }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -736,7 +736,6 @@ namespace Mirror
 
             // Network Server initially registers it's own handlers for these, so we replace them here.
             NetworkServer.ReplaceHandler<ReadyMessage>(OnServerReadyMessageInternal);
-            NetworkServer.ReplaceHandler<RemovePlayerMessage>(OnServerRemovePlayerMessageInternal);
         }
 
         void RegisterClientMessages()
@@ -1187,16 +1186,12 @@ namespace Mirror
             OnServerAddPlayer(conn);
         }
 
-        void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg)
-        {
-            if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerRemovePlayerMessageInternal");
-
-            if (conn.identity != null)
-            {
-                OnServerRemovePlayer(conn, conn.identity);
-                conn.identity = null;
-            }
-        }
+        // Deprecated 5/2/2020
+        /// <summary>
+        /// Obsolete: Removed as a security risk
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk", true)]
+        void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg) { }
 
         void OnServerErrorInternal(NetworkConnection conn, ErrorMessage msg)
         {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1188,9 +1188,9 @@ namespace Mirror
 
         // Deprecated 5/2/2020
         /// <summary>
-        /// Obsolete: Removed as a security risk
+        /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk", true)]
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk. Use NetworkServer.ReplacePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
         void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg) { }
 
         void OnServerErrorInternal(NetworkConnection conn, ErrorMessage msg)
@@ -1350,19 +1350,12 @@ namespace Mirror
             }
         }
 
+        // Deprecated 5/2/2020
         /// <summary>
-        /// Called on the server when a client removes a player.
-        /// <para>The default implementation of this function destroys the corresponding player object.</para>
+        /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
         /// </summary>
-        /// <param name="conn">The connection to remove the player from.</param>
-        /// <param name="player">The player identity to remove.</param>
-        public virtual void OnServerRemovePlayer(NetworkConnection conn, NetworkIdentity player)
-        {
-            if (player.gameObject != null)
-            {
-                NetworkServer.Destroy(player.gameObject);
-            }
-        }
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk. Use NetworkServer.ReplacePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
+        public virtual void OnServerRemovePlayer(NetworkConnection conn, NetworkIdentity player) { }
 
         /// <summary>
         /// Called on the server when a network error occurs for a client connection.

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1190,7 +1190,7 @@ namespace Mirror
         /// <summary>
         /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk. Use NetworkServer.ReplacePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk. Use NetworkServer.RemovePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
         void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg) { }
 
         void OnServerErrorInternal(NetworkConnection conn, ErrorMessage msg)
@@ -1354,7 +1354,7 @@ namespace Mirror
         /// <summary>
         /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk. Use NetworkServer.ReplacePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk. Use NetworkServer.RemovePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
         public virtual void OnServerRemovePlayer(NetworkConnection conn, NetworkIdentity player) { }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using UnityEngine;
 
 namespace Mirror
@@ -138,7 +139,6 @@ namespace Mirror
         {
             RegisterHandler<ReadyMessage>(OnClientReadyMessage);
             RegisterHandler<CommandMessage>(OnCommandMessage);
-            RegisterHandler<RemovePlayerMessage>(OnRemovePlayerMessage);
             RegisterHandler<NetworkPingMessage>(NetworkTime.OnServerPing, false);
         }
 
@@ -924,19 +924,12 @@ namespace Mirror
             SetClientReady(conn);
         }
 
-        // default remove player handler
-        static void OnRemovePlayerMessage(NetworkConnection conn, RemovePlayerMessage msg)
-        {
-            if (conn.identity != null)
-            {
-                Destroy(conn.identity.gameObject);
-                conn.identity = null;
-            }
-            else
-            {
-                Debug.LogError("Received remove player message but connection has no player");
-            }
-        }
+        // Deprecated 5/2/2020
+        /// <summary>
+        /// Obsolete: Removed as a security risk
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk", true)]
+        static void OnRemovePlayerMessage(NetworkConnection conn, RemovePlayerMessage msg) { }
 
         // Handle command from specific player, this could be one of multiple players on a single client
         static void OnCommandMessage(NetworkConnection conn, CommandMessage msg)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -926,10 +926,32 @@ namespace Mirror
 
         // Deprecated 5/2/2020
         /// <summary>
-        /// Obsolete: Removed as a security risk
+        /// Obsolete: Removed as a security risk. Use <see cref="NetworkServer.RemovePlayerForConnection(NetworkConnection, GameObject, bool)"/> instead.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk", true)]
+        [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Removed as a security risk. Use NetworkServer.RemovePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false) instead", true)]
         static void OnRemovePlayerMessage(NetworkConnection conn, RemovePlayerMessage msg) { }
+
+        /// <summary>
+        /// Removes the player object from the connection
+        /// </summary>
+        /// <param name="conn">The connection of the client to remove from</param>
+        /// <param name="destroyServerObject">Indicates whether the server object should be destroyed</param>
+        public static void RemovePlayerForConnection(NetworkConnection conn, bool destroyServerObject)
+        {
+            if (conn.identity != null)
+            {
+                if (destroyServerObject)
+                    Destroy(conn.identity.gameObject);
+                else
+                    UnSpawn(conn.identity.gameObject);
+
+                conn.identity = null;
+            }
+            else
+            {
+                if (LogFilter.Debug) Debug.Log($"Connection {conn} has no identity");
+            }
+        }
 
         // Handle command from specific player, this could be one of multiple players on a single client
         static void OnCommandMessage(NetworkConnection conn, CommandMessage msg)

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -149,17 +149,6 @@ public class #SCRIPTNAME# : NetworkManager
     }
 
     /// <summary>
-    /// Called on the server when a client removes a player.
-    /// <para>The default implementation of this function destroys the corresponding player object.</para>
-    /// </summary>
-    /// <param name="conn">The connection to remove the player from.</param>
-    /// <param name="player">The player identity to remove.</param>
-    public override void OnServerRemovePlayer(NetworkConnection conn, NetworkIdentity player)
-    {
-        base.OnServerRemovePlayer(conn, player);
-    }
-
-    /// <summary>
     /// Called on the server when a client disconnects.
     /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
     /// </summary>


### PR DESCRIPTION
BREAKING CHANGE: Eliminates RemovePlayerMessage

RemovePlayerMessage is a built-in message that Mirror inherited from UNet. Since it's an automatically handled message, that Mirror devs may not know about or pay much attention to, it exposes a security risk where a molested client could push this message and get the player object removed while holding the connection open, potentially cascading to bunches of unexpected Null Ref Exceptions.

This PR cuts out all the functionality, while leave an Error-tagged Obsolete so after upgrading users will be aware of it and make necessary changes, if any.

By gutting the code out of the obsolete methods, the risk is mitigated, and the obsolete methods will be removed in the June Asset Store release.

The unity tests for RemovePlayerMessage remain, and will be removed at the same time as the rest.