### PR TITLE
weaver: throwing instead of returning null

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -31,6 +31,7 @@ namespace Mirror.Weaver
             This way we do not need to modify the code anywhere else,  and this works
             correctly in dependent assemblies
         */
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
         public static MethodDefinition ProcessCommandCall(TypeDefinition td, MethodDefinition md, CustomAttribute commandAttr)
         {
             MethodDefinition cmd = MethodProcessor.SubstituteMethod(td, md);
@@ -43,8 +44,7 @@ namespace Mirror.Weaver
             NetworkBehaviourProcessor.WriteCreateWriter(worker);
 
             // write all the arguments that the user passed to the Cmd call
-            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.Command))
-                return null;
+            NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.Command);
 
             string cmdName = md.Name;
             int channel = commandAttr.GetField("channel", 0);

--- a/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MessageClassProcessor.cs
@@ -15,6 +15,11 @@ namespace Mirror.Weaver
             return body.Instructions.All(instruction => instruction.OpCode == OpCodes.Nop || instruction.OpCode == OpCodes.Ret);
         }
 
+        /// <summary>
+        /// Create Serialize/Deserialize for IMessageBase
+        /// </summary>
+        /// <param name="td"></param>
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
         public static void Process(TypeDefinition td)
         {
             Weaver.DLog(td, "MessageClassProcessor Start");
@@ -29,6 +34,7 @@ namespace Mirror.Weaver
             Weaver.DLog(td, "MessageClassProcessor Done");
         }
 
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
         static void GenerateSerialization(TypeDefinition td)
         {
             Weaver.DLog(td, "  GenerateSerialization");
@@ -93,20 +99,15 @@ namespace Mirror.Weaver
             }
         }
 
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
         static void CallWriter(ILProcessor worker, FieldDefinition field)
         {
             MethodReference writeFunc = Writers.GetWriteFunc(field.FieldType);
-            if (writeFunc != null)
-            {
-                worker.Append(worker.Create(OpCodes.Ldarg_1));
-                worker.Append(worker.Create(OpCodes.Ldarg_0));
-                worker.Append(worker.Create(OpCodes.Ldfld, field));
-                worker.Append(worker.Create(OpCodes.Call, writeFunc));
-            }
-            else
-            {
-                Weaver.Error($"{field.Name} has unsupported type", field);
-            }
+
+            worker.Append(worker.Create(OpCodes.Ldarg_1));
+            worker.Append(worker.Create(OpCodes.Ldarg_0));
+            worker.Append(worker.Create(OpCodes.Ldfld, field));
+            worker.Append(worker.Create(OpCodes.Call, writeFunc));
         }
 
         static void CallBase(TypeDefinition td, ILProcessor worker, string name)

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -90,16 +90,18 @@ namespace Mirror.Weaver
             }
             GenerateConstants();
 
-            GenerateSerialization();
-            if (Weaver.WeavingFailed)
+            try
             {
-                // originally Process returned true in every case, except if already processed.
-                // maybe return false here in the future.
-                return true;
+                GenerateSerialization();
+
+                GenerateDeSerialization();
+                Weaver.DLog(netBehaviourSubclass, "Process Done");
+            }
+            catch (WeaverException e)
+            {
+                Weaver.Error(e.Message, e.MemberReference);
             }
 
-            GenerateDeSerialization();
-            Weaver.DLog(netBehaviourSubclass, "Process Done");
             return true;
         }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -426,8 +426,15 @@ namespace Mirror.Weaver
                 worker.Append(worker.Create(OpCodes.Ldarg_0));
                 worker.Append(worker.Create(OpCodes.Ldfld, syncVar));
 
