### PR TITLE
Simplifing IsClientAlive check

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -20,8 +20,9 @@ namespace Mirror
             return true;
         }
 
-        // override for host client: always return true.
-        internal override bool IsClientAlive() => true;
+        // true because local connections never timeout
+        /// <inheritdoc/>
+        internal override bool IsAlive(float timeout) => true;
 
         internal void DisconnectInternal()
         {
@@ -135,5 +136,9 @@ namespace Mirror
             connectionToClient.DisconnectInternal();
             DisconnectInternal();
         }
+
+        // true because local connections never timeout
+        /// <inheritdoc/>
+        internal override bool IsAlive(float timeout) => true;
     }
 }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -293,16 +293,18 @@ namespace Mirror
             }
         }
 
-        // Failsafe to kick clients that have stopped sending anything to the server.
-        // Clients Ping the server every 2 seconds but transports are unreliable
-        // when it comes to properly generating Disconnect messages to the server.
-        // This cannot be abstract because then NetworkConnectionToServer
-        // would require and override that would never be called
-        // This is overriden in NetworkConnectionToClient.
-        internal virtual bool IsClientAlive()
-        {
-            return true;
-        }
+        /// <summary>
+        /// Checks if cliet has sent a message within timeout
+        /// <para>
+        /// Some transports are unreliable at sending disconnect message to the server
+        /// so this acts as a failsafe to make sure clients are kicked
+        /// </para>
+        /// <para>
+        /// Client should send ping message to server every 2 seconds to keep this alive
+        /// </para>
+        /// </summary>
+        /// <returns>True if server has recently recieved a message</returns>
+        internal virtual bool IsAlive(float timeout) => Time.time - lastMessageTime < timeout;
 
         internal void AddOwnedObject(NetworkIdentity obj)
         {

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -16,10 +16,6 @@ namespace Mirror
         // the client. they would be detected as a message. send messages instead.
         readonly List<int> singleConnectionId = new List<int> { -1 };
 
-        // Failsafe to kick clients that have stopped sending anything to the server.
-        // Clients ping the server every 2 seconds but transports are unreliable
-        // when it comes to properly generating Disconnect messages to the server.
-        internal override bool IsClientAlive() => Time.time - lastMessageTime < NetworkServer.disconnectInactiveTimeout;
 
         internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -499,17 +499,7 @@ namespace Mirror
 
             // Check for dead clients but exclude the host client because it
             // doesn't ping itself and therefore may appear inactive.
-            if (disconnectInactiveConnections)
-            {
-                foreach (NetworkConnectionToClient conn in connections.Values)
-                {
-                    if (!conn.IsClientAlive())
-                    {
-                        logger.LogWarning($"Disconnecting {conn} for inactivity!");
-                        conn.Disconnect();
-                    }
-                }
-            }
+            CheckForInavtiveConnections();
 
             // update all server objects
             foreach (KeyValuePair<uint, NetworkIdentity> kvp in NetworkIdentity.spawned)
@@ -524,6 +514,21 @@ namespace Mirror
                     // spawned list should have no null entries because we
                     // always call Remove in OnObjectDestroy everywhere.
                     logger.LogWarning("Found 'null' entry in spawned list for netId=" + kvp.Key + ". Please call NetworkServer.Destroy to destroy networked objects. Don't use GameObject.Destroy.");
+                }
+            }
+        }
+
+        static void CheckForInavtiveConnections()
+        {
+            if (!disconnectInactiveConnections)
+                return;
+
+            foreach (NetworkConnectionToClient conn in connections.Values)
+            {
+                if (!conn.IsAlive(disconnectInactiveTimeout))
+                {
+                    logger.LogWarning($"Disconnecting {conn} for inactivity!");
+                    conn.Disconnect();
                 }
             }
         }


### PR DESCRIPTION
* moving check to base connection because it could be used for either
* renaming to IsAlive
* passing in timeout so it doesn't need to check NetworkServer
* updating doc comment