### PR TITLE
breaking: Transport.Send(connectionId) instead of List<connectionId>, and return type changed to void. The List was only there to avoid LLAPI & Telepathy allocations. It makes everything extremely complicated and it's not necessary for any of the newer transports anymore.

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -13,11 +13,9 @@ namespace Mirror
 
         public override string address => "localhost";
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        internal override void Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             connectionToServer.buffer.Write(segment);
-
-            return true;
         }
 
         // true because local connections never timeout
@@ -89,17 +87,16 @@ namespace Mirror
 
         public override string address => "localhost";
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        internal override void Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (segment.Count == 0)
             {
                 logger.LogError("LocalConnection.SendBytes cannot send zero bytes");
-                return false;
+                return;
             }
 
             // handle the server's message directly
             connectionToClient.TransportReceive(segment, channelId);
-            return true;
         }
 
         internal void Update()

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -238,20 +238,17 @@ namespace Mirror
         /// <typeparam name="T">The message type to unregister.</typeparam>
         /// <param name="message"></param>
         /// <param name="channelId"></param>
-        /// <returns>True if message was sent.</returns>
-        public static bool Send<T>(T message, int channelId = Channels.DefaultReliable) where T : NetworkMessage
+        public static void Send<T>(T message, int channelId = Channels.DefaultReliable) where T : NetworkMessage
         {
             if (connection != null)
             {
-                if (connectState != ConnectState.Connected)
+                if (connectState == ConnectState.Connected)
                 {
-                    logger.LogError("NetworkClient Send when not connected to a server");
-                    return false;
+                    connection.Send(message, channelId);
                 }
-                return connection.Send(message, channelId);
+                else logger.LogError("NetworkClient Send when not connected to a server");
             }
-            logger.LogError("NetworkClient Send with no connection");
-            return false;
+            else logger.LogError("NetworkClient Send with no connection");
         }
 
         public static void Update()

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -83,7 +83,7 @@ namespace Mirror
         /// </summary>
         internal NetworkConnection()
         {
-            // set lastTime to current time when creating connection to make sure it isn't instantly kicked for inactivity 
+            // set lastTime to current time when creating connection to make sure it isn't instantly kicked for inactivity
             lastMessageTime = Time.time;
         }
 
@@ -112,15 +112,14 @@ namespace Mirror
         /// <typeparam name="T">The message type to unregister.</typeparam>
         /// <param name="msg">The message to send.</param>
         /// <param name="channelId">The transport layer channel to send on.</param>
-        /// <returns></returns>
-        public bool Send<T>(T msg, int channelId = Channels.DefaultReliable) where T : NetworkMessage
+        public void Send<T>(T msg, int channelId = Channels.DefaultReliable) where T : NetworkMessage
         {
             using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
             {
                 // pack message and send allocation free
                 MessagePacker.Pack(msg, writer);
                 NetworkDiagnostics.OnSend(msg, channelId, writer.Position, 1);
-                return Send(writer.ToArraySegment(), channelId);
+                Send(writer.ToArraySegment(), channelId);
             }
         }
 
@@ -150,7 +149,7 @@ namespace Mirror
 
         // internal because no one except Mirror should send bytes directly to
         // the client. they would be detected as a message. send messages instead.