-                MethodReference writeFunc = Writers.GetWriteFunc(syncVar.FieldType);
-                worker.Append(worker.Create(OpCodes.Call, writeFunc));
+                try
+                {
+                    MethodReference writeFunc = Writers.GetWriteFunc(syncVar.FieldType);
+                    worker.Append(worker.Create(OpCodes.Call, writeFunc));
+                }
+                catch (WeaverException e)
+                {
+                    throw new SyncVarException(syncVar, e);
+                }
             }
 
             // always return true if forceAll

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -58,6 +58,7 @@ namespace Mirror.Weaver
             This way we do not need to modify the code anywhere else,  and this works
             correctly in dependent assemblies
         */
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
         public static MethodDefinition ProcessRpcCall(TypeDefinition td, MethodDefinition md, CustomAttribute clientRpcAttr)
         {
             MethodDefinition rpc = MethodProcessor.SubstituteMethod(td, md);
@@ -75,8 +76,7 @@ namespace Mirror.Weaver
             NetworkBehaviourProcessor.WriteCreateWriter(worker);
 
             // write all the arguments that the user passed to the Rpc call
-            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.ClientRpc))
-                return null;
+            NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.ClientRpc);
 
             string rpcName = md.Name;
             int channel = clientRpcAttr.GetField("channel", 0);

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncDictionaryProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncDictionaryProcessor.cs
@@ -11,6 +11,8 @@ namespace Mirror.Weaver
         /// Generates serialization methods for synclists
         /// </summary>
         /// <param name="td">The synclist class</param>
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for itemType</exception>
+        /// <exception cref="SyncObjectException">Throws when Serialization functions could not be created</exception>
         public static void Process(TypeDefinition td)
         {
             GenericArgumentResolver resolver = new GenericArgumentResolver(2);

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncListProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncListProcessor.cs
@@ -12,6 +12,8 @@ namespace Mirror.Weaver
         /// </summary>
         /// <param name="td">The synclist class</param>
         /// <param name="mirrorBaseType">the base SyncObject td inherits from</param>
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for itemType</exception>
+        /// <exception cref="SyncObjectException">Throws when Serialization functions could not be created</exception>
         public static void Process(TypeDefinition td, TypeReference mirrorBaseType)
         {
             GenericArgumentResolver resolver = new GenericArgumentResolver(1);

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
@@ -48,6 +48,7 @@ namespace Mirror.Weaver
         /// <param name="mirrorBaseType">the base SyncObject td inherits from</param>
         /// <param name="serializeMethod">The name of the serialize method</param>
         /// <param name="deserializeMethod">The name of the deserialize method</param>
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for itemType</exception>
         public static void GenerateSerialization(TypeDefinition td, TypeReference itemType, TypeReference mirrorBaseType, string serializeMethod, string deserializeMethod)
         {
             Weaver.DLog(td, "SyncObjectProcessor Start item:" + itemType.FullName);
@@ -64,7 +65,7 @@ namespace Mirror.Weaver
                 Weaver.DLog(td, "SyncObjectProcessor Done");
         }
 
-        // serialization of individual element
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for itemType</exception>
         static bool GenerateSerialization(string methodName, TypeDefinition td, TypeReference itemType, TypeReference mirrorBaseType)
         {
             Weaver.DLog(td, "  GenerateSerialization");
@@ -92,17 +93,11 @@ namespace Mirror.Weaver
             ILProcessor worker = serializeFunc.Body.GetILProcessor();
 
             MethodReference writeFunc = Writers.GetWriteFunc(itemType);
-            if (writeFunc != null)
-            {
-                worker.Append(worker.Create(OpCodes.Ldarg_1));
-                worker.Append(worker.Create(OpCodes.Ldarg_2));
-                worker.Append(worker.Create(OpCodes.Call, writeFunc));
-            }
-            else
-            {
-                Weaver.Error($"{td.Name} has sync object generic type {itemType.Name}.  Use a type supported by mirror instead", td);
-                return false;
-            }
+
+            worker.Append(worker.Create(OpCodes.Ldarg_1));
+            worker.Append(worker.Create(OpCodes.Ldarg_2));
+            worker.Append(worker.Create(OpCodes.Call, writeFunc));
+
             worker.Append(worker.Create(OpCodes.Ret));
 
             td.Methods.Add(serializeFunc);

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -85,6 +85,7 @@ namespace Mirror.Weaver
             correctly in dependent assemblies
 
         */
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
         public static MethodDefinition ProcessTargetRpcCall(TypeDefinition td, MethodDefinition md, CustomAttribute targetRpcAttr)
         {
             MethodDefinition rpc = MethodProcessor.SubstituteMethod(td, md);
@@ -97,8 +98,7 @@ namespace Mirror.Weaver
 
             // write all the arguments that the user passed to the TargetRpc call
             // (skip first one if first one is NetworkConnection)
-            if (!NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.TargetRpc))
-                return null;
+            NetworkBehaviourProcessor.WriteArguments(worker, md, RemoteCallType.TargetRpc);
 
             string rpcName = md.Name;
 

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -181,8 +181,16 @@ namespace Mirror.Weaver
                     //Console.WriteLine("AssemblyResolutionException: "+ ex.ToString());
                 }
 
-                // process this
-                MessageClassProcessor.Process(td);
+                try
+                {
+                    // process this
+                    MessageClassProcessor.Process(td);
+                }
+                catch (WeaverException e)
+                {
+                    Weaver.Error(e.Message, e.MemberReference);
+                }
+
                 WeaveLists.ProcessedMessages.Add(td.FullName);
                 modified = true;
             }
@@ -215,20 +223,27 @@ namespace Mirror.Weaver
             // because we still need to check for embeded types
             if (td.IsClass || !td.IsAbstract)
             {
-                if (td.IsDerivedFrom(WeaverTypes.SyncListType))
+                try
                 {
-                    SyncListProcessor.Process(td, WeaverTypes.SyncListType);
-                    modified = true;
+                    if (td.IsDerivedFrom(WeaverTypes.SyncListType))
+                    {
+                        SyncListProcessor.Process(td, WeaverTypes.SyncListType);
+                        modified = true;
+                    }
+                    else if (td.IsDerivedFrom(WeaverTypes.SyncSetType))
+                    {
+                        SyncListProcessor.Process(td, WeaverTypes.SyncSetType);
+                        modified = true;
+                    }
+                    else if (td.IsDerivedFrom(WeaverTypes.SyncDictionaryType))
+                    {
+                        SyncDictionaryProcessor.Process(td);
+                        modified = true;
+                    }
                 }
-                else if (td.IsDerivedFrom(WeaverTypes.SyncSetType))
+                catch (WeaverException e)
                 {
-                    SyncListProcessor.Process(td, WeaverTypes.SyncSetType);
-                    modified = true;
-                }
-                else if (td.IsDerivedFrom(WeaverTypes.SyncDictionaryType))
-                {
-                    SyncDictionaryProcessor.Process(td);
-                    modified = true;
+                    Weaver.Error(e.Message, e.MemberReference);
                 }
             }
 

--- a/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs
@@ -1,0 +1,25 @@
+using System;
+using Mono.CecilX;
+
+namespace Mirror.Weaver
+{
+    [Serializable]
+    public abstract class WeaverException : Exception
+    {
+        public MemberReference MemberReference { get; }
+
+        protected WeaverException(string message, MemberReference member) : base(message)
+        {
+            MemberReference = member;
+        }
+
+        protected WeaverException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+    }
+
+    [Serializable]
+    public class GenerateWriterException : WeaverException
+    {
+        public GenerateWriterException(string message, MemberReference member) : base(message, member) { }
+        protected GenerateWriterException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+    }
+}

--- a/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs
@@ -3,6 +3,9 @@ using Mono.CecilX;
 
 namespace Mirror.Weaver
 {
+    // we dont care about serialization for Exceptions
+#pragma warning disable CA2229 // Implement serialization constructors
+
     [Serializable]
     public abstract class WeaverException : Exception
     {
@@ -13,13 +16,23 @@ namespace Mirror.Weaver
             MemberReference = member;
         }
 
-        protected WeaverException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+        protected WeaverException(string message, MemberReference member, Exception innerException) : base(message, innerException)
+        {
+            MemberReference = member;
+        }
     }
 
     [Serializable]
     public class GenerateWriterException : WeaverException
     {
         public GenerateWriterException(string message, MemberReference member) : base(message, member) { }
-        protected GenerateWriterException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
     }
+
+    [Serializable]
+    public class SyncVarException : WeaverException
+    {
+        public SyncVarException(MemberReference member, Exception innerException) : base($"Invalid SyncVar: {innerException.Message}", member, innerException) { }
+    }
+
+#pragma warning restore CA2229 // Implement serialization constructors
 }

