### PR TITLE
feat: Transports can implement different features

### DIFF
--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -21,7 +21,7 @@ namespace Mirror
     public class CommandAttribute : Attribute
     {
         // this is zero
-        public int channel = Channels.DefaultReliable;
+        public Transport.Delivery delivery = Transport.Delivery.Reliable;
         public bool ignoreAuthority = false;
     }
 

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -16,6 +16,15 @@ namespace Mirror
 
     public abstract class Transport : MonoBehaviour
     {
+        [Flags]
+        public enum Delivery
+        {
+            // note reliable is 0, because all transports must support reliable
+            Reliable = 0,
+            Unreliable = 1,
+            Encryption = 2,
+            Compression = 4
+        }
         /// <summary>
         /// The current transport used by Mirror.
         /// </summary>
@@ -29,6 +38,8 @@ namespace Mirror
         /// </summary>
         /// <returns>True if this transport works in the current platform</returns>
         public abstract bool Available();
+
+        public virtual Delivery SupportedFeatures => Delivery.Reliable;
 
         #region Client
         /// <summary>
@@ -83,7 +94,7 @@ namespace Mirror
         /// as new channels</param>
         /// <param name="segment">The data to send to the server. Will be recycled after returning, so either use it directly or copy it internally. This allows for allocation-free sends!</param>
         /// <returns>true if the send was successful</returns>
-        public abstract bool ClientSend(int channelId, ArraySegment<byte> segment);
+        public abstract bool ClientSend(Delivery features, ArraySegment<byte> segment);
 
         /// <summary>
         /// Disconnect this client from the server
@@ -146,7 +157,7 @@ namespace Mirror
         /// other features such as unreliable, encryption, compression, etc...</param>
         /// <param name="data"></param>
         /// <returns>true if the data was sent to all clients</returns>
-        public abstract bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment);
+        public abstract bool ServerSend(List<int> connectionIds, Delivery feature, ArraySegment<byte> segment);
 
         /// <summary>
         /// Disconnect a client from this server.  Useful to kick people out.


### PR DESCRIPTION
Currently,  transports can support different features by adding channels.
The problem is that there is no way to tell what channel supports what feature.  
For example, consider this:
```
[Command(channel=3)]
public void CmdSomething()
{
}
```

There is no way to tell what channel 3 means, and it may mean different things for different transports.
Thus there is no transport-independent way to say "I want unreliable" or "I want encryption".

This PR changes it so that you can specify how you want your message delivered:

```
[Command(delivery = Transport.Delivery.Encryption)]
public void CmdSomething()
{
}
```
This would work with any transport that supports encryption.  Mirror would give an error if you try to send a message
and transport cannot satisfy the delivery requirement.

In the future we can add other transport options.