### PR TITLE
breaking: adding SenderConnection Attribute that will set NetworkConnection sent in a Command

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -51,7 +51,7 @@ namespace Mirror.Weaver
             NetworkBehaviourProcessor.WriteCreateWriter(worker);
 
             // write all the arguments that the user passed to the Cmd call
-            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, false))
+            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.Command))
                 return null;
 
             string cmdName = md.Name;
@@ -111,7 +111,7 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Castclass, td));
 
-            if (!NetworkBehaviourProcessor.ReadArguments(method, worker, false))
+            if (!NetworkBehaviourProcessor.ReadArguments(method, worker, RemoteCallType.Command))
                 return null;
 
             // invoke actual command function

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -153,6 +153,12 @@ namespace Mirror.Weaver
                     argNum += 1;
                     continue;
                 }
+                // skip SenderConnection in Command
+                if (IsSenderConnection(param, callType))
+                {
+                    argNum += 1;
+                    continue;
+                }
 
                 MethodReference writeFunc = Writers.GetWriteFunc(param.ParameterType);
                 if (writeFunc == null)
@@ -798,6 +804,12 @@ namespace Mirror.Weaver
                 // NetworkConnection is not sent via the NetworkWriter so skip it here
                 // skip first for NetworkConnection in TargetRpc
                 if (argNum == 1 && skipFirst)
+                {
+                    argNum += 1;
+                    continue;
+                }
+                // skip SenderConnection in Command
+                if (IsSenderConnection(param, callType))
                 {
                     argNum += 1;
                     continue;

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -844,6 +844,8 @@ namespace Mirror.Weaver
         {
             collection.Add(new ParameterDefinition("obj", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkBehaviourType)));
             collection.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkReaderType)));
+            // senderConnection is only used for commands but NetworkBehaviour.CmdDelegate is used for all remote calls
+            collection.Add(new ParameterDefinition("senderConnection", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(Weaver.NetworkConnectionType)));
         }
 
         public static bool ProcessMethodsValidateFunction(MethodReference md)

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -9,7 +9,9 @@ namespace Mirror.Weaver
         Command,
         ClientRpc,
         TargetRpc,
+        SyncEvent
     }
+
 
     /// <summary>
     /// processes SyncVars, Cmds, Rpcs, etc. of NetworkBehaviours
@@ -128,7 +130,7 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Call, Weaver.RecycleWriterReference));
         }
 
-        public static bool WriteArguments(ILProcessor worker, MethodDefinition method, bool skipFirst)
+        public static bool WriteArguments(ILProcessor worker, MethodDefinition method, RemoteCallType callType)
         {
             // write each argument
             // example result
@@ -136,6 +138,9 @@ namespace Mirror.Weaver
             writer.WritePackedInt32(someNumber);
             writer.WriteNetworkIdentity(someTarget);
              */
+
+            bool skipFirst = (callType == RemoteCallType.TargetRpc
+                && TargetRpcProcessor.HasNetworkConnectionParameter(method));
 
             // arg of calling  function, arg 0 is "this" so start counting at 1
             int argNum = 1;
@@ -775,13 +780,16 @@ namespace Mirror.Weaver
             netBehaviourSubclass.Methods.Add(serialize);
         }
 
