### PR TITLE
fix: Cleaning up network objects when server stops

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -777,6 +777,8 @@ namespace Mirror
                     Destroy(identity.gameObject);
                 }
             }
+
+            NetworkIdentity.spawned.Clear();
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -763,9 +763,19 @@ namespace Mirror
 
         void CleanupNetworkIdentities()
         {
-            foreach (NetworkIdentity identity in Resources.FindObjectsOfTypeAll<NetworkIdentity>())
+            foreach (KeyValuePair<uint, NetworkIdentity> kvp in NetworkIdentity.spawned)
             {
-                identity.Reset();
+                NetworkIdentity identity = kvp.Value;
+
+                if (identity.sceneId != 0)
+                {
+                    identity.Reset();
+                    identity.gameObject.SetActive(false);
+                }
+                else
+                {
+                    Destroy(identity.gameObject);
+                }
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -765,7 +765,6 @@ namespace Mirror
         {
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
             {
-
                 if (identity.sceneId != 0)
                 {
                     identity.Reset();

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -763,7 +763,7 @@ namespace Mirror
 
         void CleanupNetworkIdentities()
         {
-            foreach (KeyValuePair<uint, NetworkIdentity> kvp in NetworkIdentity.spawned)
+            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
             {
                 NetworkIdentity identity = kvp.Value;
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -765,7 +765,6 @@ namespace Mirror
         {
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
             {
-                NetworkIdentity identity = kvp.Value;
 
                 if (identity.sceneId != 0)
                 {


### PR DESCRIPTION
Fixes #1856 

Not sure why the old version was using `Resources.FindObjectsOfTypeAll` so we need to test this fix in real projects before we merge