### PR TITLE
WIP - breaking: Websocket Transport now requires full path to PFX certificate file

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -109,9 +109,9 @@ namespace Mirror.Websocket
                 server._sslConfig = new Server.SslConfiguration
                 {
                         Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath, CertificatePassword),
-                    ClientCertificateRequired = false,
-                    CheckCertificateRevocation = false,
-                    EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default
+                        ClientCertificateRequired = false,
+                        CheckCertificateRevocation = false,
+                        EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default
                 };
             }
             _ = server.Listen(port);

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -108,8 +108,7 @@ namespace Mirror.Websocket
                 server._secure = Secure;
                 server._sslConfig = new Server.SslConfiguration
                 {
-                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath,
-                        CertificatePassword),
+                        Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath, CertificatePassword),
                     ClientCertificateRequired = false,
                     CheckCertificateRevocation = false,
                     EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -108,10 +108,10 @@ namespace Mirror.Websocket
                 server._secure = Secure;
                 server._sslConfig = new Server.SslConfiguration
                 {
-                        Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath, CertificatePassword),
-                        ClientCertificateRequired = false,
-                        CheckCertificateRevocation = false,
-                        EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default
+                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath, CertificatePassword),
+                    ClientCertificateRequired = false,
+                    CheckCertificateRevocation = false,
+                    EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default
                 };
             }
             _ = server.Listen(port);

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -108,8 +108,7 @@ namespace Mirror.Websocket
                 server._secure = Secure;
                 server._sslConfig = new Server.SslConfiguration
                 {
-                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(
-                        System.IO.Path.Combine(Application.dataPath, CertificatePath),
+                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath,
                         CertificatePassword),
                     ClientCertificateRequired = false,
                     CheckCertificateRevocation = false,


### PR DESCRIPTION
… use application.data path since cert on server might not be able to be moved.

Signed-off-by: dragonslaya <steve.s@bigredplanetgames.com>