### PR TITLE
feat: Adding ignoreAuthority Option to Command

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -70,7 +70,9 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldstr, cmdName));
             // writer
             worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Ldc_I4, commandAttr.GetField("channel", 0)));
+            worker.Append(worker.Create(OpCodes.Ldc_I4, ca.GetField("channel", 0)));
+            bool ignoreAuthority = ca.GetField("ignoreAuthority", false);
+            worker.Append(worker.Create(ignoreAuthority ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
             worker.Append(worker.Create(OpCodes.Call, Weaver.sendCommandInternal));
 
             NetworkBehaviourProcessor.WriteRecycleWriter(worker);

--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -70,8 +70,8 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldstr, cmdName));
             // writer
             worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Ldc_I4, ca.GetField("channel", 0)));
-            bool ignoreAuthority = ca.GetField("ignoreAuthority", false);
+            worker.Append(worker.Create(OpCodes.Ldc_I4, commandAttr.GetField("channel", 0)));
+            bool ignoreAuthority = commandAttr.GetField("ignoreAuthority", false);
             worker.Append(worker.Create(ignoreAuthority ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
             worker.Append(worker.Create(OpCodes.Call, Weaver.sendCommandInternal));
 

--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -61,6 +61,10 @@ namespace Mirror.Weaver
                 cmdName = cmdName.Substring(CmdPrefix.Length);
             }
 
+            int channel = commandAttr.GetField("channel", 0);
+            bool ignoreAuthority = commandAttr.GetField("ignoreAuthority", false);
+
+
             // invoke internal send and return
             // load 'base.' to call the SendCommand function with
             worker.Append(worker.Create(OpCodes.Ldarg_0));
@@ -70,8 +74,7 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldstr, cmdName));
             // writer
             worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Ldc_I4, commandAttr.GetField("channel", 0)));