-        internal abstract bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable);
+        internal abstract void Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable);
 
         public override string ToString()
         {

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Mirror
@@ -12,38 +11,15 @@ namespace Mirror
 
         public override string address => Transport.activeTransport.ServerGetClientAddress(connectionId);
 
-        // internal because no one except Mirror should send bytes directly to
-        // the client. they would be detected as a message. send messages instead.
-        readonly List<int> singleConnectionId = new List<int> { -1 };
-
-
-        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        internal override void Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (logger.LogEnabled()) logger.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
             // validate packet size first.
             if (ValidatePacketSize(segment, channelId))
             {
-                singleConnectionId[0] = connectionId;
-                return Transport.activeTransport.ServerSend(singleConnectionId, channelId, segment);
+                Transport.activeTransport.ServerSend(connectionId, channelId, segment);
             }
-            return false;
-        }
-
-        // Send to many. basically Transport.Send(connections) + checks.
-        internal static bool Send(List<int> connectionIds, ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
-        {
-            // validate packet size first.
-            if (ValidatePacketSize(segment, channelId))
-            {
-                // only the server sends to many, we don't have that function on
-                // a client.
-                if (Transport.activeTransport.ServerActive())
-                {
-                    return Transport.activeTransport.ServerSend(connectionIds, channelId, segment);
-                }
-            }
-            return false;
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
@@ -9,16 +9,15 @@ namespace Mirror
 
         public override string address => "";
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        internal override void Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (logger.LogEnabled()) logger.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
             // validate packet size first.
             if (ValidatePacketSize(segment, channelId))
             {
-                return Transport.activeTransport.ClientSend(channelId, segment);
+                Transport.activeTransport.ClientSend(channelId, segment);
             }
-            return false;
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -73,11 +73,6 @@ namespace Mirror
         public static float disconnectInactiveTimeout = 60f;
 
         /// <summary>
-        /// cache the Send(connectionIds) list to avoid allocating each time 
-        /// </summary>
-        static readonly List<int> connectionIdsCache = new List<int>();
-
-        /// <summary>
         /// This shuts down the server and disconnects all clients.
         /// </summary>
         public static void Shutdown()
@@ -207,7 +202,7 @@ namespace Mirror
         }
 
         /// <summary>
-        /// called by LocalClient to add itself. dont call directly. 
+        /// called by LocalClient to add itself. dont call directly.
         /// </summary>
         /// <param name="conn"></param>
         internal static void SetLocalConnection(ULocalConnectionToClient conn)
@@ -266,24 +261,14 @@ namespace Mirror
                 MessagePacker.Pack(msg, writer);
                 ArraySegment<byte> segment = writer.ToArraySegment();
 
-                // filter and then send to all internet connections at once
-                // -> makes code more complicated, but is HIGHLY worth it to
-                //    avoid allocations, allow for multicast, etc.
-                connectionIdsCache.Clear();
-                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                foreach (NetworkConnection conn in identity.observers.Values)
                 {
                     // use local connection directly because it doesn't send via transport
-                    if (kvp.Value is ULocalConnectionToClient)
-                        kvp.Value.Send(segment);
-                    // gather all internet connections
+                    if (conn is ULocalConnectionToClient)
+                        conn.Send(segment);
+                    // send to regular connection
                     else
-                        connectionIdsCache.Add(kvp.Key);
-                }
-
-                // send to all internet connections at once
-                if (connectionIdsCache.Count > 0)
-                {
-                    NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
+                        conn.Send(segment, channelId);
                 }
 
                 NetworkDiagnostics.OnSend(msg, channelId, segment.Count, identity.observers.Count);
@@ -298,13 +283,12 @@ namespace Mirror
         /// <param name="msg">Message</param>
         /// <param name="channelId">Transport channel to use</param>
         /// <param name="sendToReadyOnly">Indicates if only ready clients should receive the message</param>
-        /// <returns></returns>
-        public static bool SendToAll<T>(T msg, int channelId = Channels.DefaultReliable, bool sendToReadyOnly = false) where T : NetworkMessage
+        public static void SendToAll<T>(T msg, int channelId = Channels.DefaultReliable, bool sendToReadyOnly = false) where T : NetworkMessage
         {
             if (!active)
             {
                 logger.LogWarning("Can not send using NetworkServer.SendToAll<T>(T msg) because NetworkServer is not active");
-                return false;
+                return;
             }
 
             if (logger.LogEnabled()) logger.Log("Server.SendToAll id:" + typeof(T));
@@ -318,33 +302,23 @@ namespace Mirror
                 // filter and then send to all internet connections at once
                 // -> makes code more complicated, but is HIGHLY worth it to
                 //    avoid allocations, allow for multicast, etc.
-                connectionIdsCache.Clear();
-                bool result = true;
                 int count = 0;
-                foreach (KeyValuePair<int, NetworkConnectionToClient> kvp in connections)
+                foreach (NetworkConnectionToClient conn in connections.Values)
                 {
-                    if (sendToReadyOnly && !kvp.Value.isReady)
+                    if (sendToReadyOnly && !conn.isReady)
                         continue;
 
                     count++;
 
                     // use local connection directly because it doesn't send via transport
-                    if (kvp.Value is ULocalConnectionToClient)
-                        result &= kvp.Value.Send(segment);
-                    // gather all internet connections
+                    if (conn is ULocalConnectionToClient)
+                        conn.Send(segment);
+                    // send to regular connection
                     else
-                        connectionIdsCache.Add(kvp.Key);
-                }
-
-                // send to all internet connections at once
-                if (connectionIdsCache.Count > 0)
-                {
-                    result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
+                        conn.Send(segment, channelId);
                 }
 
                 NetworkDiagnostics.OnSend(msg, channelId, segment.Count, count);
-
-                return result;
             }
         }
 
