### PR TITLE
fix: making sure CallOnClientExitRoom is called when object is disabled/destroyed

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -231,7 +231,7 @@ namespace Mirror
                 }
         }
 
-        void CallOnClientExitRoom()
+        internal void CallOnClientExitRoom()
         {
             OnRoomClientExit();
             foreach (NetworkRoomPlayer player in roomSlots)

--- a/Assets/Mirror/Components/NetworkRoomPlayer.cs
+++ b/Assets/Mirror/Components/NetworkRoomPlayer.cs
@@ -71,6 +71,8 @@ namespace Mirror
             {
                 room.roomSlots.Remove(this);
                 room.RecalculateRoomPlayerIndices();
+
+                room.CallOnClientExitRoom();
             }
         }
 


### PR DESCRIPTION
`OnClientExitRoom` wasn't being called on all client when a client left, it was only called on the client that left.

`OnClientEnterRoom` is called on every client, so `OnClientExitRoom` should match it.