### PR TITLE
feat: Support reading and writing recursive types

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -8,7 +8,6 @@ namespace Mirror.Weaver
 {
     public static class Readers
     {
-        const int MaxRecursionCount = 128;
         static Dictionary<string, MethodReference> readFuncs;
 
         public static void Init()
@@ -21,7 +20,7 @@ namespace Mirror.Weaver
             readFuncs[dataType.FullName] = methodReference;
         }
 
-        public static MethodReference GetReadFunc(TypeReference variableReference, int recursionCount = 0)
+        public static MethodReference GetReadFunc(TypeReference variableReference)
         {
             if (readFuncs.TryGetValue(variableReference.FullName, out MethodReference foundFunc))
             {
@@ -34,7 +33,7 @@ namespace Mirror.Weaver
             // thus check if it is an array and skip all the checks.
             if (variableReference.IsArray)
             {
-                return GenerateArrayReadFunc(variableReference, recursionCount);
+                return GenerateArrayReadFunc(variableReference);
             }
 
             TypeDefinition variableDefinition = variableReference.Resolve();
@@ -86,14 +85,14 @@ namespace Mirror.Weaver
             }
             else if (variableDefinition.Is(typeof(ArraySegment<>)))
             {
-                return GenerateArraySegmentReadFunc(variableReference, recursionCount);
+                return GenerateArraySegmentReadFunc(variableReference);
             }
             else if (variableDefinition.Is(typeof(List<>)))
             {
-                return GenerateListReadFunc(variableReference, recursionCount);
+                return GenerateListReadFunc(variableReference);
             }
 
-            return GenerateClassOrStructReadFunction(variableReference, recursionCount);
+            return GenerateClassOrStructReadFunction(variableReference);
         }
 
         static void RegisterReadFunc(TypeReference typeReference, MethodDefinition newReaderFunc)
@@ -105,7 +104,7 @@ namespace Mirror.Weaver
             Weaver.WeaveLists.generateContainerClass.Methods.Add(newReaderFunc);
         }
 
-        static MethodDefinition GenerateArrayReadFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArrayReadFunc(TypeReference variable)
         {
             if (!variable.IsArrayType())
             {
@@ -113,15 +112,15 @@ namespace Mirror.Weaver
                 return null;
             }
 
+            MethodDefinition readerFunc = GenerateReaderFunction(variable);
             TypeReference elementType = variable.GetElementType();
-            MethodReference elementReadFunc = GetReadFunc(elementType, recursionCount + 1);
+            MethodReference elementReadFunc = GetReadFunc(elementType);
             if (elementReadFunc == null)
             {
                 Weaver.Error($"Cannot generate reader for Array because element {elementType.Name} does not have a reader. Use a supported type or provide a custom reader", variable);
-                return null;
+                return readerFunc;
             }
 
-            MethodDefinition readerFunc = GenerateReaderFunction(variable);
 
             readerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             readerFunc.Body.Variables.Add(new VariableDefinition(variable));
@@ -201,12 +200,12 @@ namespace Mirror.Weaver
             return readerFunc;
         }
 