@@ -355,16 +329,15 @@ namespace Mirror
         /// <typeparam name="T">Message type.</typeparam>
         /// <param name="msg">Message</param>
         /// <param name="channelId">Transport channel to use</param>
-        /// <returns></returns>
-        public static bool SendToReady<T>(T msg, int channelId = Channels.DefaultReliable) where T : NetworkMessage
+        public static void SendToReady<T>(T msg, int channelId = Channels.DefaultReliable) where T : NetworkMessage
         {
             if (!active)
             {
                 logger.LogWarning("Can not send using NetworkServer.SendToReady<T>(T msg) because NetworkServer is not active");
-                return false;
+                return;
             }
 
-            return SendToAll(msg, channelId, true);
+            SendToAll(msg, channelId, true);
         }
 
         /// <summary>
@@ -376,13 +349,12 @@ namespace Mirror
         /// <param name="msg">Message</param>
         /// <param name="includeOwner">Should the owner of the object be included</param>
         /// <param name="channelId">Transport channel to use</param>
-        /// <returns></returns>
-        public static bool SendToReady<T>(NetworkIdentity identity, T msg, bool includeOwner = true, int channelId = Channels.DefaultReliable) where T : NetworkMessage
+        public static void SendToReady<T>(NetworkIdentity identity, T msg, bool includeOwner = true, int channelId = Channels.DefaultReliable) where T : NetworkMessage
         {
             if (logger.LogEnabled()) logger.Log("Server.SendToReady msgType:" + typeof(T));
 
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
-                return false;
+                return;
 
             using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
             {
@@ -390,37 +362,24 @@ namespace Mirror
                 MessagePacker.Pack(msg, writer);
                 ArraySegment<byte> segment = writer.ToArraySegment();
 
-                // filter and then send to all internet connections at once
-                // -> makes code more complicated, but is HIGHLY worth it to
-                //    avoid allocations, allow for multicast, etc.
-                connectionIdsCache.Clear();
-                bool result = true;
                 int count = 0;
-                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                foreach (NetworkConnection conn in identity.observers.Values)
                 {
-                    bool isOwner = kvp.Value == identity.connectionToClient;
-                    if ((!isOwner || includeOwner) && kvp.Value.isReady)
+                    bool isOwner = conn == identity.connectionToClient;
+                    if ((!isOwner || includeOwner) && conn.isReady)
                     {
                         count++;
 
                         // use local connection directly because it doesn't send via transport
-                        if (kvp.Value is ULocalConnectionToClient)
-                            result &= kvp.Value.Send(segment);
-                        // gather all internet connections
+                        if (conn is ULocalConnectionToClient)
+                            conn.Send(segment);
+                        // send to connection
                         else
-                            connectionIdsCache.Add(kvp.Key);
+                            conn.Send(segment, channelId);
                     }
                 }
 
-                // send to all internet connections at once
-                if (connectionIdsCache.Count > 0)
-                {
-                    result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
-                }
-
                 NetworkDiagnostics.OnSend(msg, channelId, segment.Count, count);
-
-                return result;
             }
         }
 
