### PR TITLE
fix: isServer false in OnDestroy

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -190,6 +190,11 @@ namespace Mirror
         public bool serverOnly;
 
         /// <summary>
+        /// Set to try before Destroy is called so that OnDestroy doesn't try to destroy the object again
+        /// </summary>
+        internal bool destroyCalled;
+
+        /// <summary>
         /// The NetworkConnection associated with this NetworkIdentity. This is only valid for player objects on a local client.
         /// </summary>
         public NetworkConnection connectionToServer { get; internal set; }
@@ -705,7 +710,8 @@ namespace Mirror
 
             // If false the object has already been unspawned
             // if it is still true, then we need to unspawn it
-            if (isServer)
+            // if destroy is already called don't call it again
+            if (isServer && !destroyCalled)
             {
                 // Do not add logging to this (see above)
                 NetworkServer.Destroy(gameObject);

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1249,7 +1249,12 @@ namespace Mirror
             {
                 UnityEngine.Object.Destroy(identity.gameObject);
             }
-            identity.Reset();
+            // if we are destroying the server object we don't need to reset the identity
+            // reseting it will cause isClient/isServer to be false in the OnDestroy call
+            else
+            {
+                identity.Reset();
+            }
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1247,6 +1247,7 @@ namespace Mirror
             // when unspawning, dont destroy the server's object
             if (destroyServerObject)
             {
+                identity.destroyCalled = true;
                 UnityEngine.Object.Destroy(identity.gameObject);
             }
             // if we are destroying the server object we don't need to reset the identity


### PR DESCRIPTION
When calling `NetworkServer.Destroy` the `isServer` variable will be reset before the `OnDestroy` method is called.

If the object is being destroyed we don't need to also reset them.