### PR TITLE
fix: Don't call RegisterClientMessages twice

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1056,7 +1056,6 @@ namespace Mirror
 
             if (NetworkClient.isConnected)
             {
-                RegisterClientMessages();
                 OnClientSceneChanged(NetworkClient.connection);
             }
         }


### PR DESCRIPTION
This was already called in StartClient - calling it again here throws warnings that the handlers are being replaced needlessly.