### PR TITLE
fix: Fixing NullReferenceException caused by calling this.gameObject inside null unity object

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -985,7 +985,8 @@ namespace Mirror
         // helper function to handle SyncEvent/Command/Rpc
         void HandleRemoteCall(int componentIndex, int functionHash, MirrorInvokeType invokeType, NetworkReader reader, NetworkConnectionToClient senderConnection = null)
         {
-            if (gameObject == null)
+            // check if unity object has been destroyed
+            if (this == null)
             {
                 logger.LogWarning(invokeType + " [" + functionHash + "] received for deleted object [netId=" + netId + "]");
                 return;
@@ -1021,7 +1022,8 @@ namespace Mirror
         // happens on server
         internal NetworkBehaviour.CommandInfo GetCommandInfo(int componentIndex, int cmdHash)
         {
-            if (gameObject == null)
+            // check if unity object has been destroyed
+            if (this == null)
             {
                 // error can be logged later
                 return default;


### PR DESCRIPTION
Had a `NullReferenceException` caused by `HandleRemoteCall` in my game. Checking `this` instead of `this.gameobject` should fix the problem

