### PR TITLE
fix: Use world coordinates for spawn position & rotation

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1071,11 +1071,11 @@ namespace Mirror
                     sceneId = identity.sceneId,
                     assetId = identity.assetId,
                     // use local values for VR support
-                    position = identity.transform.localPosition,
-                    rotation = identity.transform.localRotation,
+                    position = identity.transform.position,
+                    rotation = identity.transform.rotation,
                     scale = identity.transform.localScale,
 
-                    payload = payload,
+                    payload = payload
                 };
 
                 conn.Send(msg);


### PR DESCRIPTION
Using local position and rotation is fine for Network Transform, but we went to far in using them for spawning because if the object is parented to something that isn't at 0,0,0 position / rotation, the client gets the wrong coordinates because there's no hierarchy.

While it's obvious and well documented that NetworkTransform uses local coordinates for VR support, it's not at all obvious that locals are also used for spawning without hierarchy.

This has come up in discord where users are instantiating objects as child of something (non-networked) in an additive subscene because it's easier than figuring out which subscene (or subscene instance in the case of multiples) to move the thing to after it's instantiated in the main active scene on the server.  NetworkSceneChecker requires the object to be in the correct subscene on the server so that only clients in the same subscene are told about it.

Unity doesn't provide a way to specify the scene to instantiate an object, so it's always instantiated in the main active scene, and then has to be moved to a subscene for NetworkSceneChecker to work.