### PR TITLE
Add Accept and Reject methods to Authenticator

### DIFF
--- a/Assets/Mirror/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/BasicAuthenticator.cs
@@ -14,9 +14,9 @@ namespace Mirror.Authenticators
         public string username;
         public string password;
 
-		#region Messages
+        #region Messages
 
-		public struct AuthRequestMessage : NetworkMessage
+        public struct AuthRequestMessage : NetworkMessage
         {
             // use whatever credentials make sense for your game
             // for example, you might want to pass the accessToken if using oauth

--- a/Assets/Mirror/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/BasicAuthenticator.cs
@@ -74,8 +74,8 @@ namespace Mirror.Authenticators
 
                 conn.Send(authResponseMessage);
 
-                // Invoke the event to complete a successful authentication
-                OnServerAuthenticated.Invoke(conn);
+                // Accept the successful authentication
+                base.ServerAccept(conn);
             }
             else
             {
@@ -99,7 +99,9 @@ namespace Mirror.Authenticators
         IEnumerator DelayedDisconnect(NetworkConnection conn, float waitTime)
         {
             yield return new WaitForSeconds(waitTime);
-            conn.Disconnect();
+
+            // Reject the unsuccessful authentication
+            base.ServerReject(conn);
         }
 
         #endregion
@@ -142,18 +144,15 @@ namespace Mirror.Authenticators
             {
                 if (logger.LogEnabled()) logger.LogFormat(LogType.Log, "Authentication Response: {0}", msg.message);
 
-                // Invoke the event to complete a successful authentication
-                OnClientAuthenticated.Invoke(conn);
+                // Authentication has been accepted
+                base.ClientAccept(conn);
             }
             else
             {
                 logger.LogFormat(LogType.Error, "Authentication Response: {0}", msg.message);
 
-                // Set this on the client for local reference
-                conn.isAuthenticated = false;
-
-                // disconnect the client
-                conn.Disconnect();
+                // Authentication has been rejected
+                base.ClientReject(conn);
             }
         }
 

--- a/Assets/Mirror/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/BasicAuthenticator.cs
@@ -75,7 +75,7 @@ namespace Mirror.Authenticators
                 conn.Send(authResponseMessage);
 
                 // Accept the successful authentication
-                base.ServerAccept(conn);
+                ServerAccept(conn);
             }
             else
             {
@@ -101,7 +101,7 @@ namespace Mirror.Authenticators
             yield return new WaitForSeconds(waitTime);
 
             // Reject the unsuccessful authentication
-            base.ServerReject(conn);
+            ServerReject(conn);
         }
 
         #endregion
@@ -145,14 +145,14 @@ namespace Mirror.Authenticators
                 if (logger.LogEnabled()) logger.LogFormat(LogType.Log, "Authentication Response: {0}", msg.message);
 
                 // Authentication has been accepted
-                base.ClientAccept(conn);
+                ClientAccept(conn);
             }
             else
             {
                 logger.LogFormat(LogType.Error, "Authentication Response: {0}", msg.message);
 
                 // Authentication has been rejected
-                base.ClientReject(conn);
+                ClientReject(conn);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -43,6 +43,16 @@ namespace Mirror
         /// <param name="conn">Connection to client.</param>
         public abstract void OnServerAuthenticate(NetworkConnection conn);
 
+        protected void ServerAccept(NetworkConnection conn)
+        {
+            OnServerAuthenticated.Invoke(conn);
+        }
+
+        protected void ServerReject(NetworkConnection conn)
+        {
+            conn.Disconnect();
+        }
+
         #endregion
 
         #region client
@@ -58,6 +68,20 @@ namespace Mirror
         /// </summary>
         /// <param name="conn">Connection of the client.</param>
         public abstract void OnClientAuthenticate(NetworkConnection conn);
+
+        protected void ClientAccept(NetworkConnection conn)
+        {
+            OnClientAuthenticated.Invoke(conn);
+        }
+
+        protected void ClientReject(NetworkConnection conn)
+		{
+            // Set this on the client for local reference
+            conn.isAuthenticated = false;
+
+            // disconnect the client
+            conn.Disconnect();
+        }
 
         #endregion
 

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -75,7 +75,7 @@ namespace Mirror
         }
 
         protected void ClientReject(NetworkConnection conn)
-		{
+        {
             // Set this on the client for local reference
             conn.isAuthenticated = false;
 


### PR DESCRIPTION
Ease of use:  Devs can just call the base methods instead of having to invoke.