### PR TITLE
feat: adding function to server when visibility changes for a connection

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -693,5 +693,20 @@ namespace Mirror
         /// <para>When NetworkIdentity.RemoveClientAuthority is called on the server, this will be called on the client that owns the object.</para>
         /// </summary>
         public virtual void OnStopAuthority() { }
+
+        /// <summary>
+        /// Called on Server after Object is spawned for connection
+        /// <para>This inclides first spawn and when connection is added to observers</para>
+        /// </summary>
+        /// <param name="conn">Connection this object was shown to</param>
+        public virtual void OnShownForConnection(NetworkConnection conn) { }
+
+        /// <summary>
+        /// Called on Server after object is hideen for connection
+        /// <para>This happens when a connection is removed as an observer</para>
+        /// <para>NOTE this is not called when the object is destroyed on the server</para>
+        /// </summary>
+        /// <param name="conn">Connection this object was hidden for</param>
+        public virtual void OnHiddenForConnection(NetworkConnection conn) { }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1691,6 +1691,5 @@ namespace Mirror
                 comp.OnHiddenForConnection(conn);
             }
         }
-
     }
 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1664,5 +1664,33 @@ namespace Mirror
                 comp.ResetSyncObjects();
             }
         }
+
+        /// <summary>
+        /// Called on Server when Object is spawned for connection
+        /// <para>This inclides first spawn and when connection is added to observers</para>
+        /// </summary>
+        /// <param name="conn"></param>
+        internal void OnShownForConnection(NetworkConnection conn)
+        {
+            foreach (NetworkBehaviour comp in NetworkBehaviours)
+            {
+                comp.OnShownForConnection(conn);
+            }
+        }
+
+        /// <summary>
+        /// Called on Server when object is hideen for connection
+        /// <para>This happens when a connection is removed as an observer</para>
+        /// <para>NOTE this is not called when the object is destroyed on the server</para>
+        /// </summary>
+        /// <param name="conn"></param>
+        internal void OnHiddenForConnection(NetworkConnection conn)
+        {
+            foreach (NetworkBehaviour comp in NetworkBehaviours)
+            {
+                comp.OnHiddenForConnection(conn);
+            }
+        }
+
     }
 }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -929,7 +929,11 @@ namespace Mirror
         internal static void ShowForConnection(NetworkIdentity identity, NetworkConnection conn)
         {
             if (conn.isReady)
+            {
                 SendSpawnMessage(identity, conn);
+
+                identity.OnShownForConnection(conn);
+            }
         }
 
         internal static void HideForConnection(NetworkIdentity identity, NetworkConnection conn)
@@ -939,6 +943,7 @@ namespace Mirror
                 netId = identity.netId
             };
             conn.Send(msg);
+            identity.OnHiddenForConnection(conn);
         }
 
         /// <summary>

--- a/Assets/Mirror/Tests/Editor/OnVisibilityChangeTest.cs
+++ b/Assets/Mirror/Tests/Editor/OnVisibilityChangeTest.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mirror.Tests
+{
+    public class FakeVisibility : NetworkVisibility
+    {
+        NetworkConnection visibleConnection;
+
+        public void SetConnectionAsVisible(NetworkConnection conn)
+        {
+            visibleConnection = conn;
+            netIdentity.RebuildObservers(false);
+        }
+
+        public override bool OnCheckObserver(NetworkConnection conn)
+        {
+            return visibleConnection == conn;
+        }
+
+        public override void OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
+        {
+            if (visibleConnection != null)
+                observers.Add(visibleConnection);
+        }
+    }
+    public class OnShowBehaviour : NetworkBehaviour
+    {
+        public event Action<NetworkConnection> onShown;
+        public event Action<NetworkConnection> onHide;
+
+        public override void OnShownForConnection(NetworkConnection conn)
+        {
+            onShown?.Invoke(conn);
+        }
+        public override void OnHiddenForConnection(NetworkConnection conn)
+        {
+            onHide?.Invoke(conn);
+        }
+    }
+    [TestFixture]
+    public class OnVisibilityChangeTest
+    {
+        private GameObject go;
+        private FakeVisibility visibility;
+        private OnShowBehaviour behaviour;
+        private FakeNetworkConnection fakeConnection;
+
+        [SetUp]
+        public void SetUp()
+        {
+            go = new GameObject();
+            NetworkIdentity identity = go.AddComponent<NetworkIdentity>();
+            visibility = go.AddComponent<FakeVisibility>();
+            behaviour = go.AddComponent<OnShowBehaviour>();
+
+            fakeConnection = new FakeNetworkConnection();
+            fakeConnection.isReady = true;
+
+            identity.OnStartServer();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GameObject.DestroyImmediate(go);
+            NetworkIdentity.spawned.Clear();
+        }
+
+        [Test]
+        public void OnShownForConnectionShouldBeCalled()
+        {
+            NetworkConnection result = null;
+            behaviour.onShown += (conn) => { result = conn; };
+
+            visibility.SetConnectionAsVisible(fakeConnection);
+
+            Assert.That(result, Is.EqualTo(fakeConnection), "onShown Should have been called with fake connection as the argument");
+        }
+
+        [Test]
+        public void OnHiddenForConnectionShouldBeCalled()
+        {
+            NetworkConnection result = null;
+            behaviour.onHide += (conn) => { result = conn; };
+
+            //set it to fake conn, then clear it
+            visibility.SetConnectionAsVisible(fakeConnection);
+            visibility.SetConnectionAsVisible(null);
+
+            Assert.That(result, Is.EqualTo(fakeConnection), "onHide Should have been called with fake connection as the argument");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/OnVisibilityChangeTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/OnVisibilityChangeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3bf533726f06e441a6eac81cd6af87a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
There doesn't seem to be a way to detect when visibility changes on the server.

adding OnShownForConnection and OnHiddenForConnection to be called on the server when an object becomes visible or hidden for a connection

