### PR TITLE
Fixed OnStopClient not being called on Client Side

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -715,12 +715,12 @@ namespace Mirror
                 {
                     if (identity != null && identity.gameObject != null)
                     {
+                        identity.OnStopClient();
                         bool wasUnspawned = InvokeUnSpawnHandler(identity.assetId, identity.gameObject);
                         if (!wasUnspawned)
                         {
                             if (identity.sceneId == 0)
                             {
-                                identity.OnStopClient();
                                 Object.Destroy(identity.gameObject);
                             }
                             else

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -720,6 +720,7 @@ namespace Mirror
                         {
                             if (identity.sceneId == 0)
                             {
+                                identity.OnStopClient();
                                 Object.Destroy(identity.gameObject);
                             }
                             else


### PR DESCRIPTION
I was looking through the open bugs in the project to contribute to it. Since I am using it in my own project it only felt right to contribute somehow. This is my first pull request in the project so I am sorry if am breaking the guidelines. I read through them but still sorry if I did the PR wrong.

I was looking through the codebase to understand why OnStopClient was not being called on client side when connection dropped/disconnected as stated in these bugs #2119 #2232 

The reason behind that is, it is only being referenced in [NetworkServer](https://github.com/vis2k/Mirror/blob/master/Assets/Mirror/Runtime/NetworkServer.cs) for shutdown/disconnect purposes. I looked through for similar calls on Client side which I could utilize rather than creating my own. I found out that there is a similar call on [ClientScene](https://github.com/vis2k/Mirror/blob/master/Assets/Mirror/Runtime/ClientScene.cs) which destroys all the [NetworkIdentity](https://github.com/vis2k/Mirror/blob/master/Assets/Mirror/Runtime/NetworkIdentity.cs) objects during shutdown/disconnect. I added a OnStopClient call before destroying the GameObject there. Worked without any issues. 

[My Test Script](https://i.ibb.co/4ZQW3yj/Test-Script.png)

[Console Log without fix](https://i.ibb.co/4S3ypFj/Without-Fix-Console.png)

[Console Log with fix](https://i.ibb.co/kgBXRHQ/With-Fix-Console.png)

Ps: Console Logs indicate the state after the client stops the connection with the server.