@@ -432,10 +391,9 @@ namespace Mirror
         /// <param name="identity">identity of the object</param>
         /// <param name="msg">Message</param>
         /// <param name="channelId">Transport channel to use</param>
-        /// <returns></returns>
-        public static bool SendToReady<T>(NetworkIdentity identity, T msg, int channelId) where T : NetworkMessage
+        public static void SendToReady<T>(NetworkIdentity identity, T msg, int channelId) where T : NetworkMessage
         {
-            return SendToReady(identity, msg, true, channelId);
+            SendToReady(identity, msg, true, channelId);
         }
 
         /// <summary>
@@ -975,7 +933,7 @@ namespace Mirror
         }
 
         /// <summary>
-        /// default ready handler. 
+        /// default ready handler.
         /// </summary>
         /// <param name="conn"></param>
         /// <param name="msg"></param>

--- a/Assets/Mirror/Runtime/Transport/FallbackTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/FallbackTransport.cs
@@ -2,7 +2,6 @@
 // example: to use Apathy if on Windows/Mac/Linux and fall back to Telepathy
 //          otherwise.
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Mirror
@@ -103,9 +102,9 @@ namespace Mirror
             available.ClientDisconnect();
         }
 
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment)
+        public override void ClientSend(int channelId, ArraySegment<byte> segment)
         {
-            return available.ClientSend(channelId, segment);
+            available.ClientSend(channelId, segment);
         }
 
         void InitServer()
@@ -139,9 +138,9 @@ namespace Mirror
             return available.ServerDisconnect(connectionId);
         }
 
-        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment)
+        public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment)
         {
-            return available.ServerSend(connectionIds, channelId, segment);
+            available.ServerSend(connectionId, channelId, segment);
         }
 
         public override void ServerStart()

--- a/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
+++ b/Assets/Mirror/Runtime/Transport/LLAPITransport.cs
@@ -7,7 +7,6 @@
 #if !(UNITY_WSA || UNITY_WSA_10_0 || UNITY_WINRT || UNITY_WINRT_10_0 || NETFX_CORE)
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -151,7 +150,7 @@ namespace Mirror
             ClientConnect(uri.Host, serverPort);
         }
 
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment)
+        public override void ClientSend(int channelId, ArraySegment<byte> segment)
         {
             // Send buffer is copied internally, so we can get rid of segment
             // immediately after returning and it still works.
@@ -160,10 +159,9 @@ namespace Mirror
             if (segment.Count <= clientSendBuffer.Length)
             {
                 Array.Copy(segment.Array, segment.Offset, clientSendBuffer, 0, segment.Count);
-                return NetworkTransport.Send(clientId, clientConnectionId, channelId, clientSendBuffer, segment.Count, out error);
+                NetworkTransport.Send(clientId, clientConnectionId, channelId, clientSendBuffer, segment.Count, out error);
             }
-            Debug.LogError("LLAPI.ClientSend: buffer( " + clientSendBuffer.Length + ") too small for: " + segment.Count);
-            return false;
+            else Debug.LogError("LLAPI.ClientSend: buffer( " + clientSendBuffer.Length + ") too small for: " + segment.Count);
         }
 
         public bool ProcessClientMessage()
@@ -256,7 +254,7 @@ namespace Mirror
             }
         }
 
-        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment)
+        public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment)
         {
             // Send buffer is copied internally, so we can get rid of segment
             // immediately after returning and it still works.
@@ -267,16 +265,10 @@ namespace Mirror
                 // copy to 0-offset
                 Array.Copy(segment.Array, segment.Offset, serverSendBuffer, 0, segment.Count);
 
-                // send to all
-                bool result = true;
-                foreach (int connectionId in connectionIds)
-                {
-                    result &= NetworkTransport.Send(serverHostId, connectionId, channelId, serverSendBuffer, segment.Count, out error);
-                }
-                return result;
+                // send
+                NetworkTransport.Send(serverHostId, connectionId, channelId, serverSendBuffer, segment.Count, out error);
             }
