### PR TITLE
fix: making weaver include public fields in base classes in auto generated Read/Write

### DIFF
--- a/Assets/Mirror/Tests/Editor/FieldsInBaseClasses.cs
+++ b/Assets/Mirror/Tests/Editor/FieldsInBaseClasses.cs
@@ -1,0 +1,53 @@
+using System;
+using Mirror.Tests.RemoteAttrributeTest;
+using NUnit.Framework;
+
+namespace Mirror.Tests.GeneratedWriterTests
+{
+    public class BaseData
+    {
+        public bool toggle;
+    }
+    public class SomeOtherData : BaseData
+    {
+        public int usefulNumber;
+    }
+
+    public class DataSenderBehaviour : NetworkBehaviour
+    {
+        public event Action<SomeOtherData> onData;
+        [Command]
+        public void CmdSendData(SomeOtherData otherData)
+        {
+            onData?.Invoke(otherData);
+        }
+    }
+
+    public class FieldsInBaseClasses : RemoteTestBase
+    {
+        [Test]
+        public void WriterShouldIncludeFieldsInBaseClass()
+        {
+            DataSenderBehaviour hostBehaviour = CreateHostObject<DataSenderBehaviour>(true);
+
+            const bool toggle = true;
+            const int usefulNumber = 10;
+
+            int callCount = 0;
+            hostBehaviour.onData += data =>
+            {
+                callCount++;
+                Assert.That(data.usefulNumber, Is.EqualTo(usefulNumber));
+                Assert.That(data.toggle, Is.EqualTo(toggle));
+            };
+            hostBehaviour.CmdSendData(new SomeOtherData
+            {
+                usefulNumber = usefulNumber,
+                toggle = toggle
+            });
+
+            ProcessMessages();
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/FieldsInBaseClasses.cs.meta
+++ b/Assets/Mirror/Tests/Editor/FieldsInBaseClasses.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 518288ffe7c7215458a98466131fc7af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
+++ b/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="GeneratedReaderWriter~\CreatesForClass.cs" />
     <Compile Include="GeneratedReaderWriter~\CreatesForClassFromDifferentAssemblies.cs" />
     <Compile Include="GeneratedReaderWriter~\CreatesForClassFromDifferentAssembliesWithValidConstructor.cs" />
+    <Compile Include="GeneratedReaderWriter~\CreatesForClassInherited.cs" />
     <Compile Include="GeneratedReaderWriter~\CreatesForClassWithValidConstructor.cs" />
     <Compile Include="GeneratedReaderWriter~\CreatesForEnums.cs" />
     <Compile Include="GeneratedReaderWriter~\CreatesForInheritedFromScriptableObject.cs" />

--- a/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClassInherited.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/GeneratedReaderWriter~/CreatesForClassInherited.cs
@@ -1,0 +1,23 @@
+using Mirror;
+
+
+namespace GeneratedReaderWriter.CreatesForClassInherited
+{
+    public class CreatesForClassInherited : NetworkBehaviour
+    {
+        [ClientRpc]
+        public void RpcDoSomething(SomeOtherData data)
+        {
+            // empty
+        }
+    }
+
+    public class BaseData
+    {
+        public bool yes;
+    }
+    public class SomeOtherData : BaseData
+    {
+        public int usefulNumber;
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
@@ -31,6 +31,12 @@ namespace Mirror.Weaver.Tests
         }
 
         [Test]
+        public void CreatesForClassInherited()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+        }
+
+        [Test]
         public void CreatesForClassWithValidConstructor()
         {
             Assert.That(weaverErrors, Is.Empty);


### PR DESCRIPTION
Weaver doesn't include fields in base classes when generating Read/Writers.

- [ ] Write base fields
- [ ] Read base fields