### PR TITLE
fix:version2 Telepathy.ClientDisconnect does not Interrupt ReceiveThread causing OnClientDisconnected to be invoked later at the wrong time

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Telepathy/Client.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Client.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Net.Sockets;
 using System.Threading;
@@ -113,7 +113,10 @@ namespace Telepathy
         {
             // not if already started
             if (Connecting || Connected)
+            {
+                Logger.LogWarning("Telepathy Client can not create connection because an existing connection is connecting or connected");
                 return;
+            }
 
             // We are connecting from now until Connect succeeds or fails
             _Connecting = true;

--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -69,15 +69,34 @@ namespace Mirror
             return Application.platform != RuntimePlatform.WebGLPlayer;
         }
 
+        public void CreateNewClient()
+        {
+            if (client != null && (client.Connecting || client.Connected))
+            {
+                Telepathy.Logger.LogWarning("Existing client is connecting or connected, can not create new");
+            }
+
+            client = new Telepathy.Client
+            {
+                NoDelay = NoDelay,
+                MaxMessageSize = clientMaxMessageSize
+            };
+        }
         // client
         public override bool ClientConnected() => client.Connected;
-        public override void ClientConnect(string address) => client.Connect(address, port);
+        public override void ClientConnect(string address)
+        {
+            CreateNewClient();
+            client.Connect(address, port);
+        }
+
         public override void ClientConnect(Uri uri)
         {
             if (uri.Scheme != Scheme)
                 throw new ArgumentException($"Invalid url {uri}, use {Scheme}://host:port instead", nameof(uri));
 
             int serverPort = uri.IsDefaultPort ? port : uri.Port;
+            CreateNewClient();
             client.Connect(uri.Host, serverPort);
         }
         public override bool ClientSend(int channelId, ArraySegment<byte> segment)