-            Debug.LogError("LLAPI.ServerSend: buffer( " + serverSendBuffer.Length + ") too small for: " + segment.Count);
-            return false;
+            else Debug.LogError("LLAPI.ServerSend: buffer( " + serverSendBuffer.Length + ") too small for: " + segment.Count);
         }
 
         public bool ProcessServerMessage()

--- a/Assets/Mirror/Runtime/Transport/MiddlewareTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MiddlewareTransport.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace Mirror
 {
@@ -21,14 +20,14 @@ namespace Mirror
         public override void ClientConnect(string address) => inner.ClientConnect(address);
         public override bool ClientConnected() => inner.ClientConnected();
         public override void ClientDisconnect() => inner.ClientDisconnect();
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment) => inner.ClientSend(channelId, segment);
+        public override void ClientSend(int channelId, ArraySegment<byte> segment) => inner.ClientSend(channelId, segment);
         #endregion
 
         #region Server
         public override bool ServerActive() => inner.ServerActive();
         public override void ServerStart() => inner.ServerStart();
         public override void ServerStop() => inner.ServerStop();
-        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment) => inner.ServerSend(connectionIds, channelId, segment);
+        public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment) => inner.ServerSend(connectionId, channelId, segment);
         public override bool ServerDisconnect(int connectionId) => inner.ServerDisconnect(connectionId);
         public override string ServerGetClientAddress(int connectionId) => inner.ServerGetClientAddress(connectionId);
         public override Uri ServerUri() => inner.ServerUri();

--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
 
@@ -11,10 +10,6 @@ namespace Mirror
         public Transport[] transports;
 
         Transport available;
-
-        // used to partition recipients for each one of the base transports
-        // without allocating a new list every time
-        List<int>[] recipientsCache;
 
         public void Awake()
         {
@@ -115,9 +110,9 @@ namespace Mirror
                 available.ClientDisconnect();
         }
 
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment)
+        public override void ClientSend(int channelId, ArraySegment<byte> segment)
         {
-            return available.ClientSend(channelId, segment);
+            available.ClientSend(channelId, segment);
         }
 
         #endregion
@@ -145,13 +140,9 @@ namespace Mirror
 
         void InitServer()
         {
-            recipientsCache = new List<int>[transports.Length];
-
             // wire all the base transports to my events
             for (int i = 0; i < transports.Length; i++)
             {
-                recipientsCache[i] = new List<int>();
-
                 // this is required for the handlers,  if I use i directly
                 // then all the handlers will use the last i
                 int locali = i;
@@ -213,32 +204,18 @@ namespace Mirror
             return transports[transportId].ServerDisconnect(baseConnectionId);
         }
 
-        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment)
+        public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment)
         {
-            // the message may be for different transports,
-            // partition the recipients by transport
-            foreach (List<int> list in recipientsCache)
-            {
-                list.Clear();
-            }
+            int baseConnectionId = ToBaseId(connectionId);
+            int transportId = ToTransportId(connectionId);
 
-            foreach (int connectionId in connectionIds)
-            {
-                int baseConnectionId = ToBaseId(connectionId);
-                int transportId = ToTransportId(connectionId);
-                recipientsCache[transportId].Add(baseConnectionId);
-            }
-
-            bool result = true;
             for (int i = 0; i < transports.Length; ++i)
             {
-                List<int> baseRecipients = recipientsCache[i];
-                if (baseRecipients.Count > 0)
+                if (i == transportId)
                 {
-                    result &= transports[i].ServerSend(baseRecipients, channelId, segment);
+                    transports[i].ServerSend(baseConnectionId, channelId, segment);
                 }
             }
-            return result;
         }
 
         public override void ServerStart()

--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/Server/SimpleWebServer.cs
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/Server/SimpleWebServer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Mirror.SimpleWeb
@@ -38,17 +37,13 @@ namespace Mirror.SimpleWeb
             Active = false;
         }
 
