### PR TITLE
fix: Replacing ClearDelegates with RemoveDelegates for test

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -385,15 +385,23 @@ namespace Mirror
 
         static readonly Dictionary<int, Invoker> cmdHandlerDelegates = new Dictionary<int, Invoker>();
 
-        // helper function register a Command/Rpc/SyncEvent delegate
+        /// <summary>
+        /// helper function register a Command/Rpc/SyncEvent delegate
+        /// </summary>
+        /// <param name="invokeClass"></param>
+        /// <param name="cmdName"></param>
+        /// <param name="invokerType"></param>
+        /// <param name="func"></param>
+        /// <param name="cmdIgnoreAuthority"></param>
+        /// <returns>remote function hash</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected static void RegisterDelegate(Type invokeClass, string cmdName, MirrorInvokeType invokerType, CmdDelegate func, bool cmdIgnoreAuthority = false)
+        internal static int RegisterDelegate(Type invokeClass, string cmdName, MirrorInvokeType invokerType, CmdDelegate func, bool cmdIgnoreAuthority = false)
         {
             // type+func so Inventory.RpcUse != Equipment.RpcUse
             int cmdHash = GetMethodHash(invokeClass, cmdName);
 
             if (CheckIfDeligateExists(invokeClass, invokerType, func, cmdHash))
-                return;
+                return cmdHash;
 
             Invoker invoker = new Invoker
             {
@@ -410,6 +418,8 @@ namespace Mirror
                 string ingoreAuthorityMessage = invokerType == MirrorInvokeType.Command ? $" IgnoreAuthority:{cmdIgnoreAuthority}" : "";
                 logger.Log($"RegisterDelegate hash: {cmdHash} invokerType: {invokerType} method: {func.GetMethodName()}{ingoreAuthorityMessage}");
             }
+
+            return cmdHash;
         }
 
         static bool CheckIfDeligateExists(Type invokeClass, MirrorInvokeType invokerType, CmdDelegate func, int cmdHash)

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -450,9 +450,19 @@ namespace Mirror
 
         // we need a way to clean up delegates after tests
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [System.Obsolete("Removing all delegates will cause problems with other tests as their hashs can not be re-added without reloading scripts", true)]
         internal static void ClearDelegates()
         {
             cmdHandlerDelegates.Clear();
+        }
+
+        /// <summary>
+        /// We need this in order to clean up tests
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static void RemoveDelegates(int hash)
+        {
+            cmdHandlerDelegates.Remove(hash);
         }
 
         static bool GetInvokerForHash(int cmdHash, MirrorInvokeType invokeType, out Invoker invoker)

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -377,10 +377,11 @@ namespace Mirror.Tests
             NetworkServer.AddConnection(connection);
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterCommandDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
-                nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated),
-                NetworkBehaviourSendCommandInternalComponent.CommandGenerated,
-                false);
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
+                    nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated),
+                    MirrorInvokeType.Command,
+                    NetworkBehaviourSendCommandInternalComponent.CommandGenerated,
+                    false);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it
@@ -401,7 +402,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(1));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
             // clear clientscene.readyconnection
             ClientScene.Shutdown();
             NetworkClient.Shutdown();
@@ -418,8 +419,9 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(0));
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterCommandDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
                 nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated),
+                MirrorInvokeType.Command,
                 NetworkBehaviourSendCommandInternalComponent.CommandGenerated,
                 false);
 
@@ -431,7 +433,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(1));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
         }
 
         [Test]
@@ -491,8 +493,9 @@ namespace Mirror.Tests
             Assert.That(comp.isServer, Is.True);
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterRpcDelegate(typeof(NetworkBehaviourSendRPCInternalComponent),
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(NetworkBehaviourSendRPCInternalComponent),
                 nameof(NetworkBehaviourSendRPCInternalComponent.RPCGenerated),
+                MirrorInvokeType.ClientRpc,
                 NetworkBehaviourSendRPCInternalComponent.RPCGenerated);
 
             // identity needs to be in spawned dict, otherwise rpc handler
@@ -509,7 +512,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(1));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
             // clear clientscene.readyconnection
             ClientScene.Shutdown();
             NetworkServer.RemoveLocalConnection();
