### PR TITLE
fix: Don't call RegisterClientMessages every scene change

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1005,19 +1005,14 @@ namespace Mirror
                 // call OnServerSceneChanged
                 OnServerSceneChanged(networkSceneName);
 
-                if (NetworkClient.isConnected)
-                {
-                    RegisterClientMessages();
-
-                    // DO NOT call OnClientSceneChanged here.
-                    // the scene change happened because StartHost loaded the
-                    // server's online scene. it has nothing to do with the client.
-                    // this was not meant as a client scene load, so don't call it.
-                    //
-                    // otherwise AddPlayer would be called twice:
-                    // -> once for client OnConnected
-                    // -> once in OnClientSceneChanged
-                }
+                // DO NOT call OnClientSceneChanged here.
+                // the scene change happened because StartHost loaded the
+                // server's online scene. it has nothing to do with the client.
+                // this was not meant as a client scene load, so don't call it.
+                //
+                // otherwise AddPlayer would be called twice:
+                // -> once for client OnConnected
+                // -> once in OnClientSceneChanged
             }
             // otherwise we just changed a scene in host mode
             else
@@ -1030,8 +1025,6 @@ namespace Mirror
 
                 if (NetworkClient.isConnected)
                 {
-                    RegisterClientMessages();
-
                     // let client know that we changed scene
                     OnClientSceneChanged(NetworkClient.connection);
                 }


### PR DESCRIPTION
Calling RegisterClientMessages every scene change isn't necessary.
We call it from StartHostClient and that's sufficient.

The Room example is the only one with multiple scene changes, and spams warnings about replacing prefabs in master.  This PR cleans that up, and the example works correctly.