-        public void SendAll(List<int> connectionIds, ArraySegment<byte> source)
+        public void Send(int connectionId, ArraySegment<byte> source)
         {
             ArrayBuffer buffer = bufferPool.Take(source.Count);
             buffer.CopyFrom(source);
-            buffer.SetReleasesRequired(connectionIds.Count);
+            buffer.SetReleasesRequired(1);
 
-            // make copy of array before for each, data sent to each client is the same
-            foreach (int id in connectionIds)
-            {
-                server.Send(id, buffer);
-            }
+            server.Send(connectionId, buffer);
         }
 
         public bool KickClient(int connectionId)

--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Security.Authentication;
 using UnityEngine;
@@ -116,7 +115,7 @@ namespace Mirror.SimpleWeb
         string GetScheme() => sslEnabled ? SecureScheme : NormalScheme;
         public override bool ClientConnected()
         {
-            // not null and not NotConnected (we want to return true if connecting or disconnecting) 
+            // not null and not NotConnected (we want to return true if connecting or disconnecting)
             return client != null && client.ConnectionState != ClientState.NotConnected;
         }
 
@@ -164,28 +163,27 @@ namespace Mirror.SimpleWeb
             client?.Disconnect();
         }
 
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment)
+        public override void ClientSend(int channelId, ArraySegment<byte> segment)
         {
             if (!ClientConnected())
             {
                 Debug.LogError("Not Connected");
-                return false;
+                return;
             }
 
             if (segment.Count > maxMessageSize)
             {
                 Log.Error("Message greater than max size");
-                return false;
+                return;
             }
 
             if (segment.Count == 0)
             {
                 Log.Error("Message count was zero");
-                return false;
+                return;
             }
 
             client.Send(segment);
-            return true;
         }
         #endregion
 
@@ -235,28 +233,27 @@ namespace Mirror.SimpleWeb
             return server.KickClient(connectionId);
         }
 
-        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment)
+        public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment)
         {
             if (!ServerActive())
             {
                 Debug.LogError("SimpleWebServer Not Active");
-                return false;
+                return;
             }
 
             if (segment.Count > maxMessageSize)
             {
                 Log.Error("Message greater than max size");
-                return false;
+                return;
             }
 
             if (segment.Count == 0)
             {
                 Log.Error("Message count was zero");
-                return false;
+                return;
             }
 
-            server.SendAll(connectionIds, segment);
-            return true;
+            server.Send(connectionId, segment);
         }
 
         public override string ServerGetClientAddress(int connectionId)

--- a/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs
@@ -1,6 +1,5 @@
 // wraps Telepathy for use as HLAPI TransportLayer
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using UnityEngine;
@@ -71,13 +70,13 @@ namespace Mirror
             int serverPort = uri.IsDefaultPort ? port : uri.Port;
             client.Connect(uri.Host, serverPort);
         }
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment)
+        public override void ClientSend(int channelId, ArraySegment<byte> segment)
         {
             // telepathy doesn't support allocation-free sends yet.
             // previously we allocated in Mirror. now we do it here.
             byte[] data = new byte[segment.Count];
             Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
-            return client.Send(data);
+            client.Send(data);
         }
 
         bool ProcessClientMessage()
@@ -167,18 +166,15 @@ namespace Mirror
         // server
         public override bool ServerActive() => server.Active;
         public override void ServerStart() => server.Start(port);
