### PR TITLE
Refactor TimeoutAuthenticator to pass through client/server start callbacks

### DIFF
--- a/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
@@ -16,17 +16,21 @@ namespace Mirror.Authenticators
 
         [Range(0, 600), Tooltip("Timeout to auto-disconnect in seconds. Set to 0 for no timeout.")]
         public float timeout = 60;
+        
+        public void Awake()
+        {
+            authenticator.OnClientAuthenticated.AddListener(connection => OnClientAuthenticated.Invoke(connection));
+            authenticator.OnServerAuthenticated.AddListener(connection => OnServerAuthenticated.Invoke(connection));
+        }
 
         public override void OnStartClient()
         {
             authenticator.OnStartClient();
-            authenticator.OnClientAuthenticated.AddListener(connection => OnClientAuthenticated.Invoke(connection));
         }
 
         public override void OnStartServer()
         {
             authenticator.OnStartServer();
-            authenticator.OnServerAuthenticated.AddListener(connection => OnServerAuthenticated.Invoke(connection));
         }
 
         public override void OnClientAuthenticate(NetworkConnection conn)

--- a/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
@@ -16,7 +16,7 @@ namespace Mirror.Authenticators
 
         [Range(0, 600), Tooltip("Timeout to auto-disconnect in seconds. Set to 0 for no timeout.")]
         public float timeout = 60;
- 
+
         public void Awake()
         {
             authenticator.OnClientAuthenticated.AddListener(connection => OnClientAuthenticated.Invoke(connection));

--- a/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
@@ -17,9 +17,15 @@ namespace Mirror.Authenticators
         [Range(0, 600), Tooltip("Timeout to auto-disconnect in seconds. Set to 0 for no timeout.")]
         public float timeout = 60;
 
-        public void Awake()
+        public override void OnStartClient()
         {
+            authenticator.OnStartClient();
             authenticator.OnClientAuthenticated.AddListener(connection => OnClientAuthenticated.Invoke(connection));
+        }
+
+        public override void OnStartServer()
+        {
+            authenticator.OnStartServer();
             authenticator.OnServerAuthenticated.AddListener(connection => OnServerAuthenticated.Invoke(connection));
         }
 

--- a/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
@@ -16,7 +16,7 @@ namespace Mirror.Authenticators
 
         [Range(0, 600), Tooltip("Timeout to auto-disconnect in seconds. Set to 0 for no timeout.")]
         public float timeout = 60;
-        
+ 
         public void Awake()
         {
             authenticator.OnClientAuthenticated.AddListener(connection => OnClientAuthenticated.Invoke(connection));


### PR DESCRIPTION
Overrides the `OnStartClient()` and `OnStartServer()` methods to pass the calls to the nested authenticator.

This will fix #2073 