-            bool ignoreAuthority = commandAttr.GetField("ignoreAuthority", false);
+            worker.Append(worker.Create(OpCodes.Ldc_I4, channel));
             worker.Append(worker.Create(ignoreAuthority ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
             worker.Append(worker.Create(OpCodes.Call, Weaver.sendCommandInternal));
 

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -13,7 +13,7 @@ namespace Mirror.Weaver
         readonly List<FieldDefinition> syncObjects = new List<FieldDefinition>();
         // <SyncVarField,NetIdField>
         readonly Dictionary<FieldDefinition, FieldDefinition> syncVarNetIds = new Dictionary<FieldDefinition, FieldDefinition>();
-        readonly List<MethodDefinition> commands = new List<MethodDefinition>();
+        readonly List<CmdResult> commands = new List<CmdResult>();
         readonly List<MethodDefinition> clientRpcs = new List<MethodDefinition>();
         readonly List<MethodDefinition> targetRpcs = new List<MethodDefinition>();
         readonly List<EventDefinition> eventRpcs = new List<EventDefinition>();
@@ -23,6 +23,12 @@ namespace Mirror.Weaver
         readonly List<MethodDefinition> eventRpcInvocationFuncs = new List<MethodDefinition>();
 
         readonly TypeDefinition netBehaviourSubclass;
+
+        public struct CmdResult
+        {
+            public MethodDefinition method;
+            public bool ignoreAuthority;
+        }
 
         public NetworkBehaviourProcessor(TypeDefinition td)
         {
@@ -228,22 +234,23 @@ namespace Mirror.Weaver
 
             for (int i = 0; i < commands.Count; ++i)
             {
-                GenerateRegisterCommandDelegate(cctorWorker, Weaver.registerCommandDelegateReference, commandInvocationFuncs[i], commands[i].Name);
+                CmdResult cmdResult = commands[i];
+                GenerateRegisterCommandDelegate(cctorWorker, Weaver.registerCommandDelegateReference, commandInvocationFuncs[i], cmdResult);
             }
 
             for (int i = 0; i < clientRpcs.Count; ++i)
             {
-                GenerateRegisterCommandDelegate(cctorWorker, Weaver.registerRpcDelegateReference, clientRpcInvocationFuncs[i], clientRpcs[i].Name);
+                GenerateRegisterRemoteDelegate(cctorWorker, Weaver.registerRpcDelegateReference, clientRpcInvocationFuncs[i], clientRpcs[i].Name);
             }
 
             for (int i = 0; i < targetRpcs.Count; ++i)
             {
-                GenerateRegisterCommandDelegate(cctorWorker, Weaver.registerRpcDelegateReference, targetRpcInvocationFuncs[i], targetRpcs[i].Name);
+                GenerateRegisterRemoteDelegate(cctorWorker, Weaver.registerRpcDelegateReference, targetRpcInvocationFuncs[i], targetRpcs[i].Name);
             }
 
             for (int i = 0; i < eventRpcs.Count; ++i)
             {
-                GenerateRegisterCommandDelegate(cctorWorker, Weaver.registerEventDelegateReference, eventRpcInvocationFuncs[i], eventRpcs[i].Name);
+                GenerateRegisterRemoteDelegate(cctorWorker, Weaver.registerEventDelegateReference, eventRpcInvocationFuncs[i], eventRpcs[i].Name);
             }
 
             foreach (FieldDefinition fd in syncObjects)
@@ -268,7 +275,7 @@ namespace Mirror.Weaver
             // This generates code like:
             NetworkBehaviour.RegisterCommandDelegate(base.GetType(), "CmdThrust", new NetworkBehaviour.CmdDelegate(ShipControl.InvokeCmdCmdThrust));
         */
-        void GenerateRegisterCommandDelegate(ILProcessor worker, MethodReference registerMethod, MethodDefinition func, string cmdName)
+        void GenerateRegisterRemoteDelegate(ILProcessor worker, MethodReference registerMethod, MethodDefinition func, string cmdName)
         {
             worker.Append(worker.Create(OpCodes.Ldtoken, netBehaviourSubclass));
             worker.Append(worker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference));
@@ -279,6 +286,25 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Newobj, Weaver.CmdDelegateConstructor));
             //
             worker.Append(worker.Create(OpCodes.Call, registerMethod));
+        }
+        
+        void GenerateRegisterCommandDelegate(ILProcessor awakeWorker, MethodReference registerMethod, MethodDefinition func, CmdResult cmdResult)
+        {
+            string cmdName = cmdResult.method.Name;
+            bool ignoreAuthority = cmdResult.ignoreAuthority;
+
+            awakeWorker.Append(awakeWorker.Create(OpCodes.Ldtoken, netBehaviourSubclass));
+            awakeWorker.Append(awakeWorker.Create(OpCodes.Call, Weaver.getTypeFromHandleReference));
+            awakeWorker.Append(awakeWorker.Create(OpCodes.Ldstr, cmdName));
+            awakeWorker.Append(awakeWorker.Create(OpCodes.Ldnull));
+            awakeWorker.Append(awakeWorker.Create(OpCodes.Ldftn, func));
+
+            awakeWorker.Append(awakeWorker.Create(OpCodes.Newobj, Weaver.CmdDelegateConstructor));
+
+            awakeWorker.Append(awakeWorker.Create(ignoreAuthority ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
+
+            //
+            awakeWorker.Append(awakeWorker.Create(OpCodes.Call, registerMethod));
         }
 
         void GenerateSerialization()
@@ -909,8 +935,14 @@ namespace Mirror.Weaver
                 return;
             }
 
+            bool ignoreAuthority = commandAttr.GetField("ignoreAuthority", false);
+
             names.Add(md.Name);
-            commands.Add(md);
+            commands.Add(new CmdResult
+            {
+                method = md,
+                ignoreAuthority = ignoreAuthority
+            });
 
             MethodDefinition cmdCallFunc = CommandProcessor.ProcessCommandCall(netBehaviourSubclass, md, commandAttr);
 

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -22,6 +22,7 @@ namespace Mirror
     {
         // this is zero
         public int channel = Channels.DefaultReliable;
+        public bool ignoreAuthority = false;
     }
 
     /// <summary>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -224,9 +224,9 @@ namespace Mirror
         /// <param name="reader">Parameters to pass to the command.</param>
         /// <returns>Returns true if successful.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual bool InvokeCommand(int cmdHash, NetworkReader reader, NetworkConnection conn = null)
+        public virtual bool InvokeCommand(int cmdHash, NetworkReader reader)
         {
-            return InvokeHandlerDelegate(cmdHash, MirrorInvokeType.Command, reader, conn);
+            return InvokeHandlerDelegate(cmdHash, MirrorInvokeType.Command, reader);
         }
         #endregion
 
@@ -358,7 +358,7 @@ namespace Mirror
         /// </summary>
         /// <param name="obj"></param>
         /// <param name="reader"></param>
-        public delegate void CmdDelegate(NetworkBehaviour obj, NetworkReader reader, NetworkConnection conn = null);
+        public delegate void CmdDelegate(NetworkBehaviour obj, NetworkReader reader);
 
         protected class Invoker
         {
@@ -447,11 +447,11 @@ namespace Mirror
         }
 
         // InvokeCmd/Rpc/SyncEventDelegate can all use the same function here
-        internal bool InvokeHandlerDelegate(int cmdHash, MirrorInvokeType invokeType, NetworkReader reader, NetworkConnection conn = null)
+        internal bool InvokeHandlerDelegate(int cmdHash, MirrorInvokeType invokeType, NetworkReader reader)
         {
             if (GetInvokerForHash(cmdHash, invokeType, out Invoker invoker) && invoker.invokeClass.IsInstanceOfType(this))
             {
-                invoker.invokeFunction(this, reader, conn);
+                invoker.invokeFunction(this, reader);
                 return true;
             }
             return false;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -965,7 +965,7 @@ namespace Mirror
         }
 
         // helper function to handle SyncEvent/Command/Rpc
-        void HandleRemoteCall(int componentIndex, int functionHash, MirrorInvokeType invokeType, NetworkReader reader)
+        void HandleRemoteCall(int componentIndex, int functionHash, MirrorInvokeType invokeType, NetworkReader reader, NetworkConnection conn = null)
         {
             if (gameObject == null)
             {
@@ -977,7 +977,7 @@ namespace Mirror
             if (0 <= componentIndex && componentIndex < NetworkBehaviours.Length)
             {
                 NetworkBehaviour invokeComponent = NetworkBehaviours[componentIndex];
-                if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader))
+                if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader, conn))
                 {
                     logger.LogError("Found no receiver for incoming " + invokeType + " [" + functionHash + "] on " + gameObject + ",  the server and client should have the same NetworkBehaviour instances [netId=" + netId + "].");
                 }
