### PR TITLE
Adding coverage exclusions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
           projectKey: vis2k_Mirror
           projectName: Mirror
           sonarOrganisation: vis2k
-          beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml,Tests/playimode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml,Tests/workspace-opencov/PlayMode/TestCoverageResults_0000.xml
+          beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml,Tests/playimode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml,Tests/workspace-opencov/PlayMode/TestCoverageResults_0000.xml /d:sonar.coverage.exclusions=Assets/Mirror/Runtime/Transport/Telepathy/**/*.cs,Assets/Mirror/Runtime/Transport/Websocket/**/*.cs,Assets/Mirror/Runtime/Transport/LLAPITransport.cs,Assets/Mirror/Cloud/**/*.cs,Assets/Mirror/Examples/**/*.cs
         env:
           FrameworkPathOverride: /opt/Unity/Editor/Data/MonoBleedingEdge/
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
           projectKey: vis2k_Mirror
           projectName: Mirror
           sonarOrganisation: vis2k
-          beginArguments: >
+          beginArguments: >-
               /d:sonar.verbose="true" 
               /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml,Tests/playimode-results.xml 
               /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml,Tests/workspace-opencov/PlayMode/TestCoverageResults_0000.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,12 @@ jobs:
           projectName: Mirror
           sonarOrganisation: vis2k
           beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml,Tests/playimode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml,Tests/workspace-opencov/PlayMode/TestCoverageResults_0000.xml /d:sonar.coverage.exclusions=Assets/Mirror/Runtime/Transport/Telepathy/**/*.cs,Assets/Mirror/Runtime/Transport/Websocket/**/*.cs,Assets/Mirror/Runtime/Transport/LLAPITransport.cs,Assets/Mirror/Cloud/**/*.cs,Assets/Mirror/Examples/**/*.cs
+          # files ignored in code coverage:
+          # Assets/Mirror/Runtime/Transport/Telepathy/** - has its one test in the Telepathy repo
+          # Assets/Mirror/Runtime/Transport/Websocket/** - needs tests but should be done in its own repo
+          # Assets/Mirror/Runtime/Transport/LLAPITransport.cs - is Obsolete so does not need tests
+          # Assets/Mirror/Cloud/** - has its own tests in private cloud repo
+          # Assets/Mirror/Examples/** - examples dont need test coverage
         env:
           FrameworkPathOverride: /opt/Unity/Editor/Data/MonoBleedingEdge/
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,11 +95,10 @@ jobs:
           projectKey: vis2k_Mirror
           projectName: Mirror
           sonarOrganisation: vis2k
-          beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml,Tests/playimode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml,Tests/workspace-opencov/PlayMode/TestCoverageResults_0000.xml /d:sonar.coverage.exclusions=Assets/Mirror/Runtime/Transport/Telepathy/**/*.cs,Assets/Mirror/Runtime/Transport/Websocket/**/*.cs,Assets/Mirror/Runtime/Transport/LLAPITransport.cs,Assets/Mirror/Cloud/**/*.cs,Assets/Mirror/Examples/**/*.cs
+          beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml,Tests/playimode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml,Tests/workspace-opencov/PlayMode/TestCoverageResults_0000.xml /d:sonar.coverage.exclusions=Assets/Mirror/Runtime/Transport/Telepathy/**/*.cs,Assets/Mirror/Runtime/Transport/Websocket/**/*.cs,Assets/Mirror/Cloud/**/*.cs,Assets/Mirror/Examples/**/*.cs
           # files ignored in code coverage:
           # Assets/Mirror/Runtime/Transport/Telepathy/** - has its one test in the Telepathy repo
           # Assets/Mirror/Runtime/Transport/Websocket/** - needs tests but should be done in its own repo
-          # Assets/Mirror/Runtime/Transport/LLAPITransport.cs - is Obsolete so does not need tests
           # Assets/Mirror/Cloud/** - has its own tests in private cloud repo
           # Assets/Mirror/Examples/** - examples dont need test coverage
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,11 @@ jobs:
           projectKey: vis2k_Mirror
           projectName: Mirror
           sonarOrganisation: vis2k
-          beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml,Tests/playimode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml,Tests/workspace-opencov/PlayMode/TestCoverageResults_0000.xml /d:sonar.coverage.exclusions=Assets/Mirror/Runtime/Transport/Telepathy/**/*.cs,Assets/Mirror/Runtime/Transport/Websocket/**/*.cs,Assets/Mirror/Cloud/**/*.cs,Assets/Mirror/Examples/**/*.cs
+          beginArguments: >
+              /d:sonar.verbose="true" 
+              /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml,Tests/playimode-results.xml 
+              /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml,Tests/workspace-opencov/PlayMode/TestCoverageResults_0000.xml
+              /d:sonar.coverage.exclusions=Assets/Mirror/Runtime/Transport/Telepathy/**/*.cs,Assets/Mirror/Runtime/Transport/Websocket/**/*.cs,Assets/Mirror/Cloud/**/*.cs,Assets/Mirror/Examples/**/*.cs
           # files ignored in code coverage:
           # Assets/Mirror/Runtime/Transport/Telepathy/** - has its one test in the Telepathy repo
           # Assets/Mirror/Runtime/Transport/Websocket/** - needs tests but should be done in its own repo


### PR DESCRIPTION
Some files and folders not need to be included in code coverage, we can ignore them using `/d:sonar.coverage.exclusions`

files ignored in code coverage:
`Assets/Mirror/Runtime/Transport/Telepathy/**` - has its one test in the Telepathy repo
`Assets/Mirror/Runtime/Transport/Websocket/**` - needs tests but should be done in its own repo
`Assets/Mirror/Runtime/Transport/LLAPITransport.cs` - is Obsolete so does not need tests
`Assets/Mirror/Cloud/**` - has its own tests in private cloud repo
`Assets/Mirror/Examples/**` - examples dont need test coverage

I have tested with `dotnet-sonarscanner.exe` locally and it works on my fork