### PR TITLE
fix(weaver): Fixing weaver not writing when assemble didn't have NetworkBehaviour

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
@@ -19,11 +19,6 @@ namespace Mirror.Weaver
                 }
             }
 
-            if (Weaver.WeaveLists.generateContainerClass != null)
-            {
-                moduleDef.Types.Add(Weaver.WeaveLists.generateContainerClass);
-            }
-
             Console.WriteLine("  ProcessSitesModule " + moduleDef.Name + " elapsed time:" + (DateTime.Now - startTime));
         }
 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -108,7 +108,6 @@ namespace Mirror.Weaver
         {
             readFuncs[typeReference.FullName] = newReaderFunc;
 
-            Weaver.WeaveLists.ConfirmGeneratedCodeClass();
             Weaver.WeaveLists.generateContainerClass.Methods.Add(newReaderFunc);
         }
 

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -24,7 +24,6 @@ namespace Mirror.Weaver
         {
             writeFuncs[typeReference.FullName] = newWriterFunc;
 
-            Weaver.WeaveLists.ConfirmGeneratedCodeClass();
             Weaver.WeaveLists.generateContainerClass.Methods.Add(newWriterFunc);
         }
 


### PR DESCRIPTION
* Making `ReaderWriterProcessor` return if it found custom functions (not counting ones in mirror.dll)
* Always writing `generateContainerClass` if modified
* processing `PropertySiteProcessor` if either `ReaderWriterProcessor` or `WeaveModule` are successful
* creating `generateContainerClass` in WeaverList constructor
* Moving new WeaverList to after `WeaverTypes.SetupTargetTypes`