### PR TITLE
perf: adding check for no connections

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -480,7 +480,6 @@ namespace Mirror
             connections.Clear();
         }
 
-
         /// <summary>
         /// If connections is empty or if only has host
         /// </summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -73,11 +73,6 @@ namespace Mirror
         public static float disconnectInactiveTimeout = 60f;
 
         /// <summary>
-        /// Skips Update if there are no connections or only host
-        /// </summary>
-        public static bool skipUpdateIfNoConnections = true;
-
-        /// <summary>
         /// cache the Send(connectionIds) list to avoid allocating each time 
         /// </summary>
         static readonly List<int> connectionIdsCache = new List<int>();
@@ -501,14 +496,9 @@ namespace Mirror
         /// </summary>
         public static void Update()
         {
-            if (!active)
+            // dont need to update server if not active or no client connections
+            if (!active || NoConnections())
                 return;
-
-            // dont need to update server if there are no client connections
-            if (skipUpdateIfNoConnections && NoConnections())
-            {
-                return;
-            }
 
             // Check for dead clients but exclude the host client because it
             // doesn't ping itself and therefore may appear inactive.

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -485,7 +485,7 @@ namespace Mirror
             connections.Clear();
         }
 
-      
+
         /// <summary>
         /// If connections is empty or if only has host
         /// </summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -73,6 +73,11 @@ namespace Mirror
         public static float disconnectInactiveTimeout = 60f;
 
         /// <summary>
+        /// Skips Update if there are no connections or only host
+        /// </summary>
+        public static bool skipUpdateIfNoConnections = true;
+
+        /// <summary>
         /// cache the Send(connectionIds) list to avoid allocating each time 
         /// </summary>
         static readonly List<int> connectionIdsCache = new List<int>();
@@ -500,7 +505,7 @@ namespace Mirror
                 return;
 
             // dont need to update server if there are no client connections
-            if (NoConnections())
+            if (skipUpdateIfNoConnections && NoConnections())
             {
                 return;
             }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -480,6 +480,16 @@ namespace Mirror
             connections.Clear();
         }
 
+      
+        /// <summary>
+        /// If connections is empty or if only has host
+        /// </summary>
+        /// <returns></returns>
+        public static bool NoConnections()
+        {
+            return connections.Count == 0 || (connections.Count == 1 && localConnection != null);
+        }
+
         /// <summary>
         /// Called from NetworkManager in LateUpdate
         /// <para>The user should never need to pump the update loop manually</para>
@@ -488,6 +498,12 @@ namespace Mirror
         {
             if (!active)
                 return;
+
+            // dont need to update server if there are no client connections
+            if (NoConnections())
+            {
+                return;
+            }
 
             // Check for dead clients but exclude the host client because it
             // doesn't ping itself and therefore may appear inactive.

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -1118,5 +1118,61 @@ namespace Mirror.Tests
                     break;
             }
         }
+
+
+        [Test]
+        public void NoConnectionsTest_WithNoConnection()
+        {
+            Assert.That(NetworkServer.NoConnections(), Is.True);
+            Assert.That(NetworkServer.connections.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void NoConnectionsTest_WithConnections()
+        {
+            NetworkServer.connections.Add(1, null);
+            NetworkServer.connections.Add(2, null);
+            Assert.That(NetworkServer.NoConnections(), Is.False);
+            Assert.That(NetworkServer.connections.Count, Is.EqualTo(2));
+
+            NetworkServer.connections.Clear();
+        }
+
+        [Test]
+        public void NoConnectionsTest_WithHostOnly()
+        {
+            ULocalConnectionToServer connectionToServer = new ULocalConnectionToServer();
+            ULocalConnectionToClient connectionToClient = new ULocalConnectionToClient();
+            connectionToServer.connectionToClient = connectionToClient;
+            connectionToClient.connectionToServer = connectionToServer;
+
+            NetworkServer.SetLocalConnection(connectionToClient);
+            NetworkServer.connections.Add(0, connectionToClient);
+
+            Assert.That(NetworkServer.NoConnections(), Is.True);
+            Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
+
+            NetworkServer.connections.Clear();
+            NetworkServer.RemoveLocalConnection();
+        }
+
+        [Test]
+        public void NoConnectionsTest_WithHostAndConnection()
+        {
+            ULocalConnectionToServer connectionToServer = new ULocalConnectionToServer();
+            ULocalConnectionToClient connectionToClient = new ULocalConnectionToClient();
+            connectionToServer.connectionToClient = connectionToClient;
+            connectionToClient.connectionToServer = connectionToServer;
+
+            NetworkServer.SetLocalConnection(connectionToClient);
+            NetworkServer.connections.Add(0, connectionToClient);
+            NetworkServer.connections.Add(1, null);
+
+            Assert.That(NetworkServer.NoConnections(), Is.False);
+            Assert.That(NetworkServer.connections.Count, Is.EqualTo(2));
+
+            NetworkServer.connections.Clear();
+            NetworkServer.RemoveLocalConnection();
+        }
     }
 }


### PR DESCRIPTION
Dont need to run Server Update if there are no connections.

It would be useful to use the same game code for single player and multiplayer, this helps to remove the overhead when running in host mode with no other connections.
