### PR TITLE
spawn objects in clients in same order as server

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -747,7 +747,8 @@ namespace Mirror
 
             // add connection to each nearby NetworkIdentity's observers, which
             // internally sends a spawn message for each one to the connection.
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            // we order them by netId so the gameObjects get initiatialized in the same order as on the server
+            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values.OrderBy(e => e.netId))
             {
                 // try with far away ones in ummorpg!
                 if (identity.gameObject.activeSelf) //TODO this is different


### PR DESCRIPTION
spawn(1)
spawn(2)

can currently spawn 2 before 1 on the client, which is unexpected behaviour. Since the sorting only has to be done once when starting a new connection, the performance impact is fine.