### PR TITLE
perf: Only checking netIdentityCache == null once 

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -128,10 +128,11 @@ namespace Mirror
                 if (netIdentityCache == null)
                 {
                     netIdentityCache = GetComponent<NetworkIdentity>();
-                }
-                if (netIdentityCache == null)
-                {
-                    logger.LogError("There is no NetworkIdentity on " + name + ". Please add one.");
+                    // do this 2nd check inside first if so that we are not checking == twice on unity Object
+                    if (netIdentityCache == null)
+                    {
+                        logger.LogError("There is no NetworkIdentity on " + name + ". Please add one.");
+                    }
                 }
                 return netIdentityCache;
             }


### PR DESCRIPTION
We only need to check `netIdentityCache == null` a 2nd time after we call `GetComponent`