-        public static bool ReadArguments(MethodDefinition method, ILProcessor worker, bool skipFirst)
+        public static bool ReadArguments(MethodDefinition method, ILProcessor worker, RemoteCallType callType)
         {
             // read each argument
             // example result
             /*
             CallCmdDoSomething(reader.ReadPackedInt32(), reader.ReadNetworkIdentity());
              */
+
+            bool skipFirst = (callType == RemoteCallType.TargetRpc
+                && TargetRpcProcessor.HasNetworkConnectionParameter(method));
 
             // arg of calling  function, arg 0 is "this" so start counting at 1
             int argNum = 1;

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -901,7 +901,7 @@ namespace Mirror.Weaver
             {
                 if (callType == RemoteCallType.Command)
                 {
-                    Weaver.Error($"{method.Name} has invalid parameter {param}, Cannot pass NeworkConnections. Instead use use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server", method);
+                    Weaver.Error($"{method.Name} has invalid parameter {param}, Cannot pass NeworkConnections. Instead use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server", method);
                 }
                 else
                 {

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -26,7 +26,7 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Castclass, td));
 
-            if (!NetworkBehaviourProcessor.ReadArguments(md, worker, false))
+            if (!NetworkBehaviourProcessor.ReadArguments(md, worker, RemoteCallType.ClientRpc))
                 return null;
 
             // invoke actual command function
@@ -71,7 +71,7 @@ namespace Mirror.Weaver
             NetworkBehaviourProcessor.WriteCreateWriter(worker);
 
             // write all the arguments that the user passed to the Rpc call
-            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, false))
+            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.ClientRpc))
                 return null;
 
             string rpcName = md.Name;

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncEventProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncEventProcessor.cs
@@ -53,7 +53,7 @@ namespace Mirror.Weaver
 
             // read the event arguments
             MethodReference invoke = Resolvers.ResolveMethod(eventField.FieldType, Weaver.CurrentAssembly, "Invoke");
-            if (!NetworkBehaviourProcessor.ReadArguments(invoke.Resolve(), worker, false))
+            if (!NetworkBehaviourProcessor.ReadArguments(invoke.Resolve(), worker, RemoteCallType.SyncEvent))
                 return null;
 
             // invoke actual event delegate function
@@ -87,7 +87,7 @@ namespace Mirror.Weaver
             NetworkBehaviourProcessor.WriteCreateWriter(worker);
 
             // write all the arguments that the user passed to the syncevent
-            if (!NetworkBehaviourProcessor.WriteArguments(worker, invoke.Resolve(), false))
+            if (!NetworkBehaviourProcessor.WriteArguments(worker, invoke.Resolve(), RemoteCallType.SyncEvent))
                 return null;
 
             // invoke interal send and return

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -34,15 +34,15 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Castclass, td));
 
             // NetworkConnection parameter is optional
-            bool hasNetworkConnection = HasNetworkConnectionParameter(md);
-            if (hasNetworkConnection)
+            if (HasNetworkConnectionParameter(md))
             {
+                // if call has NetworkConnection write clients connection as first arg 
                 //ClientScene.readyconnection
                 worker.Append(worker.Create(OpCodes.Call, Weaver.ReadyConnectionReference));
             }
 
             // process reader parameters and skip first one if first one is NetworkConnection
-            if (!NetworkBehaviourProcessor.ReadArguments(md, worker, hasNetworkConnection))
+            if (!NetworkBehaviourProcessor.ReadArguments(md, worker, RemoteCallType.TargetRpc))
                 return null;
 
             // invoke actual command function
@@ -97,12 +97,9 @@ namespace Mirror.Weaver
 
             NetworkBehaviourProcessor.WriteCreateWriter(worker);
 
-            // NetworkConnection parameter is optional
-            bool hasNetworkConnection = HasNetworkConnectionParameter(md);
-
             // write all the arguments that the user passed to the TargetRpc call
             // (skip first one if first one is NetworkConnection)
-            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, hasNetworkConnection))
+            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.TargetRpc))
                 return null;
 
             string rpcName = md.Name;

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -26,6 +26,15 @@ namespace Mirror
     }
 
     /// <summary>
+    /// Used to replace NetworkConnection sent in a Command
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class SenderConnectionAttribute : Attribute
+    {
+
+    }
+
+    /// <summary>
     /// The server uses a Remote Procedure Call (RPC) to run this function on clients.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -468,11 +468,12 @@ namespace Mirror
         }
 
         // InvokeCmd/Rpc/SyncEventDelegate can all use the same function here
