### PR TITLE
adding doc comment

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1268,6 +1268,9 @@ namespace Mirror
             }
         }
 
+        /// <summary>
+        /// Called when NetworkIdentity is destroyed
+        /// </summary>
         internal void ClearObservers()
         {
             if (observers != null)


### PR DESCRIPTION
adding doc comment to say when `ClearObservers` is called 

helps to explain why `conn.RemoveFromVisList(this, true);` has isDestroyed as true