### PR TITLE
fix: auto fill serialize/deserialize for classes

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -110,7 +110,7 @@ namespace Mirror.Weaver
 
         static void CallBase(TypeDefinition td, ILProcessor worker, string name)
         {
-            MethodReference method = Resolvers.ResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, name);
+            MethodReference method = Resolvers.TryResolveMethodInParents(td.BaseType, Weaver.CurrentAssembly, name);
             if (method != null)
             {
                 // base

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -371,7 +371,7 @@ namespace Mirror.Weaver
             VariableDefinition dirtyLocal = new VariableDefinition(Weaver.boolType);
             serialize.Body.Variables.Add(dirtyLocal);
 
-            MethodReference baseSerialize = Resolvers.ResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, SerializeMethodName);
+            MethodReference baseSerialize = Resolvers.TryResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, SerializeMethodName);
             if (baseSerialize != null)
             {
                 // base
@@ -730,7 +730,7 @@ namespace Mirror.Weaver
             VariableDefinition dirtyBitsLocal = new VariableDefinition(Weaver.int64Type);
             serialize.Body.Variables.Add(dirtyBitsLocal);
 
-            MethodReference baseDeserialize = Resolvers.ResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, DeserializeMethodName);
+            MethodReference baseDeserialize = Resolvers.TryResolveMethodInParents(netBehaviourSubclass.BaseType, Weaver.CurrentAssembly, DeserializeMethodName);
             if (baseDeserialize != null)
             {
                 // base

--- a/Assets/Mirror/Editor/Weaver/Resolvers.cs
+++ b/Assets/Mirror/Editor/Weaver/Resolvers.cs
@@ -39,7 +39,7 @@ namespace Mirror.Weaver
             return null;
         }
 
-        public static MethodReference ResolveMethodInParents(TypeReference tr, AssemblyDefinition scriptDef, string name)
+        public static MethodReference TryResolveMethodInParents(TypeReference tr, AssemblyDefinition scriptDef, string name)
         {
             if (tr == null)
             {
@@ -54,7 +54,7 @@ namespace Mirror.Weaver
             }
 
             // Could not find the method in this class,  try the parent
-            return ResolveMethodInParents(tr.Resolve().BaseType, scriptDef, name);
+            return TryResolveMethodInParents(tr.Resolve().BaseType, scriptDef, name);
         }
 
         // System.Byte[] arguments need a version with a string

--- a/Assets/Mirror/Editor/Weaver/Resolvers.cs
+++ b/Assets/Mirror/Editor/Weaver/Resolvers.cs
@@ -53,8 +53,15 @@ namespace Mirror.Weaver
                     return scriptDef.MainModule.ImportReference(methodRef);
                 }
             }
-            // Could not find the method in this class,  try the parent
-            return ResolveMethodInParents(tr.Resolve().BaseType, scriptDef, name);
+
+            var parent = tr.Resolve().BaseType;
+
+            if (parent != null)
+            {
+                // Could not find the method in this class,  try the parent
+                return ResolveMethodInParents(tr.Resolve().BaseType, scriptDef, name);
+            }
+            return null;
         }
 
         // System.Byte[] arguments need a version with a string

--- a/Assets/Mirror/Editor/Weaver/Resolvers.cs
+++ b/Assets/Mirror/Editor/Weaver/Resolvers.cs
@@ -43,7 +43,6 @@ namespace Mirror.Weaver
         {
             if (tr == null)
             {
-                Weaver.Error($"Cannot resolve method {name} without a type");
                 return null;
             }
             foreach (MethodDefinition methodRef in tr.Resolve().Methods)
@@ -54,14 +53,8 @@ namespace Mirror.Weaver
                 }
             }
 
-            var parent = tr.Resolve().BaseType;
-
-            if (parent != null)
-            {
-                // Could not find the method in this class,  try the parent
-                return ResolveMethodInParents(tr.Resolve().BaseType, scriptDef, name);
-            }
-            return null;
+            // Could not find the method in this class,  try the parent
+            return ResolveMethodInParents(tr.Resolve().BaseType, scriptDef, name);
         }
 
         // System.Byte[] arguments need a version with a string

--- a/Assets/Mirror/Tests/Editor/MessageBaseTests.cs
+++ b/Assets/Mirror/Tests/Editor/MessageBaseTests.cs
@@ -40,6 +40,16 @@ namespace Mirror.Tests
         public void Serialize(NetworkWriter writer) { }
     }
 
+    class ArrayIntIMessage : IMessageBase
+    {
+        public int[] array;
+
+        // Mirror will fill out these empty methods
+        public void Deserialize(NetworkReader reader) { }
+        public void Serialize(NetworkWriter writer) { }
+    }
+
+
     [TestFixture]
     public class MessageBaseTests
     {
@@ -62,5 +72,21 @@ namespace Mirror.Tests
             Assert.AreEqual("2", t.StringValue);
             Assert.AreEqual(3.3, t.DoubleValue);
         }
+
+        [Test]
+        public void TestIntArrayInIMessageBase()
+        {
+            ArrayIntIMessage intMessage = new ArrayIntIMessage
+            {
+                array = new[] { 3, 4, 5 }
+            };
+
+            byte[] data = MessagePacker.Pack(intMessage);
+
+            ArrayIntIMessage unpacked = MessagePacker.Unpack<ArrayIntIMessage>(data);
+
+            Assert.That(unpacked.array, Is.EquivalentTo(new int[] { 3, 4, 5 }));
+        }
+
     }
 }


### PR DESCRIPTION
fixes #2117 

This now works:
```cs
 class ArrayIntMessage : IMessageBase
    {
        public int[] array;

        // Mirror will fill out these empty methods
        public void Deserialize(NetworkReader reader) { }
        public void Serialize(NetworkWriter writer) { }
    }
```