-        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment)
+        public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment)
         {
             // telepathy doesn't support allocation-free sends yet.
             // previously we allocated in Mirror. now we do it here.
             byte[] data = new byte[segment.Count];
             Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
 
-            // send to all
-            bool result = true;
-            foreach (int connectionId in connectionIds)
-                result &= server.Send(connectionId, data);
-            return result;
+            // send
+            server.Send(connectionId, data);
         }
         public bool ProcessServerMessage()
         {

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -86,8 +85,7 @@ namespace Mirror
         /// but some transports might want to provide unreliable, encrypted, compressed, or any other feature
         /// as new channels</param>
         /// <param name="segment">The data to send to the server. Will be recycled after returning, so either use it directly or copy it internally. This allows for allocation-free sends!</param>
-        /// <returns>true if the send was successful</returns>
-        public abstract bool ClientSend(int channelId, ArraySegment<byte> segment);
+        public abstract void ClientSend(int channelId, ArraySegment<byte> segment);
 
         /// <summary>
         /// Disconnect this client from the server
@@ -139,18 +137,13 @@ namespace Mirror
         public abstract void ServerStart();
 
         /// <summary>
-        /// Send data to one or multiple clients. We provide a list, so that transports can make use
-        /// of multicasting, and avoid allocations where possible.
-        ///
-        /// We don't provide a single ServerSend function to reduce complexity. Simply overwrite this
-        /// one in your Transport.
+        /// Send data to a client.
         /// </summary>
-        /// <param name="connectionIds">The list of client connection ids to send the data to</param>
+        /// <param name="connectionId">The client connection id to send the data to</param>
         /// <param name="channelId">The channel to be used.  Transports can use channels to implement
         /// other features such as unreliable, encryption, compression, etc...</param>
         /// <param name="data"></param>
-        /// <returns>true if the data was sent to all clients</returns>
-        public abstract bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment);
+        public abstract void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment);
 
         /// <summary>
         /// Disconnect a client from this server.  Useful to kick people out.

--- a/Assets/Mirror/Tests/Common/FakeNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Common/FakeNetworkConnection.cs
@@ -15,9 +15,8 @@ namespace Mirror.Tests
             // nothing
         }
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = 0)
+        internal override void Send(ArraySegment<byte> segment, int channelId = 0)
         {
-            return true;
         }
     }
 }

--- a/Assets/Mirror/Tests/Common/MemoryTransport.cs
+++ b/Assets/Mirror/Tests/Common/MemoryTransport.cs
@@ -46,7 +46,7 @@ namespace Mirror.Tests
                 clientConnected = true;
             }
         }
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment)
+        public override void ClientSend(int channelId, ArraySegment<byte> segment)
         {
             // only  if client connected
             if (clientConnected)
@@ -57,9 +57,7 @@ namespace Mirror.Tests
 
                 // add server data message with connId=1 because 0 is reserved
                 serverIncoming.Enqueue(new Message(1, EventType.Data, data));
-                return true;
             }
-            return false;
         }
         public override void ClientDisconnect()
         {
@@ -110,7 +108,7 @@ namespace Mirror.Tests
         public override bool ServerActive() => serverActive;
         public override Uri ServerUri() => throw new NotImplementedException();
         public override void ServerStart() { serverActive = true; }
-        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment)
+        public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment)
         {
             // only if server is running and client is connected
             if (serverActive && clientConnected)
@@ -121,9 +119,7 @@ namespace Mirror.Tests
 
                 // add client data message
                 clientIncoming.Enqueue(new Message(0, EventType.Data, data));
-                return true;
             }
-            return false;
         }
 
         public override bool ServerDisconnect(int connectionId)

--- a/Assets/Mirror/Tests/Editor/FallbackTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/FallbackTransportTest.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -153,20 +151,14 @@ namespace Mirror.Tests
             // on connect, send a message back
             void SendMessage(int connectionId)
             {
-                List<int> connectionIds = new List<int>(new[] { connectionId });
-                transport.ServerSend(connectionIds, 5, segment);
+                transport.ServerSend(connectionId, 5, segment);
             }
 
             transport.OnServerConnected.AddListener(SendMessage);
 
             transport1.OnServerConnected.Invoke(1);
 
-            int[] expectedIds = { 1 };
-
-            transport1.Received().ServerSend(
-                Arg.Is<List<int>>(x => x.SequenceEqual(expectedIds)),
-                5,
-                segment);
+            transport1.Received().ServerSend(1, 5, segment);
         }
 
 

