### PR TITLE
Restore ScriptTemplates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
   
       - name: Package
         run: |
-          unity-packer pack Mirror.unitypackage Assets/Mirror Assets/Mirror LICENSE Assets/Mirror/LICENSE
+          unity-packer pack Mirror.unitypackage Assets/Mirror Assets/Mirror Assets/ScriptTemplates Assets/ScriptTemplates LICENSE Assets/Mirror/LICENSE
 
       - uses: actions/upload-artifact@v1
         with:

--- a/Assets/ScriptTemplates.meta
+++ b/Assets/ScriptTemplates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44ffc995e27cf42399ce512dd0e86f9a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -1,0 +1,250 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Mirror;
+
+/*
+	Documentation: https://mirror-networking.com/docs/Components/NetworkManager.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkManager.html
+*/
+
+public class #SCRIPTNAME# : NetworkManager
+{
+    #region Unity Callbacks
+
+    public override void OnValidate()
+    {
+        base.OnValidate();
+    }
+
+    /// <summary>
+    /// Runs on both Server and Client
+    /// Networking is NOT initialized when this fires
+    /// </summary>
+    public override void Awake()
+    {
+        base.Awake();
+    }
+
+    /// <summary>
+    /// Runs on both Server and Client
+    /// Networking is NOT initialized when this fires
+    /// </summary>
+    public override void Start()
+    {
+        base.Start();
+    }
+
+    /// <summary>
+    /// Runs on both Server and Client
+    /// </summary>
+    public override void LateUpdate()
+    {
+        base.LateUpdate();
+    }
+
+    /// <summary>
+    /// Runs on both Server and Client
+    /// </summary>
+    public override void OnDestroy()
+    {
+        base.OnDestroy();
+    }
+
+    #endregion
+
+    #region Start & Stop
+
+    /// <summary>
+    /// Set the frame rate for a headless server.
+    /// <para>Override if you wish to disable the behavior or set your own tick rate.</para>
+    /// </summary>
+    public override void ConfigureServerFrameRate()
+    {
+        base.ConfigureServerFrameRate();
+    }
+
+    /// <summary>
+    /// called when quitting the application by closing the window / pressing stop in the editor
+    /// </summary>
+    public override void OnApplicationQuit()
+    {
+        base.OnApplicationQuit();
+    }
+
+    #endregion
+
+    #region Scene Management
+
+    /// <summary>
+    /// This causes the server to switch scenes and sets the networkSceneName.
+    /// <para>Clients that connect to this server will automatically switch to this scene. This is called autmatically if onlineScene or offlineScene are set, but it can be called from user code to switch scenes again while the game is in progress. This automatically sets clients to be not-ready. The clients must call NetworkClient.Ready() again to participate in the new scene.</para>
+    /// </summary>
+    /// <param name="newSceneName"></param>
+    public override void ServerChangeScene(string newSceneName)
+    {
+        base.ServerChangeScene(newSceneName);
+    }
+
+    /// <summary>
+    /// Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed
+    /// <para>This allows server to do work / cleanup / prep before the scene changes.</para>
+    /// </summary>
+    /// <param name="newSceneName">Name of the scene that's about to be loaded</param>
+    public override void OnServerChangeScene(string newSceneName) { }
+
+    /// <summary>
+    /// Called on the server when a scene is completed loaded, when the scene load was initiated by the server with ServerChangeScene().
+    /// </summary>
+    /// <param name="sceneName">The name of the new scene.</param>
+    public override void OnServerSceneChanged(string sceneName) { }
+
+    /// <summary>
+    /// Called from ClientChangeScene immediately before SceneManager.LoadSceneAsync is executed
+    /// <para>This allows client to do work / cleanup / prep before the scene changes.</para>
+    /// </summary>
+    /// <param name="newSceneName">Name of the scene that's about to be loaded</param>
+    /// <param name="sceneOperation">Scene operation that's about to happen</param>
+    /// <param name="customHandling">true to indicate that scene loading will be handled through overrides</param>
+    public override void OnClientChangeScene(string newSceneName, SceneOperation sceneOperation, bool customHandling) { }
+
+    /// <summary>
+    /// Called on clients when a scene has completed loaded, when the scene load was initiated by the server.
+    /// <para>Scene changes can cause player objects to be destroyed. The default implementation of OnClientSceneChanged in the NetworkManager is to add a player object for the connection if no player object exists.</para>
+    /// </summary>
+    /// <param name="conn">The network connection that the scene change message arrived on.</param>
+    public override void OnClientSceneChanged(NetworkConnection conn)
+    {
+        base.OnClientSceneChanged(conn);
+    }
+
+    #endregion
+
+    #region Server System Callbacks
+
+    /// <summary>
+    /// Called on the server when a new client connects.
+    /// <para>Unity calls this on the Server when a Client connects to the Server. Use an override to tell the NetworkManager what to do when a client connects to the server.</para>
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    public override void OnServerConnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// Called on the server when a client is ready.
+    /// <para>The default implementation of this function calls NetworkServer.SetClientReady() to continue the network setup process.</para>
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    public override void OnServerReady(NetworkConnection conn)
+    {
+        base.OnServerReady(conn);
+    }
+
+    /// <summary>
+    /// Called on the server when a client adds a new player with ClientScene.AddPlayer.
+    /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    public override void OnServerAddPlayer(NetworkConnection conn)
+    {
+        base.OnServerAddPlayer(conn);
+    }
+
+    /// <summary>
+    /// Called on the server when a client disconnects.
+    /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    public override void OnServerDisconnect(NetworkConnection conn)
+    {
+        base.OnServerDisconnect(conn);
+    }
+
+    /// <summary>
+    /// Called on the server when a network error occurs for a client connection.
+    /// </summary>
+    /// <param name="conn">Connection from client.</param>
+    /// <param name="errorCode">Error code.</param>
+    public override void OnServerError(NetworkConnection conn, int errorCode) { }
+
+    #endregion
+
+    #region Client System Callbacks
+
+    /// <summary>
+    /// Called on the client when connected to a server.
+    /// <para>The default implementation of this function sets the client as ready and adds a player. Override the function to dictate what happens when the client connects.</para>
+    /// </summary>
+    /// <param name="conn">Connection to the server.</param>
+    public override void OnClientConnect(NetworkConnection conn)
+    {
+        base.OnClientConnect(conn);
+    }
+
+    /// <summary>
+    /// Called on clients when disconnected from a server.
+    /// <para>This is called on the client when it disconnects from the server. Override this function to decide what happens when the client disconnects.</para>
+    /// </summary>
+    /// <param name="conn">Connection to the server.</param>
+    public override void OnClientDisconnect(NetworkConnection conn)
+    {
+        base.OnClientDisconnect(conn);
+    }
+
+    /// <summary>
+    /// Called on clients when a network error occurs.
+    /// </summary>
+    /// <param name="conn">Connection to a server.</param>
+    /// <param name="errorCode">Error code.</param>
+    public override void OnClientError(NetworkConnection conn, int errorCode) { }
+
+    /// <summary>
+    /// Called on clients when a servers tells the client it is no longer ready.
+    /// <para>This is commonly used when switching scenes.</para>
+    /// </summary>
+    /// <param name="conn">Connection to the server.</param>
+    public override void OnClientNotReady(NetworkConnection conn) { }
+
+    #endregion
+
+    #region Start & Stop Callbacks
+
+    // Since there are multiple versions of StartServer, StartClient and StartHost, to reliably customize
+    // their functionality, users would need override all the versions. Instead these callbacks are invoked
+    // from all versions, so users only need to implement this one case.
+
+    /// <summary>
+    /// This is invoked when a host is started.
+    /// <para>StartHost has multiple signatures, but they all cause this hook to be called.</para>
+    /// </summary>
+    public override void OnStartHost() { }
+
+    /// <summary>
+    /// This is invoked when a server is started - including when a host is started.
+    /// <para>StartServer has multiple signatures, but they all cause this hook to be called.</para>
+    /// </summary>
+    public override void OnStartServer() { }
+
+    /// <summary>
+    /// This is invoked when the client is started.
+    /// </summary>
+    public override void OnStartClient()
+    {
+        base.OnStartClient();
+    }
+
+    /// <summary>
+    /// This is called when a host is stopped.
+    /// </summary>
+    public override void OnStopHost() { }
+
+    /// <summary>
+    /// This is called when a server is stopped - including when a host is stopped.
+    /// </summary>
+    public override void OnStopServer() { }
+
+    /// <summary>
+    /// This is called when a client is stopped.
+    /// </summary>
+    public override void OnStopClient() { }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -226,10 +226,7 @@ public class #SCRIPTNAME# : NetworkManager
     /// <summary>
     /// This is invoked when the client is started.
     /// </summary>
-    public override void OnStartClient()
-    {
-        base.OnStartClient();
-    }
+    public override void OnStartClient() { }
 
     /// <summary>
     /// This is called when a host is stopped.

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt.meta
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ed73cc79a95879d4abd948a36043c798
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
+++ b/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
@@ -1,0 +1,81 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Mirror;
+
+/*
+	Authenticators: https://mirror-networking.com/docs/Components/Authenticators/
+	Documentation: https://mirror-networking.com/docs/Guides/Authentication.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkAuthenticator.html
+*/
+
+public class #SCRIPTNAME# : NetworkAuthenticator
+{
+    #region Messages
+
+    public class AuthRequestMessage : MessageBase { }
+
+    public class AuthResponseMessage : MessageBase { }
+
+    #endregion
+
+    #region Server
+
+    /// <summary>
+    /// Called on server from StartServer to initialize the Authenticator
+    /// <para>Server message handlers should be registered in this method.</para>
+    /// </summary>
+    public override void OnStartServer()
+    {
+        // register a handler for the authentication request we expect from client
+        NetworkServer.RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage, false);
+    }
+
+    /// <summary>
+    /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate
+    /// </summary>
+    /// <param name="conn">Connection to client.</param>
+    public override void OnServerAuthenticate(NetworkConnection conn) { }
+
+    public void OnAuthRequestMessage(NetworkConnection conn, AuthRequestMessage msg)
+    {
+        AuthResponseMessage authResponseMessage = new AuthResponseMessage();
+
+        conn.Send(authResponseMessage);
+
+        // Invoke the event to complete a successful authentication
+        base.OnServerAuthenticated.Invoke(conn);
+    }
+
+    #endregion
+
+    #region Client
+
+    /// <summary>
+    /// Called on client from StartClient to initialize the Authenticator
+    /// <para>Client message handlers should be registered in this method.</para>
+    /// </summary>
+    public override void OnStartClient()
+    {
+        // register a handler for the authentication response we expect from server
+        NetworkClient.RegisterHandler<AuthResponseMessage>(OnAuthResponseMessage, false);
+    }
+
+    /// <summary>
+    /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
+    /// </summary>
+    /// <param name="conn">Connection of the client.</param>
+    public override void OnClientAuthenticate(NetworkConnection conn)
+    {
+        AuthRequestMessage authRequestMessage = new AuthRequestMessage();
+
+        NetworkClient.Send(authRequestMessage);
+    }
+
+    public void OnAuthResponseMessage(NetworkConnection conn, AuthResponseMessage msg)
+    {
+        // Invoke the event to complete a successful authentication
+        base.OnClientAuthenticated.Invoke(conn);
+    }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
+++ b/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
@@ -12,9 +12,9 @@ public class #SCRIPTNAME# : NetworkAuthenticator
 {
     #region Messages
 
-    public class AuthRequestMessage : MessageBase { }
+    public class AuthRequestMessage : NetworkMessage { }
 
-    public class AuthResponseMessage : MessageBase { }
+    public class AuthResponseMessage : NetworkMessage { }
 
     #endregion
 

--- a/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt.meta
+++ b/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 12dc04aca2d89f744bef5a65622ba708
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
+++ b/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
@@ -1,0 +1,59 @@
+using UnityEngine;
+using Mirror;
+using System.Collections.Generic;
+
+/*
+	Documentation: https://mirror-networking.com/docs/Guides/NetworkBehaviour.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkBehaviour.html
+*/
+
+public class #SCRIPTNAME# : NetworkBehaviour
+{
+    #region Start & Stop Callbacks
+
+    /// <summary>
+    /// This is invoked for NetworkBehaviour objects when they become active on the server.
+    /// <para>This could be triggered by NetworkServer.Listen() for objects in the scene, or by NetworkServer.Spawn() for objects that are dynamically created.</para>
+    /// <para>This will be called for objects on a "host" as well as for object on a dedicated server.</para>
+    /// </summary>
+    public override void OnStartServer() { }
+
+    /// <summary>
+    /// Invoked on the server when the object is unspawned
+    /// <para>Useful for saving object data in persistant storage</para>
+    /// </summary>
+    public override void OnStopServer() { }
+
+    /// <summary>
+    /// Called on every NetworkBehaviour when it is activated on a client.
+    /// <para>Objects on the host have this function called, as there is a local client on the host. The values of SyncVars on object are guaranteed to be initialized correctly with the latest state from the server when this function is called on the client.</para>
+    /// </summary>
+    public override void OnStartClient() { }
+
+    /// <summary>
+    /// This is invoked on clients when the server has caused this object to be destroyed.
+    /// <para>This can be used as a hook to invoke effects or do client specific cleanup.</para>
+    /// </summary>
+    public override void OnStopClient() { }
+
+    /// <summary>
+    /// Called when the local player object has been set up.
+    /// <para>This happens after OnStartClient(), as it is triggered by an ownership message from the server. This is an appropriate place to activate components or functionality that should only be active for the local player, such as cameras and input.</para>
+    /// </summary>
+    public override void OnStartLocalPlayer() { }
+
+    /// <summary>
+    /// This is invoked on behaviours that have authority, based on context and <see cref="NetworkIdentity.hasAuthority">NetworkIdentity.hasAuthority</see>.
+    /// <para>This is called after <see cref="OnStartServer">OnStartServer</see> and before <see cref="OnStartClient">OnStartClient.</see></para>
+    /// <para>When <see cref="NetworkIdentity.AssignClientAuthority"/> is called on the server, this will be called on the client that owns the object. When an object is spawned with <see cref="NetworkServer.Spawn">NetworkServer.Spawn</see> with a NetworkConnection parameter included, this will be called on the client that owns the object.</para>
+    /// </summary>
+    public override void OnStartAuthority() { }
+
+    /// <summary>
+    /// This is invoked on behaviours when authority is removed.
+    /// <para>When NetworkIdentity.RemoveClientAuthority is called on the server, this will be called on the client that owns the object.</para>
+    /// </summary>
+    public override void OnStopAuthority() { }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
+++ b/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt
@@ -45,7 +45,7 @@ public class #SCRIPTNAME# : NetworkBehaviour
     /// <summary>
     /// This is invoked on behaviours that have authority, based on context and <see cref="NetworkIdentity.hasAuthority">NetworkIdentity.hasAuthority</see>.
     /// <para>This is called after <see cref="OnStartServer">OnStartServer</see> and before <see cref="OnStartClient">OnStartClient.</see></para>
-    /// <para>When <see cref="NetworkIdentity.AssignClientAuthority"/> is called on the server, this will be called on the client that owns the object. When an object is spawned with <see cref="NetworkServer.Spawn">NetworkServer.Spawn</see> with a NetworkConnection parameter included, this will be called on the client that owns the object.</para>
+    /// <para>When <see cref="NetworkIdentity.AssignClientAuthority">AssignClientAuthority</see> is called on the server, this will be called on the client that owns the object. When an object is spawned with <see cref="NetworkServer.Spawn">NetworkServer.Spawn</see> with a NetworkConnection parameter included, this will be called on the client that owns the object.</para>
     /// </summary>
     public override void OnStartAuthority() { }
 
@@ -54,6 +54,27 @@ public class #SCRIPTNAME# : NetworkBehaviour
     /// <para>When NetworkIdentity.RemoveClientAuthority is called on the server, this will be called on the client that owns the object.</para>
     /// </summary>
     public override void OnStopAuthority() { }
+
+    #endregion
+
+    #region Serialization
+
+    public override bool OnSerialize(NetworkWriter writer, bool initialState)
+    {
+        return base.OnSerialize(writer, initialState);
+    }
+
+    public override bool OnDeserialize(NetworkReader reader, bool initialState)
+    {
+        return base.OnDeserialize(reader, initialState);
+    }
+
+    public override bool SerializeSyncVars(NetworkWriter writer, bool initialState)
+    {
+        return base.SerializeSyncVars(writer, initialState);
+    }
+
+    public override void DeserializeSyncVars(NetworkReader reader, bool initialState) { }
 
     #endregion
 }

--- a/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt.meta
+++ b/Assets/ScriptTemplates/52-Mirror__Network Behaviour-NewNetworkBehaviour.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 29b2ae9aeacc49b47b711838dd1876a4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/53-Mirror__Network Observer-NewNetworkObserver.cs.txt
+++ b/Assets/ScriptTemplates/53-Mirror__Network Observer-NewNetworkObserver.cs.txt
@@ -1,0 +1,30 @@
+using UnityEngine;
+using Mirror;
+using System.Collections.Generic;
+
+/*
+	Visibility Guide: https://mirror-networking.com/docs/Guides/Visibility.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkBehaviour.html
+*/
+
+public class #SCRIPTNAME# : NetworkVisibility
+{
+    /// <summary>
+    /// Callback used by the visibility system to determine if an observer (player) can see this object.
+    /// <para>If this function returns true, the network connection will be added as an observer.</para>
+    /// </summary>
+    /// <param name="conn">Network connection of a player.</param>
+    /// <returns>True if the player can see this object.</returns>
+    public override bool OnCheckObserver(NetworkConnection conn)
+    {
+        return true;
+    }
+    
+    /// <summary>
+    /// Callback used by the visibility system to (re)construct the set of observers that can see this object.
+    /// <para>Implementations of this callback should add network connections of players that can see this object to the observers set.</para>
+    /// </summary>
+    /// <param name="observers">The new set of observers for this object.</param>
+    /// <param name="initialize">True if the set of observers is being built for the first time.</param>
+    public override void OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize) { }
+}

--- a/Assets/ScriptTemplates/53-Mirror__Network Observer-NewNetworkObserver.cs.txt.meta
+++ b/Assets/ScriptTemplates/53-Mirror__Network Observer-NewNetworkObserver.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4362fdd91ea5a9c44997cc575af62b3e
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/54-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt
+++ b/Assets/ScriptTemplates/54-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt
@@ -1,0 +1,182 @@
+using UnityEngine;
+using Mirror;
+
+/*
+	Documentation: https://mirror-networking.com/docs/Components/NetworkRoomManager.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkRoomManager.html
+
+	See Also: NetworkManager
+	Documentation: https://mirror-networking.com/docs/Components/NetworkManager.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkManager.html
+*/
+
+/// <summary>
+/// This is a specialized NetworkManager that includes a networked room.
+/// The room has slots that track the joined players, and a maximum player count that is enforced.
+/// It requires that the NetworkRoomPlayer component be on the room player objects.
+/// NetworkRoomManager is derived from NetworkManager, and so it implements many of the virtual functions provided by the NetworkManager class.
+/// </summary>
+public class #SCRIPTNAME# : NetworkRoomManager
+{
+    #region Server Callbacks
+
+    /// <summary>
+    /// This is called on the server when the server is started - including when a host is started.
+    /// </summary>
+    public override void OnRoomStartServer() { }
+
+    /// <summary>
+    /// This is called on the server when the server is stopped - including when a host is stopped.
+    /// </summary>
+    public override void OnRoomStopServer() { }
+
+    /// <summary>
+    /// This is called on the host when a host is started.
+    /// </summary>
+    public override void OnRoomStartHost() { }
+
+    /// <summary>
+    /// This is called on the host when the host is stopped.
+    /// </summary>
+    public override void OnRoomStopHost() { }
+
+    /// <summary>
+    /// This is called on the server when a new client connects to the server.
+    /// </summary>
+    /// <param name="conn">The new connection.</param>
+    public override void OnRoomServerConnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// This is called on the server when a client disconnects.
+    /// </summary>
+    /// <param name="conn">The connection that disconnected.</param>
+    public override void OnRoomServerDisconnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// This is called on the server when a networked scene finishes loading.
+    /// </summary>
+    /// <param name="sceneName">Name of the new scene.</param>
+    public override void OnRoomServerSceneChanged(string sceneName) { }
+
+    /// <summary>
+    /// This allows customization of the creation of the room-player object on the server.
+    /// <para>By default the roomPlayerPrefab is used to create the room-player, but this function allows that behaviour to be customized.</para>
+    /// </summary>
+    /// <param name="conn">The connection the player object is for.</param>
+    /// <returns>The new room-player object.</returns>
+    public override GameObject OnRoomServerCreateRoomPlayer(NetworkConnection conn)
+    {
+        return base.OnRoomServerCreateRoomPlayer(conn);
+    }
+
+    /// <summary>
+    /// This allows customization of the creation of the GamePlayer object on the server.
+    /// <para>By default the gamePlayerPrefab is used to create the game-player, but this function allows that behaviour to be customized. The object returned from the function will be used to replace the room-player on the connection.</para>
+    /// </summary>
+    /// <param name="conn">The connection the player object is for.</param>
+    /// <param name="roomPlayer">The room player object for this connection.</param>
+    /// <returns>A new GamePlayer object.</returns>
+    public override GameObject OnRoomServerCreateGamePlayer(NetworkConnection conn, GameObject roomPlayer)
+    {
+        return base.OnRoomServerCreateGamePlayer(conn, roomPlayer);
+    }
+
+    /// <summary>
+    /// This allows customization of the creation of the GamePlayer object on the server.
+    /// <para>This is only called for subsequent GamePlay scenes after the first one.</para>
+    /// <para>See OnRoomServerCreateGamePlayer to customize the player object for the initial GamePlay scene.</para>
+    /// </summary>
+    /// <param name="conn">The connection the player object is for.</param>
+    public override void OnRoomServerAddPlayer(NetworkConnection conn)
+    {
+        base.OnRoomServerAddPlayer(conn);
+    }
+
+    /// <summary>
+    /// This is called on the server when it is told that a client has finished switching from the room scene to a game player scene.
+    /// <para>When switching from the room, the room-player is replaced with a game-player object. This callback function gives an opportunity to apply state from the room-player to the game-player object.</para>
+    /// </summary>
+    /// <param name="conn">The connection of the player</param>
+    /// <param name="roomPlayer">The room player object.</param>
+    /// <param name="gamePlayer">The game player object.</param>
+    /// <returns>False to not allow this player to replace the room player.</returns>
+    public override bool OnRoomServerSceneLoadedForPlayer(NetworkConnection conn, GameObject roomPlayer, GameObject gamePlayer)
+    {
+        return base.OnRoomServerSceneLoadedForPlayer(conn, roomPlayer, gamePlayer);
+    }
+
+    /// <summary>
+    /// This is called on the server when all the players in the room are ready.
+    /// <para>The default implementation of this function uses ServerChangeScene() to switch to the game player scene. By implementing this callback you can customize what happens when all the players in the room are ready, such as adding a countdown or a confirmation for a group leader.</para>
+    /// </summary>
+    public override void OnRoomServerPlayersReady()
+    {
+        base.OnRoomServerPlayersReady();
+    }
+
+    /// <summary>
+    /// This is called on the server when CheckReadyToBegin finds that players are not ready
+    /// <para>May be called multiple times while not ready players are joining</para>
+    /// </summary>
+    public override void OnRoomServerPlayersNotReady() { }
+
+    #endregion
+
+    #region Client Callbacks
+
+    /// <summary>
+    /// This is a hook to allow custom behaviour when the game client enters the room.
+    /// </summary>
+    public override void OnRoomClientEnter() { }
+
+    /// <summary>
+    /// This is a hook to allow custom behaviour when the game client exits the room.
+    /// </summary>
+    public override void OnRoomClientExit() { }
+
+    /// <summary>
+    /// This is called on the client when it connects to server.
+    /// </summary>
+    /// <param name="conn">The connection that connected.</param>
+    public override void OnRoomClientConnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// This is called on the client when disconnected from a server.
+    /// </summary>
+    /// <param name="conn">The connection that disconnected.</param>
+    public override void OnRoomClientDisconnect(NetworkConnection conn) { }
+
+    /// <summary>
+    /// This is called on the client when a client is started.
+    /// </summary>
+    /// <param name="roomClient">The connection for the room.</param>
+    public override void OnRoomStartClient() { }
+
+    /// <summary>
+    /// This is called on the client when the client stops.
+    /// </summary>
+    public override void OnRoomStopClient() { }
+
+    /// <summary>
+    /// This is called on the client when the client is finished loading a new networked scene.
+    /// </summary>
+    /// <param name="conn">The connection that finished loading a new networked scene.</param>
+    public override void OnRoomClientSceneChanged(NetworkConnection conn) { }
+
+    /// <summary>
+    /// Called on the client when adding a player to the room fails.
+    /// <para>This could be because the room is full, or the connection is not allowed to have more players.</para>
+    /// </summary>
+    public override void OnRoomClientAddPlayerFailed() { }
+
+    #endregion
+
+    #region Optional UI
+
+    public override void OnGUI()
+    {
+        base.OnGUI();
+    }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/54-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt.meta
+++ b/Assets/ScriptTemplates/54-Mirror__Network Room Manager-NewNetworkRoomManager.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2e5656107e61a93439544b91e5f541f6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/55-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt
+++ b/Assets/ScriptTemplates/55-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt
@@ -1,0 +1,106 @@
+using UnityEngine;
+using Mirror;
+
+/*
+	Documentation: https://mirror-networking.com/docs/Components/NetworkRoomPlayer.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkRoomPlayer.html
+*/
+
+/// <summary>
+/// This component works in conjunction with the NetworkRoomManager to make up the multiplayer room system.
+/// The RoomPrefab object of the NetworkRoomManager must have this component on it.
+/// This component holds basic room player data required for the room to function.
+/// Game specific data for room players can be put in other components on the RoomPrefab or in scripts derived from NetworkRoomPlayer.
+/// </summary>
+public class #SCRIPTNAME# : NetworkRoomPlayer
+{
+    #region Start & Stop Callbacks
+
+    /// <summary>
+    /// This is invoked for NetworkBehaviour objects when they become active on the server.
+    /// <para>This could be triggered by NetworkServer.Listen() for objects in the scene, or by NetworkServer.Spawn() for objects that are dynamically created.</para>
+    /// <para>This will be called for objects on a "host" as well as for object on a dedicated server.</para>
+    /// </summary>
+    public override void OnStartServer() { }
+
+    /// <summary>
+    /// Invoked on the server when the object is unspawned
+    /// <para>Useful for saving object data in persistant storage</para>
+    /// </summary>
+    public override void OnStopServer() { }
+
+    /// <summary>
+    /// Called on every NetworkBehaviour when it is activated on a client.
+    /// <para>Objects on the host have this function called, as there is a local client on the host. The values of SyncVars on object are guaranteed to be initialized correctly with the latest state from the server when this function is called on the client.</para>
+    /// </summary>
+    public override void OnStartClient() { }
+
+    /// <summary>
+    /// This is invoked on clients when the server has caused this object to be destroyed.
+    /// <para>This can be used as a hook to invoke effects or do client specific cleanup.</para>
+    /// </summary>
+    public override void OnStopClient() { }
+
+    /// <summary>
+    /// Called when the local player object has been set up.
+    /// <para>This happens after OnStartClient(), as it is triggered by an ownership message from the server. This is an appropriate place to activate components or functionality that should only be active for the local player, such as cameras and input.</para>
+    /// </summary>
+    public override void OnStartLocalPlayer() { }
+
+    /// <summary>
+    /// This is invoked on behaviours that have authority, based on context and <see cref="NetworkIdentity.hasAuthority">NetworkIdentity.hasAuthority</see>.
+    /// <para>This is called after <see cref="OnStartServer">OnStartServer</see> and before <see cref="OnStartClient">OnStartClient.</see></para>
+    /// <para>When <see cref="NetworkIdentity.AssignClientAuthority"/> is called on the server, this will be called on the client that owns the object. When an object is spawned with <see cref="NetworkServer.Spawn">NetworkServer.Spawn</see> with a NetworkConnection parameter included, this will be called on the client that owns the object.</para>
+    /// </summary>
+    public override void OnStartAuthority() { }
+
+    /// <summary>
+    /// This is invoked on behaviours when authority is removed.
+    /// <para>When NetworkIdentity.RemoveClientAuthority is called on the server, this will be called on the client that owns the object.</para>
+    /// </summary>
+    public override void OnStopAuthority() { }
+
+    #endregion
+
+    #region Room Client Callbacks
+
+    /// <summary>
+    /// This is a hook that is invoked on all player objects when entering the room.
+    /// <para>Note: isLocalPlayer is not guaranteed to be set until OnStartLocalPlayer is called.</para>
+    /// </summary>
+    public override void OnClientEnterRoom() { }
+
+    /// <summary>
+    /// This is a hook that is invoked on all player objects when exiting the room.
+    /// </summary>
+    public override void OnClientExitRoom() { }
+
+    #endregion
+
+    #region SyncVar Hooks
+
+    /// <summary>
+    /// This is a hook that is invoked on clients when the index changes.
+    /// </summary>
+    /// <param name="oldIndex">The old index value</param>
+    /// <param name="newIndex">The new index value</param>
+    public override void IndexChanged(int oldIndex, int newIndex) { }
+
+    /// <summary>
+    /// This is a hook that is invoked on clients when a RoomPlayer switches between ready or not ready.
+    /// <para>This function is called when the a client player calls SendReadyToBeginMessage() or SendNotReadyToBeginMessage().</para>
+    /// </summary>
+    /// <param name="readyState">Whether the player is ready or not.</param>
+    public override void ReadyStateChanged(bool _, bool readyState) { }
+
+    #endregion
+
+    #region Optional UI
+
+    public override void OnGUI()
+    {
+        base.OnGUI();
+    }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/55-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt.meta
+++ b/Assets/ScriptTemplates/55-Mirror__Network Room Player-NewNetworkRoomPlayer.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1ca8a6309173d4248bc7fa0c6ae001e0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/56-Mirror__Network Discovery-NewNetworkDiscovery.cs.txt
+++ b/Assets/ScriptTemplates/56-Mirror__Network Discovery-NewNetworkDiscovery.cs.txt
@@ -1,0 +1,84 @@
+using System.Net;
+using Mirror;
+using Mirror.Discovery;
+
+/*
+	Discovery Guide: https://mirror-networking.com/docs/Guides/NetworkDiscovery.html
+    Documentation: https://mirror-networking.com/docs/Components/NetworkDiscovery.html
+    API Reference: https://mirror-networking.com/docs/api/Mirror.Discovery.NetworkDiscovery.html
+*/
+
+public class DiscoveryRequest : MessageBase
+{
+    // Add properties for whatever information you want sent by clients
+    // in their broadcast messages that servers will consume.
+}
+
+public class DiscoveryResponse : MessageBase
+{
+    // Add properties for whatever information you want the server to return to
+    // clients for them to display or consume for establishing a connection.
+}
+
+public class #SCRIPTNAME# : NetworkDiscoveryBase<DiscoveryRequest, DiscoveryResponse>
+{
+    #region Server
+
+    /// <summary>
+    /// Reply to the client to inform it of this server
+    /// </summary>
+    /// <remarks>
+    /// Override if you wish to ignore server requests based on
+    /// custom criteria such as language, full server game mode or difficulty
+    /// </remarks>
+    /// <param name="request">Request comming from client</param>
+    /// <param name="endpoint">Address of the client that sent the request</param>
+    protected override void ProcessClientRequest(DiscoveryRequest request, IPEndPoint endpoint)
+    {
+        base.ProcessClientRequest(request, endpoint);
+    }
+
+    /// <summary>
+    /// Process the request from a client
+    /// </summary>
+    /// <remarks>
+    /// Override if you wish to provide more information to the clients
+    /// such as the name of the host player
+    /// </remarks>
+    /// <param name="request">Request comming from client</param>
+    /// <param name="endpoint">Address of the client that sent the request</param>
+    /// <returns>A message containing information about this server</returns>
+    protected override DiscoveryResponse ProcessRequest(DiscoveryRequest request, IPEndPoint endpoint) 
+    {
+        return new DiscoveryResponse();
+    }
+
+    #endregion
+
+    #region Client
+
+    /// <summary>
+    /// Create a message that will be broadcasted on the network to discover servers
+    /// </summary>
+    /// <remarks>
+    /// Override if you wish to include additional data in the discovery message
+    /// such as desired game mode, language, difficulty, etc... </remarks>
+    /// <returns>An instance of ServerRequest with data to be broadcasted</returns>
+    protected override DiscoveryRequest GetRequest()
+    {
+        return new DiscoveryRequest();
+    }
+
+    /// <summary>
+    /// Process the answer from a server
+    /// </summary>
+    /// <remarks>
+    /// A client receives a reply from a server, this method processes the
+    /// reply and raises an event
+    /// </remarks>
+    /// <param name="response">Response that came from the server</param>
+    /// <param name="endpoint">Address of the server that replied</param>
+    protected override void ProcessResponse(DiscoveryResponse response, IPEndPoint endpoint) { }
+
+    #endregion
+}

--- a/Assets/ScriptTemplates/56-Mirror__Network Discovery-NewNetworkDiscovery.cs.txt
+++ b/Assets/ScriptTemplates/56-Mirror__Network Discovery-NewNetworkDiscovery.cs.txt
@@ -8,13 +8,13 @@ using Mirror.Discovery;
     API Reference: https://mirror-networking.com/docs/api/Mirror.Discovery.NetworkDiscovery.html
 */
 
-public class DiscoveryRequest : MessageBase
+public class DiscoveryRequest : NetworkMessage
 {
     // Add properties for whatever information you want sent by clients
     // in their broadcast messages that servers will consume.
 }
 
-public class DiscoveryResponse : MessageBase
+public class DiscoveryResponse : NetworkMessage
 {
     // Add properties for whatever information you want the server to return to
     // clients for them to display or consume for establishing a connection.

--- a/Assets/ScriptTemplates/56-Mirror__Network Discovery-NewNetworkDiscovery.cs.txt.meta
+++ b/Assets/ScriptTemplates/56-Mirror__Network Discovery-NewNetworkDiscovery.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 04337367db30af3459bf9e9f3f880734
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Removing these was ill advised, especially while I was away.

- ScriptTemplates is a known special folder that Asset Store allows to be in the Assets root
- They've proven themselves helpful to new Mirror users that don't know what all the virtuals are
- They require very little maintenance because changes in Mirror to virtual methods are **rare**.
- Making Mirror easier to use lowers our support burden far more than the maintenance.