-        internal bool InvokeHandlerDelegate(int cmdHash, MirrorInvokeType invokeType, NetworkReader reader)
+        internal bool InvokeHandlerDelegate(int cmdHash, MirrorInvokeType invokeType, NetworkReader reader, NetworkConnectionToClient senderConnection = null)
         {
             if (GetInvokerForHash(cmdHash, invokeType, out Invoker invoker) && invoker.invokeClass.IsInstanceOfType(this))
             {
-                invoker.invokeFunction(this, reader);
+                invoker.invokeFunction(this, reader, senderConnection);
+
                 return true;
             }
             return false;

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -362,8 +362,8 @@ namespace Mirror
 
         protected class Invoker
         {
-            public MirrorInvokeType invokeType;
             public Type invokeClass;
+            public MirrorInvokeType invokeType;
             public CmdDelegate invokeFunction;
             public bool cmdIgnoreAuthority;
 
@@ -374,6 +374,7 @@ namespace Mirror
                      invokeFunction == function);
             }
         }
+
         public struct CommandInfo
         {
             public bool ignoreAuthority;

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -366,6 +366,13 @@ namespace Mirror
             public Type invokeClass;
             public CmdDelegate invokeFunction;
             public bool cmdIgnoreAuthority;
+
+            public bool AreEqual(Type invokeClass, MirrorInvokeType invokeType, CmdDelegate function)
+            {
+                return (this.invokeClass == invokeClass &&
+                     this.invokeType == invokeType &&
+                     invokeFunction == function);
+            }
         }
         public struct CommandInfo
         {
@@ -381,20 +388,9 @@ namespace Mirror
             // type+func so Inventory.RpcUse != Equipment.RpcUse
             int cmdHash = GetMethodHash(invokeClass, cmdName);
 
-            if (cmdHandlerDelegates.ContainsKey(cmdHash))
-            {
-                // something already registered this hash
-                Invoker oldInvoker = cmdHandlerDelegates[cmdHash];
-                if (oldInvoker.invokeClass == invokeClass &&
-                    oldInvoker.invokeType == invokerType &&
-                    oldInvoker.invokeFunction == func)
-                {
-                    // it's all right,  it was the same function
-                    return;
-                }
+            if (CheckIfDeligateExists(invokeClass, invokerType, func, cmdHash))
+                return;
 
-                logger.LogError($"Function {oldInvoker.invokeClass}.{oldInvoker.invokeFunction.GetMethodName()} and {invokeClass}.{func.GetMethodName()} have the same hash.  Please rename one of them");
-            }
             Invoker invoker = new Invoker
             {
                 invokeType = invokerType,
@@ -402,8 +398,32 @@ namespace Mirror
                 invokeFunction = func,
                 cmdIgnoreAuthority = cmdIgnoreAuthority,
             };
+
             cmdHandlerDelegates[cmdHash] = invoker;
-            if (logger.LogEnabled()) logger.Log("RegisterDelegate hash:" + cmdHash + " invokerType: " + invokerType + " method:" + func.GetMethodName());
+
+            if (logger.LogEnabled())
+            {
+                string ingoreAuthorityMessage = invokerType == MirrorInvokeType.Command ? $" IgnoreAuthority:{cmdIgnoreAuthority}" : "";
+                logger.Log($"RegisterDelegate hash: {cmdHash} invokerType: {invokerType} method: {func.GetMethodName()}{ingoreAuthorityMessage}");
+            }
+        }
+
+        static bool CheckIfDeligateExists(Type invokeClass, MirrorInvokeType invokerType, CmdDelegate func, int cmdHash)
+        {
+            if (cmdHandlerDelegates.ContainsKey(cmdHash))
+            {
+                // something already registered this hash
+                Invoker oldInvoker = cmdHandlerDelegates[cmdHash];
+                if (oldInvoker.AreEqual(invokeClass, invokerType, func))
+                {
+                    // it's all right,  it was the same function
+                    return true;
+                }
+
+                logger.LogError($"Function {oldInvoker.invokeClass}.{oldInvoker.invokeFunction.GetMethodName()} and {invokeClass}.{func.GetMethodName()} have the same hash.  Please rename one of them");
+            }
+
+            return false;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -358,7 +358,7 @@ namespace Mirror
         /// </summary>
         /// <param name="obj"></param>
         /// <param name="reader"></param>
-        public delegate void CmdDelegate(NetworkBehaviour obj, NetworkReader reader);
+        public delegate void CmdDelegate(NetworkBehaviour obj, NetworkReader reader, NetworkConnection senderConnection);
 
         protected class Invoker
         {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -965,7 +965,7 @@ namespace Mirror
         }
 
         // helper function to handle SyncEvent/Command/Rpc
-        void HandleRemoteCall(int componentIndex, int functionHash, MirrorInvokeType invokeType, NetworkReader reader)
+        void HandleRemoteCall(int componentIndex, int functionHash, MirrorInvokeType invokeType, NetworkReader reader, NetworkConnectionToClient senderConnection = null)
         {
             if (gameObject == null)
             {
@@ -977,7 +977,7 @@ namespace Mirror
             if (0 <= componentIndex && componentIndex < NetworkBehaviours.Length)
             {
                 NetworkBehaviour invokeComponent = NetworkBehaviours[componentIndex];
-                if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader))
+                if (!invokeComponent.InvokeHandlerDelegate(functionHash, invokeType, reader, senderConnection))
                 {
                     logger.LogError("Found no receiver for incoming " + invokeType + " [" + functionHash + "] on " + gameObject + ",  the server and client should have the same NetworkBehaviour instances [netId=" + netId + "].");
                 }
@@ -995,9 +995,9 @@ namespace Mirror
         }
 
         // happens on server
-        internal void HandleCommand(int componentIndex, int cmdHash, NetworkReader reader)
+        internal void HandleCommand(int componentIndex, int cmdHash, NetworkReader reader, NetworkConnectionToClient senderConnection)
         {
-            HandleRemoteCall(componentIndex, cmdHash, MirrorInvokeType.Command, reader);
+            HandleRemoteCall(componentIndex, cmdHash, MirrorInvokeType.Command, reader, senderConnection);
         }
 
         // happens on server

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1008,7 +1008,7 @@ namespace Mirror
             if (logger.LogEnabled()) logger.Log("OnCommandMessage for netId=" + msg.netId + " conn=" + conn);
 
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
-                identity.HandleCommand(msg.componentIndex, msg.functionHash, networkReader);
+                identity.HandleCommand(msg.componentIndex, msg.functionHash, networkReader, conn as NetworkConnectionToClient);
         }
 
         internal static void SpawnObject(GameObject obj, NetworkConnection ownerConnection)

