### PR TITLE
fix: adding error when Server/Client is used on abstract methods

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
@@ -62,7 +62,10 @@ namespace Mirror.Weaver
 
             if (md.IsAbstract)
             {
-                Weaver.Error("Server or Client Attributes can't be added to abstract method. Server and Client Attributes are not inherited so they need to be applied to the override methods instead.", md);
+                if (ServerClientAttributeProcessor.HasServerClientAttribute(md))
+                {
+                    Weaver.Error("Server or Client Attributes can't be added to abstract method. Server and Client Attributes are not inherited so they need to be applied to the override methods instead.", md);
+                }
                 return;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
@@ -60,6 +60,12 @@ namespace Mirror.Weaver
                 md.Name.StartsWith(Weaver.InvokeRpcPrefix))
                 return;
 
+            if (md.IsAbstract)
+            {
+                Weaver.Error("Server or Client Attributes can't be added to abstract method", md);
+                return;
+            }
+
             if (md.Body != null && md.Body.Instructions != null)
             {
                 // TODO move this to NetworkBehaviourProcessor

--- a/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
@@ -62,7 +62,7 @@ namespace Mirror.Weaver
 
             if (md.IsAbstract)
             {
-                Weaver.Error("Server or Client Attributes can't be added to abstract method", md);
+                Weaver.Error("Server or Client Attributes can't be added to abstract method. Server and Client Attributes are not inherited so they need to be applied to the override methods instead.", md);
                 return;
             }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
@@ -8,6 +8,24 @@ namespace Mirror.Weaver
     /// </summary>
     static class ServerClientAttributeProcessor
     {
+        public static bool HasServerClientAttribute(MethodDefinition md)
+        {
+            foreach (CustomAttribute attr in md.CustomAttributes)
+            {
+                switch (attr.Constructor.DeclaringType.ToString())
+                {
+                    case "Mirror.ServerAttribute":
+                    case "Mirror.ServerCallbackAttribute":
+                    case "Mirror.ClientAttribute":
+                    case "Mirror.ClientCallbackAttribute":
+                        return true;
+                    default:
+                        break;
+                }
+            }
+            return false;
+        }
+
         public static void ProcessMethodAttributes(TypeDefinition td, MethodDefinition md)
         {
             foreach (CustomAttribute attr in md.CustomAttributes)

--- a/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
+++ b/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
@@ -91,6 +91,9 @@
     <Compile Include="WeaverClientRpcTests~\VirtualClientRpc.cs" />
     <Compile Include="WeaverClientServerAttributeTests~\NetworkBehaviourClient.cs" />
     <Compile Include="WeaverClientServerAttributeTests~\NetworkBehaviourServer.cs" />
+    <Compile Include="WeaverClientServerAttributeTests~\ServerAttributeOnAbstractMethod.cs" />
+    <Compile Include="WeaverClientServerAttributeTests~\ServerAttributeOnOverrideMethod.cs" />
+    <Compile Include="WeaverClientServerAttributeTests~\ServerAttributeOnVirutalMethod.cs" />
     <Compile Include="WeaverCommandTests~\AbstractCommand.cs" />
     <Compile Include="WeaverCommandTests~\CommandCantBeStatic.cs" />
     <Compile Include="WeaverCommandTests~\CommandStartsWithCmd.cs" />

--- a/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
+++ b/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
@@ -89,6 +89,9 @@
     <Compile Include="WeaverClientRpcTests~\OverrideAbstractClientRpc.cs" />
     <Compile Include="WeaverClientRpcTests~\OverrideVirtualClientRpc.cs" />
     <Compile Include="WeaverClientRpcTests~\VirtualClientRpc.cs" />
+    <Compile Include="WeaverClientServerAttributeTests~\ClientAttributeOnAbstractMethod.cs" />
+    <Compile Include="WeaverClientServerAttributeTests~\ClientAttributeOnOverrideMethod.cs" />
+    <Compile Include="WeaverClientServerAttributeTests~\ClientAttributeOnVirutalMethod.cs" />
     <Compile Include="WeaverClientServerAttributeTests~\NetworkBehaviourClient.cs" />
     <Compile Include="WeaverClientServerAttributeTests~\NetworkBehaviourServer.cs" />
     <Compile Include="WeaverClientServerAttributeTests~\ServerAttributeOnAbstractMethod.cs" />

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
@@ -29,7 +29,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void ServerAttributeOnAbstractMethod()
         {
-            Assert.That(weaverErrors, Contains.Item("Server or Client Attributes can't be added to abstract method (at System.Void WeaverClientServerAttributeTests.ServerAttributeOnAbstractMethod.ServerAttributeOnAbstractMethod::ServerOnlyMethod())"));
+            Assert.That(weaverErrors, Contains.Item("Server or Client Attributes can't be added to abstract method. Server and Client Attributes are not inherited so they need to be applied to the override methods instead. (at System.Void WeaverClientServerAttributeTests.ServerAttributeOnAbstractMethod.ServerAttributeOnAbstractMethod::ServerOnlyMethod())"));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void ClientAttributeOnAbstractMethod()
         {
-            Assert.That(weaverErrors, Contains.Item("Server or Client Attributes can't be added to abstract method (at System.Void WeaverClientServerAttributeTests.ClientAttributeOnAbstractMethod.ClientAttributeOnAbstractMethod::ClientOnlyMethod())"));
+            Assert.That(weaverErrors, Contains.Item("Server or Client Attributes can't be added to abstract method. Server and Client Attributes are not inherited so they need to be applied to the override methods instead. (at System.Void WeaverClientServerAttributeTests.ClientAttributeOnAbstractMethod.ClientAttributeOnAbstractMethod::ClientOnlyMethod())"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
@@ -29,7 +29,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void ServerAttributeOnAbstractMethod()
         {
-            Assert.That(weaverErrors, Contains.Item("Server Attribute can't be added to abstract method (at System.Void WeaverClientServerAttributeTests.ServerAttributeOnAbstractMethod.ServerAttributeOnAbstractMethod::ServerOnlyMethod())"));
+            Assert.That(weaverErrors, Contains.Item("Server or Client Attributes can't be added to abstract method (at System.Void WeaverClientServerAttributeTests.ServerAttributeOnAbstractMethod.ServerAttributeOnAbstractMethod::ServerOnlyMethod())"));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void ClientAttributeOnAbstractMethod()
         {
-            Assert.That(weaverErrors, Contains.Item("Client Attribute can't be added to abstract method (at System.Void WeaverClientServerAttributeTests.ClientAttributeOnAbstractMethod.ClientAttributeOnAbstractMethod::ClientOnlyMethod())"));
+            Assert.That(weaverErrors, Contains.Item("Server or Client Attributes can't be added to abstract method (at System.Void WeaverClientServerAttributeTests.ClientAttributeOnAbstractMethod.ClientAttributeOnAbstractMethod::ClientOnlyMethod())"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
@@ -22,7 +22,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(weaverErrors, Is.Empty);
 
-            string networkServerGetActive = Weaver.NetworkServerGetActive.ToString();
+            string networkServerGetActive = WeaverTypes.NetworkServerGetActive.ToString();
             CheckAddedCode(networkServerGetActive, "WeaverClientServerAttributeTests.ServerAttributeOnVirutalMethod.ServerAttributeOnVirutalMethod", "ServerOnlyMethod");
         }
 
@@ -37,7 +37,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(weaverErrors, Is.Empty);
 
-            string networkServerGetActive = Weaver.NetworkServerGetActive.ToString();
+            string networkServerGetActive = WeaverTypes.NetworkServerGetActive.ToString();
             CheckAddedCode(networkServerGetActive, "WeaverClientServerAttributeTests.ServerAttributeOnOverrideMethod.ServerAttributeOnOverrideMethod", "ServerOnlyMethod");
         }
 
@@ -55,7 +55,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(weaverErrors, Is.Empty);
 
-            string networkClientGetActive = Weaver.NetworkClientGetActive.ToString();
+            string networkClientGetActive = WeaverTypes.NetworkClientGetActive.ToString();
             CheckAddedCode(networkClientGetActive, "WeaverClientServerAttributeTests.ClientAttributeOnVirutalMethod.ClientAttributeOnVirutalMethod", "ClientOnlyMethod");
         }
 
@@ -70,7 +70,7 @@ namespace Mirror.Weaver.Tests
         {
             Assert.That(weaverErrors, Is.Empty);
 
-            string networkClientGetActive = Weaver.NetworkClientGetActive.ToString();
+            string networkClientGetActive = WeaverTypes.NetworkClientGetActive.ToString();
             CheckAddedCode(networkClientGetActive, "WeaverClientServerAttributeTests.ClientAttributeOnOverrideMethod.ClientAttributeOnOverrideMethod", "ClientOnlyMethod");
         }
 

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
@@ -11,18 +11,41 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void NetworkBehaviourServer()
         {
-            Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
             Assert.That(weaverErrors, Is.Empty);
+
             string networkServerGetActive = WeaverTypes.NetworkServerGetActive.ToString();
             CheckAddedCode(networkServerGetActive, "WeaverClientServerAttributeTests.NetworkBehaviourServer.NetworkBehaviourServer", "ServerOnlyMethod");
+        }
 
+        [Test]
+        public void ServerAttributeOnVirutalMethod()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+
+            string networkServerGetActive = Weaver.NetworkServerGetActive.ToString();
+            CheckAddedCode(networkServerGetActive, "WeaverClientServerAttributeTests.ServerAttributeOnVirutalMethod.ServerAttributeOnVirutalMethod", "ServerOnlyMethod");
+        }
+
+        [Test]
+        public void ServerAttributeOnAbstractMethod()
+        {
+            Assert.That(weaverErrors, Contains.Item("Server Attribute can't be added to abstract method (at System.Void WeaverClientServerAttributeTests.ServerAttributeOnAbstractMethod.ServerAttributeOnAbstractMethod::ServerOnlyMethod())"));
+        }
+
+        [Test]
+        public void ServerAttributeOnOverrideMethod()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+
+            string networkServerGetActive = Weaver.NetworkServerGetActive.ToString();
+            CheckAddedCode(networkServerGetActive, "WeaverClientServerAttributeTests.ServerAttributeOnOverrideMethod.ServerAttributeOnOverrideMethod", "ServerOnlyMethod");
         }
 
         [Test]
         public void NetworkBehaviourClient()
         {
-            Assert.That(CompilationFinishedHook.WeaveFailed, Is.False);
             Assert.That(weaverErrors, Is.Empty);
+
             string networkClientGetActive = WeaverTypes.NetworkClientGetActive.ToString();
             CheckAddedCode(networkClientGetActive, "WeaverClientServerAttributeTests.NetworkBehaviourClient.NetworkBehaviourClient", "ClientOnlyMethod");
         }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
@@ -50,6 +50,30 @@ namespace Mirror.Weaver.Tests
             CheckAddedCode(networkClientGetActive, "WeaverClientServerAttributeTests.NetworkBehaviourClient.NetworkBehaviourClient", "ClientOnlyMethod");
         }
 
+        [Test]
+        public void ClientAttributeOnVirutalMethod()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+
+            string networkClientGetActive = Weaver.NetworkClientGetActive.ToString();
+            CheckAddedCode(networkClientGetActive, "WeaverClientServerAttributeTests.ClientAttributeOnVirutalMethod.ClientAttributeOnVirutalMethod", "ClientOnlyMethod");
+        }
+
+        [Test]
+        public void ClientAttributeOnAbstractMethod()
+        {
+            Assert.That(weaverErrors, Contains.Item("Client Attribute can't be added to abstract method (at System.Void WeaverClientServerAttributeTests.ClientAttributeOnAbstractMethod.ClientAttributeOnAbstractMethod::ClientOnlyMethod())"));
+        }
+
+        [Test]
+        public void ClientAttributeOnOverrideMethod()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+
+            string networkClientGetActive = Weaver.NetworkClientGetActive.ToString();
+            CheckAddedCode(networkClientGetActive, "WeaverClientServerAttributeTests.ClientAttributeOnOverrideMethod.ClientAttributeOnOverrideMethod", "ClientOnlyMethod");
+        }
+
         /// <summary>
         /// Checks that first Instructions in MethodBody is addedString
         /// </summary>

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ClientAttributeOnAbstractMethod.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ClientAttributeOnAbstractMethod.cs
@@ -1,0 +1,10 @@
+using Mirror;
+
+namespace WeaverClientServerAttributeTests.ClientAttributeOnAbstractMethod
+{
+    abstract class ClientAttributeOnAbstractMethod : NetworkBehaviour
+    {
+        [Client]
+        protected abstract void ClientOnlyMethod();
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ClientAttributeOnOverrideMethod.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ClientAttributeOnOverrideMethod.cs
@@ -1,0 +1,21 @@
+using Mirror;
+
+namespace WeaverClientServerAttributeTests.ClientAttributeOnOverrideMethod
+{
+    class ClientAttributeOnOverrideMethod : BaseClass
+    {
+        [Client]
+        protected override void ClientOnlyMethod()
+        {
+            // test method
+        }
+    }
+
+    class BaseClass : NetworkBehaviour
+    {
+        protected virtual void ClientOnlyMethod()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ClientAttributeOnVirutalMethod.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ClientAttributeOnVirutalMethod.cs
@@ -1,0 +1,13 @@
+using Mirror;
+
+namespace WeaverClientServerAttributeTests.ClientAttributeOnVirutalMethod
+{
+    class ClientAttributeOnVirutalMethod : NetworkBehaviour
+    {
+        [Client]
+        protected virtual void ClientOnlyMethod()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ServerAttributeOnAbstractMethod.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ServerAttributeOnAbstractMethod.cs
@@ -1,0 +1,10 @@
+using Mirror;
+
+namespace WeaverClientServerAttributeTests.ServerAttributeOnAbstractMethod
+{
+    abstract class ServerAttributeOnAbstractMethod : NetworkBehaviour
+    {
+        [Server]
+        protected abstract void ServerOnlyMethod();
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ServerAttributeOnOverrideMethod.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ServerAttributeOnOverrideMethod.cs
@@ -1,0 +1,21 @@
+using Mirror;
+
+namespace WeaverClientServerAttributeTests.ServerAttributeOnOverrideMethod
+{
+    class ServerAttributeOnOverrideMethod : BaseClass
+    {
+        [Server]
+        protected override void ServerOnlyMethod()
+        {
+            // test method
+        }
+    }
+
+    class BaseClass : NetworkBehaviour
+    {
+        protected virtual void ServerOnlyMethod()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ServerAttributeOnVirutalMethod.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ServerAttributeOnVirutalMethod.cs
@@ -1,0 +1,14 @@
+﻿using Mirror;
+
+
+namespace WeaverClientServerAttributeTests.ServerAttributeOnVirutalMethod
+{
+    class ServerAttributeOnVirutalMethod : NetworkBehaviour
+    {
+        [Server]
+        protected virtual void ServerOnlyMethod()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ServerAttributeOnVirutalMethod.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/ServerAttributeOnVirutalMethod.cs
@@ -1,6 +1,5 @@
 ﻿using Mirror;
 
-
 namespace WeaverClientServerAttributeTests.ServerAttributeOnVirutalMethod
 {
     class ServerAttributeOnVirutalMethod : NetworkBehaviour


### PR DESCRIPTION
Adding an error because adding Server/Client to abstract method does nothing and may lead people to leave the attribute off the overridden method.

also test for virtual, abstract and override methods