--- a/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
+++ b/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
@@ -1,6 +1,4 @@
-using System;
 using NUnit.Framework;
-using UnityEngine.TestTools;
 
 namespace Mirror.Tests
 {
@@ -95,16 +93,5 @@ namespace Mirror.Tests
 
             Assert.True(invoked, "handler should have been invoked");
         }*/
-
-        [Test]
-        public void ClientToServerFailTest()
-        {
-            // error log is expected
-            LogAssert.ignoreFailingMessages = true;
-            bool result = connectionToServer.Send(new ArraySegment<byte>(new byte[0]));
-            LogAssert.ignoreFailingMessages = false;
-
-            Assert.That(result, Is.False);
-        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/MultiplexTest.cs
+++ b/Assets/Mirror/Tests/Editor/MultiplexTest.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -168,20 +166,14 @@ namespace Mirror.Tests
             // on connect, send a message back
             void SendMessage(int connectionId)
             {
-                List<int> connectionIds = new List<int>(new[] { connectionId });
-                transport.ServerSend(connectionIds, 5, segment);
+                transport.ServerSend(connectionId, 5, segment);
             }
 
             transport.OnServerConnected.AddListener(SendMessage);
 
             transport1.OnServerConnected.Invoke(1);
 
-            List<int> expectedIds = new List<int>(new[] { 1 });
-
-            transport1.Received().ServerSend(
-                Arg.Is<List<int>>(x => x.SequenceEqual(expectedIds)),
-                5,
-                segment);
+            transport1.Received().ServerSend(1, 5, segment);
         }
 
 

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -748,8 +748,7 @@ namespace Mirror.Tests
             TestMessage1 message = new TestMessage1 { IntValue = 1, DoubleValue = 2, StringValue = "3" };
 
             // send it to all
-            bool result = NetworkServer.SendToAll(message);
-            Assert.That(result, Is.True);
+            NetworkServer.SendToAll(message);
 
             // update local connection once so that the incoming queue is processed
             connection.connectionToServer.Update();
@@ -1125,17 +1124,14 @@ namespace Mirror.Tests
         public void SendCalledWhileNotActive_ShouldGiveWarning(string functionName)
         {
             LogAssert.Expect(LogType.Warning, $"Can not send using NetworkServer.{functionName}<T>(T msg) because NetworkServer is not active");
-            bool success;
 
             switch (functionName)
             {
                 case nameof(NetworkServer.SendToAll):
-                    success = NetworkServer.SendToAll(new NetworkPingMessage { });
-                    Assert.That(success, Is.False);
+                    NetworkServer.SendToAll(new NetworkPingMessage { });
                     break;
                 case nameof(NetworkServer.SendToReady):
-                    success = NetworkServer.SendToReady(new NetworkPingMessage { });
-                    Assert.That(success, Is.False);
+                    NetworkServer.SendToReady(new NetworkPingMessage { });
                     break;
                 default:
                     Debug.LogError("Could not find function name");

--- a/Assets/Mirror/Tests/Editor/TargetRpcTest.cs
+++ b/Assets/Mirror/Tests/Editor/TargetRpcTest.cs
@@ -108,7 +108,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             public override string address => throw new NotImplementedException();
             public override void Disconnect() => throw new NotImplementedException();
-            internal override bool Send(ArraySegment<byte> segment, int channelId = 0) => throw new NotImplementedException();
+            internal override void Send(ArraySegment<byte> segment, int channelId = 0) => throw new NotImplementedException();
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Performance/Editor/FakeNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Performance/Editor/FakeNetworkConnection.cs
@@ -16,9 +16,8 @@ namespace Mirror.Tests.Performance
             // nothing
         }
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = 0)
+        internal override void Send(ArraySegment<byte> segment, int channelId = 0)
         {
-            return true;
         }
     }
 }


### PR DESCRIPTION
preparing for kcp.

@James-Frowen note how SimpleWebsocketTransport send was simplified.
looks like you don't need SetReleasesRequired anymore.