### PR TITLE
feat: new generic Read and Write methods for all types

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -144,6 +144,22 @@ namespace Mirror.Weaver
             return Weaver.CurrentAssembly.MainModule.ImportReference(reference);
         }
 
+        /// <summary>
+        /// Given a field of a generic class such as Writer<T>.write,
+        /// and a generic instance such as ArraySegment`int
+        /// Creates a reference to the specialized method  ArraySegment`int`.get_Count
+        /// <para> Note that calling ArraySegment`T.get_Count directly gives an invalid IL error </para>
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="instanceType"></param>
+        /// <returns></returns>
+        public static FieldReference SpecializeField(this FieldReference self, GenericInstanceType instanceType)
+        {
+            FieldReference reference = new FieldReference(self.Name, self.FieldType, instanceType);
+
+            return Weaver.CurrentAssembly.MainModule.ImportReference(reference);
+        }
+
         public static CustomAttribute GetCustomAttribute<TAttribute>(this ICustomAttributeProvider method)
         {
             foreach (CustomAttribute ca in method.CustomAttributes)

--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -16,20 +16,12 @@ namespace Mirror.Weaver
 
             foreach (Assembly unityAsm in CompilationPipeline.GetAssemblies())
             {
-                if (unityAsm.name != CurrentAssembly.Name.Name)
+                if (unityAsm.name == "Mirror")
                 {
-                    try
+                    using (DefaultAssemblyResolver asmResolver = new DefaultAssemblyResolver())
+                    using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(unityAsm.outputPath, new ReaderParameters { ReadWrite = false, ReadSymbols = false, AssemblyResolver = asmResolver }))
                     {
-                        using (DefaultAssemblyResolver asmResolver = new DefaultAssemblyResolver())
-                        using (AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(unityAsm.outputPath, new ReaderParameters { ReadWrite = false, ReadSymbols = false, AssemblyResolver = asmResolver }))
-                        {
-                            ProcessAssemblyClasses(CurrentAssembly, assembly);
-                        }
-                    }
-                    catch (FileNotFoundException)
-                    {
-                        // During first import,  this gets called before some assemblies
-                        // are built,  just skip them
+                        ProcessAssemblyClasses(CurrentAssembly, assembly);
                     }
                 }
             }

--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -1,9 +1,8 @@
 // finds all readers and writers and register them
-using System.IO;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
-using UnityEditor;
 using UnityEditor.Compilation;
+using UnityEngine;
 
 namespace Mirror.Weaver
 {
@@ -106,9 +105,10 @@ namespace Mirror.Weaver
                     MethodAttributes.Static,
                     WeaverTypes.Import(typeof(void)));
 
-            System.Reflection.ConstructorInfo attributeconstructor = typeof(InitializeOnLoadMethodAttribute).GetConstructors()[0];
+            System.Reflection.ConstructorInfo attributeconstructor = typeof(RuntimeInitializeOnLoadMethodAttribute).GetConstructor(new [] { typeof(RuntimeInitializeLoadType)});
 
             CustomAttribute customAttributeRef = new CustomAttribute(currentAssembly.MainModule.ImportReference(attributeconstructor));
+            customAttributeRef.ConstructorArguments.Add(new CustomAttributeArgument(WeaverTypes.Import<RuntimeInitializeLoadType>(), RuntimeInitializeLoadType.BeforeSceneLoad));
             rwInitializer.CustomAttributes.Add(customAttributeRef);
 
             ILProcessor worker = rwInitializer.Body.GetILProcessor();

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -416,5 +416,40 @@ namespace Mirror.Weaver
                 Log.Warning($"{variable} has no public or non-static fields to deserialize");
             }
         }