@@ -995,9 +995,9 @@ namespace Mirror
         }
 
         // happens on server
-        internal void HandleCommand(int componentIndex, int cmdHash, NetworkReader reader)
+        internal void HandleCommand(int componentIndex, int cmdHash, NetworkReader reader, NetworkConnection conn = null)
         {
-            HandleRemoteCall(componentIndex, cmdHash, MirrorInvokeType.Command, reader);
+            HandleRemoteCall(componentIndex, cmdHash, MirrorInvokeType.Command, reader, conn);
         }
 
         // happens on client

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1000,6 +1000,28 @@ namespace Mirror
             HandleRemoteCall(componentIndex, cmdHash, MirrorInvokeType.Command, reader, conn);
         }
 
+        // happens on server
+        internal NetworkBehaviour.CommandInfo GetCommandInfo(int componentIndex, int cmdHash)
+        {
+            if (gameObject == null)
+            {
+                // error can be logged later
+                return default;
+            }
+
+            // find the right component to invoke the function on
+            if (0 <= componentIndex && componentIndex < NetworkBehaviours.Length)
+            {
+                NetworkBehaviour invokeComponent = NetworkBehaviours[componentIndex];
+                return invokeComponent.GetCommandInfo(cmdHash);
+            }
+            else
+            {
+                // error can be logged later
+                return default;
+            }
+        }
+
         // happens on client
         internal void HandleRPC(int componentIndex, int rpcHash, NetworkReader reader)
         {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -965,7 +965,7 @@ namespace Mirror
         }
 
         // helper function to handle SyncEvent/Command/Rpc
