### PR TITLE
perf: Use invokeRepeating instead of Update

### DIFF
--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -31,18 +31,19 @@ namespace Mirror
         [Tooltip("Enable to force this object to be hidden from players.")]
         public bool forceHidden;
 
-        float lastUpdateTime;
 
-        void Update()
+        public override void OnStartServer()
         {
-            if (!NetworkServer.active)
-                return;
+            InvokeRepeating(nameof(RebuildObservers), 0, visUpdateInterval);
+        }
+        public override void OnStopServer()
+        {
+            CancelInvoke(nameof(RebuildObservers));
+        }
 
-            if (Time.time - lastUpdateTime > visUpdateInterval)
-            {
+        void RebuildObservers()
+        {
                 netIdentity.RebuildObservers(false);
-                lastUpdateTime = Time.time;
-            }
         }
 
         /// <summary>

--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -43,7 +43,7 @@ namespace Mirror
 
         void RebuildObservers()
         {
-                netIdentity.RebuildObservers(false);
+            netIdentity.RebuildObservers(false);
         }
 
         /// <summary>


### PR DESCRIPTION
If you have low-frequency calls, InvokeRepeating is a lot faster than
Update().  Use InvokeRepeating for NetworkProximityChecker

A little hard to measure,  but it saves roughly 3-5% CPU time in the 2k example in the server.

Before:
<img width="683" alt="Screen Shot 2020-07-04 at 8 41 58 AM" src="https://user-images.githubusercontent.com/466007/86513761-714ee880-bdd2-11ea-9ad6-4a85be05176e.png">

After:
<img width="692" alt="Screen Shot 2020-07-04 at 8 37 12 AM" src="https://user-images.githubusercontent.com/466007/86513777-8b88c680-bdd2-11ea-8882-659c83a2c5ba.png">
