### PR TITLE
fix: Adding warning to Telepathy Client connect when client is already connecting or connected

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Telepathy/Client.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Client.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Net.Sockets;
 using System.Threading;
@@ -113,7 +113,10 @@ namespace Telepathy
         {
             // not if already started
             if (Connecting || Connected)
+            {
+                Logger.LogWarning("Telepathy Client can not create connection because an existing connection is connecting or connected");
                 return;
+            }
 
             // We are connecting from now until Connect succeeds or fails
             _Connecting = true;


### PR DESCRIPTION
If someone calls `NetworkClient.Connect(networkAddress);` or `Transport.activeTransport.ClientConnect(address);` while an existing client is connecting/connected the user has no way of knowing that the new connect fails. 

This can be a problem if a user tries to connect to multiple servers quickly before first request times out.