-        static MethodDefinition GenerateArraySegmentReadFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArraySegmentReadFunc(TypeReference variable)
         {
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
 
-            MethodReference elementReadFunc = GetReadFunc(elementType, recursionCount + 1);
+            MethodReference elementReadFunc = GetReadFunc(elementType);
             if (elementReadFunc == null)
             {
                 Weaver.Error($"Cannot generate reader for ArraySegment because element {elementType.Name} does not have a reader. Use a supported type or provide a custom reader", variable);
@@ -293,19 +292,20 @@ namespace Mirror.Weaver
             return readerFunc;
         }
 
-        static MethodDefinition GenerateListReadFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateListReadFunc(TypeReference variable)
         {
+            MethodDefinition readerFunc = GenerateReaderFunction(variable);
+
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
 
-            MethodReference elementReadFunc = GetReadFunc(elementType, recursionCount + 1);
+            MethodReference elementReadFunc = GetReadFunc(elementType);
             if (elementReadFunc == null)
             {
                 Weaver.Error($"Cannot generate reader for List because element {elementType.Name} does not have a reader. Use a supported type or provide a custom reader", variable);
-                return null;
+                return readerFunc;
             }
 
-            MethodDefinition readerFunc = GenerateReaderFunction(variable);
 
             readerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             readerFunc.Body.Variables.Add(new VariableDefinition(variable));
@@ -380,14 +380,8 @@ namespace Mirror.Weaver
         }
 
 
-        static MethodDefinition GenerateClassOrStructReadFunction(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateClassOrStructReadFunction(TypeReference variable)
         {
-            if (recursionCount > MaxRecursionCount)
-            {
-                Weaver.Error($"{variable.Name} can't be deserialized because it references itself", variable);
-                return null;
-            }
-
             MethodDefinition readerFunc = GenerateReaderFunction(variable);
 
             // create local for return value
@@ -398,7 +392,7 @@ namespace Mirror.Weaver
             TypeDefinition td = variable.Resolve();
 
             CreateNew(variable, worker, td);
-            ReadAllFields(variable, recursionCount, worker);
+            ReadAllFields(variable, worker);
 
             worker.Append(worker.Create(OpCodes.Ldloc_0));
             worker.Append(worker.Create(OpCodes.Ret));
@@ -439,7 +433,7 @@ namespace Mirror.Weaver
             }
         }
 
-        static void ReadAllFields(TypeReference variable, int recursionCount, ILProcessor worker)
+        static void ReadAllFields(TypeReference variable, ILProcessor worker)
         {
             uint fields = 0;
             foreach (FieldDefinition field in variable.FindAllPublicFields())
@@ -448,7 +442,7 @@ namespace Mirror.Weaver
                 OpCode opcode = variable.IsValueType ? OpCodes.Ldloca : OpCodes.Ldloc;
                 worker.Append(worker.Create(opcode, 0));
 
-                MethodReference readFunc = GetReadFunc(field.FieldType, recursionCount + 1);
+                MethodReference readFunc = GetReadFunc(field.FieldType);
                 if (readFunc != null)
                 {
                     worker.Append(worker.Create(OpCodes.Ldarg_0));

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -21,9 +21,9 @@ namespace Mirror.Weaver
             writeFuncs[dataType.FullName] = methodReference;
         }
 
-        static void RegisterWriteFunc(string name, MethodDefinition newWriterFunc)
+        static void RegisterWriteFunc(TypeReference typeReference, MethodDefinition newWriterFunc)
         {
-            writeFuncs[name] = newWriterFunc;
+            writeFuncs[typeReference.FullName] = newWriterFunc;
             Weaver.WeaveLists.generatedWriteFunctions.Add(newWriterFunc);
 
             Weaver.WeaveLists.ConfirmGeneratedCodeClass();
@@ -43,26 +43,8 @@ namespace Mirror.Weaver
             {
                 return foundFunc;
             }
-            else
-            {
-                MethodDefinition newWriterFunc = null;
 
-                // this try/catch will be removed in future PR and make `GetWriteFunc` throw instead
-                try
-                {
-                    newWriterFunc = GenerateWriter(variable, recursionCount);
-                }
-                catch (GenerateWriterException e)
-                {
-                    Weaver.Error(e.Message, e.MemberReference);
-                }
-
-                if (newWriterFunc != null)
-                {
-                    RegisterWriteFunc(variable.FullName, newWriterFunc);
-                }
-                return newWriterFunc;
-            }
+            return GenerateWriter(variable, recursionCount);
         }
 
         /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
@@ -165,6 +147,8 @@ namespace Mirror.Weaver
             writerFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, WeaverTypes.Import<Mirror.NetworkWriter>()));
             writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(variable)));
             writerFunc.Body.InitLocals = true;
+
+            RegisterWriteFunc(variable, writerFunc);
             return writerFunc;
         }
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -138,16 +138,7 @@ namespace Mirror.Weaver
 
         private static MethodDefinition GenerateEnumWriteFunc(TypeReference variable)
         {
-            string functionName = "_Write_" + variable.FullName ;
-            // create new writer for this type
-            var writerFunc = new MethodDefinition(functionName,
-                    MethodAttributes.Public |
-                    MethodAttributes.Static |
-                    MethodAttributes.HideBySig,
-                    WeaverTypes.Import(typeof(void)));
-
-            writerFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, WeaverTypes.Import<Mirror.NetworkWriter>()));
-            writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(variable)));
+            MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
 
