### PR TITLE
CI: Making Action run on Pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,12 @@ on:
     paths-ignore:
       - 'doc/**'
       - '*.md'
+  pull_request_target:
+    branches: 
+      - master
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
   
 jobs:
 


### PR DESCRIPTION
I think we need to use `pull_request_target` so that it uses the workflow and secrets from the target branch (eg mirror). this posted talks more about it https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/