### PR TITLE
feat: check for headless in runtime

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 // Based on https://github.com/EnlightenedOne/MirrorNetworkDiscovery
 // forked from https://github.com/in0finite/MirrorNetworkDiscovery
@@ -63,9 +64,8 @@ namespace Mirror.Discovery
         public virtual void Start()
         {
             // Server mode? then start advertising
-#if UNITY_SERVER
-            AdvertiseServer();
-#endif
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null)
+                AdvertiseServer();
         }
 
         // Ensure the ports are cleared no matter when Game/Unity UI exits

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Rendering;
 using UnityEngine.SceneManagement;
 
 namespace Mirror.Examples.NetworkRoom
@@ -55,11 +56,10 @@ namespace Mirror.Examples.NetworkRoom
         public override void OnRoomServerPlayersReady()
         {
             // calling the base method calls ServerChangeScene as soon as all players are in Ready state.
-#if UNITY_SERVER
-            base.OnRoomServerPlayersReady();
-#else
-            showStartButton = true;
-#endif
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null)
+                base.OnRoomServerPlayersReady();
+            else
+                showStartButton = true;
         }
 
         public override void OnGUI()

--- a/Assets/Mirror/Runtime/Logging/NetworkHeadlessLogger.cs
+++ b/Assets/Mirror/Runtime/Logging/NetworkHeadlessLogger.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Mirror.Logging
 {
@@ -14,9 +15,8 @@ namespace Mirror.Logging
 
         void Awake()
         {
-#if UNITY_SERVER
-            LogFactory.ReplaceLogHandler(new ConsoleColorLogHandler(showExceptionStackTrace));
-#endif
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null)
+                LogFactory.ReplaceLogHandler(new ConsoleColorLogHandler(showExceptionStackTrace));
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -261,12 +261,10 @@ namespace Mirror
             // some transports might not be ready until Start.
             //
             // (tick rate is applied in StartServer!)
-#if UNITY_SERVER
-            if (autoStartServerBuild)
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null && autoStartServerBuild)
             {
                 StartServer();
             }
-#endif
         }
 
         // NetworkIdentity.UNetStaticUpdate is called from UnityEngine while LLAPI network is active.
@@ -684,10 +682,11 @@ namespace Mirror
         public virtual void ConfigureServerFrameRate()
         {
             // only set framerate for server build
-#if UNITY_SERVER
-            Application.targetFrameRate = serverTickRate;
-            if (logger.logEnabled) logger.Log("Server Tick Rate set to: " + Application.targetFrameRate + " Hz.");
-#endif
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null)
+            {
+                Application.targetFrameRate = serverTickRate;
+                if (logger.logEnabled) logger.Log("Server Tick Rate set to: " + Application.targetFrameRate + " Hz.");
+            }
         }
 
         bool InitializeSingleton()


### PR DESCRIPTION
Check for headless environment at runtime instead of compile-time.

If we rely on `#if UNITY_SERVER` then we don't properly detect headless mode when I start the game like this:
```
MyGame.exe -batchmode -nographics
```

Also, the `#if` hides compiler errors. We might delete a using statement and not realize we broke headless builds.  This has happened to me a lot in Cubica with other defines.
