### PR TITLE
Implement IReadOnlyDictionary for SyncDictionaries

### DIFF
--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -6,7 +6,7 @@ using JetBrains.Annotations;
 namespace Mirror
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public abstract class SyncIDictionary<TKey, TValue> : IDictionary<TKey, TValue>, SyncObject
+    public abstract class SyncIDictionary<TKey, TValue> : IDictionary<TKey, TValue>, SyncObject, IReadOnlyDictionary<TKey, TValue>
     {
         public delegate void SyncDictionaryChanged(Operation op, TKey key, TValue item);
 
@@ -56,6 +56,10 @@ namespace Mirror
         public ICollection<TKey> Keys => objects.Keys;
 
         public ICollection<TValue> Values => objects.Values;
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => objects.Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => objects.Values;
 
         // throw away all the changes
         // this should be called after a successfull sync


### PR DESCRIPTION
SyncDictionary don't implement readonly interfaces unlike Dictionary or SyncList. This fixes it.