### PR TITLE
Adding TransformValues to reduce bandwidth 

### DIFF
--- a/Assets/Mirror/Components/Experimental/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkTransformBase.cs
@@ -115,7 +115,7 @@ namespace Mirror.Experimental
             // let the clients know that this has moved
             if (isServer && HasEitherMovedRotatedScaled())
             {
-                RpcMove(targetTransform.localPosition, targetTransform.localRotation, targetTransform.localScale);
+                ServerUpdate();
             }
 
             if (isClient)
@@ -124,35 +124,49 @@ namespace Mirror.Experimental
                 // -> only if connectionToServer has been initialized yet too
                 if (IsOwnerWithClientAuthority)
                 {
-                    if (!isServer && HasEitherMovedRotatedScaled())
-                    {
-                        // serialize
-                        // local position/rotation for VR support
-                        // send to server
-                        CmdClientToServerSync(targetTransform.localPosition, targetTransform.localRotation, targetTransform.localScale);
-                    }
+                    ClientAuthorityUpdate();
                 }
                 else if (goal.isValid)
                 {
-                    // teleport or interpolate
-                    if (NeedsTeleport())
-                    {
-                        // local position/rotation for VR support
-                        ApplyPositionRotationScale(goal.localPosition, goal.localRotation, goal.localScale);
-
-                        // reset data points so we don't keep interpolating
-                        start = new DataPoint();
-                        goal = new DataPoint();
-                    }
-                    else
-                    {
-                        // local position/rotation for VR support
-                        ApplyPositionRotationScale(InterpolatePosition(start, goal, targetTransform.localPosition),
-                                                   InterpolateRotation(start, goal, targetTransform.localRotation),
-                                                   InterpolateScale(start, goal, targetTransform.localScale));
-                    }
-
+                    ClientRemoteUpdate();
                 }
+            }
+        }
+
+        void ServerUpdate()
+        {
+            RpcMove(targetTransform.localPosition, targetTransform.localRotation, targetTransform.localScale);
+        }
+
+        void ClientAuthorityUpdate()
+        {
+            if (!isServer && HasEitherMovedRotatedScaled())
+            {
+                // serialize
+                // local position/rotation for VR support
+                // send to server
+                CmdClientToServerSync(targetTransform.localPosition, targetTransform.localRotation, targetTransform.localScale);
+            }
+        }
+
+        void ClientRemoteUpdate()
+        {
+            // teleport or interpolate
+            if (NeedsTeleport())
+            {
+                // local position/rotation for VR support
+                ApplyPositionRotationScale(goal.localPosition, goal.localRotation, goal.localScale);
+
+                // reset data points so we don't keep interpolating
+                start = new DataPoint();
+                goal = new DataPoint();
+            }
+            else
+            {
+                // local position/rotation for VR support
+                ApplyPositionRotationScale(InterpolatePosition(start, goal, targetTransform.localPosition),
+                                           InterpolateRotation(start, goal, targetTransform.localRotation),
+                                           InterpolateScale(start, goal, targetTransform.localScale));
             }
         }
 


### PR DESCRIPTION
We dont need to send pos/rot/sca every time one of them changes. Instead send just the values that was changed.

This can be acheved using a struct that has 1 byte keeping track of what values have changed

requires: https://github.com/vis2k/Mirror/pull/2375