### PR TITLE
adding GetComponent to networkmanager awake

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -241,6 +241,14 @@ namespace Mirror
 
             // setup OnSceneLoaded callback
             SceneManager.sceneLoaded += OnSceneLoaded;
+
+            if (transport == null)
+            {
+                // was a transport added yet? if not, add one
+                transport = GetComponent<Transport>();
+
+                Debug.Assert(transport != null, "Could not find Transport on NetworkManager");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Onvalidate does not run when a networkmanager is created at runtime. This means that there is now way to set the transport. Adding GetComponent to Awake will allow someone to add transport then networkmanager at runtime.

This will help us create Transports in tests.