### PR TITLE
fix: fixing first import of package 

### DIFF
--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -1,4 +1,3 @@
-#if MIRROR
 using System;
 using System.Linq;
 using System.Net;
@@ -169,4 +168,3 @@ namespace kcp2k
         }
     }
 }
-#endif

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -1,3 +1,4 @@
+//#if MIRROR <- commented out because MIRROR isn't defined on first import yet
 using System;
 using System.Linq;
 using System.Net;
@@ -168,3 +169,4 @@ namespace kcp2k
         }
     }
 }
+//#endif MIRROR <- commented out because MIRROR isn't defined on first import yet

--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
@@ -166,7 +166,6 @@ namespace Mirror.SimpleWeb
             client?.Disconnect();
         }
 
-#if MIRROR_26_0_OR_NEWER
         public override void ClientSend(int channelId, ArraySegment<byte> segment)
         {
             if (!ClientConnected())
@@ -189,31 +188,6 @@ namespace Mirror.SimpleWeb
 
             client.Send(segment);
         }
-#else
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment)
-        {
-            if (!ClientConnected())
-            {
-                Debug.LogError("Not Connected");
-                return false;
-            }
-
-            if (segment.Count > maxMessageSize)
-            {
-                Log.Error("Message greater than max size");
-                return false;
-            }
-
-            if (segment.Count == 0)
-            {
-                Log.Error("Message count was zero");
-                return false;
-            }
-
-            client.Send(segment);
-            return true;
-        }
-#endif
         #endregion
 
         #region Server
@@ -262,7 +236,6 @@ namespace Mirror.SimpleWeb
             return server.KickClient(connectionId);
         }
 
-#if MIRROR_26_0_OR_NEWER
         public override void ServerSend(int connectionId, int channelId, ArraySegment<byte> segment)
         {
             if (!ServerActive())
@@ -286,31 +259,6 @@ namespace Mirror.SimpleWeb
             server.SendOne(connectionId, segment);
             return;
         }
-#else
-        public override bool ServerSend(System.Collections.Generic.List<int> connectionIds, int channelId, ArraySegment<byte> segment)
-        {
-            if (!ServerActive())
-            {
-                Debug.LogError("SimpleWebServer Not Active");
-                return false;
-            }
-
-            if (segment.Count > maxMessageSize)
-            {
-                Log.Error("Message greater than max size");
-                return false;
-            }
-
-            if (segment.Count == 0)
-            {
-                Log.Error("Message count was zero");
-                return false;
-            }
-
-            server.SendAll(connectionIds, segment);
-            return true;
-        }
-#endif
 
         public override string ServerGetClientAddress(int connectionId)
         {


### PR DESCRIPTION
Defines are not set when mirror is first imported so will give errors if we use `#IF MIRROR` or other defines within the mirror package.

Tested in `2018.4.28f1` and `2019.4.3f1`. 
- New empty project
- Download v26.1 package from github
- Get this error
![image](https://user-images.githubusercontent.com/23101891/97808113-c1dd3200-1c5c-11eb-9e5e-f5a3c1921c61.png)
