### PR TITLE
feat: Moving methods to NetworkHost and making them public

### DIFF
--- a/Assets/Mirror/Runtime/NetworkHost.cs
+++ b/Assets/Mirror/Runtime/NetworkHost.cs
@@ -1,11 +1,17 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace Mirror
 {
+    /// <summary>
+    /// The NetworkHost helps to set up the NetworkClient and NetworkServer in host mode
+    /// </summary>
     public static class NetworkHost
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkHost));
 
+        /// <summary>
+        /// Creates and Connects Local connection to server
+        /// </summary>
         public static void ConnectHost()
         {
             logger.Log("Client Connect Host to Server");
@@ -53,7 +59,7 @@ namespace Mirror
         }
 
         /// <summary>
-        /// 
+        /// Calls OnStartClient on spawned objects
         /// </summary>
         public static void ActivateHostScene()
         {

--- a/Assets/Mirror/Runtime/NetworkHost.cs
+++ b/Assets/Mirror/Runtime/NetworkHost.cs
@@ -1,0 +1,71 @@
+﻿using UnityEngine;
+
+namespace Mirror
+{
+    public static class NetworkHost
+    {
+        static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkHost));
+
+        public static void ConnectHost()
+        {
+            logger.Log("Client Connect Host to Server");
+
+            NetworkClient.RegisterSystemHandlers(true);
+
+            NetworkClient.connectState = ConnectState.Connected;
+
+            // create local connection objects and connect them
+            ULocalConnectionToServer connectionToServer = new ULocalConnectionToServer();
+            ULocalConnectionToClient connectionToClient = new ULocalConnectionToClient();
+            connectionToServer.connectionToClient = connectionToClient;
+            connectionToClient.connectionToServer = connectionToServer;
+
+            NetworkClient.SetConnection(connectionToServer);
+
+            // create server connection to local client
+            NetworkServer.SetLocalConnection(connectionToClient);
+        }
+
+        /// <summary>
+        /// connect host mode
+        /// </summary>
+        public static void ConnectLocalServer()
+        {
+            NetworkServer.OnConnected(NetworkServer.localConnection);
+            NetworkServer.localConnection.Send(new ConnectMessage());
+        }
+
+        /// <summary>
+        /// disconnect host mode. this is needed to call DisconnectMessage for
+        /// the host client too.
+        /// </summary>
+        public static void DisconnectLocalServer()
+        {
+            // only if host connection is running
+            if (NetworkServer.localConnection != null)
+            {
+                // TODO ConnectLocalServer manually sends a ConnectMessage to the
+                // local connection. should we send a DisconnectMessage here too?
+                // (if we do then we get an Unknown Message ID log)
+                //NetworkServer.localConnection.Send(new DisconnectMessage());
+                NetworkServer.OnDisconnected(NetworkServer.localConnection.connectionId);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static void ActivateHostScene()
+        {
+            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            {
+                if (!identity.isClient)
+                {
+                    if (logger.LogEnabled()) logger.Log("ActivateHostScene " + identity.netId + " " + identity);
+
+                    identity.OnStartClient();
+                }
+            }
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/NetworkHost.cs.meta
+++ b/Assets/Mirror/Runtime/NetworkHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f82da375fe9e1f645a078f905280a286
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -530,7 +530,7 @@ namespace Mirror
             //             isn't called in host mode!
             //
             // TODO call this after spawnobjects and worry about the syncvar hook fix later?
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
 
             // server scene was loaded. now spawn all the objects
             NetworkServer.SpawnObjects();
@@ -554,12 +554,12 @@ namespace Mirror
             }
 
             networkAddress = "localhost";
-            NetworkServer.ActivateHostScene();
+            NetworkHost.ActivateHostScene();
             RegisterClientMessages();
 
             // ConnectLocalServer needs to be called AFTER RegisterClientMessages
             // (https://github.com/vis2k/Mirror/pull/1249/)
-            NetworkClient.ConnectLocalServer();
+            NetworkHost.ConnectLocalServer();
 
             OnStartClient();
         }
@@ -577,7 +577,7 @@ namespace Mirror
             // DisconnectLocalServer needs to be called so that the host client
             // receives a DisconnectMessage too.
             // fixes: https://github.com/vis2k/Mirror/issues/1515
-            NetworkClient.DisconnectLocalServer();
+            NetworkHost.DisconnectLocalServer();
 
             StopClient();
             StopServer();

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -238,19 +238,6 @@ namespace Mirror
             RemoveConnection(0);
         }
 
-        internal static void ActivateHostScene()
-        {
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
-            {
-                if (!identity.isClient)
-                {
-                    if (logger.LogEnabled()) logger.Log("ActivateHostScene " + identity.netId + " " + identity);
-
-                    identity.OnStartClient();
-                }
-            }
-        }
-
         // this is like SendToReady - but it doesn't check the ready flag on the connection.
         // this is used for ObjectDestroy messages.
         static void SendToObservers<T>(NetworkIdentity identity, T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -466,7 +466,7 @@ namespace Mirror.Tests
             Assert.That(NetworkServer.active, Is.True);
 
             // connect host client
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
             Assert.That(NetworkClient.active, Is.True);
 
             // get the host connection which already has client->server and
@@ -552,7 +552,7 @@ namespace Mirror.Tests
             Assert.That(NetworkServer.active, Is.True);
 
             // connect host client
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
             Assert.That(NetworkClient.active, Is.True);
 
             // get the host connection which already has client->server and
@@ -668,7 +668,7 @@ namespace Mirror.Tests
             Assert.That(NetworkServer.active, Is.True);
 
             // connect host client
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
             Assert.That(NetworkClient.active, Is.True);
 
             // get the host connection which already has client->server and

--- a/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
@@ -4,7 +4,10 @@ using UnityEngine;
 
 namespace Mirror.Tests
 {
-    public class NetworkClientTests
+    /// <summary>
+    /// Used by NetworkClientTests and NetworkHostTests
+    /// </summary>
+    public class NetworkClientTestsBase
     {
         GameObject transportGO;
 
@@ -34,22 +37,10 @@ namespace Mirror.Tests
             GameObject.DestroyImmediate(transportGO);
             Transport.activeTransport = null;
         }
+    }
 
-        [Test]
-        public void serverIp()
-        {
-            NetworkHost.ConnectHost();
-            Assert.That(NetworkClient.serverIp, Is.EqualTo("localhost"));
-        }
-
-        [Test]
-        public void isConnected()
-        {
-            Assert.That(NetworkClient.isConnected, Is.False);
-            NetworkHost.ConnectHost();
-            Assert.That(NetworkClient.isConnected, Is.True);
-        }
-
+    public class NetworkClientTests : NetworkClientTestsBase
+    {
         [Test]
         public void ConnectUri()
         {
@@ -57,18 +48,6 @@ namespace Mirror.Tests
             // update transport so connect event is processed
             ((MemoryTransport)Transport.activeTransport).LateUpdate();
             Assert.That(NetworkClient.isConnected, Is.True);
-        }
-
-        [Test]
-        public void DisconnectInHostMode()
-        {
-            NetworkHost.ConnectHost();
-            Assert.That(NetworkClient.isConnected, Is.True);
-            Assert.That(NetworkServer.localConnection, !Is.Null);
-
-            NetworkClient.Disconnect();
-            Assert.That(NetworkClient.isConnected, Is.False);
-            Assert.That(NetworkServer.localConnection, Is.Null);
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -38,7 +38,7 @@ namespace Mirror.Tests
         [Test]
         public void serverIp()
         {
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
             Assert.That(NetworkClient.serverIp, Is.EqualTo("localhost"));
         }
 
@@ -46,7 +46,7 @@ namespace Mirror.Tests
         public void isConnected()
         {
             Assert.That(NetworkClient.isConnected, Is.False);
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
             Assert.That(NetworkClient.isConnected, Is.True);
         }
 
@@ -62,7 +62,7 @@ namespace Mirror.Tests
         [Test]
         public void DisconnectInHostMode()
         {
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
             Assert.That(NetworkClient.isConnected, Is.True);
             Assert.That(NetworkServer.localConnection, !Is.Null);
 

--- a/Assets/Mirror/Tests/Editor/NetworkHostTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkHostTests.cs
@@ -1,0 +1,67 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mirror.Tests
+{
+    public class NetworkHostTests : NetworkClientTestsBase
+    {
+        [Test]
+        public void LocalConnectionHasAddressEqualToLocalHost()
+        {
+            NetworkHost.ConnectHost();
+            Assert.That(NetworkClient.serverIp, Is.EqualTo("localhost"));
+        }
+
+        [Test]
+        public void IsConnectedAfterHostConnect()
+        {
+            Assert.That(NetworkClient.isConnected, Is.False);
+            NetworkHost.ConnectHost();
+            Assert.That(NetworkClient.isConnected, Is.True);
+        }
+
+
+
+        [Test]
+        public void IsNotConnectedAfterHostDisconnect()
+        {
+            NetworkHost.ConnectHost();
+            Assert.That(NetworkClient.isConnected, Is.True);
+            Assert.That(NetworkServer.localConnection, !Is.Null);
+
+            NetworkClient.Disconnect();
+            Assert.That(NetworkClient.isConnected, Is.False);
+            Assert.That(NetworkServer.localConnection, Is.Null);
+        }
+
+        [Test]
+        public void ActivateHostSceneCallsOnStartClient()
+        {
+            // add an identity with a networkbehaviour to .spawned
+            GameObject go = new GameObject();
+            NetworkIdentity identity = go.AddComponent<NetworkIdentity>();
+            identity.netId = 42;
+            // for authority check
+            //identity.connectionToClient = connection;
+            OnStartClientTestNetworkBehaviour comp = go.AddComponent<OnStartClientTestNetworkBehaviour>();
+            Assert.That(comp.called, Is.EqualTo(0));
+            //connection.identity = identity;
+            NetworkIdentity.spawned[identity.netId] = identity;
+
+            // ActivateHostScene
+            NetworkHost.ActivateHostScene();
+
+            // was OnStartClient called for all .spawned networkidentities?
+            Assert.That(comp.called, Is.EqualTo(1));
+
+            // clean up
+            NetworkIdentity.spawned.Clear();
+            NetworkServer.Shutdown();
+            // destroy the test gameobject AFTER server was stopped.
+            // otherwise isServer is true in OnDestroy, which means it would try
+            // to call Destroy(go). but we need to use DestroyImmediate in
+            // Editor
+            GameObject.DestroyImmediate(go);
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkHostTests.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkHostTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 386969046dd50464aa936377258de6be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -396,7 +396,7 @@ namespace Mirror.Tests
             NetworkServer.Listen(1000);
 
             // start the client
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
 
             // add component
             IsClientServerCheckComponent component = gameObject.AddComponent<IsClientServerCheckComponent>();

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -663,36 +663,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void ActivateHostSceneCallsOnStartClient()
-        {
-            // add an identity with a networkbehaviour to .spawned
-            GameObject go = new GameObject();
-            NetworkIdentity identity = go.AddComponent<NetworkIdentity>();
-            identity.netId = 42;
-            // for authority check
-            //identity.connectionToClient = connection;
-            OnStartClientTestNetworkBehaviour comp = go.AddComponent<OnStartClientTestNetworkBehaviour>();
-            Assert.That(comp.called, Is.EqualTo(0));
-            //connection.identity = identity;
-            NetworkIdentity.spawned[identity.netId] = identity;
-
-            // ActivateHostScene
-            NetworkHost.ActivateHostScene();
-
-            // was OnStartClient called for all .spawned networkidentities?
-            Assert.That(comp.called, Is.EqualTo(1));
-
-            // clean up
-            NetworkIdentity.spawned.Clear();
-            NetworkServer.Shutdown();
-            // destroy the test gameobject AFTER server was stopped.
-            // otherwise isServer is true in OnDestroy, which means it would try
-            // to call Destroy(go). but we need to use DestroyImmediate in
-            // Editor
-            GameObject.DestroyImmediate(go);
-        }
-
-        [Test]
         public void SendToAllTest()
         {
             // message handlers

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -677,7 +677,7 @@ namespace Mirror.Tests
             NetworkIdentity.spawned[identity.netId] = identity;
 
             // ActivateHostScene
-            NetworkServer.ActivateHostScene();
+            NetworkHost.ActivateHostScene();
 
             // was OnStartClient called for all .spawned networkidentities?
             Assert.That(comp.called, Is.EqualTo(1));

--- a/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
@@ -15,10 +15,10 @@ namespace Mirror.Tests.RemoteAttrributeTest
 
             // start server/client
             NetworkServer.Listen(1);
-            NetworkClient.ConnectHost();
+            NetworkHost.ConnectHost();
             NetworkServer.SpawnObjects();
-            NetworkServer.ActivateHostScene();
-            NetworkClient.ConnectLocalServer();
+            NetworkHost.ActivateHostScene();
+            NetworkHost.ConnectLocalServer();
 
             NetworkServer.localConnection.isAuthenticated = true;
             NetworkClient.connection.isAuthenticated = true;
@@ -30,7 +30,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         public void TearDown()
         {
             // stop server/client
-            NetworkClient.DisconnectLocalServer();
+            NetworkHost.DisconnectLocalServer();
 
             NetworkClient.Disconnect();
             NetworkClient.Shutdown();

--- a/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -18,15 +18,15 @@ namespace Mirror.Tests.Runtime
             yield return null;
 
             // connection host and wait 1 frame
-            NetworkClient.ConnectHost();
-            NetworkClient.ConnectLocalServer();
+            NetworkHost.ConnectHost();
+            NetworkHost.ConnectLocalServer();
             yield return null;
         }
 
         [TearDown]
         public void TearDown()
         {
-            NetworkClient.DisconnectLocalServer();
+            NetworkHost.DisconnectLocalServer();
             NetworkClient.Disconnect();
             NetworkClient.Shutdown();
 


### PR DESCRIPTION
Adding a `NetworkHost` class that will hold methods that set up the local connection between NetworkClient and NetworkServer

Moving methods to new class now before they are public will avoid breaking change if we want to move them later on.