### PR TITLE
Generate reader and writer functions for enums

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -37,11 +37,6 @@ namespace Mirror.Weaver
             {
                 return foundFunc;
             }
-            else if (variable.Resolve().IsEnum)
-            {
-                // serialize enum as their base type
-                return GetWriteFunc(variable.Resolve().GetEnumUnderlyingType());
-            }
             else
             {
                 MethodDefinition newWriterFunc = GenerateWriter(variable, recursionCount);
@@ -69,6 +64,12 @@ namespace Mirror.Weaver
             if (variableReference.IsArray)
             {
                 return GenerateArrayWriteFunc(variableReference, recursionCount);
+            }
+
+            if (variableReference.Resolve()?.IsEnum ?? false)
+            {
+                // serialize enum as their base type
+                return GenerateEnumWriteFunc(variableReference);
             }
 
             // check for collections
@@ -124,6 +125,39 @@ namespace Mirror.Weaver
             // generate writer for class/struct
 
             return GenerateClassOrStructWriterFunction(variableReference, recursionCount);
+        }
+
+        private static MethodDefinition GenerateEnumWriteFunc(TypeReference variable)
+        {
+            string functionName = "_Write" + variable.Name + "_";
+            if (variable.DeclaringType != null)
+            {
+                functionName += variable.DeclaringType.Name;
+            }
+            else
+            {
+                functionName += "None";
+            }
+            // create new writer for this type
+            var writerFunc = new MethodDefinition(functionName,
+                    MethodAttributes.Public |
+                    MethodAttributes.Static |
+                    MethodAttributes.HideBySig,
+                    WeaverTypes.Import(typeof(void)));
+
+            writerFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, WeaverTypes.Import<Mirror.NetworkWriter>()));
+            writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(variable)));
+
+            ILProcessor worker = writerFunc.Body.GetILProcessor();
+
+            MethodReference underlyingWriter = Writers.GetWriteFunc(variable.Resolve().GetEnumUnderlyingType());
+
+            worker.Append(worker.Create(OpCodes.Ldarg_0));
+            worker.Append(worker.Create(OpCodes.Ldarg_1));
+            worker.Append(worker.Create(OpCodes.Call, underlyingWriter));
+
+            worker.Append(worker.Create(OpCodes.Ret));
+            return writerFunc;
         }
 
         static MethodDefinition GenerateClassOrStructWriterFunction(TypeReference variable, int recursionCount)


### PR DESCRIPTION
Currently,  whenever we want to serialize an enum,
we simply serialize the underlying type (byte, short, int)

This works fine,  but in order to get the reader and writer
at runtime I need a function for each type.

With this PR, we generate a reader and writer function for enums too,
the function body simply calls the underlying reader and writer.