### PR TITLE
Fix Experimental Rigidbody Component on Unity 2020.2

### DIFF
--- a/Assets/Mirror/Components/Experimental/Mirror.Experimental.asmdef
+++ b/Assets/Mirror/Components/Experimental/Mirror.Experimental.asmdef
@@ -1,0 +1,14 @@
+﻿{
+  "name": "Mirror.Experimental",
+  "references": [
+    "Mirror"
+  ],
+  "optionalUnityReferences": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": []
+}

--- a/Assets/Mirror/Components/Experimental/Mirror.Experimental.asmdef.meta
+++ b/Assets/Mirror/Components/Experimental/Mirror.Experimental.asmdef.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: be2b509b47ec410ebffd33eb2d16c6fd
+timeCreated: 1603194829

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
@@ -38,7 +38,7 @@ namespace Mirror.Experimental
         [SerializeField] float angularVelocitySensitivity = 0.1f;
 
         /// <summary>
-        /// Values sent on client with authoirty after they are sent to the server
+        /// Values sent on client with authority after they are sent to the server
         /// </summary>
         readonly ClientSyncState previousValue = new ClientSyncState();
 
@@ -157,7 +157,6 @@ namespace Mirror.Experimental
         /// <summary>
         /// Updates sync var values on server so that they sync to the client
         /// </summary>
-        [Server]
         void SyncToClients()
         {
             // only update if they have changed more than Sensitivity
@@ -190,7 +189,6 @@ namespace Mirror.Experimental
         /// <summary>
         /// Uses Command to send values to server
         /// </summary>
-        [Client]
         void SendToServer()
         {
             if (!hasAuthority)
@@ -203,7 +201,6 @@ namespace Mirror.Experimental
             SendRigidBodySettings();
         }
 
-        [Client]
         void SendVelocity()
         {
             float now = Time.time;
@@ -238,7 +235,6 @@ namespace Mirror.Experimental
             }
         }
 
-        [Client]
         void SendRigidBodySettings()
         {
             // These shouldn't change often so it is ok to send in their own Command


### PR DESCRIPTION
Hi! 

I was trying to use experimental Rigidbody Component on Unity version 2020.2, but when i was trying to use it I keep getting the error `InvalidProgramException: Invalid IL code in Mirror.Experimental.NetworkRigidbody:SyncToClients (): IL_000f: call` for every frame and component in the scene, I tried a lot of things, and fixed it removing unnecessary decorators. Being honest I don't know much about the mono/.net ecosystem, I assume that it has something to do with communication between namespaces.

I added a asmdef because it was missing, I don't think it makes any difference though.

What do you think about this ?

