### PR TITLE
using null propagation instead of catching null ref

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -262,9 +262,9 @@ namespace Mirror.Weaver
 
                 try
                 {
-                    typeDefinition = typeDefinition.BaseType.Resolve();
+                    typeDefinition = typeDefinition.BaseType?.Resolve();
                 }
-                catch
+                catch (AssemblyResolutionException)
                 {
                     break;
                 }


### PR DESCRIPTION
- only catching AssemblyResolutionException
- using null propagation instead of null ref


Will merge when tests pass