### PR TITLE
Fix: If socket is undefined it will return false. See #1486

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Websocket/Plugins/WebSocket.jslib
+++ b/Assets/Mirror/Runtime/Transport/Websocket/Plugins/WebSocket.jslib
@@ -88,7 +88,11 @@ var LibraryWebSockets = {
 	SocketState: function (socketInstance)
 	{
 		var socket = webSocketInstances[socketInstance];
-		return socket.readyState;
+
+		if(socket)
+			return socket.readyState;
+
+		return false; 
 	},
 
 	SocketSend: function (socketInstance, ptr, length)


### PR DESCRIPTION
See #1486

Short: Socket is undefined (in my case) if I use client.ClientConnected() before I connect and cause error in the webgl version. The change fixes that.