--- a/Assets/Mirror/Tests/Editor/CommandTest.cs
+++ b/Assets/Mirror/Tests/Editor/CommandTest.cs
@@ -27,6 +27,28 @@ namespace Mirror.Tests.RemoteAttrributeTest
         }
     }
 
+    class SenderConnectionBehaviour : NetworkBehaviour
+    {
+        public event Action<int, NetworkConnection> onSendInt;
+
+        [Command]
+        public void CmdSendInt(int someInt, [SenderConnection] NetworkConnection conn = null)
+        {
+            onSendInt?.Invoke(someInt, conn);
+        }
+    }
+
+    class SenderConnectionIgnoreAuthorityBehaviour : NetworkBehaviour
+    {
+        public event Action<int, NetworkConnection> onSendInt;
+
+        [Command(ignoreAuthority = true)]
+        public void CmdSendInt(int someInt, [SenderConnection] NetworkConnection conn = null)
+        {
+            onSendInt?.Invoke(someInt, conn);
+        }
+    }
+
     public class CommandTest : RemoteTestBase
     {
         [Test]
@@ -96,6 +118,49 @@ namespace Mirror.Tests.RemoteAttrributeTest
             {
                 callCount++;
                 Assert.That(incomingInt, Is.EqualTo(someInt));
+            };
+            hostBehaviour.CmdSendInt(someInt);
+            ProcessMessages();
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SenderConnectionIsSetWhenCommandIsRecieved()
+        {
+            SenderConnectionBehaviour hostBehaviour = CreateHostObject<SenderConnectionBehaviour>(true);
+
+            const int someInt = 20;
+            NetworkConnectionToClient connectionToClient = NetworkServer.connections[0];
+            Debug.Assert(connectionToClient != null, $"connectionToClient was null, This means that the test is broken and will give the wrong results");
+
+
+            int callCount = 0;
+            hostBehaviour.onSendInt += (incomingInt, incomingConn) =>
+            {
+                callCount++;
+                Assert.That(incomingInt, Is.EqualTo(someInt));
+                Assert.That(incomingConn, Is.EqualTo(connectionToClient));
+            };
+            hostBehaviour.CmdSendInt(someInt);
+            ProcessMessages();
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SenderConnectionIsSetWhenCommandIsRecievedWithIgnoreAuthority()
+        {
+            SenderConnectionIgnoreAuthorityBehaviour hostBehaviour = CreateHostObject<SenderConnectionIgnoreAuthorityBehaviour>(false);
+
+            const int someInt = 20;
+            NetworkConnectionToClient connectionToClient = NetworkServer.connections[0];
+            Debug.Assert(connectionToClient != null, $"connectionToClient was null, This means that the test is broken and will give the wrong results");
+
+            int callCount = 0;
+            hostBehaviour.onSendInt += (incomingInt, incomingConn) =>
+            {
+                callCount++;
+                Assert.That(incomingInt, Is.EqualTo(someInt));
+                Assert.That(incomingConn, Is.EqualTo(connectionToClient));
             };
             hostBehaviour.CmdSendInt(someInt);
             ProcessMessages();

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -32,7 +32,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection)
         {
             ++((NetworkBehaviourSendCommandInternalComponent)comp).called;
         }
@@ -52,7 +52,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void RPCGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void RPCGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection)
         {
             ++((NetworkBehaviourSendRPCInternalComponent)comp).called;
         }
@@ -72,7 +72,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void TargetRPCGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void TargetRPCGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection)
         {
             ++((NetworkBehaviourSendTargetRPCInternalComponent)comp).called;
         }