-        void HandleRemoteCall(int componentIndex, int functionHash, MirrorInvokeType invokeType, NetworkReader reader, NetworkConnection conn = null)
+        void HandleRemoteCall(int componentIndex, int functionHash, MirrorInvokeType invokeType, NetworkReader reader)
         {
             if (gameObject == null)
             {
@@ -977,7 +977,7 @@ namespace Mirror
             if (0 <= componentIndex && componentIndex < NetworkBehaviours.Length)
             {
                 NetworkBehaviour invokeComponent = NetworkBehaviours[componentIndex];
-                if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader, conn))
+                if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader))
                 {
                     logger.LogError("Found no receiver for incoming " + invokeType + " [" + functionHash + "] on " + gameObject + ",  the server and client should have the same NetworkBehaviour instances [netId=" + netId + "].");
                 }
@@ -995,9 +995,9 @@ namespace Mirror
         }
 
         // happens on server
-        internal void HandleCommand(int componentIndex, int cmdHash, NetworkReader reader, NetworkConnection conn = null)
+        internal void HandleCommand(int componentIndex, int cmdHash, NetworkReader reader)
         {
-            HandleRemoteCall(componentIndex, cmdHash, MirrorInvokeType.Command, reader, conn);
+            HandleRemoteCall(componentIndex, cmdHash, MirrorInvokeType.Command, reader);
         }
 
         // happens on server

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1005,7 +1005,7 @@ namespace Mirror
             if (logger.LogEnabled()) logger.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn);
 
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
-                identity.HandleCommand(msg.componentIndex, msg.functionHash, networkReader);
+                identity.HandleCommand(msg.componentIndex, msg.functionHash, networkReader, conn);
         }
 
         internal static void SpawnObject(GameObject obj, NetworkConnection ownerConnection)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -993,10 +993,13 @@ namespace Mirror
                 return;
             }
 
+            NetworkBehaviour.CommandInfo commandInfo = identity.GetCommandInfo(msg.componentIndex, msg.functionHash);
+
             // Commands can be for player objects, OR other objects with client-authority
             // -> so if this connection's controller has a different netId then
             //    only allow the command if clientAuthorityOwner
-            if (identity.connectionToClient != conn)
+            bool needAuthority = !commandInfo.ignoreAuthority;
+            if (needAuthority && identity.connectionToClient != conn)
             {
                 logger.LogWarning("Command for object without authority [netId=" + msg.netId + "]");
                 return;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1008,7 +1008,7 @@ namespace Mirror
             if (logger.LogEnabled()) logger.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn);
 
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
-                identity.HandleCommand(msg.componentIndex, msg.functionHash, networkReader, conn);
+                identity.HandleCommand(msg.componentIndex, msg.functionHash, networkReader);
         }
 
         internal static void SpawnObject(GameObject obj, NetworkConnection ownerConnection)

