### PR TITLE
Avoid global import of registerCommandDelegateReference and registerRpcDelegateReference

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Mirror.RemoteCalls;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
 
@@ -283,21 +284,25 @@ namespace Mirror.Weaver
             ILProcessor ctorWorker = ctor.Body.GetILProcessor();
             ILProcessor cctorWorker = cctor.Body.GetILProcessor();
 
+            MethodReference registerCommandRef = WeaverTypes.Import<Type, string, CmdDelegate, bool>(RemoteCallHelper.RegisterCommandDelegate);
+
             for (int i = 0; i < commands.Count; ++i)
             {
                 CmdResult cmdResult = commands[i];
-                GenerateRegisterCommandDelegate(cctorWorker, WeaverTypes.registerCommandDelegateReference, commandInvocationFuncs[i], cmdResult);
+                GenerateRegisterCommandDelegate(cctorWorker, registerCommandRef, commandInvocationFuncs[i], cmdResult);
             }
+
+            MethodReference registerRpcRef = WeaverTypes.Import<Type, string, CmdDelegate>(RemoteCallHelper.RegisterRpcDelegate);
 
             for (int i = 0; i < clientRpcs.Count; ++i)
             {
                 ClientRpcResult clientRpcResult = clientRpcs[i];
-                GenerateRegisterRemoteDelegate(cctorWorker, WeaverTypes.registerRpcDelegateReference, clientRpcInvocationFuncs[i], clientRpcResult.method.Name);
+                GenerateRegisterRemoteDelegate(cctorWorker, registerRpcRef, clientRpcInvocationFuncs[i], clientRpcResult.method.Name);
             }
 
             for (int i = 0; i < targetRpcs.Count; ++i)
             {
-                GenerateRegisterRemoteDelegate(cctorWorker, WeaverTypes.registerRpcDelegateReference, targetRpcInvocationFuncs[i], targetRpcs[i].Name);
+                GenerateRegisterRemoteDelegate(cctorWorker, registerRpcRef, targetRpcInvocationFuncs[i], targetRpcs[i].Name);
             }
 
             foreach (FieldDefinition fd in syncObjects)

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Mono.CecilX;
 
 namespace Mirror.Weaver
@@ -44,8 +45,6 @@ namespace Mirror.Weaver
         public static MethodReference getSyncVarGameObjectReference;
         public static MethodReference setSyncVarNetworkIdentityReference;
         public static MethodReference getSyncVarNetworkIdentityReference;
-        public static MethodReference registerCommandDelegateReference;
-        public static MethodReference registerRpcDelegateReference;
         public static MethodReference getTypeReference;
         public static MethodReference getTypeFromHandleReference;
         public static MethodReference logErrorReference;
@@ -59,6 +58,18 @@ namespace Mirror.Weaver
         public static TypeReference Import<T>() => Import(typeof(T));
 
         public static TypeReference Import(Type t) => currentAssembly.MainModule.ImportReference(t);
+
+        public static MethodReference Import(MethodBase method) => currentAssembly.MainModule.ImportReference(method);
+
+        public static MethodReference Import<A>(Func<A> del) => Import(del.GetMethodInfo());
+        public static MethodReference Import<A,B>(Func<A,B> del) => Import(del.GetMethodInfo());
+        public static MethodReference Import<A,B,C>(Func<A,B,C> del) => Import(del.GetMethodInfo());
+
+        public static MethodReference Import(Action del) => Import(del.GetMethodInfo());
+        public static MethodReference Import<A>(Action<A> del) => Import(del.GetMethodInfo());
+        public static MethodReference Import<A, B>(Action<A, B> del) => Import(del.GetMethodInfo());
+        public static MethodReference Import<A, B, C>(Action<A, B, C> del) => Import(del.GetMethodInfo());
+        public static MethodReference Import<A, B, C, D>(Action<A, B, C, D> del) => Import(del.GetMethodInfo());
 
         public static void SetupTargetTypes(AssemblyDefinition currentAssembly)
         {
@@ -87,7 +98,6 @@ namespace Mirror.Weaver
             CmdDelegateConstructor = Resolvers.ResolveMethod(cmdDelegateReference, currentAssembly, ".ctor");
 
             TypeReference NetworkBehaviourType = Import<Mirror.NetworkBehaviour>();
-            TypeReference RemoteCallHelperType = Import(typeof(Mirror.RemoteCalls.RemoteCallHelper));
 
             TypeReference ScriptableObjectType = Import<UnityEngine.ScriptableObject>();
 
@@ -114,8 +124,6 @@ namespace Mirror.Weaver
             getSyncVarGameObjectReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "GetSyncVarGameObject");
             setSyncVarNetworkIdentityReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "SetSyncVarNetworkIdentity");
             getSyncVarNetworkIdentityReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "GetSyncVarNetworkIdentity");
-            registerCommandDelegateReference = Resolvers.ResolveMethod(RemoteCallHelperType, currentAssembly, "RegisterCommandDelegate");
-            registerRpcDelegateReference = Resolvers.ResolveMethod(RemoteCallHelperType, currentAssembly, "RegisterRpcDelegate");
             TypeReference unityDebug = Import(typeof(UnityEngine.Debug));
             logErrorReference = Resolvers.ResolveMethod(unityDebug, currentAssembly, "LogError");
             logWarningReference = Resolvers.ResolveMethod(unityDebug, currentAssembly, "LogWarning");


### PR DESCRIPTION
# before:

A static variable is defined in WeaverTypes:
```cs
public static MethodReference registerCommandDelegateReference
```

2) Global lookup of the method in SetupTargetTypes:
```cs
TypeReference RemoteCallHelperType = Import(typeof(Mirror.RemoteCalls.RemoteCallHelper));
registerCommandDelegateReference = Resolvers.ResolveMethod(RemoteCallHelperType, currentAssembly, "RegisterCommandDelegate");
```
Note lookup happens with a string,  so it is invisible to IDEs.
3) use it this way:
```
GenerateRegisterCommandDelegate(cctorWorker, WeaverTypes.registerCommandDelegateReference, commandInvocationFuncs[i], cmdResult);
```

# after

Import the method with full type checking and write a call instruction.  Note that having the types here is useful because you will need to push each one of them in the stack,  so it becomes self documenting.
```cs
MethodReference registerCommandRef = WeaverTypes.Import<Type, string, CmdDelegate, bool>(RemoteCallHelper.RegisterCommandDelegate);
GenerateRegisterCommandDelegate(cctorWorker, registerCommandRef, commandInvocationFuncs[i], cmdResult);
```
