### PR TITLE
fix: fixed sender connection in commands for il2cpp

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -861,7 +861,7 @@ namespace Mirror.Weaver
             collection.Add(new ParameterDefinition("obj", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(WeaverTypes.NetworkBehaviourType)));
             collection.Add(new ParameterDefinition("reader", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(WeaverTypes.NetworkReaderType)));
             // senderConnection is only used for commands but NetworkBehaviour.CmdDelegate is used for all remote calls
-            collection.Add(new ParameterDefinition("senderConnection", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(WeaverTypes.NetworkConnectionType)));
+            collection.Add(new ParameterDefinition("senderConnection", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(WeaverTypes.NetworkConnectionToClientType)));
         }
 
         // check if a Command/TargetRpc/Rpc function & parameters are valid for weaving

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -11,6 +11,7 @@ namespace Mirror.Weaver
         public static TypeReference MonoBehaviourType;
         public static TypeReference ScriptableObjectType;
         public static TypeReference NetworkConnectionType;
+        public static TypeReference NetworkConnectionToClientType;
 
         public static TypeReference MessageBaseType;
         public static TypeReference IMessageBaseType;
@@ -188,7 +189,6 @@ namespace Mirror.Weaver
 
             NetworkBehaviourType = mirrorAssembly.MainModule.GetType("Mirror.NetworkBehaviour");
             RemoteCallHelperType = mirrorAssembly.MainModule.GetType("Mirror.RemoteCalls.RemoteCallHelper");
-            NetworkConnectionType = mirrorAssembly.MainModule.GetType("Mirror.NetworkConnection");
 
             MonoBehaviourType = unityAssembly.MainModule.GetType("UnityEngine.MonoBehaviour");
             ScriptableObjectType = unityAssembly.MainModule.GetType("UnityEngine.ScriptableObject");
@@ -199,6 +199,9 @@ namespace Mirror.Weaver
 
             NetworkConnectionType = mirrorAssembly.MainModule.GetType("Mirror.NetworkConnection");
             NetworkConnectionType = currentAssembly.MainModule.ImportReference(NetworkConnectionType);
+
+            NetworkConnectionToClientType = mirrorAssembly.MainModule.GetType("Mirror.NetworkConnectionToClient");
+            NetworkConnectionToClientType = currentAssembly.MainModule.ImportReference(NetworkConnectionToClientType);
 
             MessageBaseType = mirrorAssembly.MainModule.GetType("Mirror.MessageBase");
             IMessageBaseType = mirrorAssembly.MainModule.GetType("Mirror.IMessageBase");


### PR DESCRIPTION
InvokeUserCode was using `NetworkConnection` instead of `NetworkConnectionToClient`, `CmdDeligate` already used `NetworkConnectionToClient` so there the InvokeUserCode  function can also use it.


![image](https://user-images.githubusercontent.com/23101891/93527720-2e140880-f931-11ea-9094-3858af302acc.png)

fixes: https://github.com/vis2k/Mirror/issues/2122

will merge when tests pass