### PR TITLE
changing serverBroadcastListenPort variable access permissions to protected

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -29,7 +29,7 @@ namespace Mirror.Discovery
 
         [SerializeField]
         [Tooltip("The UDP port the server will listen for multi-cast messages")]
-        int serverBroadcastListenPort = 47777;
+        protected int serverBroadcastListenPort = 47777;
 
         [SerializeField]
         [Tooltip("Time in seconds between multi-cast messages")]


### PR DESCRIPTION
This pull request is done in order to address the issue in https://github.com/vis2k/Mirror/issues/2099. As you requested i made the change. I also underline that I simply changed the .cs file without opening it in Unity so the .meta file has not been updated. However, I believe this should not be an issue. 

If I can be of any other help let me know.

Regards,

Francesco Strada