--- a/Assets/Mirror/Tests/Editor/CommandAttrributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/CommandAttrributeTest.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Mirror.Tests.CommandAttrributeTest
+{
+    class AuthorityBehaviour : NetworkBehaviour
+    {
+        public event Action<int> onSendInt;
+
+        [Command]
+        public void CmdSendInt(int someInt)
+        {
+            onSendInt?.Invoke(someInt);
+        }
+    }
+
+    class IgnoreAuthorityBehaviour : NetworkBehaviour
+    {
+        public event Action<int> onSendInt;
+
+        [Command(ignoreAuthority = true)]
+        public void CmdSendInt(int someInt)
+        {
+            onSendInt?.Invoke(someInt);
+        }
+    }
+
+    public class CommandTest
+    {
+        private List<GameObject> spawned = new List<GameObject>();
+
+        [SetUp]
+        public void Setup()
+        {
+            Transport.activeTransport = new GameObject().AddComponent<MemoryTransport>();
+
+            // start server/client
+            NetworkServer.Listen(1);
+            NetworkClient.ConnectHost();
+            NetworkServer.SpawnObjects();
+            NetworkServer.ActivateHostScene();
+            NetworkClient.ConnectLocalServer();
+
+            NetworkServer.localConnection.isAuthenticated = true;
+            NetworkClient.connection.isAuthenticated = true;
+
+            ClientScene.Ready(NetworkClient.connection);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // stop server/client
+            NetworkClient.DisconnectLocalServer();
+
+            NetworkClient.Disconnect();
+            NetworkClient.Shutdown();
+
+            NetworkServer.Shutdown();
+
+            // destroy left over objects
+            foreach (GameObject item in spawned)
+            {
+                if (item != null)
+                {
+                    GameObject.DestroyImmediate(item);
+                }
+            }
+
+            spawned.Clear();
+
+            NetworkIdentity.spawned.Clear();
+
+            GameObject.DestroyImmediate(Transport.activeTransport.gameObject);
+        }
+
+
+        T CreateHostObject<T>(bool spawnWithAuthority) where T : NetworkBehaviour
+        {
+            GameObject gameObject = new GameObject();
+            spawned.Add(gameObject);
+
+            gameObject.AddComponent<NetworkIdentity>();
+
+            T behaviour = gameObject.AddComponent<T>();
+
+            // spawn outwith authority
+            if (spawnWithAuthority)
+            {
+                NetworkServer.Spawn(gameObject, NetworkServer.localConnection);
+            }
+            else
+            {
+                NetworkServer.Spawn(gameObject);
+            }
+            ProcessMessages();
+
+
+            return behaviour;
+        }
+
+        private static void ProcessMessages()
+        {
+            // run update so message are processed
+            NetworkServer.Update();
+            NetworkClient.Update();
+        }
+
+        [Test]
+        public void CommandIsSentWithAuthority()
+        {
+            AuthorityBehaviour hostBehaviour = CreateHostObject<AuthorityBehaviour>(true);
+
+            const int someInt = 20;
+
+            int callCount = 0;
+            hostBehaviour.onSendInt += incomingInt =>
+            {
+                callCount++;
+                Assert.That(incomingInt, Is.EqualTo(someInt));
+            };
+            hostBehaviour.CmdSendInt(someInt);
+            ProcessMessages();
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void WarningForCommandSentWithoutAuthority()
+        {
+            AuthorityBehaviour hostBehaviour = CreateHostObject<AuthorityBehaviour>(false);
+
+            const int someInt = 20;
+
+            int callCount = 0;
+            hostBehaviour.onSendInt += incomingInt =>
+            {
+                callCount++;
+            };
+            LogAssert.Expect(LogType.Warning, $"Trying to send command for object without authority. {typeof(AuthorityBehaviour).ToString()}.{nameof(AuthorityBehaviour.CmdSendInt)}");
+            hostBehaviour.CmdSendInt(someInt);
+            ProcessMessages();
+            Assert.That(callCount, Is.Zero);
+        }
+
+
+        [Test]
+        public void CommandIsSentWithAuthorityWhenIgnoringAuthority()
+        {
+            IgnoreAuthorityBehaviour hostBehaviour = CreateHostObject<IgnoreAuthorityBehaviour>(true);
+
+            const int someInt = 20;
+
+            int callCount = 0;
+            hostBehaviour.onSendInt += incomingInt =>
+            {
+                callCount++;
+                Assert.That(incomingInt, Is.EqualTo(someInt));
+            };
+            hostBehaviour.CmdSendInt(someInt);
+            ProcessMessages();
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CommandIsSentWithoutAuthorityWhenIgnoringAuthority()
+        {
+            IgnoreAuthorityBehaviour hostBehaviour = CreateHostObject<IgnoreAuthorityBehaviour>(false);
+
+            const int someInt = 20;
+
+            int callCount = 0;
+            hostBehaviour.onSendInt += incomingInt =>
+            {
+                callCount++;
+                Assert.That(incomingInt, Is.EqualTo(someInt));
+            };
+            hostBehaviour.CmdSendInt(someInt);
+            ProcessMessages();
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/CommandAttrributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/CommandAttrributeTest.cs
@@ -98,6 +98,7 @@ namespace Mirror.Tests.CommandAttrributeTest
             }
             ProcessMessages();
 
+            Debug.Assert(behaviour.hasAuthority == spawnWithAuthority, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
 
             return behaviour;
         }

--- a/Assets/Mirror/Tests/Editor/CommandAttrributeTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/CommandAttrributeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dd3f8a95eee6f74997bc8abcd43a401
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/CustomAttrributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/CustomAttrributeTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 namespace Mirror.Tests
 {

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -32,7 +32,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
         {
             ++((NetworkBehaviourSendCommandInternalComponent)comp).called;
         }
@@ -52,7 +52,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void RPCGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void RPCGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
         {
             ++((NetworkBehaviourSendRPCInternalComponent)comp).called;
         }
@@ -72,7 +72,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void TargetRPCGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void TargetRPCGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
         {
             ++((NetworkBehaviourSendTargetRPCInternalComponent)comp).called;
         }
@@ -92,7 +92,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void EventGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void EventGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
         {
             ++((NetworkBehaviourSendEventInternalComponent)comp).called;
         }
@@ -107,8 +107,8 @@ namespace Mirror.Tests
     // we need to inherit from networkbehaviour to test protected functions
     public class NetworkBehaviourDelegateComponent : NetworkBehaviour
     {
-        public static void Delegate(NetworkBehaviour comp, NetworkReader reader) { }
-        public static void Delegate2(NetworkBehaviour comp, NetworkReader reader) { }
+        public static void Delegate(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null) { }
+        public static void Delegate2(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null) { }
     }
 
     // we need to inherit from networkbehaviour to test protected functions

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -381,7 +381,7 @@ namespace Mirror.Tests
             // register the command delegate, otherwise it's not found
             NetworkBehaviour.RegisterCommandDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
                 nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated),
-                NetworkBehaviourSendCommandInternalComponent.CommandGenerated);
+                NetworkBehaviourSendCommandInternalComponent.CommandGenerated, false);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it
@@ -421,7 +421,7 @@ namespace Mirror.Tests
             // register the command delegate, otherwise it's not found
             NetworkBehaviour.RegisterCommandDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
                 nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated),
-                NetworkBehaviourSendCommandInternalComponent.CommandGenerated);
+                NetworkBehaviourSendCommandInternalComponent.CommandGenerated, false);
 
             // invoke command
             int cmdHash = NetworkBehaviour.GetMethodHash(
@@ -750,14 +750,14 @@ namespace Mirror.Tests
             NetworkBehaviour.RegisterCommandDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
-                NetworkBehaviourDelegateComponent.Delegate);
+                NetworkBehaviourDelegateComponent.Delegate, false);
 
             // registering the exact same one should be fine. it should simply
             // do nothing.
             NetworkBehaviour.RegisterCommandDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
