### PR TITLE
wip: perf: Setting isClient per behaviour

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -114,51 +114,16 @@ namespace Mirror
         protected readonly List<SyncObject> syncObjects = new List<SyncObject>();
 
         /// <summary>
-        /// NetworkIdentity component caching for easier access
-        /// </summary>
-        NetworkIdentity netIdentityCache;
-
-        /// <summary>
         /// Returns the NetworkIdentity of this object
         /// </summary>
-        public NetworkIdentity netIdentity
-        {
-            get
-            {
-                if (netIdentityCache == null)
-                {
-                    netIdentityCache = GetComponent<NetworkIdentity>();
-                    // do this 2nd check inside first if so that we are not checking == twice on unity Object
-                    if (netIdentityCache == null)
-                    {
-                        logger.LogError("There is no NetworkIdentity on " + name + ". Please add one.");
-                    }
-                }
-                return netIdentityCache;
-            }
-        }
+        public NetworkIdentity netIdentity { get; internal set; }
 
         /// <summary>
         /// Returns the index of the component on this object
+        /// <para>Defaults to -1 before it is set by NetworkIdentity</para>
         /// </summary>
-        public int ComponentIndex
-        {
-            get
-            {
-                // note: FindIndex causes allocations, we search manually instead
-                for (int i = 0; i < netIdentity.NetworkBehaviours.Length; i++)
-                {
-                    NetworkBehaviour component = netIdentity.NetworkBehaviours[i];
-                    if (component == this)
-                        return i;
-                }
+        public int ComponentIndex { get; internal set; } = -1;
 
-                // this should never happen
-                logger.LogError("Could not find component in GameObject. You should not add/remove components in networked objects dynamically", this);
-
-                return -1;
-            }
-        }
 
         // this gets called in the constructor by the weaver
         // for every SyncObject in the component (e.g. SyncLists).

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -47,12 +47,12 @@ namespace Mirror
         /// Returns true if this object is active on an active server.
         /// <para>This is only true if the object has been spawned. This is different from NetworkServer.active, which is true if the server itself is active rather than this object being active.</para>
         /// </summary>
-        public bool isServer => netIdentity.isServer;
+        public bool isServer { get; internal set; }
 
         /// <summary>
         /// Returns true if running as a client and this object was spawned by a server.
         /// </summary>
-        public bool isClient => netIdentity.isClient;
+        public bool isClient { get; internal set; }
 
         /// <summary>
         /// This returns true if this object is the one that represents the player on the local machine.

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1587,13 +1587,13 @@ namespace Mirror
         /// </summary>
         internal void Reset()
         {
-            // make sure to call this before networkBehavioursCache is cleared below
-            ResetSyncObjects();
+            ResetNetworkBehaviourValues();
 
             hasSpawned = false;
             clientStarted = false;
-            isClient = false;
-            isServer = false;
+            // reset fields not properties because Behaviours values are reset in ResetNetworkBehaviourValues
+            _isClient = false;
+            _isServer = false;
 
             netId = 0;
             connectionToServer = null;
@@ -1699,13 +1699,15 @@ namespace Mirror
             }
         }
 
-        void ResetSyncObjects()
+        void ResetNetworkBehaviourValues()
         {
             // need null check here incase this is called at edit time before NetworkBehaviours is set
             NetworkBehaviour[] behaviours = NetworkBehaviours ?? GetComponents<NetworkBehaviour>();
             foreach (NetworkBehaviour comp in behaviours)
             {
                 comp.ResetSyncObjects();
+                comp.isServer = false;
+                comp.isClient = false;
             }
         }
     }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -110,8 +110,12 @@ namespace Mirror
 
         NetworkBehaviour[] networkBehavioursCache;
 
+        private bool _isClient;
+
         /// <summary>
         /// Returns true if running as a client and this object was spawned by a server.
+        /// </summary>
+        /// <remarks>
         /// <para>
         ///     <b>IMPORTANT:</b> checking NetworkClient.active means that isClient is false in OnDestroy:
         /// </para>
@@ -125,11 +129,21 @@ namespace Mirror
         /// <para>
         ///     => fixes <see href="https://github.com/vis2k/Mirror/issues/1475"/>
         /// </para>
-        /// </summary>
-        /// <remarks>
         /// </remarks>
-        public bool isClient { get; internal set; }
+        public bool isClient
+        {
+            get => _isClient;
+            internal set
+            {
+                _isClient = value;
+                foreach (NetworkBehaviour behaviour in NetworkBehaviours)
+                {
+                    behaviour.isClient = value;
+                }
+            }
+        }
 
+        private bool _isServer;
         /// <summary>
         /// Returns true if NetworkServer.active and server is not stopped.
         /// </summary>
@@ -148,7 +162,18 @@ namespace Mirror
         ///     => fixes <see href="https://github.com/vis2k/Mirror/issues/1484"/>
         /// </para>
         /// </remarks>
-        public bool isServer { get; internal set; }
+        public bool isServer
+        {
+            get => _isServer;
+            internal set
+            {
+                _isServer = value;
+                foreach (NetworkBehaviour behaviour in NetworkBehaviours)
+                {
+                    behaviour.isServer = value;
+                }
+            }
+        }
 
         /// <summary>
         /// This returns true if this object is the one that represents the player on the local machine.

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -418,7 +418,7 @@ namespace Mirror
             InitializeBehaviourValues();
         }
 
