### PR TITLE
fix: renaming call/invoke prefix for Cmd/Rpc

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -8,8 +8,6 @@ namespace Mirror.Weaver
     /// </summary>
     public static class CommandProcessor
     {
-        const string CmdPrefix = "InvokeCmd";
-
         /*
             // generates code like:
             public void CmdThrust(float thrusting, int spin)
@@ -28,14 +26,14 @@ namespace Mirror.Weaver
             Originally HLAPI put the send message code inside the Call function
             and then proceeded to replace every call to CmdTrust with CallCmdTrust
 
-            This method moves all the user's code into the "Call" method
+            This method moves all the user's code into the "CallCmd" method
             and replaces the body of the original method with the send message code.
             This way we do not need to modify the code anywhere else,  and this works
             correctly in dependent assemblies
         */
         public static MethodDefinition ProcessCommandCall(TypeDefinition td, MethodDefinition md, CustomAttribute commandAttr)
         {
-            MethodDefinition cmd = MethodProcessor.SubstituteMethod(td, md, "Call" + md.Name);
+            MethodDefinition cmd = MethodProcessor.SubstituteMethod(td, md, Weaver.RpcPrefix + md.Name);
 
             ILProcessor worker = md.Body.GetILProcessor();
 
@@ -51,7 +49,6 @@ namespace Mirror.Weaver
             string cmdName = md.Name;
             int channel = commandAttr.GetField("channel", 0);
             bool ignoreAuthority = commandAttr.GetField("ignoreAuthority", false);
-
 
             // invoke internal send and return
             // load 'base.' to call the SendCommand function with
@@ -86,7 +83,7 @@ namespace Mirror.Weaver
         */
         public static MethodDefinition ProcessCommandInvoke(TypeDefinition td, MethodDefinition method, MethodDefinition cmdCallFunc)
         {
-            MethodDefinition cmd = new MethodDefinition(CmdPrefix + method.Name,
+            MethodDefinition cmd = new MethodDefinition(Weaver.InvokeRpcPrefix + method.Name,
                 MethodAttributes.Family | MethodAttributes.Static | MethodAttributes.HideBySig,
                 Weaver.voidType);
 

--- a/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
@@ -69,13 +69,13 @@ namespace Mirror.Weaver
         {
             string callName = method.Name;
 
-            // all Commands/Rpc start with "Call"
+            // Cmd/rpc start with Weaver.RpcPrefix
             // eg CallCmdDoSomething
-            if (!callName.StartsWith("Call"))
+            if (!callName.StartsWith(Weaver.RpcPrefix))
                 return;
 
             // eg CmdDoSomething
-            string baseRemoteCallName = method.Name.Substring(4);
+            string baseRemoteCallName = method.Name.Substring(Weaver.RpcPrefix.Length);
 
             foreach (Instruction instruction in method.Body.Instructions)
             {

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -8,12 +8,10 @@ namespace Mirror.Weaver
     /// </summary>
     public static class RpcProcessor
     {
-        public const string RpcPrefix = "InvokeRpc";
-
         public static MethodDefinition ProcessRpcInvoke(TypeDefinition td, MethodDefinition md, MethodDefinition rpcCallFunc)
         {
             MethodDefinition rpc = new MethodDefinition(
-                RpcPrefix + md.Name,
+                Weaver.InvokeRpcPrefix + md.Name,
                 MethodAttributes.Family | MethodAttributes.Static | MethodAttributes.HideBySig,
                 Weaver.voidType);
 
@@ -55,14 +53,14 @@ namespace Mirror.Weaver
             Originally HLAPI put the send message code inside the Call function
             and then proceeded to replace every call to RpcTest with CallRpcTest
 
-            This method moves all the user's code into the "Call" method
+            This method moves all the user's code into the "CallRpc" method
             and replaces the body of the original method with the send message code.
             This way we do not need to modify the code anywhere else,  and this works
             correctly in dependent assemblies
         */
         public static MethodDefinition ProcessRpcCall(TypeDefinition td, MethodDefinition md, CustomAttribute clientRpcAttr)
         {
-            MethodDefinition rpc = MethodProcessor.SubstituteMethod(td, md, "Call" + md.Name);
+            MethodDefinition rpc = MethodProcessor.SubstituteMethod(td, md, Weaver.RpcPrefix + md.Name);
 
             ILProcessor worker = md.Body.GetILProcessor();
 

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -8,8 +8,6 @@ namespace Mirror.Weaver
     /// </summary>
     public static class TargetRpcProcessor
     {
-        const string TargetRpcPrefix = "InvokeTargetRpc";
-
         // helper functions to check if the method has a NetworkConnection parameter
         public static bool HasNetworkConnectionParameter(MethodDefinition md)
         {
@@ -19,7 +17,7 @@ namespace Mirror.Weaver
 
         public static MethodDefinition ProcessTargetRpcInvoke(TypeDefinition td, MethodDefinition md, MethodDefinition rpcCallFunc)
         {
-            MethodDefinition rpc = new MethodDefinition(RpcProcessor.RpcPrefix + md.Name, MethodAttributes.Family |
+            MethodDefinition rpc = new MethodDefinition(Weaver.InvokeRpcPrefix + md.Name, MethodAttributes.Family |
                     MethodAttributes.Static |
                     MethodAttributes.HideBySig,
                     Weaver.voidType);
@@ -81,7 +79,7 @@ namespace Mirror.Weaver
             Originally HLAPI put the send message code inside the Call function
             and then proceeded to replace every call to TargetTest with CallTargetTest
 
-            This method moves all the user's code into the "Call" method
+            This method moves all the user's code into the "CallTargetRpc" method
             and replaces the body of the original method with the send message code.
             This way we do not need to modify the code anywhere else,  and this works
             correctly in dependent assemblies
@@ -89,7 +87,7 @@ namespace Mirror.Weaver
         */
         public static MethodDefinition ProcessTargetRpcCall(TypeDefinition td, MethodDefinition md, CustomAttribute targetRpcAttr)
         {
-            MethodDefinition rpc = MethodProcessor.SubstituteMethod(td, md, "Call" + md.Name);
+            MethodDefinition rpc = MethodProcessor.SubstituteMethod(td, md, Weaver.RpcPrefix + md.Name);
 
             ILProcessor worker = md.Body.GetILProcessor();
 

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -29,6 +29,9 @@ namespace Mirror.Weaver
 
     internal static class Weaver
     {
+        public static string InvokeRpcPrefix => "InvokeUserCode_";
+        public static string RpcPrefix => "UserCode_";
+
         public static WeaverLists WeaveLists { get; private set; }
         public static AssemblyDefinition CurrentAssembly { get; private set; }
         public static ModuleDefinition CorLibModule { get; private set; }


### PR DESCRIPTION
Now that Cmd prefix isnt need generated functions are more likely to collide with other user functions

renaming them to UserCode and InvokeUserCode would also make then easier to understand