### PR TITLE
breaking: Removing manual invoke for Cmd and RPC

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -207,17 +207,6 @@ namespace Mirror
             ClientScene.readyConnection.Send(message, channelId);
         }
 
-        /// <summary>
-        /// Manually invoke a Command.
-        /// </summary>
-        /// <param name="cmdHash">Hash of the Command name.</param>
-        /// <param name="reader">Parameters to pass to the command.</param>
-        /// <returns>Returns true if successful.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual bool InvokeCommand(int cmdHash, NetworkReader reader)
-        {
-            return RemoteCallHelper.InvokeHandlerDelegate(cmdHash, MirrorInvokeType.Command, reader, this);
-        }
         #endregion
 
         #region Client RPCs
@@ -295,17 +284,6 @@ namespace Mirror
             conn.Send(message, channelId);
         }
 
-        /// <summary>
-        /// Manually invoke an RPC function.
-        /// </summary>
-        /// <param name="rpcHash">Hash of the RPC name.</param>
-        /// <param name="reader">Parameters to pass to the RPC function.</param>
-        /// <returns>Returns true if successful.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual bool InvokeRPC(int rpcHash, NetworkReader reader)
-        {
-            return RemoteCallHelper.InvokeHandlerDelegate(rpcHash, MirrorInvokeType.ClientRpc, reader, this);
-        }
         #endregion
 
         #region Helpers

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -393,31 +393,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void InvokeCommand()
-        {
-            // add command component
-            NetworkBehaviourSendCommandInternalComponent comp = gameObject.AddComponent<NetworkBehaviourSendCommandInternalComponent>();
-            Assert.That(comp.called, Is.EqualTo(0));
-
-            // register the command delegate, otherwise it's not found
-            int registeredHash = RemoteCallHelper.RegisterDelegate(typeof(NetworkBehaviourSendCommandInternalComponent),
-                nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated),
-                MirrorInvokeType.Command,
-                NetworkBehaviourSendCommandInternalComponent.CommandGenerated,
-                false);
-
-            // invoke command
-            int cmdHash = RemoteCallHelper.GetMethodHash(
-                typeof(NetworkBehaviourSendCommandInternalComponent),
-                nameof(NetworkBehaviourSendCommandInternalComponent.CommandGenerated));
-            comp.InvokeCommand(cmdHash, new NetworkReader(new byte[0]));
-            Assert.That(comp.called, Is.EqualTo(1));
-
-            // clean up
-            RemoteCallHelper.RemoveDelegate(registeredHash);
-        }
-
-        [Test]
         public void SendRPCInternal()
         {
             // add rpc component
@@ -593,30 +568,6 @@ namespace Mirror.Tests
             NetworkServer.Shutdown();
             Transport.activeTransport = null;
             GameObject.DestroyImmediate(transportGO);
-        }
-
-        [Test]
-        public void InvokeRPC()
-        {
-            // add command component
-            NetworkBehaviourSendRPCInternalComponent comp = gameObject.AddComponent<NetworkBehaviourSendRPCInternalComponent>();
-            Assert.That(comp.called, Is.EqualTo(0));
-
-            // register the command delegate, otherwise it's not found
-            int registeredHash = RemoteCallHelper.RegisterDelegate(typeof(NetworkBehaviourSendRPCInternalComponent),
-                nameof(NetworkBehaviourSendRPCInternalComponent.RPCGenerated),
-                MirrorInvokeType.ClientRpc,
-                NetworkBehaviourSendRPCInternalComponent.RPCGenerated);
-
-            // invoke command
-            int rpcHash = RemoteCallHelper.GetMethodHash(
-                typeof(NetworkBehaviourSendRPCInternalComponent),
-                nameof(NetworkBehaviourSendRPCInternalComponent.RPCGenerated));
-            comp.InvokeRPC(rpcHash, new NetworkReader(new byte[0]));
-            Assert.That(comp.called, Is.EqualTo(1));
-
-            // clean up
-            RemoteCallHelper.RemoveDelegate(registeredHash);
         }
 
         [Test]


### PR DESCRIPTION
- There should be no reason to manually invoke remote code
- They are marked with `EditorBrowsableState.Never` which implies they should not be called by the user
- `GetMethodHash`  is currently internal so users have no way to create hash needed to call this method

If user does need to invoke remote code then that code should be in a non remote method, the purple of Cmd/RPC is to be invoked on other instances (server/client)