### PR TITLE
simplify serializing collections (#416)

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -33,7 +33,13 @@ namespace Mirror.Weaver
             // thus check if it is an array and skip all the checks.
             if (variableReference.IsArray)
             {
-                return GenerateArrayReadFunc(variableReference);
+                if (variableReference.IsMultidimensionalArray())
+                {
+                    Weaver.Error($"{variableReference.Name} is an unsupported type. Multidimensional arrays are not supported", variableReference);
+                    return null;
+                }
+
+                return GenerateReadCollection(variableReference, variableReference.GetElementType(), nameof(NetworkReaderExtensions.ReadArray));
             }
 
             TypeDefinition variableDefinition = variableReference.Resolve();
@@ -89,7 +95,10 @@ namespace Mirror.Weaver
             }
             else if (variableDefinition.Is(typeof(List<>)))
             {
-                return GenerateListReadFunc(variableReference);
+                var genericInstance = (GenericInstanceType)variableReference;
+                TypeReference elementType = genericInstance.GenericArguments[0];
+
+                return GenerateReadCollection(variableReference, elementType, nameof(NetworkReaderExtensions.ReadList));
             }
 
             return GenerateClassOrStructReadFunction(variableReference);
@@ -101,67 +110,6 @@ namespace Mirror.Weaver
 
             Weaver.WeaveLists.ConfirmGeneratedCodeClass();
             Weaver.WeaveLists.generateContainerClass.Methods.Add(newReaderFunc);
-        }
-
-        static MethodDefinition GenerateArrayReadFunc(TypeReference variable)
-        {
-            if (variable.IsMultidimensionalArray())
-            {
-                Weaver.Error($"{variable.Name} is an unsupported type. Multidimensional arrays are not supported", variable);
-                return null;
-            }
-
-            MethodDefinition readerFunc = GenerateReaderFunction(variable);
-            TypeReference elementType = variable.GetElementType();
-            MethodReference elementReadFunc = GetReadFunc(elementType);
-            if (elementReadFunc == null)
-            {
-                Weaver.Error($"Cannot generate reader for Array because element {elementType.Name} does not have a reader. Use a supported type or provide a custom reader", variable);
-                return readerFunc;
-            }
-
-            // int lengh
-            readerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-            // T[] array
-            readerFunc.Body.Variables.Add(new VariableDefinition(variable));
-            // int i;
-            readerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-
-            ILProcessor worker = readerFunc.Body.GetILProcessor();
-
-            // int length = reader.ReadPackedInt32();
-            GenerateReadLength(worker);
-
-            GenerateNullLengthCheck(worker);
-
-            // T value = new T[length];
-            worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Newarr, variable.GetElementType()));
-            worker.Append(worker.Create(OpCodes.Stloc_1));
-
-            // for (int i=0; i< length ; i++) {
-            GenerateFor(worker, () =>
-            {
-                // value[i] = reader.ReadT();
-                worker.Append(worker.Create(OpCodes.Ldloc_1));
-                worker.Append(worker.Create(OpCodes.Ldloc_2));
-                worker.Append(worker.Create(OpCodes.Ldelema, variable.GetElementType()));
-                worker.Append(worker.Create(OpCodes.Ldarg_0));
-                worker.Append(worker.Create(OpCodes.Call, elementReadFunc));
-                worker.Append(worker.Create(OpCodes.Stobj, variable.GetElementType()));
-            });
-
-            // return value;
-            worker.Append(worker.Create(OpCodes.Ldloc_1));
-            worker.Append(worker.Create(OpCodes.Ret));
-            return readerFunc;
-        }
-
-        private static void GenerateReadLength(ILProcessor worker)
-        {
-            worker.Append(worker.Create(OpCodes.Ldarg_0));
-            worker.Append(worker.Create(OpCodes.Call, GetReadFunc(WeaverTypes.Import<int>())));
-            worker.Append(worker.Create(OpCodes.Stloc_0));
         }
 
         static MethodDefinition GenerateEnumReadFunc(TypeReference variable)
@@ -200,37 +148,6 @@ namespace Mirror.Weaver
             return readerFunc;
         }
 
