### PR TITLE
breaking: replacing isHeadless with isServerBuild

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -62,11 +62,10 @@ namespace Mirror.Discovery
         /// </summary>
         public virtual void Start()
         {
-            // headless mode? then start advertising
-            if (NetworkManager.isServerBuild)
-            {
-                AdvertiseServer();
-            }
+            // Server mode? then start advertising
+#if UNITY_SERVER
+            AdvertiseServer();
+#endif
         }
 
         // Ensure the ports are cleared no matter when Game/Unity UI exits

--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -63,7 +63,7 @@ namespace Mirror.Discovery
         public virtual void Start()
         {
             // headless mode? then start advertising
-            if (NetworkManager.isHeadless)
+            if (NetworkManager.isServerBuild)
             {
                 AdvertiseServer();
             }

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
@@ -55,7 +55,7 @@ namespace Mirror.Examples.NetworkRoom
         public override void OnRoomServerPlayersReady()
         {
             // calling the base method calls ServerChangeScene as soon as all players are in Ready state.
-            if (isHeadless)
+            if (isServerBuild)
                 base.OnRoomServerPlayersReady();
             else
                 showStartButton = true;

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
@@ -55,10 +55,11 @@ namespace Mirror.Examples.NetworkRoom
         public override void OnRoomServerPlayersReady()
         {
             // calling the base method calls ServerChangeScene as soon as all players are in Ready state.
-            if (isServerBuild)
-                base.OnRoomServerPlayersReady();
-            else
-                showStartButton = true;
+#if UNITY_SERVER
+            base.OnRoomServerPlayersReady();
+#else
+            showStartButton = true;
+#endif
         }
 
         public override void OnGUI()

--- a/Assets/Mirror/Runtime/Logging/NetworkHeadlessLogger.cs
+++ b/Assets/Mirror/Runtime/Logging/NetworkHeadlessLogger.cs
@@ -14,10 +14,9 @@ namespace Mirror.Logging
 
         void Awake()
         {
-            if (NetworkManager.isServerBuild)
-            {
-                LogFactory.ReplaceLogHandler(new ConsoleColorLogHandler(showExceptionStackTrace));
-            }
+#if UNITY_SERVER
+            LogFactory.ReplaceLogHandler(new ConsoleColorLogHandler(showExceptionStackTrace));
+#endif
         }
     }
 }

