### PR TITLE
feat: Messages can now be sent in RPC

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -131,7 +131,8 @@ namespace Mirror.Weaver
             readFunc.Parameters.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(WeaverTypes.NetworkReaderType)));
 
             // get ReadMessage<T> method
-            MethodReference genericReadMessage = readFuncs.Values.Where(x => x.HasGenericParameters && x.Name == "ReadMessage" && x.DeclaringType.Name == "NetworkReaderExtensions").FirstOrDefault();
+            MethodReference genericReadMessage = readFuncs.Values
+                .First(x => x.HasGenericParameters && x.Name == "ReadMessage" && x.DeclaringType.Name == "NetworkReaderExtensions");
             // convert method to variable type
             GenericInstanceMethod readFunction = new GenericInstanceMethod(genericReadMessage);
             readFunction.GenericArguments.Add(variable);

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -131,8 +131,6 @@ namespace Mirror.Weaver
                 return null;
             }
 
-
-
             // generate writer for class/struct
 
             return GenerateClassOrStructWriterFunction(variableReference, recursionCount);

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -82,7 +82,7 @@ namespace Mirror.Weaver
                 return GenerateListWriteFunc(variableReference, recursionCount);
             }
 
-            // check for invalid types
+            // check if type can be resolved
 
             TypeDefinition variableDefinition = variableReference.Resolve();
             if (variableDefinition == null)
@@ -90,6 +90,16 @@ namespace Mirror.Weaver
                 Weaver.Error($"{variableReference.Name} is not a supported type. Use a supported type or provide a custom writer", variableReference);
                 return null;
             }
+
+            // does type implement IMessageBase?
+
+            if (variableDefinition.ImplementsInterface(WeaverTypes.IMessageBaseType))
+            {
+                return GenerateMessageWriteFunction(variableReference);
+            }
+
+            // check for invalid types
+
             if (variableDefinition.IsDerivedFrom(WeaverTypes.ComponentType))
             {
                 Weaver.Error($"Cannot generate writer for component type {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
@@ -121,12 +131,7 @@ namespace Mirror.Weaver
                 return null;
             }
 
-            // does type implement IMessageBase?
 
-            if (variableDefinition.ImplementsInterface(WeaverTypes.IMessageBaseType))
-            {
-                return GenerateMessageWriteFunction(variableReference);
-            }
 
             // generate writer for class/struct
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -148,9 +148,10 @@ namespace Mirror.Weaver
             writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(variable)));
 
             // get WriteMessage<T> method
-            MethodReference generic = writeFuncs.Values.Where(x => x.HasGenericParameters && x.Name == "WriteMessage" && x.DeclaringType.Name == "NetworkWriterExtensions").FirstOrDefault();
+            MethodReference genericWriteMessage = writeFuncs.Values
+                .First(x => x.HasGenericParameters && x.Name == "WriteMessage" && x.DeclaringType.Name == "NetworkWriterExtensions");
             // convert method to variable type
