### PR TITLE
fix: fixing NullReferenceException when loading scene

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -896,6 +896,8 @@ namespace Mirror
             isSpawnFinished = false;
         }
 
+
+        static readonly List<uint> toRemoveFromSpawned = new List<uint>();
         internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage _)
         {
             logger.Log("SpawnFinished");
@@ -908,9 +910,15 @@ namespace Mirror
             {
                 if (kvp.Value == null)
                 {
-                    NetworkIdentity.spawned.Remove(kvp.Key);
+                    toRemoveFromSpawned.Add(kvp.Key);
                 }
             }
+            // can't modifiy NetworkIdentity.spawned inside foreach so need 2nd loop to remove
+            foreach (uint id in toRemoveFromSpawned)
+            {
+                NetworkIdentity.spawned.Remove(id);
+            }
+            toRemoveFromSpawned.Clear();
 
             // paul: Initialize the objects in the same order as they were initialized
             // in the server.   This is important if spawned objects

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -905,6 +905,10 @@ namespace Mirror
             // use data from scene objects
             foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values.OrderBy(uv => uv.netId))
             {
+                // spawned has null objects after changing scenes on client
+                // TODO remove null objects from spawned so we dont need the check below
+                if (identity == null) { continue; }
+
                 identity.NotifyAuthority();
                 identity.OnStartClient();
                 CheckForLocalPlayer(identity);

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -897,28 +897,11 @@ namespace Mirror
         }
 
 
-        static readonly List<uint> toRemoveFromSpawned = new List<uint>();
         internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage _)
         {
             logger.Log("SpawnFinished");
 
-            // spawned has null objects after changing scenes on client using NetworkManager.ServerChangeScene
-            // remove them here so that 2nd loop below does not get NullReferenceException 
-            // see https://github.com/vis2k/Mirror/pull/2240
-            // TODO fix scene logic so that client scene doesn't have null objects
-            foreach (KeyValuePair<uint, NetworkIdentity> kvp in NetworkIdentity.spawned)
-            {
-                if (kvp.Value == null)
-                {
-                    toRemoveFromSpawned.Add(kvp.Key);
-                }
-            }
-            // can't modifiy NetworkIdentity.spawned inside foreach so need 2nd loop to remove
-            foreach (uint id in toRemoveFromSpawned)
-            {
-                NetworkIdentity.spawned.Remove(id);
-            }
-            toRemoveFromSpawned.Clear();
+            ClearNullFromSpawned();
 
             // paul: Initialize the objects in the same order as they were initialized
             // in the server.   This is important if spawned objects
@@ -930,6 +913,29 @@ namespace Mirror
                 CheckForLocalPlayer(identity);
             }
             isSpawnFinished = true;
+        }
+
+        static readonly List<uint> toRemoveFromSpawned = new List<uint>();
+        static void ClearNullFromSpawned()
+        {
+            // spawned has null objects after changing scenes on client using NetworkManager.ServerChangeScene
+            // remove them here so that 2nd loop below does not get NullReferenceException 
+            // see https://github.com/vis2k/Mirror/pull/2240
+            // TODO fix scene logic so that client scene doesn't have null objects
+            foreach (KeyValuePair<uint, NetworkIdentity> kvp in NetworkIdentity.spawned)
+            {
+                if (kvp.Value == null)
+                {
+                    toRemoveFromSpawned.Add(kvp.Key);
+                }
+            }
+
+            // can't modifiy NetworkIdentity.spawned inside foreach so need 2nd loop to remove
+            foreach (uint id in toRemoveFromSpawned)
+            {
+                NetworkIdentity.spawned.Remove(id);
+            }
+            toRemoveFromSpawned.Clear();
         }
 
         internal static void OnObjectHide(ObjectHideMessage msg)

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -896,7 +896,6 @@ namespace Mirror
             isSpawnFinished = false;
         }
 
-
         internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage _)
         {
             logger.Log("SpawnFinished");


### PR DESCRIPTION
User was having this exception 
```cs
MissingReferenceException: The object of type 'NetworkIdentity' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
UnityEngine.Object.get_name () (at <ee47be73f7ef409ca5e5ce4b121745b7>:0)
Mirror.ClientScene.CheckForLocalPlayer (Mirror.NetworkIdentity identity) (at Assets/Mirror/Runtime/ClientScene.cs:1003)
Mirror.ClientScene.OnObjectSpawnFinished (Mirror.ObjectSpawnFinishedMessage _) (at Assets/Mirror/Runtime/ClientScene.cs:876)
Mirror.NetworkClient+<>c__DisplayClass31_0`1[T].<RegisterHandler>b__0 (Mirror.NetworkConnection _, T value) (at Assets/Mirror/Runtime/NetworkClient.cs:331)
Mirror.MessagePacker+<>c__DisplayClass7_0`2[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) (at Assets/Mirror/Runtime/MessagePacker.cs:148)
Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) (at Assets/Mirror/Runtime/NetworkConnection.cs:225)
Mirror.NetworkConnection.TransportReceive (System.ArraySegment`1[T] buffer, System.Int32 channelId) (at Assets/Mirror/Runtime/NetworkConnection.cs:278)
Mirror.NetworkClient.OnDataReceived (System.ArraySegment`1[T] data, System.Int32 channelId) (at Assets/Mirror/Runtime/NetworkClient.cs:172)
UnityEngine.Events.InvokableCall`2[T1,T2].Invoke (T1 args0, T2 args1) (at <ee47be73f7ef409ca5e5ce4b121745b7>:0)
UnityEngine.Events.UnityEvent`2[T0,T1].Invoke (T0 arg0, T1 arg1) (at <ee47be73f7ef409ca5e5ce4b121745b7>:0)
Mirror.TelepathyTransport.ProcessClientMessage () (at Assets/Mirror/Runtime/Transport/TelepathyTransport.cs:102)
Mirror.TelepathyTransport.LateUpdate () (at Assets/Mirror/Runtime/Transport/TelepathyTransport.cs:136)
```

Caused by this when `identity` is destroyed and  localPlayer is either null or destroyed
```cs
static void CheckForLocalPlayer(NetworkIdentity identity)
{
    if (identity == localPlayer)
    {
        // Set isLocalPlayer to true on this NetworkIdentity and trigger OnStartLocalPlayer in all scripts on the same GO
        identity.connectionToServer = readyConnection;
        identity.OnStartLocalPlayer();

        if (logger.LogEnabled()) logger.Log("ClientScene.OnOwnerMessage - player=" + identity.name);
    }
}
```
It seems that `ObjectSpawnFinishedMessage` arrives at client before destroy messages from object in old scene
![image](https://user-images.githubusercontent.com/23101891/93006848-3f3bce80-f559-11ea-92cf-a8c8ded00dfd.png)


This seems a bit inconstant and the error doesn't show up every time
