### PR TITLE
fix: fixing sceneId when using BuildPipeline.BuildPlayer with incorrect case in path

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -560,11 +560,14 @@ namespace Mirror
         //    build indices if there are disabled scenes in build settings, and
         //    if no scene is in build settings then Editor and Build have
         //    different indices too (Editor=0, Build=-1)
+        // -> use lower case path because BuildPipeline.BuildPlayer can give
+        //    different case than is used in the editor
         // => ONLY USE THIS FROM POSTPROCESSSCENE!
         public void SetSceneIdSceneHashPartInternal()
         {
             // get deterministic scene hash
-            uint pathHash = (uint)gameObject.scene.path.GetStableHashCode();
+            string scenePath = gameObject.scene.path.ToLower();
+            uint pathHash = (uint)scenePath.GetStableHashCode();
 
             // shift hash from 0x000000FFFFFFFF to 0xFFFFFFFF00000000
             ulong shiftedHash = (ulong)pathHash << 32;


### PR DESCRIPTION
BuildPipeline.BuildPlayer takes an array of strings for scene paths. Unity will find the scene with the path case insensitive but path case is case sensitive. 

If the scene in the project is `Assets/Scenes/forest.unity` but `Assets/Scenes/Forest.unity` is given to BuildPipeline then the BuildPipeline will use `Assets/Scenes/Forest.unity` for the build and create a different hash for the scene that the editor will.

This change would make it so that these 2 paths have the same hash
```
Assets/Scenes/Forest.unity
Assets/Scenes/forest.unity
```


