### PR TITLE
fix: correctly error message so they are not misleading

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
@@ -46,7 +46,7 @@ namespace Mirror.Weaver
             worker.InsertBefore(top, worker.Create(OpCodes.Brtrue, top));
             if (logWarning)
             {
-                worker.InsertBefore(top, worker.Create(OpCodes.Ldstr, "[Server] function '" + md.FullName + "' called on client"));
+                worker.InsertBefore(top, worker.Create(OpCodes.Ldstr, $"[Server] function '{md.FullName}' called when server was not active"));
                 worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.logWarningReference));
             }
             InjectGuardParameters(md, worker, top);
@@ -68,7 +68,7 @@ namespace Mirror.Weaver
             worker.InsertBefore(top, worker.Create(OpCodes.Brtrue, top));
             if (logWarning)
             {
-                worker.InsertBefore(top, worker.Create(OpCodes.Ldstr, "[Client] function '" + md.FullName + "' called on server"));
+                worker.InsertBefore(top, worker.Create(OpCodes.Ldstr, "[Client] function '{md.FullName}' called when client was not active"));
                 worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.logWarningReference));
             }
 

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -176,7 +176,7 @@ namespace Mirror
             //       to avoid Wrapper functions. a lot of people requested this.
             if (!NetworkClient.active)
             {
-                logger.LogError("Command Function " + cmdName + " called on server without an active client.");
+                logger.LogError($"Command Function {cmdName} called without an active client.");
                 return;
             }
             // local players can always send commands, regardless of authority, other objects must have authority.


### PR DESCRIPTION
Function might be called when neither server or client is active, so saying it was "called on client" is misleading.