-                NetworkBehaviourDelegateComponent.Delegate);
+                NetworkBehaviourDelegateComponent.Delegate, false);
 
             // registering the same name with a different callback shouldn't
             // work
@@ -765,7 +765,7 @@ namespace Mirror.Tests
             NetworkBehaviour.RegisterCommandDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
-                NetworkBehaviourDelegateComponent.Delegate2);
+                NetworkBehaviourDelegateComponent.Delegate2, false);
 
             // clean up
             NetworkBehaviour.ClearDelegates();
@@ -779,7 +779,7 @@ namespace Mirror.Tests
             NetworkBehaviour.RegisterCommandDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
-                NetworkBehaviourDelegateComponent.Delegate);
+                NetworkBehaviourDelegateComponent.Delegate, false);
 
             // get handler
             int cmdHash = NetworkBehaviour.GetMethodHash(typeof(NetworkBehaviourDelegateComponent), nameof(NetworkBehaviourDelegateComponent.Delegate));

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -32,7 +32,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
+        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader)
         {
             ++((NetworkBehaviourSendCommandInternalComponent)comp).called;
         }
@@ -52,7 +52,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void RPCGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
+        public static void RPCGenerated(NetworkBehaviour comp, NetworkReader reader)
         {
             ++((NetworkBehaviourSendRPCInternalComponent)comp).called;
         }
@@ -72,7 +72,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void TargetRPCGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
+        public static void TargetRPCGenerated(NetworkBehaviour comp, NetworkReader reader)
         {
             ++((NetworkBehaviourSendTargetRPCInternalComponent)comp).called;
         }
@@ -92,7 +92,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void EventGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
+        public static void EventGenerated(NetworkBehaviour comp, NetworkReader reader)
         {
             ++((NetworkBehaviourSendEventInternalComponent)comp).called;
         }
@@ -107,8 +107,8 @@ namespace Mirror.Tests
     // we need to inherit from networkbehaviour to test protected functions
     public class NetworkBehaviourDelegateComponent : NetworkBehaviour
     {
-        public static void Delegate(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null) { }
-        public static void Delegate2(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null) { }
+        public static void Delegate(NetworkBehaviour comp, NetworkReader reader) { }
+        public static void Delegate2(NetworkBehaviour comp, NetworkReader reader) { }
     }
 
     // we need to inherit from networkbehaviour to test protected functions