@@ -92,7 +92,7 @@ namespace Mirror.Tests
 
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void EventGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void EventGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection)
         {
             ++((NetworkBehaviourSendEventInternalComponent)comp).called;
         }
@@ -107,8 +107,8 @@ namespace Mirror.Tests
     // we need to inherit from networkbehaviour to test protected functions
     public class NetworkBehaviourDelegateComponent : NetworkBehaviour
     {
-        public static void Delegate(NetworkBehaviour comp, NetworkReader reader) { }
-        public static void Delegate2(NetworkBehaviour comp, NetworkReader reader) { }
+        public static void Delegate(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection) { }
+        public static void Delegate2(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection) { }
     }
 
     // we need to inherit from networkbehaviour to test protected functions

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -1242,7 +1242,9 @@ namespace Mirror.Tests
         {
             // add component
             CommandTestNetworkBehaviour comp0 = gameObject.AddComponent<CommandTestNetworkBehaviour>();
+            NetworkConnectionToClient connection = new NetworkConnectionToClient(1);
             Assert.That(comp0.called, Is.EqualTo(0));
+            Assert.That(comp0.senderConnectionInCall, Is.Null);
 
             // register the command delegate, otherwise it's not found
             NetworkBehaviour.RegisterCommandDelegate(typeof(CommandTestNetworkBehaviour), nameof(CommandTestNetworkBehaviour.CommandGenerated), CommandTestNetworkBehaviour.CommandGenerated, false);
@@ -1254,20 +1256,22 @@ namespace Mirror.Tests
             // call HandleCommand and check if the command was called in the component
             int functionHash = NetworkBehaviour.GetMethodHash(typeof(CommandTestNetworkBehaviour), nameof(CommandTestNetworkBehaviour.CommandGenerated));
             NetworkReader payload = new NetworkReader(new byte[0]);
-            identity.HandleCommand(0, functionHash, payload);
+            identity.HandleCommand(0, functionHash, payload, connection);
             Assert.That(comp0.called, Is.EqualTo(1));
+            Assert.That(comp0.senderConnectionInCall, Is.EqualTo(connection));
+
 
             // try wrong component index. command shouldn't be called again.
             // warning is expected
             LogAssert.ignoreFailingMessages = true;
-            identity.HandleCommand(1, functionHash, payload);
+            identity.HandleCommand(1, functionHash, payload, connection);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp0.called, Is.EqualTo(1));
 
             // try wrong function hash. command shouldn't be called again.
             // warning is expected
             LogAssert.ignoreFailingMessages = true;
