### PR TITLE
feat: Support recursive data types

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -8,7 +8,6 @@ namespace Mirror.Weaver
 {
     public static class Readers
     {
-        const int MaxRecursionCount = 128;
         static Dictionary<string, MethodReference> readFuncs;
 
         public static void Init()
@@ -21,7 +20,7 @@ namespace Mirror.Weaver
             readFuncs[dataType.FullName] = methodReference;
         }
 
-        public static MethodReference GetReadFunc(TypeReference variableReference, int recursionCount = 0)
+        public static MethodReference GetReadFunc(TypeReference variableReference)
         {
             if (readFuncs.TryGetValue(variableReference.FullName, out MethodReference foundFunc))
             {
@@ -34,7 +33,7 @@ namespace Mirror.Weaver
             // thus check if it is an array and skip all the checks.
             if (variableReference.IsArray)
             {
-                return GenerateArrayReadFunc(variableReference, recursionCount);
+                return GenerateArrayReadFunc(variableReference);
             }
 
             TypeDefinition variableDefinition = variableReference.Resolve();
@@ -86,14 +85,14 @@ namespace Mirror.Weaver
             }
             else if (variableDefinition.Is(typeof(ArraySegment<>)))
             {
-                return GenerateArraySegmentReadFunc(variableReference, recursionCount);
+                return GenerateArraySegmentReadFunc(variableReference);
             }
             else if (variableDefinition.Is(typeof(List<>)))
             {
-                return GenerateListReadFunc(variableReference, recursionCount);
+                return GenerateListReadFunc(variableReference);
             }
 
-            return GenerateClassOrStructReadFunction(variableReference, recursionCount);
+            return GenerateClassOrStructReadFunction(variableReference);
         }
 
         static void RegisterReadFunc(TypeReference typeReference, MethodDefinition newReaderFunc)
@@ -105,7 +104,7 @@ namespace Mirror.Weaver
             Weaver.WeaveLists.generateContainerClass.Methods.Add(newReaderFunc);
         }
 
-        static MethodDefinition GenerateArrayReadFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArrayReadFunc(TypeReference variable)
         {
             if (!variable.IsArrayType())
             {
@@ -113,15 +112,15 @@ namespace Mirror.Weaver
                 return null;
             }
 
+            MethodDefinition readerFunc = GenerateReaderFunction(variable);
             TypeReference elementType = variable.GetElementType();
-            MethodReference elementReadFunc = GetReadFunc(elementType, recursionCount + 1);
+            MethodReference elementReadFunc = GetReadFunc(elementType);
             if (elementReadFunc == null)
             {
                 Weaver.Error($"Cannot generate reader for Array because element {elementType.Name} does not have a reader. Use a supported type or provide a custom reader", variable);
-                return null;
+                return readerFunc;
             }
 
-            MethodDefinition readerFunc = GenerateReaderFunction(variable);
 
             readerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             readerFunc.Body.Variables.Add(new VariableDefinition(variable));
@@ -201,12 +200,12 @@ namespace Mirror.Weaver
             return readerFunc;
         }
 