@@ -381,7 +381,8 @@ namespace Mirror.Tests
             // register the command delegate, otherwise it's not found
             NetworkBehaviour.RegisterCommandDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
                 nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated),
-                NetworkBehaviourSendCommandInternalComponent.CommandGenerated, false);
+                NetworkBehaviourSendCommandInternalComponent.CommandGenerated,
+                false);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it
@@ -421,7 +422,8 @@ namespace Mirror.Tests
             // register the command delegate, otherwise it's not found
             NetworkBehaviour.RegisterCommandDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
                 nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated),
-                NetworkBehaviourSendCommandInternalComponent.CommandGenerated, false);
+                NetworkBehaviourSendCommandInternalComponent.CommandGenerated,
+                false);
 
             // invoke command
             int cmdHash = NetworkBehaviour.GetMethodHash(
@@ -750,22 +752,24 @@ namespace Mirror.Tests
             NetworkBehaviour.RegisterCommandDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
-                NetworkBehaviourDelegateComponent.Delegate, false);
+                NetworkBehaviourDelegateComponent.Delegate,
+                false);
 
             // registering the exact same one should be fine. it should simply
             // do nothing.
             NetworkBehaviour.RegisterCommandDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
-                NetworkBehaviourDelegateComponent.Delegate, false);
-
+                NetworkBehaviourDelegateComponent.Delegate,
+                false);
             // registering the same name with a different callback shouldn't
             // work
             LogAssert.Expect(LogType.Error, "Function " + typeof(NetworkBehaviourDelegateComponent) + "." + nameof(NetworkBehaviourDelegateComponent.Delegate) + " and " + typeof(NetworkBehaviourDelegateComponent) + "." + nameof(NetworkBehaviourDelegateComponent.Delegate2) + " have the same hash.  Please rename one of them");
             NetworkBehaviour.RegisterCommandDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
-                NetworkBehaviourDelegateComponent.Delegate2, false);
+                NetworkBehaviourDelegateComponent.Delegate2,
+                false);
 
             // clean up
             NetworkBehaviour.ClearDelegates();
@@ -779,7 +783,8 @@ namespace Mirror.Tests
             NetworkBehaviour.RegisterCommandDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
-                NetworkBehaviourDelegateComponent.Delegate, false);
+                NetworkBehaviourDelegateComponent.Delegate,
+                false);
 
             // get handler
             int cmdHash = NetworkBehaviour.GetMethodHash(typeof(NetworkBehaviourDelegateComponent), nameof(NetworkBehaviourDelegateComponent.Delegate));

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -1245,7 +1245,7 @@ namespace Mirror.Tests
             Assert.That(comp0.called, Is.EqualTo(0));
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterCommandDelegate(typeof(CommandTestNetworkBehaviour), nameof(CommandTestNetworkBehaviour.CommandGenerated), CommandTestNetworkBehaviour.CommandGenerated);
+            NetworkBehaviour.RegisterCommandDelegate(typeof(CommandTestNetworkBehaviour), nameof(CommandTestNetworkBehaviour.CommandGenerated), CommandTestNetworkBehaviour.CommandGenerated, false);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -580,7 +580,7 @@ namespace Mirror.Tests
             connection.identity = identity;
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterCommandDelegate(typeof(CommandTestNetworkBehaviour), nameof(CommandTestNetworkBehaviour.CommandGenerated), CommandTestNetworkBehaviour.CommandGenerated);
+            NetworkBehaviour.RegisterCommandDelegate(typeof(CommandTestNetworkBehaviour), nameof(CommandTestNetworkBehaviour.CommandGenerated), CommandTestNetworkBehaviour.CommandGenerated, false);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -13,7 +13,7 @@ namespace Mirror.Tests
         public int called;
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
         {
             ++((CommandTestNetworkBehaviour)comp).called;
         }
@@ -25,7 +25,7 @@ namespace Mirror.Tests
         public int called;
         // weaver generates this from [Rpc]
         // but for tests we need to add it manually
-        public static void RpcGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void RpcGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
         {
             ++((RpcTestNetworkBehaviour)comp).called;
         }
