### PR TITLE
fix: weaver now processes multiple SyncEvent per class

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncEventProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncEventProcessor.cs
@@ -149,7 +149,6 @@ namespace Mirror.Weaver
                     Weaver.WeaveLists.replaceEvents[ed.Name] = eventCallFunc;
 
                     Weaver.DLog(td, "  Event: " + ed.Name);
-                    break;
                 }
             }
         }

--- a/Assets/Mirror/Tests/Editor/SyncEventTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncEventTest.cs
@@ -1,0 +1,103 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mirror.Tests.RemoteAttrributeTest
+{
+    public delegate void MySyncEventDelegate(int someNumber);
+    public delegate void MySyncEventDelegate2(int someNumber, Vector3 somePosition);
+
+    class SyncEventBehaviour : NetworkBehaviour
+    {
+        [SyncEvent]
+        public event MySyncEventDelegate EventOnly;
+
+        public void CallEvent(int i)
+        {
+            EventOnly.Invoke(i);
+        }
+    }
+
+    class MultipleSyncEventBehaviour : NetworkBehaviour
+    {
+        [SyncEvent]
+        public event MySyncEventDelegate EventFirst;
+
+        [SyncEvent]
+        public event MySyncEventDelegate2 EventSecond;
+
+        public void CallEvent1(int i)
+        {
+            EventFirst?.Invoke(i);
+        }
+
+        public void CallEvent2(int i, Vector3 v)
+        {
+            EventSecond?.Invoke(i, v);
+        }
+    }
+
+    public class SyncEventTest : RemoteTestBase
+    {
+        [Test]
+        public void FirstEventIsCalled()
+        {
+            SyncEventBehaviour serverBehaviour = CreateHostObject<SyncEventBehaviour>(true);
+            SyncEventBehaviour clientBehaviour = CreateHostObject<SyncEventBehaviour>(true);
+
+            // set the clientBehaviour has the serverBehaviour's Id
+            clientBehaviour.netIdentity.netId = serverBehaviour.netId;
+            NetworkIdentity.spawned[serverBehaviour.netId] = clientBehaviour.netIdentity;
+
+            const int someInt = 20;
+
+            int callCount = 0;
+            clientBehaviour.EventOnly += incomingInt =>
+            {
+                callCount++;
+                Assert.That(incomingInt, Is.EqualTo(someInt));
+            };
+            serverBehaviour.CallEvent(someInt);
+            ProcessMessages();
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SecondEventIsCalled()
+        {
+            MultipleSyncEventBehaviour serverBehaviour = CreateHostObject<MultipleSyncEventBehaviour>(true);
+            MultipleSyncEventBehaviour clientBehaviour = CreateHostObject<MultipleSyncEventBehaviour>(true);
+
+            // set the clientBehaviour has the serverBehaviour's Id
+            clientBehaviour.netIdentity.netId = serverBehaviour.netId;
+            NetworkIdentity.spawned[serverBehaviour.netId] = clientBehaviour.netIdentity;
+
+            const int someInt1 = 20;
+            const int someInt2 = 25;
+            Vector3 someVector = Vector3.left;
+
+            int callCount1 = 0;
+            int callCount2 = 0;
+            clientBehaviour.EventFirst += incomingInt =>
+            {
+                callCount1++;
+                Assert.That(incomingInt, Is.EqualTo(someInt1));
+            };
+            clientBehaviour.EventSecond += (incomingInt, incomingVector) =>
+            {
+                callCount2++;
+                Assert.That(incomingInt, Is.EqualTo(someInt2));
+                Assert.That(incomingVector, Is.EqualTo(someVector));
+            };
+
+            serverBehaviour.CallEvent1(someInt1);
+            ProcessMessages();
+            Assert.That(callCount1, Is.EqualTo(1));
+            Assert.That(callCount2, Is.EqualTo(0));
+
+            serverBehaviour.CallEvent2(someInt2, someVector);
+            ProcessMessages();
+            Assert.That(callCount1, Is.EqualTo(1));
+            Assert.That(callCount2, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/SyncEventTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/SyncEventTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4620d11d843e7844889bc7d0a4400523
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
+++ b/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
@@ -178,6 +178,7 @@
     <Compile Include="WeaverSyncDictionaryTests~\SyncDictionaryStructKeyWithCustomDeserializeOnly.cs" />
     <Compile Include="WeaverSyncDictionaryTests~\SyncDictionaryStructKeyWithCustomMethods.cs" />
     <Compile Include="WeaverSyncDictionaryTests~\SyncDictionaryStructKeyWithCustomSerializeOnly.cs" />
+    <Compile Include="WeaverSyncEventTests~\MultipleSyncEvent.cs" />
     <Compile Include="WeaverSyncListTests~\SyncList.cs" />
     <Compile Include="WeaverSyncListTests~\SyncListByteValid.cs" />
     <Compile Include="WeaverSyncListTests~\SyncListErrorForGenericStruct.cs" />

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncEventTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncEventTests.cs
@@ -11,6 +11,12 @@ namespace Mirror.Weaver.Tests
         }
 
         [Test]
+        public void MultipleSyncEvent()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+        }
+
+        [Test]
         public void ErrorWhenSyncEventDoesntStartWithEvent()
         {
             Assert.That(weaverErrors, Contains.Item("DoCoolThingsWithExcitingPeople must start with Event.  " +

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncEventTests~/MultipleSyncEvent.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncEventTests~/MultipleSyncEvent.cs
@@ -9,6 +9,8 @@ namespace WeaverSyncEventTests.MultipleSyncEvent
 
         [SyncEvent]
         public event MySyncEventDelegate EventDoCoolThingsWithExcitingPeople;
+
+        [SyncEvent]
         public event MySyncEventDelegate2 EventDoMoreCoolThingsWithExcitingPeople;
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncEventTests~/MultipleSyncEvent.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncEventTests~/MultipleSyncEvent.cs
@@ -1,0 +1,14 @@
+using Mirror;
+
+namespace WeaverSyncEventTests.MultipleSyncEvent
+{
+    class MultipleSyncEvent : NetworkBehaviour
+    {
+        public delegate void MySyncEventDelegate();
+        public delegate void MySyncEventDelegate2(int someNumber);
+
+        [SyncEvent]
+        public event MySyncEventDelegate EventDoCoolThingsWithExcitingPeople;
+        public event MySyncEventDelegate2 EventDoMoreCoolThingsWithExcitingPeople;
+    }
+}


### PR DESCRIPTION
fixes: https://github.com/vis2k/Mirror/issues/2005