@@ -582,8 +585,9 @@ namespace Mirror.Tests
             Assert.That(comp.isServer, Is.True);
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterRpcDelegate(typeof(NetworkBehaviourSendTargetRPCInternalComponent),
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(NetworkBehaviourSendTargetRPCInternalComponent),
                 nameof(NetworkBehaviourSendTargetRPCInternalComponent.TargetRPCGenerated),
+                MirrorInvokeType.ClientRpc,
                 NetworkBehaviourSendTargetRPCInternalComponent.TargetRPCGenerated);
 
             // identity needs to be in spawned dict, otherwise rpc handler
@@ -600,7 +604,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(1));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
             // clear clientscene.readyconnection
             ClientScene.Shutdown();
             NetworkServer.RemoveLocalConnection();
@@ -618,8 +622,9 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(0));
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterRpcDelegate(typeof(NetworkBehaviourSendRPCInternalComponent),
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(NetworkBehaviourSendRPCInternalComponent),
                 nameof(NetworkBehaviourSendRPCInternalComponent.RPCGenerated),
+                MirrorInvokeType.ClientRpc,
                 NetworkBehaviourSendRPCInternalComponent.RPCGenerated);
 
             // invoke command
@@ -630,7 +635,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(1));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
         }
 
         [Test]
@@ -690,9 +695,10 @@ namespace Mirror.Tests
             Assert.That(comp.isServer, Is.True);
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterEventDelegate(
+            int registeredHash = NetworkBehaviour.RegisterDelegate(
                 typeof(NetworkBehaviourSendEventInternalComponent),
                 nameof(NetworkBehaviourSendEventInternalComponent.EventGenerated),
+                MirrorInvokeType.SyncEvent,
                 NetworkBehaviourSendEventInternalComponent.EventGenerated);
 
             // identity needs to be in spawned dict, otherwise event handler
@@ -709,7 +715,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(1));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
             // clear clientscene.readyconnection
             ClientScene.Shutdown();
             NetworkServer.RemoveLocalConnection();
@@ -727,8 +733,9 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(0));
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterEventDelegate(typeof(NetworkBehaviourSendEventInternalComponent),
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(NetworkBehaviourSendEventInternalComponent),
                 nameof(NetworkBehaviourSendEventInternalComponent.EventGenerated),
+                MirrorInvokeType.SyncEvent,
                 NetworkBehaviourSendEventInternalComponent.EventGenerated);
 
             // invoke command
@@ -739,7 +746,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(1));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
         }
 
         [Test]
@@ -747,30 +754,35 @@ namespace Mirror.Tests
         {
             // registerdelegate is protected, but we can use
             // RegisterCommandDelegate which calls RegisterDelegate
-            NetworkBehaviour.RegisterCommandDelegate(
+            int registeredHash1 = NetworkBehaviour.RegisterDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
+                MirrorInvokeType.Command,
                 NetworkBehaviourDelegateComponent.Delegate,
                 false);
 
             // registering the exact same one should be fine. it should simply
             // do nothing.
-            NetworkBehaviour.RegisterCommandDelegate(
+            int registeredHash2 = NetworkBehaviour.RegisterDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
+                MirrorInvokeType.Command,
                 NetworkBehaviourDelegateComponent.Delegate,
                 false);
             // registering the same name with a different callback shouldn't
             // work
             LogAssert.Expect(LogType.Error, "Function " + typeof(NetworkBehaviourDelegateComponent) + "." + nameof(NetworkBehaviourDelegateComponent.Delegate) + " and " + typeof(NetworkBehaviourDelegateComponent) + "." + nameof(NetworkBehaviourDelegateComponent.Delegate2) + " have the same hash.  Please rename one of them");
-            NetworkBehaviour.RegisterCommandDelegate(
+            int registeredHash3 = NetworkBehaviour.RegisterDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
+                MirrorInvokeType.Command,
                 NetworkBehaviourDelegateComponent.Delegate2,
                 false);
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash1);
+            NetworkBehaviour.RemoveDelegates(registeredHash2);
+            NetworkBehaviour.RemoveDelegates(registeredHash3);
         }
 
         [Test]
