### PR TITLE
adding asmdef to kcp2k folder

### DIFF
--- a/Assets/Mirror/Runtime/Mirror.asmdef
+++ b/Assets/Mirror/Runtime/Mirror.asmdef
@@ -2,12 +2,13 @@
     "name": "Mirror",
     "references": [
         "Mirror.CompilerSymbols",
-        "Telepathy"
+        "Telepathy",
+        "kcp2k"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": true,
+    "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -117,7 +117,7 @@ namespace kcp2k
         public override void ServerStop() => server.Stop();
 
         // common
-        public override void Shutdown() { }
+        public override void Shutdown() {}
 
         // MTU
         public override int GetMaxPacketSize(int channelId = Channels.DefaultReliable) => Kcp.MTU_DEF;

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -2,8 +2,8 @@
 using System;
 using System.Linq;
 using System.Net;
-using UnityEngine;
 using Mirror;
+using UnityEngine;
 
 namespace kcp2k
 {
@@ -117,7 +117,7 @@ namespace kcp2k
         public override void ServerStop() => server.Stop();
 
         // common
-        public override void Shutdown() {}
+        public override void Shutdown() { }
 
         // MTU
         public override int GetMaxPacketSize(int channelId = Channels.DefaultReliable) => Kcp.MTU_DEF;
@@ -128,13 +128,13 @@ namespace kcp2k
         }
 
         int GetTotalSendQueue() =>
-            server.connections.Values.Sum(conn => conn.kcp.snd_queue.Count);
+            server.connections.Values.Sum(conn => conn.SendQueueCount);
         int GetTotalReceiveQueue() =>
-            server.connections.Values.Sum(conn => conn.kcp.rcv_queue.Count);
+            server.connections.Values.Sum(conn => conn.ReceiveQueueCount);
         int GetTotalSendBuffer() =>
-            server.connections.Values.Sum(conn => conn.kcp.snd_buf.Count);
+            server.connections.Values.Sum(conn => conn.SendBufferCount);
         int GetTotalReceiveBuffer() =>
-            server.connections.Values.Sum(conn => conn.kcp.rcv_buf.Count);
+            server.connections.Values.Sum(conn => conn.ReceiveBufferCount);
 
         void OnGUI()
         {
@@ -158,10 +158,10 @@ namespace kcp2k
             {
                 GUILayout.BeginVertical("Box");
                 GUILayout.Label("CLIENT");
-                GUILayout.Label("  SendQueue: " + client.connection.kcp.snd_queue.Count);
-                GUILayout.Label("  ReceiveQueue: " + client.connection.kcp.rcv_queue.Count);
-                GUILayout.Label("  SendBuffer: " + client.connection.kcp.snd_buf.Count);
-                GUILayout.Label("  ReceiveBuffer: " + client.connection.kcp.rcv_buf.Count);
+                GUILayout.Label("  SendQueue: " + client.connection.SendQueueCount);
+                GUILayout.Label("  ReceiveQueue: " + client.connection.ReceiveQueueCount);
+                GUILayout.Label("  SendBuffer: " + client.connection.SendBufferCount);
+                GUILayout.Label("  ReceiveBuffer: " + client.connection.ReceiveBufferCount);
                 GUILayout.EndVertical();
             }
 

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpConnection.cs
@@ -57,6 +57,12 @@ namespace kcp2k
         // note: we have a ChokeConnectionAutoDisconnects test for this too!
         internal const int QueueDisconnectThreshold = 10000;
 
+        // getters for queue and buffer counts, used for debug info
+        public int SendQueueCount => kcp.snd_queue.Count;
+        public int ReceiveQueueCount => kcp.rcv_queue.Count;
+        public int SendBufferCount => kcp.snd_buf.Count;
+        public int ReceiveBufferCount => kcp.rcv_buf.Count;
+
         // NoDelay, interval, window size are the most important configurations.
         // let's force require the parameters so we don't forget it anywhere.
         protected void SetupKcp(bool noDelay, uint interval = Kcp.INTERVAL, int fastResend = 0, bool congestionWindow = true, uint sendWindowSize = Kcp.WND_SND, uint receiveWindowSize = Kcp.WND_RCV)

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/kcp2k.asmdef
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/kcp2k.asmdef
@@ -1,0 +1,12 @@
+{
+    "name": "kcp2k",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/kcp2k.asmdef.meta
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/kcp2k.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6806a62c384838046a3c66c44f06d75f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
kcp2k doesn't depend on mirror so should be in its own asmdef. This means that kcp scripts one be re-compiled each time a change is made to mirror and that internal function are not used when they are not intended to be.

Added public getters for SendQueueCount (and others) so they can be used to should debug info not only by KcpTransport but also other if they want to use the kcp2k library.

Removing the `allowUnsafeCode` checkbox for mirror as it no longer needs it if kcp2k is in its own asmdef 