### PR TITLE
weaver: throwing within writers

### DIFF
--- a/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs
@@ -1,0 +1,25 @@
+using System;
+using Mono.CecilX;
+
+namespace Mirror.Weaver
+{
+    [Serializable]
+    public abstract class WeaverException : Exception
+    {
+        public MemberReference MemberReference { get; }
+
+        protected WeaverException(string message, MemberReference member) : base(message)
+        {
+            MemberReference = member;
+        }
+
+        protected WeaverException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+    }
+
+    [Serializable]
+    public class GenerateWriterException : WeaverException
+    {
+        public GenerateWriterException(string message, MemberReference member) : base(message, member) { }
+        protected GenerateWriterException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+    }
+}

--- a/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs.meta
+++ b/Assets/Mirror/Editor/Weaver/WeaverExceptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8aaaf6193bad7424492677f8e81f1b30
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
@@ -72,8 +72,6 @@ namespace Mirror.Weaver.Tests
             // we need this negative test to make sure that SyncList is being processed 
             HasError("Cannot generate writer for Object. Use a supported type or provide a custom writer",
                 "UnityEngine.Object");
-            HasError("target has unsupported type. Use a type supported by Mirror instead",
-                "UnityEngine.Object WeaverSyncListTests.SyncListNestedInAbstractClassWithInvalid.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStruct::target");
             HasError("MyNestedStructList has sync object generic type MyNestedStruct.  Use a type supported by mirror instead",
                 "WeaverSyncListTests.SyncListNestedInAbstractClassWithInvalid.SyncListNestedStructWithInvalid/SomeAbstractClass/MyNestedStructList");
         }
@@ -90,8 +88,6 @@ namespace Mirror.Weaver.Tests
             // we need this negative test to make sure that SyncList is being processed 
             HasError("Cannot generate writer for Object. Use a supported type or provide a custom writer",
                 "UnityEngine.Object");
-            HasError("target has unsupported type. Use a type supported by Mirror instead",
-                "UnityEngine.Object WeaverSyncListTests.SyncListNestedInStructWithInvalid.SyncListNestedInStructWithInvalid/SomeData::target");
             HasError("SyncList has sync object generic type SomeData.  Use a type supported by mirror instead",
                 "WeaverSyncListTests.SyncListNestedInStructWithInvalid.SyncListNestedInStructWithInvalid/SomeData/SyncList");
         }


### PR DESCRIPTION
The goal of this and future PR is to simplify error handling in weaver and to only return 1 error message to the user per error.

- Throwing GenerateWriterException instead of returning null.
- This PR only changes stuff inside of Writers, in future PR `GetWriteFunc` not catch the error and instead let the caller deal with it.

See this comment for more of plan https://github.com/vis2k/Mirror/pull/2173#issuecomment-675425003