-            GenericInstanceMethod writeFunction = new GenericInstanceMethod(generic);
+            GenericInstanceMethod writeFunction = new GenericInstanceMethod(genericWriteMessage);
             writeFunction.GenericArguments.Add(variable);
 
             /*

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -378,5 +378,14 @@ namespace Mirror
         {
             msg.Deserialize(reader);
         }
+        public static T ReadMessage<T>(this NetworkReader reader) where T : IMessageBase, new()
+        {
+            // if it is a value type, just use defult(T)
+            // otherwise allocate a new instance
+            T msg = default(T) != null ? default : new T();
+
+            msg.Deserialize(reader);
+            return msg;
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/MessageInRpcTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessageInRpcTest.cs
@@ -1,0 +1,64 @@
+using System;
+using NUnit.Framework;
+
+namespace Mirror.Tests.RemoteAttrributeTest
+{
+    public class TestMessageBehaviour : NetworkBehaviour
+    {
+        public static Action<MessageInRpcTest.MyMessage> onRpcCalled;
+
+        [ClientRpc]
+        public void RpcSendMessage(MessageInRpcTest.MyMessage message)
+        {
+            onRpcCalled?.Invoke(message);
+        }
+    }
+    [TestFixture]
+    public class MessageInRpcTest : RemoteTestBase
+    {
+        public class MyMessage : IMessageBase
+        {
+            public static Action onSerializeCalled;
+            public static Action onDeserializeCalled;
+            public const int FieldValue = 20;
+
+            public int someField;
+
+            public void Serialize(NetworkWriter writer)
+            {
+                onSerializeCalled?.Invoke();
+            }
+            public void Deserialize(NetworkReader reader)
+            {
+                someField = FieldValue;
+                onDeserializeCalled?.Invoke();
+            }
+        }
+
+        [Test]
+        public void RpcUsesMessageBaseMethods()
+        {
+            int serializeCalled = 0;
+            int deserializeCalled = 0;
+            int rpcCalled = 0;
+            MyMessage recievedMessage = null;
+
+            MyMessage.onSerializeCalled = () => { serializeCalled++; };
+            MyMessage.onDeserializeCalled = () => { deserializeCalled++; };
+            TestMessageBehaviour.onRpcCalled = (msg) => { rpcCalled++; recievedMessage = msg; };
+
+            MyMessage message = new MyMessage() { someField = 10 };
+            TestMessageBehaviour behaviour = CreateHostObject<TestMessageBehaviour>(true);
+
+            behaviour.RpcSendMessage(message);
+            ProcessMessages();
+
+            Assert.That(serializeCalled, Is.EqualTo(1));
+            Assert.That(deserializeCalled, Is.EqualTo(1));
+            Assert.That(rpcCalled, Is.EqualTo(1));
+
+            Assert.That(recievedMessage, Is.Not.Null);
+            Assert.That(recievedMessage.someField, Is.EqualTo(MyMessage.FieldValue), "Field is set to FieldValue in Deserialize not the 10 sent above");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/MessageInRpcTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/MessageInRpcTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0852edf123052de4e9f01cf204b7e643
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
+++ b/Assets/Mirror/Tests/Editor/Weaver/.WeaverTests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="WeaverCommandTests~\ErrorForOptionalNetworkConnectionThatIsNotSenderConnection.cs" />
     <Compile Include="WeaverGeneralTests~\RecursionCount.cs" />
     <Compile Include="WeaverGeneralTests~\TestingScriptableObjectArraySerialization.cs" />
+    <Compile Include="WeaverGeneratedReaderWriterTests~\MessageWriterShouldUseMessageBaseFunctions.cs" />
     <Compile Include="WeaverMessageTests~\AbstractMessageMethods.cs" />
     <Compile Include="WeaverMessageTests~\MessageMemberGeneric.cs" />
     <Compile Include="WeaverMessageTests~\MessageMemberInterface.cs" />

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
@@ -236,5 +236,11 @@ namespace Mirror.Weaver.Tests
             //HasError("Cannot generate reader for List because element MonoBehaviour does not have a reader. Use a supported type or provide a custom reader",
             //    "System.Collections.Generic.List`1<UnityEngine.MonoBehaviour>");
         }
+
+        [Test]
+        public void MessageWriterShouldUseMessageBaseFunctions()
+        {
+            IsSuccess();
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests~/MessageWriterShouldUseMessageBaseFunctions.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests~/MessageWriterShouldUseMessageBaseFunctions.cs
@@ -1,0 +1,35 @@
+using Mirror;
+using UnityEngine;
+
+namespace GeneratedReaderWriter.MessageWriterShouldUseMessageBaseFunctions
+{
+    public class MyMessage : IMessageBase
+    {
+        public int someField;
+        public MeshRenderer renderer;
+
+        public void Serialize(NetworkWriter writer)
+        {
+            writer.WriteInt32(someField);
+            writer.WriteNetworkIdentity(renderer.GetComponent<NetworkIdentity>());
+        }
+
+        public void Deserialize(NetworkReader reader)
+        {
+            someField = reader.ReadInt32();
+            NetworkIdentity netID = reader.ReadNetworkIdentity();
+            renderer = netID.GetComponent<MeshRenderer>();
+        }
+    }
+
+    public class MessageWriterShouldUseMessageBaseFunctions : NetworkBehaviour
+    {
+        // use an rpc here to force weaver to create writer for MyMessage
+        // writer should be Serialize/Deserialize so invalid type MeshRenderer shouldn't give error
+        [ClientRpc]
+        public void RpcSendMessage(MyMessage myMessage)
+        {
+            // do something with message
+        }
+    }
+}


### PR DESCRIPTION
Right now if a user tries to pass a message in a Cmd/Rpc then weaver will try to generate a new writer and treat the message like a normal class/struct. This is a problem because it wont use the Serialize/Deserialze methods of Message that the user may have overridden.

This would allow users to add IMessageBase to their types instead of using Extension Methods which would allow the code for a type to be in one place