### PR TITLE
fix: fixing Initializer for generic synclists

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
@@ -46,6 +46,13 @@ namespace Mirror.Weaver
             }
             MethodReference objectConstructor = Weaver.CurrentAssembly.MainModule.ImportReference(ctor);
 
+            // if is SyncList<int> instead of SyncListInt then we need to make the ctor generic 
+            if (fd.FieldType.IsGenericInstance)
+            {
+                GenericInstanceType genericInstance = (GenericInstanceType)fd.FieldType;
+                objectConstructor = objectConstructor.MakeHostInstanceGeneric(genericInstance);
+            }
+
             worker.Append(worker.Create(OpCodes.Ldarg_0));
             worker.Append(worker.Create(OpCodes.Newobj, objectConstructor));
             worker.Append(worker.Create(OpCodes.Stfld, fd));


### PR DESCRIPTION
Weaver should initialize `public SyncList<int> myList;`  in the same way it does for `SyncListInt`