-        private static void GenerateFor(ILProcessor worker, Action body)
-        {
-            // loop through array and deserialize each element
-            // generates code like this
-            // for (int i=0; i< length ; i++)
-            // {
-            //     <body>
-            // }
-            worker.Append(worker.Create(OpCodes.Ldc_I4_0));
-            worker.Append(worker.Create(OpCodes.Stloc_2));
-            Instruction labelHead = worker.Create(OpCodes.Nop);
-            worker.Append(worker.Create(OpCodes.Br, labelHead));
-
-            // loop body
-            Instruction labelBody = worker.Create(OpCodes.Nop);
-            worker.Append(labelBody);
-
-            body();
-
-            worker.Append(worker.Create(OpCodes.Ldloc_2));
-            worker.Append(worker.Create(OpCodes.Ldc_I4_1));
-            worker.Append(worker.Create(OpCodes.Add));
-            worker.Append(worker.Create(OpCodes.Stloc_2));
-
-            // loop while check
-            worker.Append(labelHead);
-            worker.Append(worker.Create(OpCodes.Ldloc_2));
-            worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Blt, labelBody));
-        }
-
         private static MethodDefinition GenerateReaderFunction(TypeReference variable)
         {
             string functionName = "_Read_" + variable.FullName;
@@ -249,70 +166,30 @@ namespace Mirror.Weaver
             return readerFunc;
         }
 
-        static MethodDefinition GenerateListReadFunc(TypeReference variable)
-        {
+        static MethodDefinition GenerateReadCollection(TypeReference variable, TypeReference elementType, string readerFunction)
+        { 
+            // generate readers for the element
+            GetReadFunc(elementType);
+
             MethodDefinition readerFunc = GenerateReaderFunction(variable);
 
-            GenericInstanceType genericInstance = (GenericInstanceType)variable;
-            TypeReference elementType = genericInstance.GenericArguments[0];
+            ModuleDefinition module = Weaver.CurrentAssembly.MainModule;
+            TypeReference readerExtensions = module.ImportReference(typeof(NetworkReaderExtensions));
+            MethodReference listReader = Resolvers.ResolveMethod(readerExtensions, Weaver.CurrentAssembly, readerFunction);
 
-            MethodReference elementReadFunc = GetReadFunc(elementType);
-            if (elementReadFunc == null)
-            {
-                Weaver.Error($"Cannot generate reader for List because element {elementType.Name} does not have a reader. Use a supported type or provide a custom reader", variable);
-                return readerFunc;
-            }
+            var methodRef = new GenericInstanceMethod(listReader);
+            methodRef.GenericArguments.Add(elementType);
 
-            // int length
-            readerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-            // List<T> list;
-            readerFunc.Body.Variables.Add(new VariableDefinition(variable));
-            // int i
-            readerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
+            // generates
+            // return reader.ReadList<T>();
 
             ILProcessor worker = readerFunc.Body.GetILProcessor();
+            worker.Append(worker.Create(OpCodes.Ldarg_0)); // reader
+            worker.Append(worker.Create(OpCodes.Call, methodRef)); // Read
 
-            // int length = reader.ReadPackedInt32();
-            GenerateReadLength(worker);
-
-            GenerateNullLengthCheck(worker);
-
-            // List<T> list = new List<T>();
-            worker.Append(worker.Create(OpCodes.Newobj, WeaverTypes.ListConstructorReference.MakeHostInstanceGeneric(genericInstance)));
-            worker.Append(worker.Create(OpCodes.Stloc_1));
-
-            // for(int i=0; i< length ; i++)
-            GenerateFor(worker, () =>
-            {
-                // list.Add(reader.ReadT());
-                worker.Append(worker.Create(OpCodes.Ldloc_1)); // list
-                worker.Append(worker.Create(OpCodes.Ldarg_0)); // reader
-                worker.Append(worker.Create(OpCodes.Call, elementReadFunc)); // Read
-
-                MethodReference addItem = WeaverTypes.ListAddReference.MakeHostInstanceGeneric(genericInstance);
-                worker.Append(worker.Create(OpCodes.Call, addItem)); // add
-            });
-
-            // return value;
-            worker.Append(worker.Create(OpCodes.Ldloc_1));
             worker.Append(worker.Create(OpCodes.Ret));
+
             return readerFunc;
-        }
-
-        private static void GenerateNullLengthCheck(ILProcessor worker)
-        {
-            // -1 is null list, so if count is less than 0 return null
-            // if (count < 0) {
-            //    return null
-            // }
-            worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Ldc_I4_0));
-            Instruction labelEmptyArray = worker.Create(OpCodes.Nop);
-            worker.Append(worker.Create(OpCodes.Bge, labelEmptyArray));
-            // return null
-            worker.Append(worker.Create(OpCodes.Ldnull));
-            worker.Append(worker.Create(OpCodes.Ret));
-            worker.Append(labelEmptyArray);
         }
 
         static MethodDefinition GenerateClassOrStructReadFunction(TypeReference variable)

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -69,7 +69,12 @@ namespace Mirror.Weaver
             // therefore process this before checks below
             if (variableReference.IsArray)
             {
-                return GenerateArrayWriteFunc(variableReference);
+                if (variableReference.IsMultidimensionalArray())
+                {
+                    throw new GenerateWriterException($"{variableReference.Name} is an unsupported type. Multidimensional arrays are not supported", variableReference);
+                }
+                TypeReference elementType = variableReference.GetElementType();
+                return GenerateCollectionWriter(variableReference, elementType, nameof(NetworkWriterExtensions.WriteArray));
             }
 
             if (variableReference.Resolve()?.IsEnum ?? false)
