### PR TITLE
fix: moving where CallOnClientEnterRoom is called

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -221,7 +221,7 @@ namespace Mirror
             }
         }
 
-        void CallOnClientEnterRoom()
+        internal void CallOnClientEnterRoom()
         {
             OnRoomClientEnter();
             foreach (NetworkRoomPlayer player in roomSlots)
@@ -465,7 +465,6 @@ namespace Mirror
         public override void OnClientConnect(NetworkConnection conn)
         {
             OnRoomClientConnect(conn);
-            CallOnClientEnterRoom();
             base.OnClientConnect(conn);
         }
 

--- a/Assets/Mirror/Components/NetworkRoomPlayer.cs
+++ b/Assets/Mirror/Components/NetworkRoomPlayer.cs
@@ -59,7 +59,7 @@ namespace Mirror
                 room.RecalculateRoomPlayerIndices();
 
                 if (NetworkClient.active)
-                    OnClientEnterRoom();
+                    room.CallOnClientEnterRoom();
             }
             else
                 logger.LogError("RoomPlayer could not find a NetworkRoomManager. The RoomPlayer requires a NetworkRoomManager object to function. Make sure that there is one in the scene.");


### PR DESCRIPTION
When a player object joins `NetworkRoomManager.OnRoomClientEnter` is called before the player is in the roomslot. This is a problem because there is no way to get the new player that joins using `OnRoomClientEnter`.

`NetworkRoomPlayer.OnClientEnterRoom` is called in the start method of `NetworkRoomPlayer` and `CallOnClientEnterRoom`.

This change will mean that `NetworkRoomManager.OnRoomClientEnter` and `NetworkRoomPlayer.OnClientEnterRoom`  are called when the NetworkRoomPlayer is created