-        static MethodDefinition GenerateArraySegmentReadFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArraySegmentReadFunc(TypeReference variable)
         {
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
 
-            MethodReference elementReadFunc = GetReadFunc(elementType, recursionCount + 1);
+            MethodReference elementReadFunc = GetReadFunc(elementType);
             if (elementReadFunc == null)
             {
                 Weaver.Error($"Cannot generate reader for ArraySegment because element {elementType.Name} does not have a reader. Use a supported type or provide a custom reader", variable);
@@ -293,19 +292,20 @@ namespace Mirror.Weaver
             return readerFunc;
         }
 
-        static MethodDefinition GenerateListReadFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateListReadFunc(TypeReference variable)
         {
+            MethodDefinition readerFunc = GenerateReaderFunction(variable);
+
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
 
-            MethodReference elementReadFunc = GetReadFunc(elementType, recursionCount + 1);
+            MethodReference elementReadFunc = GetReadFunc(elementType);
             if (elementReadFunc == null)
             {
                 Weaver.Error($"Cannot generate reader for List because element {elementType.Name} does not have a reader. Use a supported type or provide a custom reader", variable);
-                return null;
+                return readerFunc;
             }
 
-            MethodDefinition readerFunc = GenerateReaderFunction(variable);
 
             readerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             readerFunc.Body.Variables.Add(new VariableDefinition(variable));
@@ -380,14 +380,8 @@ namespace Mirror.Weaver
         }
 
 
-        static MethodDefinition GenerateClassOrStructReadFunction(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateClassOrStructReadFunction(TypeReference variable)
         {
-            if (recursionCount > MaxRecursionCount)
-            {
-                Weaver.Error($"{variable.Name} can't be deserialized because it references itself", variable);
-                return null;
-            }
-
             MethodDefinition readerFunc = GenerateReaderFunction(variable);
 
             // create local for return value
@@ -398,7 +392,7 @@ namespace Mirror.Weaver
             TypeDefinition td = variable.Resolve();
 
             CreateNew(variable, worker, td);
-            ReadAllFields(variable, recursionCount, worker);
+            ReadAllFields(variable, worker);
 
             worker.Append(worker.Create(OpCodes.Ldloc_0));
             worker.Append(worker.Create(OpCodes.Ret));
@@ -439,7 +433,7 @@ namespace Mirror.Weaver
             }
         }
 
-        static void ReadAllFields(TypeReference variable, int recursionCount, ILProcessor worker)
+        static void ReadAllFields(TypeReference variable, ILProcessor worker)
         {
             uint fields = 0;
             foreach (FieldDefinition field in variable.FindAllPublicFields())
@@ -448,7 +442,7 @@ namespace Mirror.Weaver
                 OpCode opcode = variable.IsValueType ? OpCodes.Ldloca : OpCodes.Ldloc;
                 worker.Append(worker.Create(opcode, 0));
 
-                MethodReference readFunc = GetReadFunc(field.FieldType, recursionCount + 1);
+                MethodReference readFunc = GetReadFunc(field.FieldType);
                 if (readFunc != null)
                 {
                     worker.Append(worker.Create(OpCodes.Ldarg_0));

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -7,8 +7,6 @@ namespace Mirror.Weaver
 {
     public static class Writers
     {
-        const int MaxRecursionCount = 128;
-
         static Dictionary<string, MethodReference> writeFuncs;
 
         public static void Init()
@@ -37,7 +35,7 @@ namespace Mirror.Weaver
         /// <param name="variable"></param>
         /// <param name="recursionCount"></param>
         /// <returns>Returns <see cref="MethodReference"/> or null</returns>
-        public static MethodReference GetWriteFunc(TypeReference variable, int recursionCount = 0)
+        public static MethodReference GetWriteFunc(TypeReference variable)
         {
             if (writeFuncs.TryGetValue(variable.FullName, out MethodReference foundFunc))
             {
@@ -48,7 +46,7 @@ namespace Mirror.Weaver
                 // this try/catch will be removed in future PR and make `GetWriteFunc` throw instead
                 try
                 {
-                    return GenerateWriter(variable, recursionCount);
+                    return GenerateWriter(variable);
                 }
                 catch (GenerateWriterException e)
                 {
@@ -59,7 +57,7 @@ namespace Mirror.Weaver
         }
 
         /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
-        static MethodDefinition GenerateWriter(TypeReference variableReference, int recursionCount = 0)
+        static MethodDefinition GenerateWriter(TypeReference variableReference)
         {
             if (variableReference.IsByReference)
             {
@@ -71,7 +69,7 @@ namespace Mirror.Weaver
             // therefore process this before checks below
             if (variableReference.IsArray)
             {
-                return GenerateArrayWriteFunc(variableReference, recursionCount);
+                return GenerateArrayWriteFunc(variableReference);
             }
 
             if (variableReference.Resolve()?.IsEnum ?? false)
@@ -84,11 +82,11 @@ namespace Mirror.Weaver
 
             if (variableReference.Is(typeof(ArraySegment<>)))
             {
-                return GenerateArraySegmentWriteFunc(variableReference, recursionCount);
+                return GenerateArraySegmentWriteFunc(variableReference);
             }
             if (variableReference.Is(typeof(List<>)))
             {
-                return GenerateListWriteFunc(variableReference, recursionCount);
+                return GenerateListWriteFunc(variableReference);
             }
 
             // check for invalid types
@@ -125,7 +123,7 @@ namespace Mirror.Weaver
 
             // generate writer for class/struct
 
-            return GenerateClassOrStructWriterFunction(variableReference, recursionCount);
+            return GenerateClassOrStructWriterFunction(variableReference);
         }
 
         private static MethodDefinition GenerateEnumWriteFunc(TypeReference variable)
@@ -162,18 +160,13 @@ namespace Mirror.Weaver
             return writerFunc;
         }
 
-        static MethodDefinition GenerateClassOrStructWriterFunction(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateClassOrStructWriterFunction(TypeReference variable)
         {
-            if (recursionCount > MaxRecursionCount)
-            {
-                throw new GenerateWriterException($"{variable.Name} can't be serialized because it references itself", variable);
-            }
-
             MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
 
-            if (!WriteAllFields(variable, recursionCount, worker))
+            if (!WriteAllFields(variable, worker))
                 return null;
 
             worker.Append(worker.Create(OpCodes.Ret));
@@ -184,15 +177,14 @@ namespace Mirror.Weaver
         /// Find all fields in type and write them
         /// </summary>
         /// <param name="variable"></param>
-        /// <param name="recursionCount"></param>
         /// <param name="worker"></param>
         /// <returns>false if fail</returns>
-        static bool WriteAllFields(TypeReference variable, int recursionCount, ILProcessor worker)
+        static bool WriteAllFields(TypeReference variable, ILProcessor worker)
         {
             uint fields = 0;
             foreach (FieldDefinition field in variable.FindAllPublicFields())
             {
-                MethodReference writeFunc = GetWriteFunc(field.FieldType, recursionCount + 1);
+                MethodReference writeFunc = GetWriteFunc(field.FieldType);
                 // need this null check till later PR when GetWriteFunc throws exception instead
                 if (writeFunc == null) { return false; }
 
@@ -213,25 +205,25 @@ namespace Mirror.Weaver
             return true;
         }
 
-        static MethodDefinition GenerateArrayWriteFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArrayWriteFunc(TypeReference variable)
         {
             if (!variable.IsArrayType())
             {
                 throw new GenerateWriterException($"{variable.Name} is an unsupported type. Jagged and multidimensional arrays are not supported", variable);
             }
+            MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
             TypeReference elementType = variable.GetElementType();
-            MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
+            MethodReference elementWriteFunc = GetWriteFunc(elementType);
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.Import<int>());
 
             // need this null check till later PR when GetWriteFunc throws exception instead
             if (elementWriteFunc == null)
             {
                 Weaver.Error($"Cannot generate writer for Array because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
+                return writerFunc;
             }
 
-            MethodDefinition writerFunc = GenerateWriterFunc(variable);
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
 
@@ -300,21 +292,21 @@ namespace Mirror.Weaver
             return writerFunc;
         }
 
-        static MethodDefinition GenerateArraySegmentWriteFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateArraySegmentWriteFunc(TypeReference variable)
         {
+            MethodDefinition writerFunc = GenerateWriterFunc(variable);
+
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
-            MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
+            MethodReference elementWriteFunc = GetWriteFunc(elementType);
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.Import<int>());
 
             // need this null check till later PR when GetWriteFunc throws exception instead
             if (elementWriteFunc == null)
             {
                 Weaver.Error($"Cannot generate writer for ArraySegment because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
+                return writerFunc;
             }
-
-            MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
@@ -378,21 +370,22 @@ namespace Mirror.Weaver
             return writerFunc;
         }
 
-        static MethodDefinition GenerateListWriteFunc(TypeReference variable, int recursionCount)
+        static MethodDefinition GenerateListWriteFunc(TypeReference variable)
         {
+            MethodDefinition writerFunc = GenerateWriterFunc(variable);
+
             GenericInstanceType genericInstance = (GenericInstanceType)variable;
             TypeReference elementType = genericInstance.GenericArguments[0];
-            MethodReference elementWriteFunc = GetWriteFunc(elementType, recursionCount + 1);
+            MethodReference elementWriteFunc = GetWriteFunc(elementType);
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.Import<int>());
 
             // need this null check till later PR when GetWriteFunc throws exception instead
             if (elementWriteFunc == null)
             {
                 Weaver.Error($"Cannot generate writer for List because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return null;
+                return writerFunc;
             }
 
-            MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
             writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests.cs
@@ -7,8 +7,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void RecursionCount()
         {
-            HasError("Potato1 can't be serialized because it references itself",
-                "WeaverGeneralTests.RecursionCount.RecursionCount/Potato1");
+            IsSuccess();
         }
 
         [Test]


### PR DESCRIPTION
Remove all the recursionCount nonsense.
This was added to prevent infinite recursion with types that reference themselves.

No need to check anymore,  the weaver can generate readers and writers for types that reference themselves such as:

```cs
class Tree {
    Tree child1;
    Tree child2;
}
```

This works by the weaver doing it the way the compiler does:  Create a function first,  memoize it,  then write the body.  If the body needs the function,  it will get itself and issue a call to itself.