--- a/Assets/Mirror/Runtime/Logging/NetworkHeadlessLogger.cs
+++ b/Assets/Mirror/Runtime/Logging/NetworkHeadlessLogger.cs
@@ -14,7 +14,7 @@ namespace Mirror.Logging
 
         void Awake()
         {
-            if (NetworkManager.isHeadless)
+            if (NetworkManager.isServerBuild)
             {
                 LogFactory.ReplaceLogHandler(new ConsoleColorLogHandler(showExceptionStackTrace));
             }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -50,10 +50,10 @@ namespace Mirror
         /// </summary>
         [Tooltip("Should the server auto-start when 'Server Build' is checked in build settings")]
         [FormerlySerializedAs("startOnHeadless")]
-        public bool startOnServerBuild = true;
+        public bool autoStartServerBuild = true;
 
-        [Obsolete("Use startOnServerBuild instead.")]
-        public bool startOnHeadless { get => startOnServerBuild; set => startOnServerBuild = value; }
+        [Obsolete("Use autoStartServerBuild instead.")]
+        public bool startOnHeadless { get => autoStartServerBuild; set => autoStartServerBuild = value; }
 
         /// <summary>
         /// Enables verbose debug messages in the console
@@ -262,7 +262,7 @@ namespace Mirror
             //
             // (tick rate is applied in StartServer!)
 #if UNITY_SERVER
-            if (startOnServerBuild)
+            if (autoStartServerBuild)
             {
                 StartServer();
             }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -198,7 +198,7 @@ namespace Mirror
         /// <para>Server build add both -batchmode and -nographics automatically</para>
         /// <para>Server build is true when "Server build" is checked in build menu, or BuildOptions.EnableHeadlessMode flag is in BuildOptions</para>
         /// </summary>
-        public static bool isServerBuild =>
+        public static readonly bool isServerBuild =
 #if UNITY_SERVER
             true;
 #else

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -52,7 +52,7 @@ namespace Mirror
         [FormerlySerializedAs("startOnHeadless")]
         public bool startOnServerBuild = true;
 
-        [System.Obsolete("Use startOnServerBuild instead.")]
+        [Obsolete("Use startOnServerBuild instead.")]
         public bool startOnHeadless { get => startOnServerBuild; set => startOnServerBuild = value; }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace Mirror
         /// <summary>
         /// headless mode detection
         /// </summary>
-        [System.Obsolete("Use #if UNITY_SERVER instead.")]
+        [Obsolete("Use #if UNITY_SERVER instead.")]
         public static bool isHeadless => SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null;
 
         // helper enum to know if we started the networkmanager as server/client/host.

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -200,7 +200,7 @@ namespace Mirror
         /// </summary>
         public static bool isServerBuild =>
 #if UNITY_SERVER
-            true
+            true;
 #else
             false;
 #endif

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -46,7 +46,7 @@ namespace Mirror
         /// <summary>
         /// Automatically invoke StartServer()
         /// <para>If the application is a Server Build, StartServer is automatically invoked.</para>
-        /// See <see cref="isServerBuild"/> for more on Server Build
+        /// <para>Server build is true when "Server build" is checked in build menu, or BuildOptions.EnableHeadlessMode flag is in BuildOptions</para>	
         /// </summary>
         [Tooltip("Should the server auto-start when 'Server Build' is checked in build settings")]
         [FormerlySerializedAs("startOnHeadless")]
@@ -193,7 +193,6 @@ namespace Mirror
         [System.Obsolete("Use #if UNITY_SERVER instead.")]
         public static bool isHeadless => SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null;
 
-
         // helper enum to know if we started the networkmanager as server/client/host.
         // -> this is necessary because when StartHost changes server scene to
         //    online scene, FinishLoadScene is called and the host client isn't
@@ -209,7 +208,6 @@ namespace Mirror
         /// </summary>
         public virtual void OnValidate()
         {
-
             // add transport if there is none yet. makes upgrading easier.
             if (transport == null)
             {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -45,10 +45,15 @@ namespace Mirror
 
         /// <summary>
         /// Automatically invoke StartServer()
-        /// <para>If the application is a Server Build or run with the -batchMode command line arguement, StartServer is automatically invoked.</para>
+        /// <para>If the application is a Server Build, StartServer is automatically invoked.</para>
+        /// See <see cref="isServerBuild"/> for more on Server Build
         /// </summary>
-        [Tooltip("Should the server auto-start when the game is started in a headless build?")]
-        public bool startOnHeadless = true;
+        [Tooltip("Should the server auto-start when 'Server Build' is checked in build settings")]
+        [FormerlySerializedAs("startOnHeadless")]
+        public bool startOnServerBuild = true;
+
+        [System.Obsolete("Use startOnServerBuild instead.")]
+        public bool startOnHeadless { get => startOnServerBuild; set => startOnServerBuild = value; }
 
         /// <summary>
         /// Enables verbose debug messages in the console
@@ -269,7 +274,7 @@ namespace Mirror
             // some transports might not be ready until Start.
             //
             // (tick rate is applied in StartServer!)
-            if (isServerBuild && startOnHeadless)
+            if (isServerBuild && startOnServerBuild)
             {
                 StartServer();
             }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -190,20 +190,9 @@ namespace Mirror
         /// <summary>
         /// headless mode detection
         /// </summary>
-        [System.Obsolete("Use isServerBuild instead.")]
+        [System.Obsolete("Use #if UNITY_SERVER instead.")]
         public static bool isHeadless => SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null;
 
-        /// <summary>
-        /// Is this build a server build.
-        /// <para>Server build add both -batchmode and -nographics automatically</para>
-        /// <para>Server build is true when "Server build" is checked in build menu, or BuildOptions.EnableHeadlessMode flag is in BuildOptions</para>
-        /// </summary>
-        public static readonly bool isServerBuild =
-#if UNITY_SERVER
-            true;
-#else
-            false;
-#endif
 
         // helper enum to know if we started the networkmanager as server/client/host.
         // -> this is necessary because when StartHost changes server scene to
@@ -274,10 +263,12 @@ namespace Mirror
             // some transports might not be ready until Start.
             //
             // (tick rate is applied in StartServer!)
-            if (isServerBuild && startOnServerBuild)
+#if UNITY_SERVER
+            if (startOnServerBuild)
             {
                 StartServer();
             }
+#endif
         }
 
         // NetworkIdentity.UNetStaticUpdate is called from UnityEngine while LLAPI network is active.
@@ -695,11 +686,10 @@ namespace Mirror
         public virtual void ConfigureServerFrameRate()
         {
             // only set framerate for server build
-            if (isServerBuild)
-            {
-                Application.targetFrameRate = serverTickRate;
-                if (logger.logEnabled) logger.Log("Server Tick Rate set to: " + Application.targetFrameRate + " Hz.");
-            }
+#if UNITY_SERVER
+            Application.targetFrameRate = serverTickRate;
+            if (logger.logEnabled) logger.Log("Server Tick Rate set to: " + Application.targetFrameRate + " Hz.");
+#endif
         }
 
         bool InitializeSingleton()

--- a/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
@@ -29,7 +29,7 @@ namespace Mirror.Tests
         {
             Assert.That(manager.dontDestroyOnLoad, Is.True);
             Assert.That(manager.runInBackground, Is.True);
-            Assert.That(manager.startOnHeadless, Is.True);
+            Assert.That(manager.startOnServerBuild, Is.True);
             Assert.That(manager.showDebugMessages, Is.False);
             Assert.That(manager.serverTickRate, Is.EqualTo(30));
             Assert.That(manager.offlineScene, Is.Empty);

--- a/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
@@ -29,7 +29,7 @@ namespace Mirror.Tests
         {
             Assert.That(manager.dontDestroyOnLoad, Is.True);
             Assert.That(manager.runInBackground, Is.True);
-            Assert.That(manager.startOnServerBuild, Is.True);
+            Assert.That(manager.autoStartServerBuild, Is.True);
             Assert.That(manager.showDebugMessages, Is.False);
             Assert.That(manager.serverTickRate, Is.EqualTo(30));
             Assert.That(manager.offlineScene, Is.Empty);

--- a/Assets/Mirror/Tests/Runtime/HostSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/HostSetup.cs
@@ -27,7 +27,7 @@ namespace Mirror.Tests.Runtime
             identity.assetId = System.Guid.NewGuid();
 
             manager.playerPrefab = playerGO;
-            manager.startOnServerBuild = false;
+            manager.autoStartServerBuild = false;
 
             yield return null;
 

--- a/Assets/Mirror/Tests/Runtime/HostSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/HostSetup.cs
@@ -27,7 +27,7 @@ namespace Mirror.Tests.Runtime
             identity.assetId = System.Guid.NewGuid();
 
             manager.playerPrefab = playerGO;
-            manager.startOnHeadless = false;
+            manager.startOnServerBuild = false;
 
             yield return null;
 


### PR DESCRIPTION
Using Server Build instead of checking GraphicsDeviceType could help stop confusion with new users create server only builds.

- using `-batchmode` does not mean that `isHeadless` is true, `-nographics` is also required.
    - This causes confusion because `startOnHeadless`'s comment say to use  "the -batchMode command line arguement"
- Server build add both `-batchmode` and `-nographics` automatically
- Server build is true when "Server build" is checked in build menu, or `BuildOptions.EnableHeadlessMode` flag is in `BuildOptions`


resolves: https://github.com/vis2k/Mirror/issues/2063

this is probably classed as breaking, before we merge we will have to add new version defines