@@ -161,16 +152,11 @@ namespace Mirror.Weaver
             return writerFunc;
         }
 
-        static MethodDefinition GenerateClassOrStructWriterFunction(TypeReference variable, int recursionCount)
+        private static MethodDefinition GenerateWriterFunc(TypeReference variable)
         {
-            if (recursionCount > MaxRecursionCount)
-            {
-                throw new GenerateWriterException($"{variable.Name} can't be serialized because it references itself", variable);
-            }
-
-            string functionName = "_Write_" + variable.Name;
+            string functionName = "_Write_" + variable.FullName;
             // create new writer for this type
-            MethodDefinition writerFunc = new MethodDefinition(functionName,
+            var writerFunc = new MethodDefinition(functionName,
                     MethodAttributes.Public |
                     MethodAttributes.Static |
                     MethodAttributes.HideBySig,
@@ -178,6 +164,18 @@ namespace Mirror.Weaver
 
             writerFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, WeaverTypes.Import<Mirror.NetworkWriter>()));
             writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(variable)));
+            writerFunc.Body.InitLocals = true;
+            return writerFunc;
+        }
+
+        static MethodDefinition GenerateClassOrStructWriterFunction(TypeReference variable, int recursionCount)
+        {
+            if (recursionCount > MaxRecursionCount)
+            {
+                throw new GenerateWriterException($"{variable.Name} can't be serialized because it references itself", variable);
+            }
+
+            MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
 
@@ -239,20 +237,10 @@ namespace Mirror.Weaver
                 return null;
             }
 
-            string functionName = "_Write_" + variable.FullName;
-            // create new writer for this type
-            MethodDefinition writerFunc = new MethodDefinition(functionName,
-                    MethodAttributes.Public |
-                    MethodAttributes.Static |
-                    MethodAttributes.HideBySig,
-                    WeaverTypes.Import(typeof(void)));
-
-            writerFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, WeaverTypes.Import<Mirror.NetworkWriter>()));
-            writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, Weaver.CurrentAssembly.MainModule.ImportReference(variable)));
-
+            MethodDefinition writerFunc = GenerateWriterFunc(variable);
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-            writerFunc.Body.InitLocals = true;
+
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
 
@@ -332,20 +320,10 @@ namespace Mirror.Weaver
                 return null;
             }
 
-            string functionName = "_Write_" + variable.FullName;
-            // create new writer for this type
-            MethodDefinition writerFunc = new MethodDefinition(functionName,
-                    MethodAttributes.Public |
-                    MethodAttributes.Static |
-                    MethodAttributes.HideBySig,
-                    WeaverTypes.Import(typeof(void)));
-
-            writerFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, WeaverTypes.Import<Mirror.NetworkWriter>()));
-            writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, variable));
+            MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-            writerFunc.Body.InitLocals = true;
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
 
@@ -420,16 +398,7 @@ namespace Mirror.Weaver
                 return null;
             }
 
-            string functionName = "_Write_" + variable.FullName;
-            // create new writer for this type
-            MethodDefinition writerFunc = new MethodDefinition(functionName,
-                    MethodAttributes.Public |
-                    MethodAttributes.Static |
-                    MethodAttributes.HideBySig,
-                    WeaverTypes.Import(typeof(void)));
-
-            writerFunc.Parameters.Add(new ParameterDefinition("writer", ParameterAttributes.None, WeaverTypes.Import<Mirror.NetworkWriter>()));
-            writerFunc.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, variable));
+            MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests.cs
@@ -7,8 +7,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void RecursionCount()
         {
-            HasError("Potato1 can't be serialized because it references itself",
-                "WeaverGeneralTests.RecursionCount.RecursionCount/Potato1");
+            IsSuccess();
         }
 
         [Test]


### PR DESCRIPTION
Remove all the recursion count nonsense.

Now mirror can generate readers and writers for recursive types.  For example:

```cs
class Tree {
    Tree child1;
    Tree child2;
}
```

The generated reader and writers will be recursive and call themselves.

This got fixed because the generated reader and writers are memoized before we fill up the code,  
so when the type has a child of the same type,  it will find the same function and use a recursive call.