### PR TITLE
SSL/TLS version in Websockets now configurable

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/WebsocketTransport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Security.Authentication;
 using UnityEngine;
 
 namespace Mirror.Websocket
@@ -32,6 +33,9 @@ namespace Mirror.Websocket
 
         [Tooltip("Password for PFX Certificate file above.")]
         public string CertificatePassword;
+
+        [Tooltip("SSL and TLS Protocols")]
+        public SslProtocols EnabledSslProtocols = SslProtocols.Default;
 
         public WebsocketTransport()
         {
@@ -161,7 +165,7 @@ namespace Mirror.Websocket
                     Certificate = new System.Security.Cryptography.X509Certificates.X509Certificate2(CertificatePath, CertificatePassword),
                     ClientCertificateRequired = false,
                     CheckCertificateRevocation = false,
-                    EnabledSslProtocols = System.Security.Authentication.SslProtocols.Default
+                    EnabledSslProtocols = EnabledSslProtocols
                 };
             }
             _ = server.Listen(port);


### PR DESCRIPTION
Chrome is now requiring TLS 1.2 for HTTPS and WSS.  I could not find anywhere in Mirror WebsocketsTransport where this is configurable.  

This PR exposes the SSL/TLS Version as a property of `WebSocketsTransports` as well as in the Unity UI:

![image](https://user-images.githubusercontent.com/7676659/89103722-96d31000-d3d9-11ea-8f8c-b4952cddc650.png)

The default value has not changed, but I would advocate updating the default to be TLS 1.2.  I'm unsure if that would be a breaking change or not, but at least for WebGL/Browser games, this would be necessary for Chrome support.
