### PR TITLE
Keep alive timer. Fix Websocket weird disconnects

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketImplementation.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Ninja.WebSockets/Internal/WebSocketImplementation.cs
@@ -534,14 +534,17 @@ namespace Ninja.WebSockets.Internal
             {
                 if (writeTask.IsCompleted)
                 {
-                    writeTask = _stream.WriteAsync(buffer.Array, buffer.Offset, buffer.Count, cancellationToken);
+                    writeTask = Task.Run(() =>
+                        _stream.WriteAsync(buffer.Array, buffer.Offset, buffer.Count, cancellationToken));
                 }
                 else
                 {
-                    writeTask = writeTask.ContinueWith((prevTask) =>
+                    writeTask.ContinueWith((prevTask) =>
                         _stream.WriteAsync(buffer.Array, buffer.Offset, buffer.Count, cancellationToken));
                 }
-                await writeTask;
+
+                Task.WaitAny(writeTask);
+
                 await _stream.FlushAsync();
             }
             else

--- a/Assets/Mirror/Runtime/Transport/Websocket/Server.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Server.cs
@@ -33,6 +33,8 @@ namespace Mirror.Websocket
 
         public bool NoDelay = true;
 
+        public int KeepAliveTimer;
+
         // connectionId counter
         // (right now we only use it from one listener thread, but we might have
         //  multiple threads later in case of WebSockets etc.)
@@ -131,7 +133,7 @@ namespace Mirror.Websocket
                 WebSocketHttpContext context = await webSocketServerFactory.ReadHttpHeaderFromStreamAsync(tcpClient, stream, token);
                 if (context.IsWebSocketRequest)
                 {
-                    WebSocketServerOptions options = new WebSocketServerOptions() { KeepAliveInterval = TimeSpan.FromSeconds(30), SubProtocol = "binary" };
+                    WebSocketServerOptions options = new WebSocketServerOptions() { KeepAliveInterval = KeepAliveTimer == 0 ? TimeSpan.Zero : TimeSpan.FromSeconds(KeepAliveTimer), SubProtocol = "binary" };
 
                     WebSocket webSocket = await webSocketServerFactory.AcceptWebSocketAsync(context, options);
 

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -113,9 +113,7 @@ namespace Mirror.Websocket
                 server._secure = Secure;
                 server._sslConfig = new Server.SslConfiguration
                 {
-                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(
-                        System.IO.Path.Combine(Application.dataPath, CertificatePath),
-                        CertificatePassword),
+                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath, CertificatePassword),
                     ClientCertificateRequired = false,
                     CheckCertificateRevocation = false,
                     EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -7,6 +7,7 @@ namespace Mirror.Websocket
 {
     public class WebsocketTransport : Transport
     {
+        [Header("Server Configurtations")]
         public const string Scheme = "ws";
         public const string SecureScheme = "wss";
 
@@ -21,6 +22,10 @@ namespace Mirror.Websocket
 
         [Tooltip("Nagle Algorithm can be disabled by enabling NoDelay")]
         public bool NoDelay = true;
+
+        [Tooltip("How long between each ping pong message before we disconnect end users Set to 0 to disable. Note" +
+                 " if server is overwhelmed or slammed with messages may need to increase this timer or disable altogether.")]
+        public int KeepAliveTimer = 300;
 
         public WebsocketTransport()
         {
@@ -116,6 +121,9 @@ namespace Mirror.Websocket
                     EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default
                 };
             }
+
+            server.KeepAliveTimer = Mathf.Max(0, KeepAliveTimer);
+
             _ = server.Listen(port);
         }
 


### PR DESCRIPTION
This allows us to change the keep alive timer on the server. The server is sending ping pong message to determine if it should disconnect the user or not. Mirror borrowed code from ninja.websockets.  In one of the load tests on there repo https://github.com/ninjasource/Ninja.WebSockets/blob/0a7c2cf03f7e28b72387eb40bdf6a438aaace6fe/Ninja.WebSockets.DemoClient/Complex/StressTest.cs#L37 i noticed and comment that suggested to turn off keep alive timer while doing that specific test. So when i asked @MrGadget1024 to test the new code i will be submitting soon with this off everything worked. So I am purposing we let end users decide the keep alive timer and they can set it high or low based on there server usage or disable all together versus the old implementation of 30 seconds. This one defaults to 5mins keep alive timer.