### PR TITLE
checking if incoming message has length 0 before checking its id

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -265,6 +265,12 @@ namespace Mirror
         /// <param name="buffer">The data received.</param>
         internal void TransportReceive(ArraySegment<byte> buffer, int channelId)
         {
+            if (buffer.Count == 0)
+            {
+                logger.LogError($"ConnectionRecv {this} Message was empty");
+                return;
+            }
+
             // unpack message
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(buffer))
             {


### PR DESCRIPTION
A more useful error in cases where the transport sends an empty array to mirror