### PR TITLE
Added Layer Weight to NetworkAnimator

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -116,7 +116,7 @@ namespace Mirror
             normalizedTime = 0;
 
             float lw = animator.GetLayerWeight(layerId);
-            if (lw != layerWeight[layerId])
+            if (Mathf.Abs(lw - layerWeight[layerId]) > 0.001f)
             {
                 layerWeight[layerId] = lw;
                 change = true;

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -149,7 +149,7 @@ namespace Mirror
                 animationHash[layerId] = st.fullPathHash;
                 return true;
             }
-            return false || change;
+            return change;
         }
 
         void CheckSendRate()

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -132,7 +132,7 @@ namespace Mirror
                     animationHash[layerId] = 0;
                     return true;
                 }
-                return false || change;
+                return change;
             }
 
             AnimatorStateInfo st = animator.GetCurrentAnimatorStateInfo(layerId);

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -41,6 +41,7 @@ namespace Mirror
         // multiple layers
         int[] animationHash;
         int[] transitionHash;
+        float[] layerWeight;
         float nextSendTime;
 
         bool SendMessagesAllowed
@@ -78,6 +79,7 @@ namespace Mirror
 
             animationHash = new int[animator.layerCount];
             transitionHash = new int[animator.layerCount];
+            layerWeight = new float[animator.layerCount];
         }
 
         void FixedUpdate()
@@ -102,15 +104,23 @@ namespace Mirror
                 using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
                 {
                     WriteParameters(writer);
-                    SendAnimationMessage(stateHash, normalizedTime, i, writer.ToArray());
+                    SendAnimationMessage(stateHash, normalizedTime, i, layerWeight[i], writer.ToArray());
                 }
             }
         }
 
         bool CheckAnimStateChanged(out int stateHash, out float normalizedTime, int layerId)
         {
+            bool change = false;
             stateHash = 0;
             normalizedTime = 0;
+
+            float lw = animator.GetLayerWeight(layerId);
+            if (lw != layerWeight[layerId])
+            {
+                layerWeight[layerId] = lw;
+                change = true;
+            }
 
             if (animator.IsInTransition(layerId))
             {
@@ -122,7 +132,7 @@ namespace Mirror
                     animationHash[layerId] = 0;
                     return true;
                 }
-                return false;
+                return false || change;
             }
 
             AnimatorStateInfo st = animator.GetCurrentAnimatorStateInfo(layerId);
@@ -139,7 +149,7 @@ namespace Mirror
                 animationHash[layerId] = st.fullPathHash;
                 return true;
             }
-            return false;
+            return false || change;
         }
 
         void CheckSendRate()
@@ -157,15 +167,15 @@ namespace Mirror
             }
         }
 
-        void SendAnimationMessage(int stateHash, float normalizedTime, int layerId, byte[] parameters)
+        void SendAnimationMessage(int stateHash, float normalizedTime, int layerId, float weight, byte[] parameters)
         {
             if (isServer)
             {
-                RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, parameters);
+                RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, weight, parameters);
             }
             else if (ClientScene.readyConnection != null)
             {
-                CmdOnAnimationServerMessage(stateHash, normalizedTime, layerId, parameters);
+                CmdOnAnimationServerMessage(stateHash, normalizedTime, layerId, weight, parameters);
             }
         }
 
@@ -181,7 +191,7 @@ namespace Mirror
             }
         }
 
-        void HandleAnimMsg(int stateHash, float normalizedTime, int layerId, NetworkReader reader)
+        void HandleAnimMsg(int stateHash, float normalizedTime, int layerId, float weight, NetworkReader reader)
         {
             if (hasAuthority && clientAuthority)
                 return;
@@ -192,6 +202,11 @@ namespace Mirror
             if (stateHash != 0 && animator.enabled)
             {
                 animator.Play(stateHash, layerId, normalizedTime);
+            }
+
+            if (animator.GetLayerWeight(layerId) != weight)
+            {
+                animator.SetLayerWeight(layerId, weight);
             }
 
             ReadParameters(reader);
@@ -340,6 +355,7 @@ namespace Mirror
                         writer.WriteInt32(st.fullPathHash);
                         writer.WriteSingle(st.normalizedTime);
                     }
+                    writer.WriteSingle(animator.GetLayerWeight(i));
                 }
                 WriteParameters(writer, initialState);
                 return true;
@@ -360,6 +376,7 @@ namespace Mirror
                 {
                     int stateHash = reader.ReadInt32();
                     float normalizedTime = reader.ReadSingle();
+                    animator.SetLayerWeight(i, reader.ReadSingle());
                     animator.Play(stateHash, i, normalizedTime);
                 }
 
@@ -468,7 +485,7 @@ namespace Mirror
         #region server message handlers
 
         [Command]
-        void CmdOnAnimationServerMessage(int stateHash, float normalizedTime, int layerId, byte[] parameters)
+        void CmdOnAnimationServerMessage(int stateHash, float normalizedTime, int layerId, float weight, byte[] parameters)
         {
             // Ignore messages from client if not in client authority mode
             if (!clientAuthority)
@@ -479,8 +496,8 @@ namespace Mirror
             // handle and broadcast
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
             {
-                HandleAnimMsg(stateHash, normalizedTime, layerId, networkReader);
-                RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, parameters);
+                HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
+                RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, weight, parameters);
             }
         }
 
@@ -532,10 +549,10 @@ namespace Mirror
         #region client message handlers
 
         [ClientRpc]
-        void RpcOnAnimationClientMessage(int stateHash, float normalizedTime, int layerId, byte[] parameters)
+        void RpcOnAnimationClientMessage(int stateHash, float normalizedTime, int layerId, float weight, byte[] parameters)
         {
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
-                HandleAnimMsg(stateHash, normalizedTime, layerId, networkReader);
+                HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
         }
 
         [ClientRpc]

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -204,10 +204,7 @@ namespace Mirror
                 animator.Play(stateHash, layerId, normalizedTime);
             }
 
-            if (animator.GetLayerWeight(layerId) != weight)
-            {
-                animator.SetLayerWeight(layerId, weight);
-            }
+            animator.SetLayerWeight(layerId, weight);
 
             ReadParameters(reader);
         }


### PR DESCRIPTION
Now NetworkAnimator is aware of each layer weight on it's references
Animator and will sync layer weights across the network.

This could be a little nicer, especially the changes in CheckAnimStateChanged. I can make changes on request.

- Ran tests and all passed
- Copied edited script into another project and ran with two clients to confirm layer weight is synced