### PR TITLE
OnStopServer Play mode exit bug fix

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -58,7 +58,6 @@ namespace Mirror
             // set not ready and handle clientscene disconnect in any case
             // (might be client or host mode here)
             isReady = false;
-            identity.OnStopServer();
             Transport.activeTransport.ServerDisconnect(connectionId);
             RemoveObservers();
         }

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -58,6 +58,7 @@ namespace Mirror
             // set not ready and handle clientscene disconnect in any case
             // (might be client or host mode here)
             isReady = false;
+            identity.OnStopServer();
             Transport.activeTransport.ServerDisconnect(connectionId);
             RemoveObservers();
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -235,6 +235,7 @@ namespace Mirror
         {
             if (localConnection != null)
             {
+                localConnection.identity.OnStopServer();
                 localConnection.Disconnect();
                 localConnection.Dispose();
                 localConnection = null;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -235,7 +235,14 @@ namespace Mirror
         {
             if (localConnection != null)
             {
-                localConnection.identity.OnStopServer();
+                //OnStopServer is not being called when PlayMode exited.
+                //On normal builds it's working just fine.
+                //In order to call OnStopServer on PlayModeExit
+                //and also prevent it being called for twice we have to do the check below.
+                if (localConnection.identity != null)
+                {
+                    localConnection.identity.OnStopServer();
+                }
                 localConnection.Disconnect();
                 localConnection.Dispose();
                 localConnection = null;


### PR DESCRIPTION
OnStopServer is being called properly if the server is 'server only' rather than 'host server'.
On host server; it is calling OnStopServer without an issue except only the local player itself.

So the underlying issue seems to be at local client on a host server. I called OnStopServer from RemoveLocalConnection which is used for disconnecting the local player from host. 

Related to: #2232