### PR TITLE
Moving variable to top of file.

### DIFF
--- a/Assets/Mirror/Components/Experimental/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkTransformBase.cs
@@ -109,6 +109,9 @@ namespace Mirror.Experimental
         public DataPoint start = new DataPoint();
         public DataPoint goal = new DataPoint();
 
+        // We need to store this locally on the server so clients can't request Authority when ever they like
+        bool clientAuthorityBeforeTeleport;
+
         void FixedUpdate()
         {
             // if server then always sync to others.
@@ -155,9 +158,6 @@ namespace Mirror.Experimental
                 }
             }
         }
-
-        // We need to store this locally on the server so clients can't request Authority when ever they like
-        bool clientAuthorityBeforeTeleport;
 
         // moved or rotated or scaled since last time we checked it?
         bool HasEitherMovedRotatedScaled()


### PR DESCRIPTION
It is best practice to put variables above all methods in c#