--- a/Assets/Mirror/Tests/Runtime/TransportTest_DisconnectBug.cs
+++ b/Assets/Mirror/Tests/Runtime/TransportTest_DisconnectBug.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections;
+using System.Text.RegularExpressions;
+using Mirror;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Telepathy.Tests.Runtime
+{
+    [TestFixture]
+    [Category("Telepathy")]
+    public class TransportTest_DisconnectBug
+    {
+        // just a random port that will hopefully not be taken
+        const int goodPort = 7777;
+        const int badPort = 7779;
+        private const string localHostIp = "127.0.0.1";
+        private const string localHost = "localhost";
+        private TelepathyTransport clientTransport;
+        private NetworkManager manager;
+        private TelepathyTransport serverTransport;
+
+
+        bool success;
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            clientTransport = new GameObject().AddComponent<TelepathyTransport>();
+            manager = clientTransport.gameObject.AddComponent<NetworkManager>();
+            manager.showDebugMessages = true;
+            LogFilter.Debug = true;
+            if (LogFilter.Debug)
+            {
+                LogFactory.EnableDebugMode();
+            }
+            Transport.activeTransport = clientTransport;
+
+            serverTransport = new GameObject().AddComponent<TelepathyTransport>();
+
+            serverTransport.port = goodPort;
+
+            yield return null;
+            serverTransport.ServerStart();
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            serverTransport.ServerStop();
+            yield return null;
+            GameObject.Destroy(clientTransport.gameObject);
+            GameObject.Destroy(serverTransport.gameObject);
+        }
+
+        [UnityTest]
+        public IEnumerator CanConnectToServer_Ip()
+        {
+            yield return CanConnectToServer(localHostIp);
+
+            Assert.IsTrue(success, "Connection closed early");
+        }
+        [UnityTest]
+        public IEnumerator CanConnectToServer_HostName()
+        {
+            yield return CanConnectToServer(localHost);
+
+            Assert.IsTrue(success, "Connection closed early");
+        }
+        IEnumerator CanConnectToServer(string hostName)
+        {
+            // good address
+            UriBuilder uriBuilder2 = new UriBuilder { Scheme = "tcp4", Host = hostName, Port = goodPort };
+            manager.StartClient(uriBuilder2.Uri);
+
+            float startTime = Time.time;
+            success = false;
+            const float waitTime = 1;
+            while (NetworkClient.active)
+            {
+                //Debug.Log($"Connected = {clientTransport.ClientConnected()}");
+                yield return null;
+
+                // stop after x seconds
+                if (Time.time > startTime + waitTime)
+                {
+                    success = true;
+                    break;
+                }
+            }
+        }
+
+
+        [UnityTest]
+        public IEnumerator StopEarlyShouldKillThread_Ip()
+        {
+            yield return StopEarlyShouldKillThread(localHostIp);
+
+            Assert.IsTrue(success, "Connection closed early");
+        }
+        [UnityTest]
+        public IEnumerator StopEarlyShouldKillThread_HostName()
+        {
+            yield return StopEarlyShouldKillThread(localHost);
+
+            Assert.IsTrue(success, "Connection closed early");
+        }
+
+        IEnumerator StopEarlyShouldKillThread(string hostName)
+        {
+            // bad address
+            UriBuilder uriBuilder1 = new UriBuilder { Scheme = "tcp4", Host = hostName, Port = badPort };
+            manager.StartClient(uriBuilder1.Uri);
+
+            float startTime = Time.time;
+            const float waitTime1 = 0.2f;
+            while (NetworkClient.active)
+            {
+                yield return null;
+
+                // stop after x seconds
+                // before timeout
+                if (Time.time > startTime + waitTime1)
+                {
+                    break;
+                }
+            }
+
+            // stop client and connect to another server
+            LogAssert.Expect(LogType.Warning, new Regex("ThreadInterruptedException"));
+            manager.StopClient();
+
+            // good address
+            UriBuilder uriBuilder2 = new UriBuilder { Scheme = "tcp4", Host = hostName, Port = goodPort };
+            manager.StartClient(uriBuilder2.Uri);
+
+            startTime = Time.time;
+            success = false;
+            const float waitTime2 = 20;
+            while (NetworkClient.active)
+            {
+                yield return null;
+
+                // stop after x seconds
+                if (Time.time > startTime + waitTime2)
+                {
+                    success = true;
+                    break;
+                }
+            }
+        }
+
+        [UnityTest]
+        [Ignore("Work in progress")]
+        public IEnumerator Call2Times_Should_Give_Warning()
+        {
+            yield return null;
+
+            //// bad address
+            //UriBuilder uriBuilder1 = new UriBuilder { Scheme = "tcp4", Host = "192.168.1.15", Port = badPort };
+            //manager.StartClient(uriBuilder1.Uri);
+
+            //yield return new WaitForSeconds(0.2f);
+
+            //// good address
+            //UriBuilder uriBuilder2 = new UriBuilder { Scheme = "tcp4", Host = "localhost", Port = goodPort };
+            //manager.StartClient(uriBuilder2.Uri);
+
+            //float startTime = Time.time;
+            //while (NetworkClient.active)
+            //{
+            //    Debug.Log($"ClientConnected = {clientTransport.ClientConnected()}");
+            //    yield return null;
+
+            //    // stop after 5 seconds
+            //    if (Time.time > startTime + 2)
+            //    {
+            //        success = true;
+            //        break;
+            //    }
+            //}
+
+            //Assert.IsTrue(success, "Connection closed early");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Runtime/TransportTest_DisconnectBug.cs
+++ b/Assets/Mirror/Tests/Runtime/TransportTest_DisconnectBug.cs
@@ -28,6 +28,7 @@ namespace Telepathy.Tests.Runtime
         {
             clientTransport = new GameObject().AddComponent<TelepathyTransport>();
             manager = clientTransport.gameObject.AddComponent<NetworkManager>();
+            manager.startOnHeadless = false;
             manager.showDebugMessages = true;
             LogFilter.Debug = true;
             if (LogFilter.Debug)

--- a/Assets/Mirror/Tests/Runtime/TransportTest_DisconnectBug.cs.meta
+++ b/Assets/Mirror/Tests/Runtime/TransportTest_DisconnectBug.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4dee4cbc55397043b6c28fb7c25d03d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Trying other fixes for : https://github.com/vis2k/Mirror/pull/1875

> Here is a write up from an issue in discord bug channel.
> 
> Calling NetworkManager.StopClient() or NetworkClient.Shutdown does not stop the ReceiveThread within Teleapathy client while it is connecting.
> 
> When `Client.Disconnect()` is called these 2 are called
> ```csharp
> receiveThread?.Interrupt();
> _Connecting = false;
> ```
> 
> Settings _Connecting to false allows a new connection to be started before the old one has fully exited.
> 
> Inside the `ReceiveThreadFunction`
> ```csharp
>  // connect (blocking)
> client.Connect(ip, port);
> ```
> 
> The Connect function is synchronous so does not get stopped by ThreadInterruptedException, instead throwing SocketException late when the connection fails/timesout. This causes OnClientDisconnected  to be called on a 2nd connection if one is open causing it to close.