### PR TITLE
Moving CleanupNetworkIdentities to NetworkServer

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -607,8 +607,6 @@ namespace Mirror
                 ServerChangeScene(offlineScene);
             }
 
-            CleanupNetworkIdentities();
-
             startPositionIndex = 0;
 
             networkSceneName = "";
@@ -642,8 +640,6 @@ namespace Mirror
             {
                 ClientChangeScene(offlineScene, SceneOperation.Normal);
             }
-
-            CleanupNetworkIdentities();
 
             networkSceneName = "";
         }
@@ -759,24 +755,6 @@ namespace Mirror
                     ClientScene.RegisterPrefab(prefab);
                 }
             }
-        }
-
-        void CleanupNetworkIdentities()
-        {
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
-            {
-                if (identity.sceneId != 0)
-                {
-                    identity.Reset();
-                    identity.gameObject.SetActive(false);
-                }
-                else
-                {
-                    Destroy(identity.gameObject);
-                }
-            }
-
-            NetworkIdentity.spawned.Clear();
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -116,7 +116,26 @@ namespace Mirror
             active = false;
             handlers.Clear();
 
+            CleanupNetworkIdentities();
             NetworkIdentity.ResetNextNetworkId();
+        }
+
+        static void CleanupNetworkIdentities()
+        {
+            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            {
+                if (identity.sceneId != 0)
+                {
+                    identity.Reset();
+                    identity.gameObject.SetActive(false);
+                }
+                else
+                {
+                    Destroy(identity.gameObject);
+                }
+            }
+
+            NetworkIdentity.spawned.Clear();
         }
 
         static void Initialize()

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -131,7 +131,7 @@ namespace Mirror
                 }
                 else
                 {
-                    Destroy(identity.gameObject);
+                    GameObject.Destroy(identity.gameObject);
                 }
             }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -124,14 +124,17 @@ namespace Mirror
         {
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
             {
-                if (identity.sceneId != 0)
+                if (identity != null)
                 {
-                    identity.Reset();
-                    identity.gameObject.SetActive(false);
-                }
-                else
-                {
-                    GameObject.Destroy(identity.gameObject);
+                    if (identity.sceneId != 0)
+                    {
+                        identity.Reset();
+                        identity.gameObject.SetActive(false);
+                    }
+                    else
+                    {
+                        GameObject.Destroy(identity.gameObject);
+                    }
                 }
             }
 

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -72,6 +73,81 @@ namespace Mirror.Tests.Runtime
             // respawn player
             NetworkServer.AddPlayerForConnection(conn, player);
             Assert.That(conn.identity != null, "identity should not be null");
+        }
+
+        [UnityTest]
+        public IEnumerator Shutdown_DestroysAllSpawnedPrefabs()
+        {
+            // setup
+            NetworkServer.Listen(1);
+
+            const string ValidPrefabAssetGuid = "33169286da0313d45ab5bfccc6cf3775";
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(ValidPrefabAssetGuid));
+
+            NetworkIdentity identity1 = spawnPrefab(prefab);
+            NetworkIdentity identity2 = spawnPrefab(prefab);
+
+
+            // test
+            NetworkServer.Shutdown();
+
+            // wait 1 frame for unity to destroy objects
+            yield return null;
+
+            // check that objects were destroyed
+            // need to use untiy `==` check
+            Assert.IsTrue(identity1 == null);
+            Assert.IsTrue(identity2 == null);
+
+            Assert.That(NetworkIdentity.spawned, Is.Empty);
+        }
+
+        static NetworkIdentity spawnPrefab(GameObject prefab)
+        {
+            GameObject clone1 = GameObject.Instantiate(prefab);
+            NetworkServer.Spawn(clone1);
+            NetworkIdentity identity1 = clone1.GetComponent<NetworkIdentity>();
+            Assert.IsTrue(NetworkIdentity.spawned.ContainsValue(identity1));
+            return identity1;
+        }
+
+        [Test]
+        public void Shutdown_DisablesAllSpawnedPrefabs()
+        {
+            // setup
+            NetworkServer.Listen(1);
+
+            NetworkIdentity identity1 = spawnSceneObject("test 1");
+            NetworkIdentity identity2 = spawnSceneObject("test 2");
+
+
+            // test
+            NetworkServer.Shutdown();
+
+            // check that objects were disabled
+            // need to use untiy `==` check
+            Assert.IsTrue(identity1 != null);
+            Assert.IsTrue(identity2 != null);
+            Assert.IsFalse(identity1.gameObject.activeSelf);
+            Assert.IsFalse(identity1.gameObject.activeSelf);
+
+            Assert.That(NetworkIdentity.spawned, Is.Empty);
+
+            // cleanup
+            GameObject.DestroyImmediate(identity1.gameObject);
+            GameObject.DestroyImmediate(identity2.gameObject);
+        }
+
+        static NetworkIdentity spawnSceneObject(string Name)
+        {
+            GameObject obj = new GameObject(Name, typeof(NetworkIdentity));
+            NetworkIdentity identity = obj.GetComponent<NetworkIdentity>();
+            obj.SetActive(false);
+            if (identity.sceneId == 0) { identity.sceneId = (ulong)obj.GetHashCode(); }
+            NetworkServer.Spawn(obj);
+
+            Assert.IsTrue(NetworkIdentity.spawned.ContainsValue(identity));
+            return identity;
         }
     }
 }


### PR DESCRIPTION
`NetworkClient.Shutdown` cleans up client objects so `NetworkServre.Shutdown` should clean up server objects


depends on https://github.com/vis2k/Mirror/pull/1868