@@ -778,9 +790,10 @@ namespace Mirror.Tests
         {
             // registerdelegate is protected, but we can use
             // RegisterCommandDelegate which calls RegisterDelegate
-            NetworkBehaviour.RegisterCommandDelegate(
+            int registeredHash = NetworkBehaviour.RegisterDelegate(
                 typeof(NetworkBehaviourDelegateComponent),
                 nameof(NetworkBehaviourDelegateComponent.Delegate),
+                MirrorInvokeType.Command,
                 NetworkBehaviourDelegateComponent.Delegate,
                 false);
 
@@ -795,7 +808,7 @@ namespace Mirror.Tests
             Assert.That(funcNull, Is.Null);
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
         }
 
         // NOTE: SyncVarGameObjectEqual should be static later

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -1297,7 +1297,11 @@ namespace Mirror.Tests
             Assert.That(comp0.senderConnectionInCall, Is.Null);
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterCommandDelegate(typeof(CommandTestNetworkBehaviour), nameof(CommandTestNetworkBehaviour.CommandGenerated), CommandTestNetworkBehaviour.CommandGenerated, false);
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(CommandTestNetworkBehaviour),
+                nameof(CommandTestNetworkBehaviour.CommandGenerated),
+                MirrorInvokeType.Command,
+                CommandTestNetworkBehaviour.CommandGenerated,
+                false);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it
@@ -1326,9 +1330,8 @@ namespace Mirror.Tests
             Assert.That(comp0.called, Is.EqualTo(1));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
             NetworkIdentity.spawned.Clear();
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
         }
 
         [Test]
@@ -1339,7 +1342,10 @@ namespace Mirror.Tests
             Assert.That(comp0.called, Is.EqualTo(0));
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterRpcDelegate(typeof(RpcTestNetworkBehaviour), nameof(RpcTestNetworkBehaviour.RpcGenerated), RpcTestNetworkBehaviour.RpcGenerated);
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(RpcTestNetworkBehaviour),
+                nameof(RpcTestNetworkBehaviour.RpcGenerated),
+                MirrorInvokeType.ClientRpc,
+                RpcTestNetworkBehaviour.RpcGenerated);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it
@@ -1367,7 +1373,7 @@ namespace Mirror.Tests
 
             // clean up
             NetworkIdentity.spawned.Clear();
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
         }
 
         [Test]
@@ -1378,7 +1384,10 @@ namespace Mirror.Tests
             Assert.That(comp0.called, Is.EqualTo(0));
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterEventDelegate(typeof(SyncEventTestNetworkBehaviour), nameof(SyncEventTestNetworkBehaviour.SyncEventGenerated), SyncEventTestNetworkBehaviour.SyncEventGenerated);
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(SyncEventTestNetworkBehaviour),
+                nameof(SyncEventTestNetworkBehaviour.SyncEventGenerated),
+                MirrorInvokeType.SyncEvent,
+                SyncEventTestNetworkBehaviour.SyncEventGenerated);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it
@@ -1407,7 +1416,7 @@ namespace Mirror.Tests
 
             // clean up
             NetworkIdentity.spawned.Clear();
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -582,7 +582,11 @@ namespace Mirror.Tests
             connection.identity = identity;
 
             // register the command delegate, otherwise it's not found
-            NetworkBehaviour.RegisterCommandDelegate(typeof(CommandTestNetworkBehaviour), nameof(CommandTestNetworkBehaviour.CommandGenerated), CommandTestNetworkBehaviour.CommandGenerated, false);
+            int registeredHash = NetworkBehaviour.RegisterDelegate(typeof(CommandTestNetworkBehaviour),
+                nameof(CommandTestNetworkBehaviour.CommandGenerated),
+                MirrorInvokeType.Command,
+                CommandTestNetworkBehaviour.CommandGenerated,
+                false);
 
             // identity needs to be in spawned dict, otherwise command handler
             // won't find it
@@ -647,9 +651,8 @@ namespace Mirror.Tests
             Assert.That(comp1.called, Is.EqualTo(0));
 
             // clean up
-            NetworkBehaviour.ClearDelegates();
             NetworkIdentity.spawned.Clear();
-            NetworkBehaviour.ClearDelegates();
+            NetworkBehaviour.RemoveDelegates(registeredHash);
             NetworkServer.Shutdown();
             // destroy the test gameobject AFTER server was stopped.
             // otherwise isServer is true in OnDestroy, which means it would try


### PR DESCRIPTION
this removes all delegates, which is a problem because other tests register their handles in static constructors so have no way to re-add their handlers
```csharp
// we need a way to clean up delegates after tests
[EditorBrowsable(EditorBrowsableState.Never)]
[System.Obsolete("Removing all delegates will cause problems with other tests as their hashs can not be re-added without reloading scripts", true)]
internal static void ClearDelegates()
{
    cmdHandlerDelegates.Clear();
}
```

Swapping tests to use `RegisterDelegate` instead of `RegisterCommandDelegate` to get returned value. Making `RegisterCommandDelegate` return the has a well requires Weaver to be changed.