### PR TITLE
perf: Avoid ticking every kcp every frame

### DIFF
--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpConnection.cs
@@ -9,7 +9,7 @@ namespace Mirror.KCP
     public abstract class KcpConnection
     {
         protected Socket socket;
-        protected EndPoint remoteEndpoint;
+        public EndPoint remoteEndpoint;
         internal Kcp kcp;
         volatile bool open;
 
@@ -53,12 +53,6 @@ namespace Mirror.KCP
                 if (open && kcp.CurrentMS < lastReceived + TIMEOUT)
                 {
                     kcp.Update();
-
-                    int check = kcp.Check();
-
-                    // call every 10 ms unless check says we can wait longer
-                    if (check < 10)
-                        check = 10;
                 }
             }
             catch (SocketException)
@@ -76,6 +70,11 @@ namespace Mirror.KCP
                 open = false;
                 Debug.LogException(ex);
             }
+        }
+
+        public int NextTick()
+        {
+            return Math.Max(kcp.Check(), 10);
         }
 
         internal void RawInput(byte[] buffer, int msgLength)

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/PriorityQueue.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/PriorityQueue.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mirror.KCP
+{
+
+    /// <summary>
+    /// A simple queue where entries are sorted by their priority.
+    /// </summary>
+    /// <remarks>The priority queue is implemented as a heap,
+    /// for more information on this well known data structure,
+    /// refer to <see href="https://en.wikipedia.org/wiki/Binary_heap"/></remarks>
+    /// <typeparam name="P">the priority of the item</typeparam>
+    /// <typeparam name="V">The item</typeparam>
+    public class PriorityQueue<P, V> where P : IComparable<P>
+    {
+        private readonly List<(P priority, V value)> items = new System.Collections.Generic.List<(P,V)>();
+
+        public PriorityQueue()
+        {
+
+        }
+
+        public int Count => items.Count;
+
+
+        // the location of the parent in the heap
+        private int Parent(int location) => (location - 1) >> 1;
+
+        // the location of the children in the heap
+        private int Children(int location) => (location << 1) + 1;
+
+        public void Enqueue(P priority, V value)
+        {
+            items.Add((priority, value));
+            BubbleUp(priority);
+        }
+
+        private void BubbleUp(P priority)
+        {
+            // the last item in the list may need to move up in order
+            // to maintain the heap integrity
+            int loc = items.Count - 1;
+            int parent = Parent(loc);
+            while (loc > 0 && items[parent].priority.CompareTo(priority) > 0)
+            {
+                swap(loc, parent);
+                loc = parent;
+                parent = Parent(loc);
+            }
+        }
+
+        private void swap(int loc1, int loc2)
+        {
+            (items[loc1], items[loc2]) = (items[loc2], items[loc1]);
+        }
+
+        public (P priority, V value) Dequeue()
+        {
+            (P priority, V value) result = items[0];
+
+            int last = items.Count - 1;
+            swap(0, last);
+            items.RemoveAt(last);
+
+            if (items.Count > 0)
+                BubbleDown(0);
+
+            return result;
+        }
+
+        private void BubbleDown(int loc)
+        {
+            // the first item in the heap may need to bubble down in order
+            // to maintain heap integrity
+            int left = Children(loc);
+            int right = left + 1;
+
+            int smallest = loc;
+
+            if (left < items.Count && items[left].priority.CompareTo(items[smallest].priority) < 0)
+                smallest = left;
+
+            if (right < items.Count && items[right].priority.CompareTo(items[smallest].priority) < 0)
+                smallest = right;
+
+            if (smallest != loc) {
+                swap(smallest, loc);
+                BubbleDown(smallest);
+            }
+        }
+
+        public (P priority, V value) Peek() => items[0];
+    }
+}

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/PriorityQueue.cs.meta
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/PriorityQueue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af6710fa5124448ca9481fb625646a67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
+++ b/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
@@ -5,7 +5,8 @@
         "Mirror.Weaver",
         "Mirror.Components",
         "Mirror.Tests.Common",
-        "Telepathy"
+        "Telepathy",
+        "KCP"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/Assets/Mirror/Tests/Editor/PriorityQueueTest.cs
+++ b/Assets/Mirror/Tests/Editor/PriorityQueueTest.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Mirror.KCP;
+using System.Linq;
+
+namespace Mirror.Tests
+{
+    public class PriorityQueueTest
+    {
+        PriorityQueue<int, string> pqueue;
+
+        [SetUp]
+        public void Setup()
+        {
+            pqueue = new PriorityQueue<int, string>();
+        }
+
+        [Test]
+        public void Empty()
+        {
+            Assert.That(pqueue.Count, Is.Zero);
+        }
+
+        [Test]
+        public void Enqueue()
+        {
+            pqueue.Enqueue(10, "10");
+
+            Assert.That(pqueue.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Dequeue()
+        {
+            int key = Random.Range(0, int.MaxValue);
+            pqueue.Enqueue(key, "" + key);
+
+            (int priority, string value) = pqueue.Dequeue();
+
+            Assert.That(priority, Is.EqualTo(key));
+            Assert.That(value, Is.EqualTo("" + key));
+
+        }
+
+        [Test]
+        public void Peek()
+        {
+            int key = Random.Range(0, int.MaxValue);
+            pqueue.Enqueue(key, "" + key);
+
+            (int priority, string value) = pqueue.Peek();
+
+            Assert.That(priority, Is.EqualTo(key));
+            Assert.That(value, Is.EqualTo("" + key));
+
+        }
+
+        [Test]
+        public void DequeueRemoves()
+        {
+            pqueue.Enqueue(1, "1");
+            pqueue.Dequeue();
+            Assert.That(pqueue.Count, Is.Zero);
+        }
+
+        [Test]
+        public void EnqueueSorts()
+        {
+            // does not matter in which order we insert entries
+            pqueue.Enqueue(3, "3");
+            pqueue.Enqueue(4, "4");
+            pqueue.Enqueue(2, "2");
+            pqueue.Enqueue(1, "1");
+            pqueue.Enqueue(5, "5");
+
+            // they should dequeue in order of priority
+            (int p, string v) = pqueue.Dequeue();
+
+            Assert.That(p, Is.EqualTo(1));
+            Assert.That(v, Is.EqualTo("1"));
+
+        }
+
+        [Test]
+        public void DequeMaintainsSort()
+        {
+            // random shuffle 1-10
+            List<int> numberList = Enumerable.Range(0, 10).OrderBy(x => Random.value).ToList();
+            foreach (int value in numberList)
+            {
+                pqueue.Enqueue(value, value.ToString());
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                // they should dequeue in order of priority
+                (int p, string v) = pqueue.Dequeue();
+
+                Assert.That(p, Is.EqualTo(i));
+                Assert.That(v, Is.EqualTo(i.ToString()));
+            }
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/PriorityQueueTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/PriorityQueueTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c087d04477ab47ba97b8104caa52d9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
If you have 1000 clients,  you were ticking 1000 kcp every single frame.

This PR asks each kcp when they want to be ticked,  then puts them on a queue sorted by the expiration time. 

Every frame,  we consume the expired timer kcp from the queues and tick them,  then ask again and put them back in the queue.   So every frame we expect to only tick a handful of kcp even if we have thousands of clients.