### PR TITLE
Adding asmdef to telepathy

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Telepathy/Telepathy.asmdef
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Telepathy.asmdef
@@ -1,8 +1,7 @@
-{
-    "name": "Mirror",
+﻿{
+    "name": "Telepathy",
     "references": [
-        "Mirror.CompilerSymbols",
-        "Telepathy"
+        
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/Assets/Mirror/Runtime/Transport/Telepathy/Telepathy.asmdef
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Telepathy.asmdef
@@ -1,8 +1,6 @@
-﻿{
+{
     "name": "Telepathy",
-    "references": [
-        
-    ],
+    "references": [],
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Mirror/Runtime/Transport/Telepathy/Telepathy.asmdef.meta
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/Telepathy.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 725ee7191c021de4dbf9269590ded755
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
+++ b/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
@@ -4,7 +4,8 @@
         "Mirror",
         "Mirror.Weaver",
         "Mirror.Components",
-        "Mirror.Tests.Common"
+        "Mirror.Tests.Common",
+        "Telepathy"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"


### PR DESCRIPTION
Mirror has to reference telepathy as it is the default transport. This also means that TelepathyTransport has to be in the mirror asmdef, which is fine because it is already there and does not need to be moved.