-            identity.HandleCommand(0, functionHash + 1, payload);
+            identity.HandleCommand(0, functionHash + 1, payload, connection);
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp0.called, Is.EqualTo(1));
 

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -11,11 +11,13 @@ namespace Mirror.Tests
     {
         // counter to make sure that it's called exactly once
         public int called;
+        public NetworkConnection senderConnectionInCall;
         // weaver generates this from [Command]
         // but for tests we need to add it manually
-        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void CommandGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection)
         {
             ++((CommandTestNetworkBehaviour)comp).called;
+            ((CommandTestNetworkBehaviour)comp).senderConnectionInCall = senderConnection;
         }
     }
 
@@ -25,7 +27,7 @@ namespace Mirror.Tests
         public int called;
         // weaver generates this from [Rpc]
         // but for tests we need to add it manually
-        public static void RpcGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void RpcGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection)
         {
             ++((RpcTestNetworkBehaviour)comp).called;
         }
@@ -37,7 +39,7 @@ namespace Mirror.Tests
         public int called;
         // weaver generates this from [SyncEvent]
         // but for tests we need to add it manually
-        public static void SyncEventGenerated(NetworkBehaviour comp, NetworkReader reader)
+        public static void SyncEventGenerated(NetworkBehaviour comp, NetworkReader reader, NetworkConnection senderConnection)
         {
             ++((SyncEventTestNetworkBehaviour)comp).called;
         }

