### PR TITLE
breaking: Websocket Transport now requires full path to PFX

### DIFF
--- a/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
+++ b/Assets/Mirror/CompilerSymbols/PreprocessorDefine.cs
@@ -29,7 +29,8 @@ namespace Mirror
                 "MIRROR_12_0_OR_NEWER",
                 "MIRROR_13_0_OR_NEWER",
                 "MIRROR_14_0_OR_NEWER",
-                "MIRROR_15_0_OR_NEWER"
+                "MIRROR_15_0_OR_NEWER",
+                "MIRROR_16_0_OR_NEWER"
             };
 
             // only touch PlayerSettings if we actually modified it.

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace Mirror.Websocket
 {
+    [HelpURL("https://mirror-networking.com/docs/Transports/WebSockets.html")]
     public class WebsocketTransport : Transport
     {
         public const string Scheme = "ws";

--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -13,14 +13,24 @@ namespace Mirror.Websocket
         protected Client client = new Client();
         protected Server server = new Server();
 
+        [Header("Transport Settings")]
+
+        [Tooltip("Connection Port.")]
         public int port = 7778;
 
-        public bool Secure;
-        public string CertificatePath;
-        public string CertificatePassword;
-
-        [Tooltip("Nagle Algorithm can be disabled by enabling NoDelay")]
+        [Tooltip("Nagle Algorithm can be disabled by enabling NoDelay.")]
         public bool NoDelay = true;
+
+        [Header("Secure Sockets (SSL/WSS).")]
+
+        [Tooltip("Indicates if SSL/WSS protocol will be used with the PFX Certificate file below.")]
+        public bool Secure;
+
+        [Tooltip("Full path and filename to PFX Certificate file generated from web hosting environment.")]
+        public string CertificatePath;
+
+        [Tooltip("Password for PFX Certificate file above.")]
+        public string CertificatePassword;
 
         public WebsocketTransport()
         {
@@ -108,9 +118,7 @@ namespace Mirror.Websocket
                 server._secure = Secure;
                 server._sslConfig = new Server.SslConfiguration
                 {
-                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(
-                        System.IO.Path.Combine(Application.dataPath, CertificatePath),
-                        CertificatePassword),
+                    Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath, CertificatePassword),
                     ClientCertificateRequired = false,
                     CheckCertificateRevocation = false,
                     EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default


### PR DESCRIPTION
Alternative to #1966 and includes version update in PreprocessorDefine.

Changes how the transport locates the PFX Certificate file.

Currently it's an undocumented relative path from Unity's `Application.dataPath` that differs by platform, so it's difficult to know where the PFX file must be located within the deployed server build.

With this change, users specify the full path to the PFX, and therefore it can be anywhere on the server that the dev finds convenient, perhaps auto-generated by LetsEncrypt on a 90-day interval, and makes it easier to update the server deployment without losing / displacing the PFX, and allows multiple server builds of different games on the same server to all use the same PFX without needing umpteen copies of it.

Also includes Headers and Tooltips for the inspector.