### PR TITLE
adding enabled check to loops

### DIFF
--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -137,6 +137,13 @@ namespace Mirror
                 {
                     break;
                 }
+
+                // Some messages can disable transport
+                // If this is disabled stop processing message in queue
+                if (!enabled)
+                {
+                    break;
+                }
             }
 
             // process a maximum amount of server messages per tick
@@ -144,6 +151,13 @@ namespace Mirror
             {
                 // stop when there is no more message
                 if (!ProcessServerMessage())
+                {
+                    break;
+                }
+
+                // Some messages can disable transport
+                // If this is disabled stop processing message in queue
+                if (!enabled)
                 {
                     break;
                 }


### PR DESCRIPTION
Message can disable transport so we need to check if it is still enabled before checking the next message.

Fixing problem with this
https://github.com/vis2k/Mirror/blob/d0e15b13787d6ac7a2d8ac9ccf054255e4dbcd15/Assets/Mirror/Runtime/NetworkManager.cs#L861-L865