--- a/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
@@ -66,6 +66,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
             if (spawnWithAuthority)
             {
                 NetworkServer.Spawn(gameObject, NetworkServer.localConnection);
+                Debug.Assert(behaviour.connectionToClient != null, $"Behaviour did not have connection to client, This means that the test is broken and will give the wrong results");
             }
             else
             {

--- a/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
+++ b/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
@@ -93,11 +93,15 @@
     <Compile Include="WeaverCommandTests~\CommandCantBeStatic.cs" />
     <Compile Include="WeaverCommandTests~\CommandStartsWithCmd.cs" />
     <Compile Include="WeaverCommandTests~\CommandThatIgnoresAuthority.cs" />
+    <Compile Include="WeaverCommandTests~\CommandThatIgnoresAuthorityWithSenderConnection.cs" />
     <Compile Include="WeaverCommandTests~\CommandValid.cs" />
     <Compile Include="WeaverCommandTests~\CommandWithArguments.cs" />
     <Compile Include="WeaverCommandTests~\OverrideAbstractCommand.cs" />
     <Compile Include="WeaverCommandTests~\OverrideVirtualCommand.cs" />
     <Compile Include="WeaverCommandTests~\VirtualCommand.cs" />
+    <Compile Include="WeaverCommandTests~\CommandWithSenderConnectionAndOtherArgs.cs" />
+    <Compile Include="WeaverCommandTests~\ErrorForNetworkConnectionThatIsNotSenderConnection.cs" />
+    <Compile Include="WeaverCommandTests~\ErrorForOptionalNetworkConnectionThatIsNotSenderConnection.cs" />
     <Compile Include="WeaverGeneralTests~\RecursionCount.cs" />
     <Compile Include="WeaverGeneralTests~\TestingScriptableObjectArraySerialization.cs" />
     <Compile Include="WeaverMessageTests~\MessageMemberGeneric.cs" />

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
@@ -49,13 +49,13 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void ErrorForOptionalNetworkConnectionThatIsNotSenderConnection()
         {
-            Assert.That(weaverErrors, Contains.Item("CmdFunction has invalid parameter connection, Cannot pass NeworkConnections. Instead use use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverCommandTests.ErrorForOptionalNetworkConnectionThatIsNotSenderConnection.ErrorForOptionalNetworkConnectionThatIsNotSenderConnection::CmdFunction(Mirror.NetworkConnection))"));
+            Assert.That(weaverErrors, Contains.Item("CmdFunction has invalid parameter connection, Cannot pass NeworkConnections. Instead use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverCommandTests.ErrorForOptionalNetworkConnectionThatIsNotSenderConnection.ErrorForOptionalNetworkConnectionThatIsNotSenderConnection::CmdFunction(Mirror.NetworkConnection))"));
         }
 
         [Test]
         public void ErrorForNetworkConnectionThatIsNotSenderConnection()
         {
-            Assert.That(weaverErrors, Contains.Item("CmdFunction has invalid parameter connection, Cannot pass NeworkConnections. Instead use use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverCommandTests.ErrorForNetworkConnectionThatIsNotSenderConnection.ErrorForNetworkConnectionThatIsNotSenderConnection::CmdFunction(Mirror.NetworkConnection))"));
+            Assert.That(weaverErrors, Contains.Item("CmdFunction has invalid parameter connection, Cannot pass NeworkConnections. Instead use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverCommandTests.ErrorForNetworkConnectionThatIsNotSenderConnection.ErrorForNetworkConnectionThatIsNotSenderConnection::CmdFunction(Mirror.NetworkConnection))"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests.cs
@@ -35,6 +35,30 @@ namespace Mirror.Weaver.Tests
         }
 
         [Test]
+        public void CommandThatIgnoresAuthorityWithSenderConnection()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+        }
+
+        [Test]
+        public void CommandWithSenderConnectionAndOtherArgs()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+        }
+
+        [Test]
+        public void ErrorForOptionalNetworkConnectionThatIsNotSenderConnection()
+        {
+            Assert.That(weaverErrors, Contains.Item("CmdFunction has invalid parameter connection, Cannot pass NeworkConnections. Instead use use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverCommandTests.ErrorForOptionalNetworkConnectionThatIsNotSenderConnection.ErrorForOptionalNetworkConnectionThatIsNotSenderConnection::CmdFunction(Mirror.NetworkConnection))"));
+        }
+
+        [Test]
+        public void ErrorForNetworkConnectionThatIsNotSenderConnection()
+        {
+            Assert.That(weaverErrors, Contains.Item("CmdFunction has invalid parameter connection, Cannot pass NeworkConnections. Instead use use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverCommandTests.ErrorForNetworkConnectionThatIsNotSenderConnection.ErrorForNetworkConnectionThatIsNotSenderConnection::CmdFunction(Mirror.NetworkConnection))"));
+        }
+
+        [Test]
         public void VirtualCommand()
         {
             Assert.That(weaverErrors, Is.Empty);

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandThatIgnoresAuthority.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandThatIgnoresAuthority.cs
@@ -1,4 +1,4 @@
-﻿using Mirror;
+using Mirror;
 
 namespace WeaverCommandTests.CommandThatIgnoresAuthority
 {

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandThatIgnoresAuthorityWithSenderConnection.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandThatIgnoresAuthorityWithSenderConnection.cs
@@ -1,0 +1,13 @@
+using Mirror;
+
+namespace WeaverCommandTests.CommandThatIgnoresAuthorityWithSenderConnection
+{
+    class CommandThatIgnoresAuthorityWithSenderConnection : NetworkBehaviour
+    {
+        [Command(ignoreAuthority = true)]
+        void CmdFunction([SenderConnection] NetworkConnection connection = null)
+        {
+            // do something
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandWithSenderConnectionAndOtherArgs.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/CommandWithSenderConnectionAndOtherArgs.cs
@@ -1,0 +1,13 @@
+using Mirror;
+
+namespace WeaverCommandTests.CommandWithSenderConnectionAndOtherArgs
+{
+    class CommandWithSenderConnectionAndOtherArgs : NetworkBehaviour
+    {
+        [Command(ignoreAuthority = true)]
+        void CmdFunction(int someNumber, NetworkIdentity someTarget, [SenderConnection] NetworkConnection connection = null)
+        {
+            // do something
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/ErrorForNetworkConnectionThatIsNotSenderConnection.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/ErrorForNetworkConnectionThatIsNotSenderConnection.cs
@@ -1,0 +1,14 @@
+﻿using Mirror;
+
+
+namespace WeaverCommandTests.ErrorForNetworkConnectionThatIsNotSenderConnection
+{
+    class ErrorForNetworkConnectionThatIsNotSenderConnection : NetworkBehaviour
+    {
+        [Command(ignoreAuthority = true)]
+        void CmdFunction(NetworkConnection connection)
+        {
+            // do something
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/ErrorForOptionalNetworkConnectionThatIsNotSenderConnection.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverCommandTests~/ErrorForOptionalNetworkConnectionThatIsNotSenderConnection.cs
@@ -1,0 +1,13 @@
+using Mirror;
+
+namespace WeaverCommandTests.ErrorForOptionalNetworkConnectionThatIsNotSenderConnection
+{
+    class ErrorForOptionalNetworkConnectionThatIsNotSenderConnection : NetworkBehaviour
+    {
+        [Command(ignoreAuthority = true)]
+        void CmdFunction(NetworkConnection connection = null)
+        {
+            // do something
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
@@ -212,7 +212,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void NetworkBehaviourCmdParamNetworkConnection()
         {
-            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamOptional has invalid parameter monkeyCon. Cannot pass NeworkConnections (at System.Void WeaverNetworkBehaviourTests.NetworkBehaviourCmdParamNetworkConnection.NetworkBehaviourCmdParamNetworkConnection::CmdCantHaveParamOptional(Mirror.NetworkConnection))"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamOptional has invalid parameter monkeyCon, Cannot pass NeworkConnections. Instead use use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverNetworkBehaviourTests.NetworkBehaviourCmdParamNetworkConnection.NetworkBehaviourCmdParamNetworkConnection::CmdCantHaveParamOptional(Mirror.NetworkConnection))"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
@@ -212,7 +212,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void NetworkBehaviourCmdParamNetworkConnection()
         {
-            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamOptional has invalid parameter monkeyCon, Cannot pass NeworkConnections. Instead use use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverNetworkBehaviourTests.NetworkBehaviourCmdParamNetworkConnection.NetworkBehaviourCmdParamNetworkConnection::CmdCantHaveParamOptional(Mirror.NetworkConnection))"));
+            Assert.That(weaverErrors, Contains.Item("CmdCantHaveParamOptional has invalid parameter monkeyCon, Cannot pass NeworkConnections. Instead use '[SenderConnection] NetworkConnection conn = null' to get the sender's connection on the server (at System.Void WeaverNetworkBehaviourTests.NetworkBehaviourCmdParamNetworkConnection.NetworkBehaviourCmdParamNetworkConnection::CmdCantHaveParamOptional(Mirror.NetworkConnection))"));
         }
 
         [Test]


### PR DESCRIPTION
alternative to https://github.com/vis2k/Mirror/pull/1932

uses https://github.com/vis2k/Mirror/pull/1948

this will finish the Cmd part of #1917 