+
+        /// <summary>
+        /// Save a delegate for each one of the readers into <see cref="Reader{T}.read"/>
+        /// </summary>
+        /// <param name="worker"></param>
+        internal static void InitializeReaders(ILProcessor worker)
+        {
+            ModuleDefinition module = Weaver.CurrentAssembly.MainModule;
+
+            TypeReference genericReaderClassRef = module.ImportReference(typeof(Reader<>));
+
+            System.Reflection.FieldInfo fieldInfo = typeof(Reader<>).GetField(nameof(Reader<object>.read));
+            FieldReference fieldRef = module.ImportReference(fieldInfo);
+            TypeReference networkReaderRef = module.ImportReference(typeof(NetworkReader));
+            TypeReference funcRef = module.ImportReference(typeof(Func<,>));
+            MethodReference funcConstructorRef = module.ImportReference(typeof(Func<,>).GetConstructors()[0]);
+
+            foreach (MethodReference readFunc in readFuncs.Values)
+            {
+                TypeReference dataType = readFunc.ReturnType;
+
+                // create a Func<NetworkReader, T> delegate
+                worker.Append(worker.Create(OpCodes.Ldnull));
+                worker.Append(worker.Create(OpCodes.Ldftn, readFunc));
+                GenericInstanceType funcGenericInstance = funcRef.MakeGenericInstanceType(networkReaderRef, dataType);
+                MethodReference funcConstructorInstance = funcConstructorRef.MakeHostInstanceGeneric(funcGenericInstance);
+                worker.Append(worker.Create(OpCodes.Newobj, funcConstructorInstance));
+
+                // save it in Writer<T>.write
+                GenericInstanceType genericInstance = genericReaderClassRef.MakeGenericInstanceType(dataType);
+                FieldReference specializedField = fieldRef.SpecializeField(genericInstance);
+                worker.Append(worker.Create(OpCodes.Stsfld, specializedField));
+            }
+
+        }
     }
 }

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -300,6 +300,8 @@ namespace Mirror.Weaver
 
                 if (modified)
                 {
+                    ReaderWriterProcessor.InitializeReaderAndWriters(CurrentAssembly);
+
                     // write to outputDir if specified, otherwise perform in-place write
                     WriterParameters writeParams = new WriterParameters { WriteSymbols = true };
                     CurrentAssembly.Write(writeParams);

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
+using Mono.CecilX.Rocks;
 
 namespace Mirror.Weaver
 {
@@ -438,5 +439,41 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Ldloc_0));
             worker.Append(worker.Create(OpCodes.Blt, labelBody));
         }
