### PR TITLE
Enhance code readability by using extension method

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -7,6 +7,10 @@ namespace Mirror.Weaver
 {
     public static class Extensions
     {
+        public static bool Is(this TypeReference td, Type t) =>
+            td.FullName == t.FullName;
+
+        public static bool Is<T>(this TypeReference td) => Is(td, typeof(T));
 
         // removes <T> from class names (if any generic parameters)
         internal static string StripGenericParametersFromClassName(string className)
@@ -67,13 +71,12 @@ namespace Mirror.Weaver
         public static bool ImplementsInterface<TInterface>(this TypeDefinition td)
         {
             TypeDefinition typedef = td;
-            Type baseInterface = typeof(TInterface);
 
             while (typedef != null)
             {
                 foreach (InterfaceImplementation iface in typedef.Interfaces)
                 {
-                    if (iface.InterfaceType.FullName == baseInterface.FullName)
+                    if (iface.InterfaceType.Is<TInterface>())
                         return true;
                 }
 
@@ -170,10 +173,9 @@ namespace Mirror.Weaver
 
         public static CustomAttribute GetCustomAttribute<TAttribute>(this ICustomAttributeProvider method)
         {
-            Type t = typeof(TAttribute);
             foreach (CustomAttribute ca in method.CustomAttributes)
             {
-                if (ca.AttributeType.FullName == t.FullName)
+                if (ca.AttributeType.Is<TAttribute>())
                     return ca;
             }
             return null;
@@ -181,9 +183,8 @@ namespace Mirror.Weaver
 
         public static bool HasCustomAttribute<TAttribute>(this ICustomAttributeProvider attributeProvider)
         {
-            Type t = typeof(TAttribute);
             // Linq allocations don't matter in weaver
-            return attributeProvider.CustomAttributes.Any(attr => attr.AttributeType.FullName == t.FullName);
+            return attributeProvider.CustomAttributes.Any(attr => attr.AttributeType.Is<TAttribute>());
         }
 
         public static T GetField<T>(this CustomAttribute ca, string field, T defaultValue)

--- a/Assets/Mirror/Editor/Weaver/Processors/MonoBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MonoBehaviourProcessor.cs
@@ -35,17 +35,17 @@ namespace Mirror.Weaver
             {
                 foreach (CustomAttribute ca in md.CustomAttributes)
                 {
-                    if (ca.AttributeType.FullName == typeof(Mirror.CommandAttribute).FullName)
+                    if (ca.AttributeType.Is<Mirror.CommandAttribute>())
                     {
                         Weaver.Error($"Command {md.Name} must be declared inside a NetworkBehaviour", md);
                     }
 
-                    if (ca.AttributeType.FullName == typeof(Mirror.ClientRpcAttribute).FullName)
+                    if (ca.AttributeType.Is<Mirror.ClientRpcAttribute>())
                     {
                         Weaver.Error($"ClientRpc {md.Name} must be declared inside a NetworkBehaviour", md);
                     }
 
-                    if (ca.AttributeType.FullName == typeof(Mirror.TargetRpcAttribute).FullName)
+                    if (ca.AttributeType.Is<Mirror.TargetRpcAttribute>())
                     {
                         Weaver.Error($"TargetRpc {md.Name} must be declared inside a NetworkBehaviour", md);
                     }

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -886,7 +886,7 @@ namespace Mirror.Weaver
                 Weaver.Error($"{md.Name} cannot be a coroutine", md);
                 return false;
             }
-            if (md.ReturnType.Is(typeof(void)))
+            if (!md.ReturnType.Is(typeof(void)))
             {
                 Weaver.Error($"{md.Name} cannot return a value.  Make it void instead", md);
                 return false;

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
@@ -517,8 +518,8 @@ namespace Mirror.Weaver
         /// <returns></returns>
         static bool IsNetworkIdentityField(FieldDefinition syncVar)
         {
-            return syncVar.FieldType.FullName == typeof(UnityEngine.GameObject).FullName ||
-                   syncVar.FieldType.FullName == typeof(Mirror.NetworkIdentity).FullName;
+            return syncVar.FieldType.Is<UnityEngine.GameObject>() ||
+                   syncVar.FieldType.Is<Mirror.NetworkIdentity>();
         }
 
         /// <summary>
@@ -844,11 +845,11 @@ namespace Mirror.Weaver
                 worker.Append(worker.Create(OpCodes.Call, readFunc));
 
                 // conversion.. is this needed?
-                if (param.ParameterType.FullName == typeof(float).FullName)
+                if (param.ParameterType.Is<float>())
                 {
                     worker.Append(worker.Create(OpCodes.Conv_R4));
                 }
-                else if (param.ParameterType.FullName == typeof(double).FullName)
+                else if (param.ParameterType.Is<double>())
                 {
                     worker.Append(worker.Create(OpCodes.Conv_R8));
                 }
@@ -880,12 +881,12 @@ namespace Mirror.Weaver
         // check if a Command/TargetRpc/Rpc function is valid for weaving
         static bool ValidateFunction(MethodReference md)
         {
-            if (md.ReturnType.FullName == typeof(System.Collections.IEnumerator).FullName)
+            if (md.ReturnType.Is<System.Collections.IEnumerator>())
             {
                 Weaver.Error($"{md.Name} cannot be a coroutine", md);
                 return false;
             }
-            if (md.ReturnType.FullName != typeof(void).FullName)
+            if (md.ReturnType.Is(typeof(void)))
             {
                 Weaver.Error($"{md.Name} cannot return a value.  Make it void instead", md);
                 return false;
@@ -915,7 +916,7 @@ namespace Mirror.Weaver
         // validate parameters for a remote function call like Rpc/Cmd
         static bool ValidateParameter(MethodReference method, ParameterDefinition param, RemoteCallType callType, bool firstParam)
         {
-            bool isNetworkConnection = param.ParameterType.FullName == typeof(Mirror.NetworkConnection).FullName;
+            bool isNetworkConnection = param.ParameterType.Is<Mirror.NetworkConnection>();
             bool isSenderConnection = IsSenderConnection(param, callType);
 
             if (param.IsOut)
@@ -958,7 +959,7 @@ namespace Mirror.Weaver
 
             TypeReference type = param.ParameterType;
 
-            return type.FullName == typeof(Mirror.NetworkConnectionToClient).FullName
+            return type.Is<Mirror.NetworkConnectionToClient>()
                 || type.Resolve().IsDerivedFrom<Mirror.NetworkConnectionToClient>();
         }
 
@@ -973,19 +974,19 @@ namespace Mirror.Weaver
             {
                 foreach (CustomAttribute ca in md.CustomAttributes)
                 {
-                    if (ca.AttributeType.FullName == typeof(Mirror.CommandAttribute).FullName)
+                    if (ca.AttributeType.Is<Mirror.CommandAttribute>())
                     {
                         ProcessCommand(names, md, ca);
                         break;
                     }
 
-                    if (ca.AttributeType.FullName == typeof(Mirror.TargetRpcAttribute).FullName)
+                    if (ca.AttributeType.Is<Mirror.TargetRpcAttribute>())
                     {
                         ProcessTargetRpc(names, md, ca);
                         break;
                     }
 
-                    if (ca.AttributeType.FullName == typeof(Mirror.ClientRpcAttribute).FullName)
+                    if (ca.AttributeType.Is<Mirror.ClientRpcAttribute>())
                     {
                         ProcessClientRpc(names, md, ca);
                         break;

--- a/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
@@ -154,7 +154,7 @@ namespace Mirror.Weaver
         // this is required to early-out from a function with a return value.
         static void InjectGuardReturnValue(MethodDefinition md, ILProcessor worker, Instruction top)
         {
-            if (md.ReturnType.FullName != typeof(void).FullName)
+            if (md.ReturnType.Is(typeof(void)))
             {
                 md.Body.Variables.Add(new VariableDefinition(md.ReturnType));
                 md.Body.InitLocals = true;

--- a/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
@@ -154,7 +154,7 @@ namespace Mirror.Weaver
         // this is required to early-out from a function with a return value.
         static void InjectGuardReturnValue(MethodDefinition md, ILProcessor worker, Instruction top)
         {
-            if (md.ReturnType.Is(typeof(void)))
+            if (!md.ReturnType.Is(typeof(void)))
             {
                 md.Body.Variables.Add(new VariableDefinition(md.ReturnType));
                 md.Body.InitLocals = true;

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -82,7 +82,7 @@ namespace Mirror.Weaver
             ILProcessor worker = get.Body.GetILProcessor();
 
             // [SyncVar] GameObject?
-            if (fd.FieldType.FullName == typeof(UnityEngine.GameObject).FullName)
+            if (fd.FieldType.Is<UnityEngine.GameObject>())
             {
                 // return this.GetSyncVarGameObject(ref field, uint netId);
                 // this.
@@ -95,7 +95,7 @@ namespace Mirror.Weaver
                 worker.Append(worker.Create(OpCodes.Ret));
             }
             // [SyncVar] NetworkIdentity?
-            else if (fd.FieldType.FullName == typeof(Mirror.NetworkIdentity).FullName)
+            else if (fd.FieldType.Is<Mirror.NetworkIdentity>())
             {
                 // return this.GetSyncVarNetworkIdentity(ref field, uint netId);
                 // this.
@@ -141,7 +141,7 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldarg_1));
             // reference to field to set
             // make generic version of SetSyncVar with field type
-            if (fd.FieldType.FullName == typeof(UnityEngine.GameObject).FullName)
+            if (fd.FieldType.Is<UnityEngine.GameObject>())
             {
                 // reference to netId Field to set
                 worker.Append(worker.Create(OpCodes.Ldarg_0));
@@ -149,7 +149,7 @@ namespace Mirror.Weaver
 
                 worker.Append(worker.Create(OpCodes.Call, WeaverTypes.syncVarGameObjectEqualReference));
             }
-            else if (fd.FieldType.FullName == typeof(Mirror.NetworkIdentity).FullName)
+            else if (fd.FieldType.Is<Mirror.NetworkIdentity>())
             {
                 // reference to netId Field to set
                 worker.Append(worker.Create(OpCodes.Ldarg_0));
@@ -191,7 +191,7 @@ namespace Mirror.Weaver
             // 8 byte integer aka long
             worker.Append(worker.Create(OpCodes.Ldc_I8, dirtyBit));
 
-            if (fd.FieldType.FullName == typeof(UnityEngine.GameObject).FullName)
+            if (fd.FieldType.Is<UnityEngine.GameObject>())
             {
                 // reference to netId Field to set
                 worker.Append(worker.Create(OpCodes.Ldarg_0));
@@ -199,7 +199,7 @@ namespace Mirror.Weaver
 
                 worker.Append(worker.Create(OpCodes.Call, WeaverTypes.setSyncVarGameObjectReference));
             }
-            else if (fd.FieldType.FullName == typeof(Mirror.NetworkIdentity).FullName)
+            else if (fd.FieldType.Is<Mirror.NetworkIdentity>())
             {
                 // reference to netId Field to set
                 worker.Append(worker.Create(OpCodes.Ldarg_0));
@@ -266,8 +266,8 @@ namespace Mirror.Weaver
 
             // GameObject/NetworkIdentity SyncVars have a new field for netId
             FieldDefinition netIdField = null;
-            if (fd.FieldType.FullName == typeof(UnityEngine.GameObject).FullName ||
-                fd.FieldType.FullName == typeof(Mirror.NetworkIdentity).FullName)
+            if (fd.FieldType.Is<UnityEngine.GameObject>() ||
+                fd.FieldType.Is<Mirror.NetworkIdentity>())
             {
                 netIdField = new FieldDefinition("___" + fd.Name + "NetId",
                     FieldAttributes.Private,
@@ -297,8 +297,8 @@ namespace Mirror.Weaver
             // netId instead
             // -> only for GameObjects, otherwise an int syncvar's getter would
             //    end up in recursion.
-            if (fd.FieldType.FullName == typeof(UnityEngine.GameObject).FullName ||
-                fd.FieldType.FullName == typeof(Mirror.NetworkIdentity).FullName)
+            if (fd.FieldType.Is<UnityEngine.GameObject>() ||
+                fd.FieldType.Is<Mirror.NetworkIdentity>())
             {
                 Weaver.WeaveLists.replacementGetterProperties[fd] = get;
             }

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -1,4 +1,3 @@
-using System;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
 

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -1,3 +1,4 @@
+using System;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
 
@@ -12,7 +13,7 @@ namespace Mirror.Weaver
         public static bool HasNetworkConnectionParameter(MethodDefinition md)
         {
             return md.Parameters.Count > 0 &&
-                   md.Parameters[0].ParameterType.FullName == typeof(Mirror.NetworkConnection).FullName;
+                   md.Parameters[0].ParameterType.Is<Mirror.NetworkConnection>();
         }
 
         public static MethodDefinition ProcessTargetRpcInvoke(TypeDefinition td, MethodDefinition md, MethodDefinition rpcCallFunc)

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -54,12 +54,12 @@ namespace Mirror.Weaver
                 Weaver.Error($"Cannot generate reader for component type {variableReference.Name}. Use a supported type or provide a custom reader", variableReference);
                 return null;
             }
-            if (variableReference.FullName == typeof(UnityEngine.Object).FullName)
+            if (variableReference.Is<UnityEngine.Object>())
             {
                 Weaver.Error($"Cannot generate reader for {variableReference.Name}. Use a supported type or provide a custom reader", variableReference);
                 return null;
             }
-            if (variableReference.FullName == typeof(UnityEngine.ScriptableObject).FullName)
+            if (variableReference.Is<UnityEngine.ScriptableObject>())
             {
                 Weaver.Error($"Cannot generate reader for {variableReference.Name}. Use a supported type or provide a custom reader", variableReference);
                 return null;

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -125,7 +125,7 @@ namespace Mirror.Weaver
             TypeDefinition parent = td;
             while (parent != null)
             {
-                if (parent.FullName == typeof(Mirror.NetworkBehaviour).FullName)
+                if (parent.Is<Mirror.NetworkBehaviour>())
                 {
                     break;
                 }

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -94,12 +94,12 @@ namespace Mirror.Weaver
                 Weaver.Error($"Cannot generate writer for component type {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
                 return null;
             }
-            if (variableReference.FullName == typeof(UnityEngine.Object).FullName)
+            if (variableReference.Is<UnityEngine.Object>())
             {
                 Weaver.Error($"Cannot generate writer for {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
                 return null;
             }
-            if (variableReference.FullName == typeof(UnityEngine.ScriptableObject).FullName)
+            if (variableReference.Is<UnityEngine.ScriptableObject>())
             {
                 Weaver.Error($"Cannot generate writer for {variableReference.Name}. Use a supported type or provide a custom writer", variableReference);
                 return null;


### PR DESCRIPTION
# Before

This is hard to read:
```
if (ca.AttributeType.FullName == typeof(Mirror.CommandAttribute).FullName) {
...
}
```

# After

```
if (ca.AttributeType.Is<Mirror.CommandAttribute>()) {
...
}
```