### PR TITLE
ci: if docs have errors, fail the PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ install:
 skip_tags: true
 
 build_script:
-  - docfx metadata doc\docfx.json
-  - docfx build doc\docfx.json
+  - docfx metadata --logLevel Warning --warningsAsErrors doc\docfx.json
+  - docfx build --logLevel Warning --warningsAsErrors doc\docfx.json
 
 image: Visual Studio 2017
 


### PR DESCRIPTION
With this change, if there are errors in the docs,  then the PR will be marked as failed.

The docs appear to have some problems that have been overlooked.  See this:
https://ci.appveyor.com/project/vis2k73562/hlapi-community-edition/builds/33894429