@@ -81,11 +86,17 @@ namespace Mirror.Weaver
             // check for collections
             if (variableReference.Is(typeof(ArraySegment<>)))
             {
-                return GenerateArraySegmentWriteFunc(variableReference);
+                var genericInstance = (GenericInstanceType)variableReference;
+                TypeReference elementType = genericInstance.GenericArguments[0];
+
+                return GenerateCollectionWriter(variableReference, elementType, nameof(NetworkWriterExtensions.WriteArraySegment));
             }
             if (variableReference.Is(typeof(List<>)))
             {
-                return GenerateListWriteFunc(variableReference);
+                var genericInstance = (GenericInstanceType)variableReference;
+                TypeReference elementType = genericInstance.GenericArguments[0];
+
+                return GenerateCollectionWriter(variableReference, elementType, nameof(NetworkWriterExtensions.WriteList));
             }
 
             // check for invalid types
@@ -224,215 +235,40 @@ namespace Mirror.Weaver
             return true;
         }
 
-        static MethodDefinition GenerateArrayWriteFunc(TypeReference variable)
+        static MethodDefinition GenerateCollectionWriter(TypeReference variable, TypeReference elementType, string writerFunction)
         {
-            if (variable.IsMultidimensionalArray())
-            {
-                throw new GenerateWriterException($"{variable.Name} is an unsupported type. Multidimensional arrays are not supported", variable);
-            }
+           
             MethodDefinition writerFunc = GenerateWriterFunc(variable);
 
-            TypeReference elementType = variable.GetElementType();
             MethodReference elementWriteFunc = GetWriteFunc(elementType);
             MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.Import<int>());
 
             // need this null check till later PR when GetWriteFunc throws exception instead
             if (elementWriteFunc == null)
             {
-                Weaver.Error($"Cannot generate writer for Array because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
+                Weaver.Error($"Cannot generate writer for {variable}. Use a supported type or provide a custom writer", variable);
                 return writerFunc;
             }
 
-            // int length 
-            writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-            // int i
-            writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
+            ModuleDefinition module = Weaver.CurrentAssembly.MainModule;
+            TypeReference readerExtensions = module.ImportReference(typeof(NetworkWriterExtensions));
+            MethodReference collectionWriter = Resolvers.ResolveMethod(readerExtensions, Weaver.CurrentAssembly, writerFunction);
+
+            var methodRef = new GenericInstanceMethod(collectionWriter);
+            methodRef.GenericArguments.Add(elementType);
+
+            // generates
+            // reader.WriteArray<T>(array);
 
             ILProcessor worker = writerFunc.Body.GetILProcessor();
-            GenerateContainerNullCheck(worker);
+            worker.Append(worker.Create(OpCodes.Ldarg_0)); // writer
+            worker.Append(worker.Create(OpCodes.Ldarg_1)); // collection
 
-            // int length = value.Length;
-            worker.Append(worker.Create(OpCodes.Ldarg_1));
-            worker.Append(worker.Create(OpCodes.Ldlen));
-            worker.Append(worker.Create(OpCodes.Stloc_0));
+            worker.Append(worker.Create(OpCodes.Call, methodRef)); // WriteArray
 
-            // writer.WritePackedInt32(count);
-            // for (int i=0; i < length; i++)
-            GenerateFor(worker, () =>
-            {
-                // writer.Write(value[i]);
-                worker.Append(worker.Create(OpCodes.Ldarg_0));
-                worker.Append(worker.Create(OpCodes.Ldarg_1));
-                worker.Append(worker.Create(OpCodes.Ldloc_1));
-                worker.Append(worker.Create(OpCodes.Ldelema, elementType));
-                worker.Append(worker.Create(OpCodes.Ldobj, elementType));
-                worker.Append(worker.Create(OpCodes.Call, elementWriteFunc));
-            });
-
-            // return
             worker.Append(worker.Create(OpCodes.Ret));
+
             return writerFunc;
-        }
-
-        private static void GenerateContainerNullCheck(ILProcessor worker)
-        {
-            // if (value == null)
-            // {
-            //     writer.WritePackedInt32(-1);
-            //     return;
-            // }
-            Instruction labelNull = worker.Create(OpCodes.Nop);
-            worker.Append(worker.Create(OpCodes.Ldarg_1));
-            worker.Append(worker.Create(OpCodes.Brtrue, labelNull));
-
-            worker.Append(worker.Create(OpCodes.Ldarg_0));
-            worker.Append(worker.Create(OpCodes.Ldc_I4_M1));
-            worker.Append(worker.Create(OpCodes.Call, GetWriteFunc(WeaverTypes.Import<int>())));
-            worker.Append(worker.Create(OpCodes.Ret));
-
-            // else not null
-            worker.Append(labelNull);
-        }
-
-        static MethodDefinition GenerateArraySegmentWriteFunc(TypeReference variable)
-        {
-            MethodDefinition writerFunc = GenerateWriterFunc(variable);
-
-            GenericInstanceType genericInstance = (GenericInstanceType)variable;
-            TypeReference elementType = genericInstance.GenericArguments[0];
-            MethodReference elementWriteFunc = GetWriteFunc(elementType);
-
-            // need this null check till later PR when GetWriteFunc throws exception instead
-            if (elementWriteFunc == null)
-            {
-                Weaver.Error($"Cannot generate writer for ArraySegment because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return writerFunc;
-            }
-
-            // int length
-            writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-            // int i
-            writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-
-            ILProcessor worker = writerFunc.Body.GetILProcessor();
-
-            MethodReference countref = WeaverTypes.ArraySegmentCountReference.MakeHostInstanceGeneric(genericInstance);
-
-            // int length = value.Count;
-            worker.Append(worker.Create(OpCodes.Ldarga_S, (byte)1));
-            worker.Append(worker.Create(OpCodes.Call, countref));
-            worker.Append(worker.Create(OpCodes.Stloc_0));
-
-            // writer.WritePackedInt32(count);
-            // for (int i=0; i < length; i++)
-            GenerateFor(worker, () =>
-            {
-                // writer.Write(value.Array[i + value.Offset]);
-                worker.Append(worker.Create(OpCodes.Ldarg_0));
-                worker.Append(worker.Create(OpCodes.Ldarga_S, (byte)1));
-                worker.Append(worker.Create(OpCodes.Call, WeaverTypes.ArraySegmentArrayReference.MakeHostInstanceGeneric(genericInstance)));
-                worker.Append(worker.Create(OpCodes.Ldloc_1));
-                worker.Append(worker.Create(OpCodes.Ldarga_S, (byte)1));
-                worker.Append(worker.Create(OpCodes.Call, WeaverTypes.ArraySegmentOffsetReference.MakeHostInstanceGeneric(genericInstance)));
-                worker.Append(worker.Create(OpCodes.Add));
-                worker.Append(worker.Create(OpCodes.Ldelema, elementType));
-                worker.Append(worker.Create(OpCodes.Ldobj, elementType));
-                worker.Append(worker.Create(OpCodes.Call, elementWriteFunc));
-            });
-
-            // return
-            worker.Append(worker.Create(OpCodes.Ret));
-            return writerFunc;
-        }
-
-        static MethodDefinition GenerateListWriteFunc(TypeReference variable)
-        {
-            MethodDefinition writerFunc = GenerateWriterFunc(variable);
-
-            GenericInstanceType genericInstance = (GenericInstanceType)variable;
-            TypeReference elementType = genericInstance.GenericArguments[0];
-            MethodReference elementWriteFunc = GetWriteFunc(elementType);
-            MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.Import<int>());
-
-            // need this null check till later PR when GetWriteFunc throws exception instead
-            if (elementWriteFunc == null)
-            {
-                Weaver.Error($"Cannot generate writer for List because element {elementType.Name} does not have a writer. Use a supported type or provide a custom writer", variable);
-                return writerFunc;
-            }
-
-            // int length
-            writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-            // int i
-            writerFunc.Body.Variables.Add(new VariableDefinition(WeaverTypes.Import<int>()));
-
-            ILProcessor worker = writerFunc.Body.GetILProcessor();
-
-            GenerateContainerNullCheck(worker);
-
-            MethodReference countref = WeaverTypes.ListCountReference.MakeHostInstanceGeneric(genericInstance);
-
-            // int count = value.Count;
-            worker.Append(worker.Create(OpCodes.Ldarg_1));
-            worker.Append(worker.Create(OpCodes.Call, countref));
-            worker.Append(worker.Create(OpCodes.Stloc_0));
-
-            // writer.WritePackedInt32(count);
-            // for (int i=0; i < length; i++)
-            GenerateFor(worker, () => {
-                MethodReference getItem = WeaverTypes.ListGetItemReference.MakeHostInstanceGeneric(genericInstance);
-
-                // writer.Write(value[i]);
-                worker.Append(worker.Create(OpCodes.Ldarg_0)); // writer
-                worker.Append(worker.Create(OpCodes.Ldarg_1)); // value
-                worker.Append(worker.Create(OpCodes.Ldloc_1)); // i
-                worker.Append(worker.Create(OpCodes.Call, getItem)); //get_Item
-                worker.Append(worker.Create(OpCodes.Call, elementWriteFunc)); // Write
-            });
-
-            // return
-            worker.Append(worker.Create(OpCodes.Ret));
-            return writerFunc;
-        }
-
-        private static void GenerateFor(ILProcessor worker, Action body)
-        {
-            MethodReference intWriterFunc = GetWriteFunc(WeaverTypes.Import<int>());
-
-            // writer.WritePackedInt32(count);
-            worker.Append(worker.Create(OpCodes.Ldarg_0));
-            worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Call, intWriterFunc));
-
-            // Loop through the List<T> and call the writer for each element.
-            // generates this:
-            // for (int i=0; i < length; i++)
-            // {
-            //    writer.WriteT(value[i]);
-            // }
-            worker.Append(worker.Create(OpCodes.Ldc_I4_0));
-            worker.Append(worker.Create(OpCodes.Stloc_1));
-            Instruction labelHead = worker.Create(OpCodes.Nop);
-            worker.Append(worker.Create(OpCodes.Br, labelHead));
-
-            // loop body
-            Instruction labelBody = worker.Create(OpCodes.Nop);
-            worker.Append(labelBody);
-
-            body();
-
-            // end for loop
-            // for loop i++ 
-            worker.Append(worker.Create(OpCodes.Ldloc_1));
-            worker.Append(worker.Create(OpCodes.Ldc_I4_1));
-            worker.Append(worker.Create(OpCodes.Add));
-            worker.Append(worker.Create(OpCodes.Stloc_1));
-
-            worker.Append(labelHead);
-            // for loop i < length
-            worker.Append(worker.Create(OpCodes.Ldloc_1));
-            worker.Append(worker.Create(OpCodes.Ldloc_0));
-            worker.Append(worker.Create(OpCodes.Blt, labelBody));
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -7,6 +7,7 @@
 //   now:
 //     0.0% CPU time,  32KB memory, 0.02ms
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using UnityEngine;
@@ -389,6 +390,32 @@ namespace Mirror
 
             if (logger.WarnEnabled()) logger.LogFormat(LogType.Warning, "ReadNetworkIdentity netId:{0} not found in spawned", netId);
             return null;