--- a/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs.meta
+++ b/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8aaaf6193bad7424492677f8e81f1b30
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Mono.CecilX;
 using Mono.CecilX.Cil;

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -51,6 +51,7 @@ namespace Mirror.Weaver
             {
                 MethodDefinition newWriterFunc = null;
 
+                // this try/catch will be removed in future PR and make `GetWriteFunc` throw instead
                 try
                 {
                     newWriterFunc = GenerateWriter(variable, recursionCount);

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -4,7 +4,6 @@ using Mono.CecilX.Cil;
 
 namespace Mirror.Weaver
 {
-
     public static class Writers
     {
         const int MaxRecursionCount = 128;
@@ -30,6 +29,13 @@ namespace Mirror.Weaver
             Weaver.WeaveLists.generateContainerClass.Methods.Add(newWriterFunc);
         }
 
+        /// <summary>
+        /// Finds existing writer for type, if non exists trys to create one
+        /// <para>This method is recursive</para>
+        /// </summary>
+        /// <param name="variable"></param>
+        /// <param name="recursionCount"></param>
+        /// <returns>Returns <see cref="MethodReference"/> or null</returns>
         public static MethodReference GetWriteFunc(TypeReference variable, int recursionCount = 0)
         {
             if (writeFuncs.TryGetValue(variable.FullName, out MethodReference foundFunc))
@@ -43,7 +49,17 @@ namespace Mirror.Weaver
             }
             else
             {
-                MethodDefinition newWriterFunc = GenerateWriter(variable, recursionCount);
+                MethodDefinition newWriterFunc = null;
+
+                try
+                {
+                    newWriterFunc = GenerateWriter(variable, recursionCount);
+                }
+                catch (GenerateWriterException e)
+                {
+                    Weaver.Error(e.Message, e.MemberReference);
+                }
+
                 if (newWriterFunc != null)
                 {
                     RegisterWriteFunc(variable.FullName, newWriterFunc);
@@ -52,14 +68,13 @@ namespace Mirror.Weaver
             }
         }
 
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
         static MethodDefinition GenerateWriter(TypeReference variableReference, int recursionCount = 0)
         {
             // TODO: do we need this check? do we ever receieve types that are "ByReference"s
             if (variableReference.IsByReference)
             {
-                // error??
-                Weaver.Error($"Cannot pass {variableReference.Name} by reference", variableReference);
-                return null;
+                throw new GenerateWriterException($"Cannot pass {variableReference.Name} by reference", variableReference);
             }
 
             // Arrays are special, if we resolve them, we get the element type,
@@ -86,33 +101,27 @@ namespace Mirror.Weaver
             TypeDefinition VariableDefinition = variableReference.Resolve();
             if (VariableDefinition == null)
             {
-                Weaver.Error($"{variableReference.Name} is not a supported type. Use a supported type or provide a custom writer", variableReference);
-                return null;
+                throw new GenerateWriterException($"{variableReference.Name} is not a supported type. Use a supported type or provide a custom writer", variableReference);
             }
             if (VariableDefinition.IsDerivedFrom(WeaverTypes.ComponentType))
             {
-                Weaver.Error($"Cannot generate writer for component type {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
-                return null;
+                throw new GenerateWriterException($"Cannot generate writer for component type {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
             }
             if (variableReference.FullName == WeaverTypes.ObjectType.FullName)
             {
-                Weaver.Error($"Cannot generate writer for {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
-                return null;
+                throw new GenerateWriterException($"Cannot generate writer for {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
             }
             if (variableReference.FullName == WeaverTypes.ScriptableObjectType.FullName)
             {
-                Weaver.Error($"Cannot generate writer for {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
-                return null;
+                throw new GenerateWriterException($"Cannot generate writer for {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
             }
             if (VariableDefinition.HasGenericParameters)
             {
-                Weaver.Error($"Cannot generate writer for generic type {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
-                return null;
+                throw new GenerateWriterException($"Cannot generate writer for generic type {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
             }
             if (VariableDefinition.IsInterface)
             {
-                Weaver.Error($"Cannot generate writer for interface {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
-                return null;
+                throw new GenerateWriterException($"Cannot generate writer for interface {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
             }
 
             // generate writer for class/struct
@@ -124,8 +133,7 @@ namespace Mirror.Weaver
         {
             if (recursionCount > MaxRecursionCount)
             {
-                Weaver.Error($"{variable.Name} can't be serialized because it references itself", variable);
-                return null;
+                throw new GenerateWriterException($"{variable.Name} can't be serialized because it references itself", variable);
             }
 
             string functionName = "_Write" + variable.Name + "_";
@@ -169,21 +177,14 @@ namespace Mirror.Weaver
             foreach (FieldDefinition field in variable.FindAllPublicFields())
             {
                 MethodReference writeFunc = GetWriteFunc(field.FieldType, recursionCount + 1);
-                if (writeFunc != null)
-                {
-                    FieldReference fieldRef = Weaver.CurrentAssembly.MainModule.ImportReference(field);
 
-                    fields++;
-                    worker.Append(worker.Create(OpCodes.Ldarg_0));
-                    worker.Append(worker.Create(OpCodes.Ldarg_1));
-                    worker.Append(worker.Create(OpCodes.Ldfld, fieldRef));
-                    worker.Append(worker.Create(OpCodes.Call, writeFunc));
-                }
-                else
-                {
-                    Weaver.Error($"{field.Name} has unsupported type. Use a type supported by Mirror instead", field);
-                    return false;
-                }
+                FieldReference fieldRef = Weaver.CurrentAssembly.MainModule.ImportReference(field);
+
+                fields++;
+                worker.Append(worker.Create(OpCodes.Ldarg_0));
+                worker.Append(worker.Create(OpCodes.Ldarg_1));
+                worker.Append(worker.Create(OpCodes.Ldfld, fieldRef));
+                worker.Append(worker.Create(OpCodes.Call, writeFunc));
             }
 
             if (fields == 0)
@@ -198,18 +199,12 @@ namespace Mirror.Weaver
         {
             if (!variable.IsArrayType())
             {
-                Weaver.Error($"{variable.Name} is an unsupported type. Jagged and multidimensional arrays are not supported", variable);
-                return null;
+                throw new GenerateWriterException($"{variable.Name} is an unsupported type. Jagged and multidimensional arrays are not supported", variable);
             }
 
             TypeReference elementType = variable.GetElementType();
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
-            if (elementWriteFunc == null)
-            {
-                Weaver.Error($"Cannot generate writer for Array because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
-            }
 
             string functionName = "_WriteArray" + variable.GetElementType().Name + "_";
             if (variable.DeclaringType != null)
@@ -306,12 +301,6 @@ namespace Mirror.Weaver
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
-            if (elementWriteFunc == null)
-            {
-                Weaver.Error($"Cannot generate writer for ArraySegment because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
-            }
-
             string functionName = "_WriteArraySegment_" + elementType.Name + "_";
             if (variable.DeclaringType != null)
             {
@@ -402,11 +391,6 @@ namespace Mirror.Weaver
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
-            if (elementWriteFunc == null)
-            {
-                Weaver.Error($"Cannot generate writer for List because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
-            }
 
             string functionName = "_WriteList_" + elementType.Name + "_";
             if (variable.DeclaringType != null)

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -103,27 +103,27 @@ namespace Mirror.Weaver
             TypeDefinition VariableDefinition = variableReference.Resolve();
             if (VariableDefinition == null)
             {
-                throw new GenerateWriterException($"{variableReference.Name} is not a supported type. Use a supported type or provide a custom writer", variableReference);
+                throw new GenerateWriterException($"{variableReference.Name} is not a supported type", variableReference);
             }
             if (VariableDefinition.IsDerivedFrom(WeaverTypes.ComponentType))
             {
-                throw new GenerateWriterException($"Cannot generate writer for component type {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
+                throw new GenerateWriterException($"Cannot generate writer for component type {variableReference.Name}", variableReference);
             }
             if (variableReference.FullName == WeaverTypes.ObjectType.FullName)
             {
-                throw new GenerateWriterException($"Cannot generate writer for {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
+                throw new GenerateWriterException($"Cannot generate writer for {variableReference.Name}", variableReference);
             }
             if (variableReference.FullName == WeaverTypes.ScriptableObjectType.FullName)
             {
-                throw new GenerateWriterException($"Cannot generate writer for {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
+                throw new GenerateWriterException($"Cannot generate writer for {variableReference.Name}", variableReference);
             }
             if (VariableDefinition.HasGenericParameters)
             {
-                throw new GenerateWriterException($"Cannot generate writer for generic type {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
+                throw new GenerateWriterException($"Cannot generate writer for generic type {variableReference.Name}", variableReference);
             }
             if (VariableDefinition.IsInterface)
             {
-                throw new GenerateWriterException($"Cannot generate writer for interface {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
+                throw new GenerateWriterException($"Cannot generate writer for interface {variableReference.Name}", variableReference);
             }
 
             // generate writer for class/struct

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
@@ -50,22 +51,15 @@ namespace Mirror.Weaver
             }
             else
             {
-                MethodDefinition newWriterFunc = null;
-
-                // this try/catch will be removed in future PR and make `GetWriteFunc` throw instead
-                try
+                MethodDefinition newWriterFunc = GenerateWriter(variable, recursionCount);
+                if (newWriterFunc == null)
                 {
-                    newWriterFunc = GenerateWriter(variable, recursionCount);
-                }
-                catch (GenerateWriterException e)
-                {
-                    Weaver.Error(e.Message, e.MemberReference);
+                    // GenerateWriter should never return null
+                    // this check is to make sure the code is working correct
+                    throw new ArgumentNullException(nameof(newWriterFunc));
                 }
 
-                if (newWriterFunc != null)
-                {
-                    RegisterWriteFunc(variable.FullName, newWriterFunc);
-                }
+                RegisterWriteFunc(variable.FullName, newWriterFunc);
                 return newWriterFunc;
             }
         }

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -180,8 +180,6 @@ namespace Mirror.Weaver
             foreach (FieldDefinition field in variable.FindAllPublicFields())
             {
                 MethodReference writeFunc = GetWriteFunc(field.FieldType, recursionCount + 1);
-                // need this null check till later PR when GetWriteFunc throws expetion instead
-                if (writeFunc == null) { return false; }
 
                 FieldReference fieldRef = Weaver.CurrentAssembly.MainModule.ImportReference(field);
 
@@ -209,11 +207,6 @@ namespace Mirror.Weaver
 
             TypeReference elementType = variable.GetElementType();
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
-            // need this null check till later PR when GetWriteFunc throws expetion instead
-            if (elementWriteFunc == null)
-            {
-                throw new GenerateWriterException($"Cannot generate writer for Array because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-            }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
             string functionName = "_WriteArray" + variable.GetElementType().Name + "_";
@@ -309,11 +302,6 @@ namespace Mirror.Weaver
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
-            // need this null check till later PR when GetWriteFunc throws expetion instead
-            if (elementWriteFunc == null)
-            {
-                throw new GenerateWriterException($"Cannot generate writer for ArraySegment because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-            }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
             string functionName = "_WriteArraySegment_" + elementType.Name + "_";
@@ -404,11 +392,6 @@ namespace Mirror.Weaver
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
-            // need this null check till later PR when GetWriteFunc throws expetion instead
-            if (elementWriteFunc == null)
-            {
-                throw new GenerateWriterException($"Cannot generate writer for List because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-            }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
@@ -35,7 +36,8 @@ namespace Mirror.Weaver
         /// </summary>
         /// <param name="variable"></param>
         /// <param name="recursionCount"></param>
-        /// <returns>Returns <see cref="MethodReference"/> or null</returns>
+        /// <returns>Returns <see cref="MethodReference"/> or throws</returns>
+        /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
         public static MethodReference GetWriteFunc(TypeReference variable, int recursionCount = 0)
         {
             if (writeFuncs.TryGetValue(variable.FullName, out MethodReference foundFunc))
@@ -210,8 +212,7 @@ namespace Mirror.Weaver
             // need this null check till later PR when GetWriteFunc throws expetion instead
             if (elementWriteFunc == null)
             {
-                Weaver.Error($"Cannot generate writer for Array because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
+                throw new GenerateWriterException($"Cannot generate writer for Array because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
             }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
@@ -311,8 +312,7 @@ namespace Mirror.Weaver
             // need this null check till later PR when GetWriteFunc throws expetion instead
             if (elementWriteFunc == null)
             {
-                Weaver.Error($"Cannot generate writer for ArraySegment because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
+                throw new GenerateWriterException($"Cannot generate writer for ArraySegment because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
             }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
@@ -407,8 +407,7 @@ namespace Mirror.Weaver
             // need this null check till later PR when GetWriteFunc throws expetion instead
             if (elementWriteFunc == null)
             {
-                Weaver.Error($"Cannot generate writer for List because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
+                throw new GenerateWriterException($"Cannot generate writer for List because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
             }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -177,6 +177,8 @@ namespace Mirror.Weaver
             foreach (FieldDefinition field in variable.FindAllPublicFields())
             {
                 MethodReference writeFunc = GetWriteFunc(field.FieldType, recursionCount + 1);
+                // need this null check till later PR when GetWriteFunc throws expetion instead
+                if (writeFunc == null) { return false; }
 
                 FieldReference fieldRef = Weaver.CurrentAssembly.MainModule.ImportReference(field);
 
@@ -204,6 +206,12 @@ namespace Mirror.Weaver
 
             TypeReference elementType = variable.GetElementType();
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
+            // need this null check till later PR when GetWriteFunc throws expetion instead
+            if (elementWriteFunc == null)
+            {
+                Weaver.Error($"Cannot generate writer for Array because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
+                return null;
+            }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
             string functionName = "_WriteArray" + variable.GetElementType().Name + "_";
@@ -299,6 +307,12 @@ namespace Mirror.Weaver
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
+            // need this null check till later PR when GetWriteFunc throws expetion instead
+            if (elementWriteFunc == null)
+            {
+                Weaver.Error($"Cannot generate writer for ArraySegment because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
+                return null;
+            }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
             string functionName = "_WriteArraySegment_" + elementType.Name + "_";
@@ -389,6 +403,12 @@ namespace Mirror.Weaver
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
             MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
+            // need this null check till later PR when GetWriteFunc throws expetion instead
+            if (elementWriteFunc == null)
+            {
+                Weaver.Error($"Cannot generate writer for List because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
+                return null;
+            }
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.int32Type);
 
 

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
@@ -90,8 +90,6 @@ namespace Mirror.Weaver.Tests
             // we need this negative test to make sure that SyncList is being processed 
             HasError("Cannot generate writer for Object. Use a supported type or provide a custom writer",
                 "UnityEngine.Object");
-            HasError("target has unsupported type. Use a type supported by Mirror instead",
-                "UnityEngine.Object WeaverSyncListTests.SyncListNestedInStructWithInvalid.SyncListNestedInStructWithInvalid/SomeData::target");
             HasError("SyncList has sync object generic type SomeData.  Use a type supported by mirror instead",
                 "WeaverSyncListTests.SyncListNestedInStructWithInvalid.SyncListNestedInStructWithInvalid/SomeData/SyncList");
         }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
@@ -72,8 +72,6 @@ namespace Mirror.Weaver.Tests
             // we need this negative test to make sure that SyncList is being processed 
             HasError("Cannot generate writer for Object. Use a supported type or provide a custom writer",
                 "UnityEngine.Object");
-            HasError("target has unsupported type. Use a type supported by Mirror instead",
-                "UnityEngine.Object WeaverSyncListTests.SyncListNestedInAbstractClassWithInvalid.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStruct::target");
             HasError("MyNestedStructList has sync object generic type MyNestedStruct.  Use a type supported by mirror instead",
                 "WeaverSyncListTests.SyncListNestedInAbstractClassWithInvalid.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStructList");
         }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
@@ -13,9 +13,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void SyncVarsDerivedNetworkBehaviour()
         {
-            HasError("Cannot generate writer for component type MyBehaviour. Use a supported type or provide a custom writer",
-                "WeaverSyncVarTests.SyncVarsDerivedNetworkBehaviour.MyBehaviour");
-            HasError("invalidVar has unsupported type. Use a supported Mirror type instead",
+            HasError("Invalid SyncVar: Cannot generate writer for component type MyBehaviour",
                 "WeaverSyncVarTests.SyncVarsDerivedNetworkBehaviour.MyBehaviour WeaverSyncVarTests.SyncVarsDerivedNetworkBehaviour.SyncVarsDerivedNetworkBehaviour::invalidVar");
         }
 
@@ -29,27 +27,21 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void SyncVarsGenericParam()
         {
-            HasError("Cannot generate writer for generic type MySyncVar`1. Use a supported type or provide a custom writer",
-                "WeaverSyncVarTests.SyncVarsGenericParam.SyncVarsGenericParam/MySyncVar`1<System.Int32>");
-            HasError("invalidVar has unsupported type. Use a supported Mirror type instead",
+            HasError("Invalid SyncVar: Cannot generate writer for generic type MySyncVar`1",
                 "WeaverSyncVarTests.SyncVarsGenericParam.SyncVarsGenericParam/MySyncVar`1<System.Int32> WeaverSyncVarTests.SyncVarsGenericParam.SyncVarsGenericParam::invalidVar");
         }
 
         [Test]
         public void SyncVarsInterface()
         {
-            HasError("Cannot generate writer for interface IMySyncVar. Use a supported type or provide a custom writer",
-                "WeaverSyncVarTests.SyncVarsInterface.SyncVarsInterface/IMySyncVar");
-            HasError("invalidVar has unsupported type. Use a supported Mirror type instead",
-                "WeaverSyncVarTests.SyncVarsInterface.SyncVarsInterface/IMySyncVar WeaverSyncVarTests.SyncVarsInterface.SyncVarsInterface::invalidVar");
+            HasError("Invalid SyncVar: Cannot generate writer for interface IMySyncVar",
+               "WeaverSyncVarTests.SyncVarsInterface.SyncVarsInterface/IMySyncVar WeaverSyncVarTests.SyncVarsInterface.SyncVarsInterface::invalidVar");
         }
 
         [Test]
         public void SyncVarsUnityComponent()
         {
-            HasError("Cannot generate writer for component type TextMesh. Use a supported type or provide a custom writer",
-                "UnityEngine.TextMesh");
-            HasError("invalidVar has unsupported type. Use a supported Mirror type instead",
+            HasError("Invalid SyncVar: Cannot generate writer for component type TextMesh",
                 "UnityEngine.TextMesh WeaverSyncVarTests.SyncVarsUnityComponent.SyncVarsUnityComponent::invalidVar");
         }
 


### PR DESCRIPTION
requires: https://github.com/vis2k/Mirror/pull/2172
requires: https://github.com/vis2k/Mirror/pull/2174
requires: https://github.com/vis2k/Mirror/pull/2175

This means we dont need null checks after every return from `GetWriteFunc`. Instead we can catch and log the Exception when it is a problem.

for example, if we can't generate a writer for a type within a SyncObject, we can catch the Exception at the sync object level and tell the user their sync object wont work, and why it wont work.