-        void InitializeBehaviourValues()
+        internal void InitializeBehaviourValues()
         {
             NetworkBehaviours = GetComponents<NetworkBehaviour>();
             if (NetworkBehaviours.Length > 64)

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -251,7 +251,7 @@ namespace Mirror
         /// <summary>
         /// Behaviours that are on the same Gameobject as this NetworkIdentity
         /// </summary>
-        public NetworkBehaviour[] NetworkBehaviours { get; private set; }
+        public NetworkBehaviour[] NetworkBehaviours;
 
         NetworkVisibility visibilityCache;
         public NetworkVisibility visibility

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1701,7 +1701,9 @@ namespace Mirror
 
         void ResetSyncObjects()
         {
-            foreach (NetworkBehaviour comp in NetworkBehaviours)
+            // need null check here incase this is called at edit time before NetworkBehaviours is set
+            NetworkBehaviour[] behaviours = NetworkBehaviours ?? GetComponents<NetworkBehaviour>();
+            foreach (NetworkBehaviour comp in behaviours)
             {
                 comp.ResetSyncObjects();
             }

--- a/Assets/Mirror/Tests/Editor/ClientSceneTests_OnSpawn.cs
+++ b/Assets/Mirror/Tests/Editor/ClientSceneTests_OnSpawn.cs
@@ -581,12 +581,14 @@ namespace Mirror.Tests.ClientSceneTests
             _createdObjects.Add(serverObject);
             NetworkIdentity serverIdentity = serverObject.AddComponent<NetworkIdentity>();
             PayloadTestBehaviour serverPayloadBehaviour = serverObject.AddComponent<PayloadTestBehaviour>();
+            serverIdentity.InitializeBehaviourValues();
 
             // client object
             GameObject clientObject = new GameObject();
             _createdObjects.Add(clientObject);
             NetworkIdentity clientIdentity = clientObject.AddComponent<NetworkIdentity>();
             PayloadTestBehaviour clientPayloadBehaviour = clientObject.AddComponent<PayloadTestBehaviour>();
+            clientIdentity.InitializeBehaviourValues();
 
             int onSerializeCalled = 0;
             serverPayloadBehaviour.OnSerializeCalled += () => { onSerializeCalled++; };
@@ -727,6 +729,7 @@ namespace Mirror.Tests.ClientSceneTests
 
             NetworkIdentity identity = go.AddComponent<NetworkIdentity>();
             BehaviourWithEvents events = go.AddComponent<BehaviourWithEvents>();
+            identity.InitializeBehaviourValues();
 
             int onStartAuthorityCalled = 0;
             int onStartClientCalled = 0;

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -1176,12 +1176,14 @@ namespace Mirror.Tests
         [Test]
         public void GetSyncVarGameObjectOnServer()
         {
+            // add test component
+            // make sure component is added before OnStartServer because of behaviour cache
+            NetworkBehaviourGetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarGameObjectComponent>();
+
             // call OnStartServer so isServer is true
             identity.OnStartServer();
             Assert.That(identity.isServer, Is.True);
 
-            // add test component
-            NetworkBehaviourGetSyncVarGameObjectComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarGameObjectComponent>();
             // for isDirty check
             comp.syncInterval = 0;
 
@@ -1374,12 +1376,14 @@ namespace Mirror.Tests
         [Test]
         public void GetSyncVarNetworkIdentityOnServer()
         {
+            // add test component
+            // make sure component is added before OnStartServer because of behaviour cache
+            NetworkBehaviourGetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarNetworkIdentityComponent>();
+
             // call OnStartServer so isServer is true
             identity.OnStartServer();
             Assert.That(identity.isServer, Is.True);
 
-            // add test component
-            NetworkBehaviourGetSyncVarNetworkIdentityComponent comp = gameObject.AddComponent<NetworkBehaviourGetSyncVarNetworkIdentityComponent>();
             // for isDirty check
             comp.syncInterval = 0;
 

--- a/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
@@ -58,9 +58,10 @@ namespace Mirror.Tests.RemoteAttrributeTest
             GameObject gameObject = new GameObject();
             spawned.Add(gameObject);
 
-            gameObject.AddComponent<NetworkIdentity>();
+            NetworkIdentity identity = gameObject.AddComponent<NetworkIdentity>();
 
             T behaviour = gameObject.AddComponent<T>();
+            identity.InitializeBehaviourValues();
 
             // spawn outwith authority
             if (spawnWithAuthority)


### PR DESCRIPTION
Checking identity.isClient is expensive because it has to call multipleproperties and also check if identity cache is null.

Setting isClient on each behaviour when it is set on the Identity will make this a lot more effcient when isClient is called in the hot path.

Testing on benchmark scene
**Before 6.94ms**
**After 0.27ms**

![before](https://cdn.discordapp.com/attachments/586459454187503626/739503669778841770/unknown.png)

![after](https://cdn.discordapp.com/attachments/586459454187503626/739505662299734086/unknown.png)


Not sure if it is worth doing full performance tests for this as the gain is very noticeable without it