+        }
+
+        public static List<T> ReadList<T>(this NetworkReader reader)
+        {
+            int length = reader.ReadPackedInt32();
+            if (length < 0)
+                return null;
+            var result = new List<T>(length);
+            for (int i=0; i< length; i++)
+            {
+                result.Add(reader.Read<T>());
+            }
+            return result;
+        }
+
+        public static T[] ReadArray<T>(this NetworkReader reader)
+        {
+            int length = reader.ReadPackedInt32();
+            if (length < 0)
+                return null;
+            var result = new T[length];
+            for (int i = 0; i < length; i++)
+            {
+                result[i] = reader.Read<T>();
+            }
+            return result;
         }
 
         public static Uri ReadUri(this NetworkReader reader)

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using UnityEngine;
@@ -556,6 +557,40 @@ namespace Mirror
         public static void WriteUri(this NetworkWriter writer, Uri uri)
         {
             writer.WriteString(uri.ToString());
+        }
+
+        public static void WriteList<T>(this NetworkWriter writer, List<T> list)
+        {
+            if (list is null)
+            {
+                writer.WritePackedInt32(-1);
+                return;
+            }
+            writer.WritePackedInt32(list.Count);
+            for (int i=0; i< list.Count; i++)
+                writer.Write(list[i]);
+        }
+
+        public static void WriteArray<T>(this NetworkWriter writer, T[] array)
+        {
+            if (array is null)
+            {
+                writer.WritePackedInt32(-1);
+                return;
+            }
+            writer.WritePackedInt32(array.Length);
+            for (int i = 0; i < array.Length; i++)
+                writer.Write(array[i]);
+        }
+
+        public static void WriteArraySegment<T>(this NetworkWriter writer, ArraySegment<T> segment)
+        {
+            int length = segment.Count;
+            writer.WritePackedInt32(length);
+            for (int i = 0; i< length; i++)
+            {
+                writer.Write(segment.Array[segment.Offset + i]);
+            }
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -1148,6 +1149,29 @@ namespace Mirror.Tests
 
             NetworkReader reader = new NetworkReader(writer.ToArray());
             Assert.That(reader.ReadUri(), Is.EqualTo(testUri));
+        }
+
+        [Test]
+        public void TestList()
+        {
+            var original = new List<int>() { 1, 2, 3, 4, 5 };
+            var writer = new NetworkWriter();
+            writer.Write(original);
+
+            var reader = new NetworkReader(writer.ToArray());
+            var readList = reader.Read<List<int>>();
+            Assert.That(readList, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void TestNullList()
+        {
+            var writer = new NetworkWriter();
+            writer.Write<List<int>>(null);
+
+            var reader = new NetworkReader(writer.ToArray());
+            var readList = reader.Read<List<int>>();
+            Assert.That(readList, Is.Null);
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
@@ -197,7 +197,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void GivesErrorForInvalidArrayType()
         {
-            HasError("Cannot generate writer for Array because element MonoBehaviour does not have a writer. Use a supported type or provide a custom writer",
+            HasError("Cannot generate writer for UnityEngine.MonoBehaviour[]. Use a supported type or provide a custom writer",
                 "UnityEngine.MonoBehaviour[]");
             // TODO change weaver to run checks for write/read at the same time
             //HasError("Cannot generate reader for Array because element MonoBehaviour does not have a reader. Use a supported type or provide a custom reader",
@@ -207,7 +207,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void GivesErrorForInvalidArraySegmentType()
         {
-            HasError("Cannot generate writer for ArraySegment because element MonoBehaviour does not have a writer. Use a supported type or provide a custom writer",
+            HasError("Cannot generate writer for System.ArraySegment`1<UnityEngine.MonoBehaviour>. Use a supported type or provide a custom writer",
                 "System.ArraySegment`1<UnityEngine.MonoBehaviour>");
             // TODO change weaver to run checks for write/read at the same time
             //HasError("Cannot generate reader for ArraySegment because element MonoBehaviour does not have a reader. Use a supported type or provide a custom reader",
@@ -229,7 +229,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void GivesErrorForInvalidListType()
         {
-            HasError("Cannot generate writer for List because element MonoBehaviour does not have a writer. Use a supported type or provide a custom writer",
+            HasError("Cannot generate writer for System.Collections.Generic.List`1<UnityEngine.MonoBehaviour>. Use a supported type or provide a custom writer",
                 "System.Collections.Generic.List`1<UnityEngine.MonoBehaviour>");
             // TODO change weaver to run checks for write/read at the same time
             //HasError("Cannot generate reader for List because element MonoBehaviour does not have a reader. Use a supported type or provide a custom reader",


### PR DESCRIPTION
The code to serialize lists, arrays, and array segments is now in the runtime instead of generated in the weaver.

removes about 300 LOC of weaver witchcraft