@@ -37,7 +37,7 @@ namespace Mirror.Tests
         public int called;
         // weaver generates this from [SyncEvent]
         // but for tests we need to add it manually
-        public static void SyncEventGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void SyncEventGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
         {
             ++((SyncEventTestNetworkBehaviour)comp).called;
         }

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -13,7 +13,7 @@ namespace Mirror.Tests
         public int called;
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
+        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader)
         {
             ++((CommandTestNetworkBehaviour)comp).called;
         }
@@ -25,7 +25,7 @@ namespace Mirror.Tests
         public int called;
         // weaver generates this from [Rpc]
         // but for tests we need to add it manually
-        public static void RpcGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
+        public static void RpcGenerated(NetworkBehaviour comp, NetworkReader reader)
         {
             ++((RpcTestNetworkBehaviour)comp).called;
         }
@@ -37,7 +37,7 @@ namespace Mirror.Tests
         public int called;
         // weaver generates this from [SyncEvent]
         // but for tests we need to add it manually
-        public static void SyncEventGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection conn = null)
+        public static void SyncEventGenerated(NetworkBehaviour comp, NetworkReader reader)
         {
             ++((SyncEventTestNetworkBehaviour)comp).called;
         }

--- a/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
+++ b/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
@@ -86,7 +86,9 @@
     <Compile Include="WeaverClientServerAttributeTests~\NetworkBehaviourServer.cs" />
     <Compile Include="WeaverCommandTests~\CommandCantBeStatic.cs" />
     <Compile Include="WeaverCommandTests~\CommandStartsWithCmd.cs" />
+    <Compile Include="WeaverCommandTests~\CommandThatIgnoresAuthority.cs" />
     <Compile Include="WeaverCommandTests~\CommandValid.cs" />
+    <Compile Include="WeaverCommandTests~\CommandWithArguments.cs" />
     <Compile Include="WeaverGeneralTests~\RecursionCount.cs" />
     <Compile Include="WeaverGeneralTests~\TestingScriptableObjectArraySerialization.cs" />
     <Compile Include="WeaverMessageTests~\MessageMemberGeneric.cs" />

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 namespace Mirror.Weaver.Tests
 {
@@ -20,6 +20,19 @@ namespace Mirror.Weaver.Tests
         public void CommandCantBeStatic()
         {
             Assert.That(weaverErrors, Contains.Item("CmdCantBeStatic cannot be static (at System.Void WeaverCommandTests.CommandCantBeStatic.CommandCantBeStatic::CmdCantBeStatic())"));
+        }
+
+        [Test]
+        public void CommandThatIgnoresAuthority()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+        }
+
+
+        [Test]
+        public void CommandWithArguments()
+        {
+            Assert.That(weaverErrors, Is.Empty);
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandThatIgnoresAuthority.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandThatIgnoresAuthority.cs
@@ -1,0 +1,13 @@
+﻿using Mirror;
+
+namespace WeaverCommandTests.CommandThatIgnoresAuthority
+{
+    class CommandThatIgnoresAuthority : NetworkBehaviour
+    {
+        [Command(ignoreAuthority = true)]
+        void CmdFunction()
+        {
+            // do something
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandValid.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandValid.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections;
-using UnityEngine;
 using Mirror;
 
 namespace WeaverCommandTests.CommandValid
@@ -8,6 +5,6 @@ namespace WeaverCommandTests.CommandValid
     class CommandValid : NetworkBehaviour
     {
         [Command]
-        void CmdThatIsTotallyValid() {}
+        void CmdThatIsTotallyValid() { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandWithArguments.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandWithArguments.cs
@@ -1,0 +1,13 @@
+﻿using Mirror;
+
+namespace WeaverCommandTests.CommandWithArguments
+{
+    class CommandWithArguments : NetworkBehaviour
+    {
+        [Command]
+        void CmdThatIsTotallyValid(int someNumber, NetworkIdentity someTarget)
+        {
+            // do something
+        }
+    }
+}


### PR DESCRIPTION
See #1917 

PR can be reviewed on a per-commit basis.

**Current State:**
Need solution for `NetworkServer.OnCommandMessage` where authority is checked on incoming messages for how/where to access the `ignoreAuthority` parameter of the Command being called.

Tests are just patched for now - more tests will be added.

Haven't started ClientRpc work yet.