+
+        /// <summary>
+        /// Save a delegate for each one of the writers into <see cref="Writer{T}.write"/>
+        /// </summary>
+        /// <param name="worker"></param>
+        internal static void InitializeWriters(ILProcessor worker)
+        {
+            ModuleDefinition module = Weaver.CurrentAssembly.MainModule;
+
+            TypeReference genericWriterClassRef = module.ImportReference(typeof(Writer<>));
+
+            System.Reflection.FieldInfo fieldInfo = typeof(Writer<>).GetField(nameof(Writer<object>.write));
+            FieldReference fieldRef = module.ImportReference(fieldInfo);
+            TypeReference networkWriterRef = module.ImportReference(typeof(NetworkWriter));
+            TypeReference actionRef = module.ImportReference(typeof(Action<,>));
+            MethodReference actionConstructorRef = module.ImportReference(typeof(Action<,>).GetConstructors()[0]);
+
+            foreach (MethodReference writerMethod in writeFuncs.Values)
+            {
+
+                TypeReference dataType = writerMethod.Parameters[1].ParameterType;
+
+                // create a Action<NetworkWriter, T> delegate
+                worker.Append(worker.Create(OpCodes.Ldnull));
+                worker.Append(worker.Create(OpCodes.Ldftn, writerMethod));
+                GenericInstanceType actionGenericInstance = actionRef.MakeGenericInstanceType(networkWriterRef, dataType);
+                MethodReference actionRefInstance = actionConstructorRef.MakeHostInstanceGeneric(actionGenericInstance);
+                worker.Append(worker.Create(OpCodes.Newobj, actionRefInstance));
+
+                // save it in Writer<T>.write
+                GenericInstanceType genericInstance = genericWriterClassRef.MakeGenericInstanceType(dataType);
+                FieldReference specializedField = fieldRef.SpecializeField(genericInstance);
+                worker.Append(worker.Create(OpCodes.Stsfld, specializedField));
+            }
+        }
+
     }
 }

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -13,6 +13,18 @@ using UnityEngine;
 
 namespace Mirror
 {
+    /// <summary>
+    /// a class that holds readers for the different types
+    /// Note that c# creates a different static variable for each
+    /// type
+    /// This will be populated by the weaver
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public static class Reader<T>
+    {
+        public static Func<NetworkReader, T> read;
+    }
+
     // Note: This class is intended to be extremely pedantic, and
     // throw exceptions whenever stuff is going slightly wrong.
     // The exceptions will be handled in NetworkServer/NetworkClient.
@@ -107,6 +119,16 @@ namespace Mirror
         public override string ToString()
         {
             return "NetworkReader pos=" + Position + " len=" + Length + " buffer=" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count);
+        }
+
+        /// <summary>
+        /// Reads any data type that mirror supports
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public T Read<T>()
+        {
+            return Reader<T>.read(this);
         }
     }
 

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -6,6 +6,18 @@ using UnityEngine;
 namespace Mirror
 {
     /// <summary>
+    /// a class that holds writers for the different types
+    /// Note that c# creates a different static variable for each
+    /// type
+    /// This will be populated by the weaver
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public static class Writer<T>
+    {
+        public static Action<NetworkWriter, T> write;
+    }
+
+    /// <summary>
     /// Binary stream Writer. Supports simple types, buffers, arrays, structs, and nested types
     /// <para>Use <see cref="NetworkWriterPool.GetWriter">NetworkWriter.GetWriter</see> to reduce memory allocation</para>
     /// </summary>
@@ -154,6 +166,16 @@ namespace Mirror
         }
 
         public void WriteInt64(long value) => WriteUInt64((ulong)value);
+
+        /// <summary>
+        /// Writes any type that mirror supports
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="msg"></param>
+        public void Write<T>(T msg)
+        {
+            Writer<T>.write(this, msg);
+        }
     }
 
 

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -171,10 +171,10 @@ namespace Mirror
         /// Writes any type that mirror supports
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="msg"></param>
-        public void Write<T>(T msg)
+        /// <param name="value"></param>
+        public void Write<T>(T value)
         {
-            Writer<T>.write(this, msg);
+            Writer<T>.write(this, value);
         }
     }
 

--- a/Assets/Mirror/Tests/Editor/NetworkReaderWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderWriterTest.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    [TestFixture]
+    public class NetworkReaderWriterTest
+    {
+        [Test]
+        public void TestIntWriterNotNull()
+        {
+            Assert.That(Writer<int>.write, Is.Not.Null);
+        }
+
+        [Test]
+        public void TestIntReaderNotNull()
+        {
+            Assert.That(Reader<int>.read, Is.Not.Null);
+        }
+
+        [Test]
+        public void TestAccessingCustomWriterAndReader()
+        {
+            NetworkWriter writer = new NetworkWriter();
+            writer.Write<int>(3);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            int copy = reader.Read<int>();
+
+            Assert.That(copy, Is.EqualTo(3));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkReaderWriterTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderWriterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4db12e3e883ac4c3aac177c638ee93e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Currently in mirror,  there is no way for Mirror itself to invoke
readers and writers for types it does not know about.

This causes us to have to generate code for lists, dictionaries and messages.

This PR makes it so that if there is a reader and writer anywhere in the
code for type X, then the writer can be invoked like this:

```cs
X x = ...;
writer.Write<X>(x);
```

and the reader can be invoked like this:
```cs
X x = reader.Read<X>();
```