### PR TITLE
breaking: Users must initialize synclists (#391)

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
 

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
@@ -8,54 +8,8 @@ namespace Mirror.Weaver
     {
         public static void GenerateSyncObjectInitializer(ILProcessor worker, FieldDefinition fd)
         {
-            // call syncobject constructor
-            GenerateSyncObjectInstanceInitializer(worker, fd);
-
             // register syncobject in network behaviour
             GenerateSyncObjectRegistration(worker, fd);
-        }
-
-        // generates 'syncListInt = new SyncListInt()' if user didn't do that yet
-        static void GenerateSyncObjectInstanceInitializer(ILProcessor worker, FieldDefinition fd)
-        {
-            // check the ctor's instructions for an Stfld op-code for this specific sync list field.
-            foreach (Instruction ins in worker.Body.Instructions)
-            {
-                if (ins.OpCode.Code == Code.Stfld)
-                {
-                    FieldDefinition field = (FieldDefinition)ins.Operand;
-                    if (field.DeclaringType == fd.DeclaringType && field.Name == fd.Name)
-                    {
-                        // Already initialized by the user in the field definition, e.g:
-                        // public SyncListInt Foo = new SyncListInt();
-                        return;
-                    }
-                }
-            }
-
-            // Not initialized by the user in the field definition, e.g:
-            // public SyncListInt Foo;
-
-            TypeDefinition fieldType = fd.FieldType.Resolve();
-            // find ctor with no parameters
-            MethodDefinition ctor = fieldType.Methods.FirstOrDefault(x => x.Name == ".ctor" && !x.HasParameters);
-            if (ctor == null)
-            {
-                Weaver.Error($"Can not initialize field {fd.Name} because no default constructor was found. Manually initialize the field (call the constructor) or add constructor without Parameter", fd);
-                return;
-            }
-            MethodReference objectConstructor = Weaver.CurrentAssembly.MainModule.ImportReference(ctor);
-
-            // if is SyncList<int> instead of SyncListInt then we need to make the ctor generic 
-            if (fd.FieldType.IsGenericInstance)
-            {
-                GenericInstanceType genericInstance = (GenericInstanceType)fd.FieldType;
-                objectConstructor = objectConstructor.MakeHostInstanceGeneric(genericInstance);
-            }
-
-            worker.Append(worker.Create(OpCodes.Ldarg_0));
-            worker.Append(worker.Create(OpCodes.Newobj, objectConstructor));
-            worker.Append(worker.Create(OpCodes.Stfld, fd));
         }
 
         public static bool ImplementsSyncObject(TypeReference typeRef)

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -165,7 +165,10 @@ namespace Mirror
         // We collect all of them and we synchronize them with OnSerialize/OnDeserialize
         protected void InitSyncObject(SyncObject syncObject)
         {
-            syncObjects.Add(syncObject);
+            if (syncObject == null)
+                logger.LogError("Uninitialized SyncObject. Assign a valid SyncList, SyncSet or SyncDictionary", this);
+            else
+                syncObjects.Add(syncObject);
         }
 
         #region Commands

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests.cs
@@ -43,8 +43,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void SyncListMissingParamlessCtor()
         {
-            HasError("Can not initialize field Foo because no default constructor was found. Manually initialize the field (call the constructor) or add constructor without Parameter",
-                "WeaverSyncListTests.SyncListMissingParamlessCtor.SyncListMissingParamlessCtor/SyncListString2 WeaverSyncListTests.SyncListMissingParamlessCtor.SyncListMissingParamlessCtor::Foo");
+            IsSuccess();
         }
 
         [Test]


### PR DESCRIPTION
Users need to initialize their SyncLists themselves.  For example:

```cs
public class Pepe: NetworkBehavior {

    // BAD
    public SyncList<int> mylist;

    // GOOD
    public SyncList<int> mylist = new SyncList<int>();
}
```

This is completely unnecessary magic we inherited from HLAPI.   Users normally have to initialize their normal lists,  so why should SyncLists be different?  This also means that sync objects no longer have to have a default constructor.

This also affects SyncSets and SyncDictionaries.

BREAKING CHANGE: You must initialize all your SyncLists, SyncSets and SyncDictionaries