### PR TITLE
fix: Examples No Longer Rely On Sequential connectionId

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -302,6 +302,9 @@ namespace Mirror
             base.OnServerDisconnect(conn);
         }
 
+        // Sequential index used in round-robin deployment of players into instances and score positioning
+        public int clientIndex;
+
         /// <summary>
         /// Called on the server when a client adds a new player with ClientScene.AddPlayer.
         /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
@@ -309,6 +312,9 @@ namespace Mirror
         /// <param name="conn">Connection from client.</param>
         public override void OnServerAddPlayer(NetworkConnection conn)
         {
+            // increment the index before adding the player, so first player starts at 1
+            clientIndex++;
+
             if (IsSceneActive(RoomScene))
             {
                 if (roomSlots.Count == maxConnections)

--- a/Assets/Mirror/Examples/Basic/Scenes/Example.unity
+++ b/Assets/Mirror/Examples/Basic/Scenes/Example.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657868, g: 0.49641263, b: 0.57481706, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -87,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -199,7 +208,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 249891953}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8aab4c8111b7c411b9b92cf3dbc5bd4e, type: 3}
+  m_Script: {fileID: 11500000, guid: 20460c43f0320ed4baf8c1dcf953eafa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 0
@@ -209,7 +218,7 @@ MonoBehaviour:
   serverTickRate: 30
   offlineScene: 
   onlineScene: 
-  transport: {fileID: 0}
+  transport: {fileID: 249891955}
   networkAddress: localhost
   maxConnections: 16
   disconnectInactiveConnections: 0
@@ -272,9 +281,10 @@ Camera:
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -362,12 +372,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 379082678}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0}
   m_RaycastTarget: 0
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -380,6 +391,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!222 &379082681
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -415,7 +427,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 522137823}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_HorizontalAxis: Horizontal
@@ -434,7 +446,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 522137823}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_FirstSelected: {fileID: 0}
@@ -482,7 +494,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 533055200}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
@@ -499,7 +511,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 533055200}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_UiScaleMode: 0
@@ -578,12 +590,14 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 707756284}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -593,6 +607,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -600,12 +632,15 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &707756286

--- a/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
@@ -22,7 +22,7 @@ namespace Mirror.Examples.Basic
             GameObject go = Instantiate(playerPrefab);
             Player player = go.GetComponent<Player>();
             player.playerColor = Random.ColorHSV(0f, 1f, 0.9f, 0.9f, 1f, 1f);
-            player.playerNo = clientIndex;
+            player.playerNumber = clientIndex;
 
             // increment the index after setting on player, so first player starts at 0
             clientIndex++;

--- a/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
@@ -1,6 +1,4 @@
-﻿using UnityEngine;
-using UnityEngine.SceneManagement;
-using Mirror;
+using UnityEngine;
 
 /*
 	Documentation: https://mirror-networking.com/docs/Components/NetworkManager.html

--- a/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
@@ -1,0 +1,35 @@
+﻿using UnityEngine;
+using UnityEngine.SceneManagement;
+using Mirror;
+
+/*
+	Documentation: https://mirror-networking.com/docs/Components/NetworkManager.html
+	API Reference: https://mirror-networking.com/docs/api/Mirror.NetworkManager.html
+*/
+
+namespace Mirror.Examples.Basic
+{
+    public class BasicNetManager : NetworkManager
+    {
+        // Sequential index used in round-robin deployment of players into instances and score positioning
+        int clientIndex;
+
+        /// <summary>
+        /// Called on the server when a client adds a new player with ClientScene.AddPlayer.
+        /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
+        /// </summary>
+        /// <param name="conn">Connection from client.</param>
+        public override void OnServerAddPlayer(NetworkConnection conn)
+        {
+            GameObject go = Instantiate(playerPrefab);
+            Player player = go.GetComponent<Player>();
+            player.playerColor = Random.ColorHSV(0f, 1f, 0.9f, 0.9f, 1f, 1f);
+            player.playerNo = clientIndex;
+
+            // increment the index after setting on player, so first player starts at 0
+            clientIndex++;
+
+            NetworkServer.AddPlayerForConnection(conn, go);
+        }
+    }
+}

--- a/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs.meta
+++ b/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20460c43f0320ed4baf8c1dcf953eafa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Examples/Basic/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/Player.cs
@@ -16,7 +16,7 @@ namespace Mirror.Examples.Basic
         // These are set in BasicNetManager::OnServerAddPlayer
         [Header("SyncVars")]
         [SyncVar]
-        public int playerNo;
+        public int playerNumber;
         [SyncVar]
         public Color playerColor;
 
@@ -56,13 +56,13 @@ namespace Mirror.Examples.Basic
             transform.SetParent(GameObject.Find("PlayersPanel").transform);
 
             // Calculate position in the layout panel
-            int x = 100 + ((playerNo % 4) * 150);
-            int y = -170 - ((playerNo / 4) * 80);
+            int x = 100 + ((playerNumber % 4) * 150);
+            int y = -170 - ((playerNumber / 4) * 80);
             rectTransform.anchoredPosition = new Vector2(x, y);
 
             // Apply SyncVar values
             playerNameText.color = playerColor;
-            playerNameText.text = string.Format("Player {0:00}", playerNo);
+            playerNameText.text = string.Format("Player {0:00}", playerNumber);
         }
 
         // This only fires on the local client when this player object is network-ready

--- a/Assets/Mirror/Examples/Basic/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/Player.cs
@@ -36,9 +36,6 @@ namespace Mirror.Examples.Basic
         {
             base.OnStartServer();
 
-            // Set SyncVar values
-            playerColor = Random.ColorHSV(0f, 1f, 0.9f, 0.9f, 1f, 1f);
-
             // Start generating updates
             InvokeRepeating(nameof(UpdateData), 1, 1);
         }

--- a/Assets/Mirror/Examples/Basic/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/Player.cs
@@ -13,11 +13,12 @@ namespace Mirror.Examples.Basic
         public Text playerNameText;
         public Text playerDataText;
 
-        // These are set in OnStartServer and used in OnStartClient
+        // These are set in BasicNetManager::OnServerAddPlayer
+        [Header("SyncVars")]
         [SyncVar]
-        int playerNo;
+        public int playerNo;
         [SyncVar]
-        Color playerColor;
+        public Color playerColor;
 
         // This is updated by UpdateData which is called from OnStartServer via InvokeRepeating
         [SyncVar(hook = nameof(OnPlayerDataChanged))]
@@ -36,7 +37,6 @@ namespace Mirror.Examples.Basic
             base.OnStartServer();
 
             // Set SyncVar values
-            playerNo = connectionToClient.connectionId;
             playerColor = Random.ColorHSV(0f, 1f, 0.9f, 0.9f, 1f, 1f);
 
             // Start generating updates

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scenes/Game.unity
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scenes/Game.unity
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 2
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -87,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 112000002, guid: 83612f89e0d5b404fbd99891bda78df4,
     type: 2}
   m_UseShadowmask: 1
@@ -193,12 +202,46 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   forceHidden: 0
+--- !u!1 &473309615
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 473309616}
+  m_Layer: 0
+  m_Name: Tumblers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &473309616
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 473309615}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 535961556}
+  - {fileID: 1069065321}
+  - {fileID: 2061474489}
+  - {fileID: 1072549450}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &535961555
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 473309616}
     m_Modifications:
     - target: {fileID: -7012348765844800875, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -228,17 +271,17 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -248,7 +291,7 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -267,12 +310,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a104de86221e66a48832c222471d4f1e, type: 3}
+--- !u!4 &535961556 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
+    type: 3}
+  m_PrefabInstance: {fileID: 535961555}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1069065320
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 473309616}
     m_Modifications:
     - target: {fileID: -7012348765844800875, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -287,7 +336,7 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -302,17 +351,17 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -322,7 +371,7 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -341,12 +390,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a104de86221e66a48832c222471d4f1e, type: 3}
+--- !u!4 &1069065321 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1069065320}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1072549449
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 473309616}
     m_Modifications:
     - target: {fileID: -7012348765844800875, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -361,7 +416,7 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -376,17 +431,17 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -396,7 +451,7 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -415,6 +470,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a104de86221e66a48832c222471d4f1e, type: 3}
+--- !u!4 &1072549450 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1072549449}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1305256737
 GameObject:
   m_ObjectHideFlags: 0
@@ -504,6 +565,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -515,6 +577,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -537,9 +600,9 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 3
+  serializedVersion: 4
   m_Convex: 0
-  m_CookingOptions: 14
+  m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &1305256744
 MeshFilter:
@@ -611,7 +674,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 473309616}
     m_Modifications:
     - target: {fileID: -7012348765844800875, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -641,17 +704,17 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -661,7 +724,7 @@ PrefabInstance:
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
         type: 3}
@@ -680,3 +743,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a104de86221e66a48832c222471d4f1e, type: 3}
+--- !u!4 &2061474489 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5513112217680897778, guid: a104de86221e66a48832c222471d4f1e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2061474488}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scenes/Main.unity
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scenes/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 690741348}
-  m_IndirectSpecularColor: {r: 0.43667564, g: 0.48427147, b: 0.56452364, a: 1}
+  m_IndirectSpecularColor: {r: 0.17276844, g: 0.21589246, b: 0.2978263, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 2
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -87,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -150,9 +159,10 @@ Camera:
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -206,6 +216,7 @@ GameObject:
   - component: {fileID: 69965669}
   - component: {fileID: 69965667}
   - component: {fileID: 69965668}
+  - component: {fileID: 69965671}
   m_Layer: 0
   m_Name: Network
   m_TagString: Untagged
@@ -229,6 +240,95 @@ MonoBehaviour:
   offsetX: 0
   offsetY: 0
 --- !u!114 &69965668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 69965666}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7424c1070fad4ba2a7a96b02fbeb4bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnClientConnected:
+    m_PersistentCalls:
+      m_Calls: []
+  OnClientDataReceived:
+    m_PersistentCalls:
+      m_Calls: []
+  OnClientError:
+    m_PersistentCalls:
+      m_Calls: []
+  OnClientDisconnected:
+    m_PersistentCalls:
+      m_Calls: []
+  OnServerConnected:
+    m_PersistentCalls:
+      m_Calls: []
+  OnServerDataReceived:
+    m_PersistentCalls:
+      m_Calls: []
+  OnServerError:
+    m_PersistentCalls:
+      m_Calls: []
+  OnServerDisconnected:
+    m_PersistentCalls:
+      m_Calls: []
+  port: 7777
+  NoDelay: 1
+  serverMaxMessageSize: 16384
+  serverMaxReceivesPerTick: 10000
+  clientMaxMessageSize: 16384
+  clientMaxReceivesPerTick: 1000
+--- !u!114 &69965669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 69965666}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b982a1fd37427e64e8310a863d03d2c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dontDestroyOnLoad: 0
+  runInBackground: 1
+  autoStartServerBuild: 1
+  showDebugMessages: 0
+  serverTickRate: 30
+  offlineScene: 
+  onlineScene: 
+  transport: {fileID: 69965671}
+  networkAddress: localhost
+  maxConnections: 100
+  disconnectInactiveConnections: 0
+  disconnectInactiveTimeout: 60
+  authenticator: {fileID: 0}
+  playerPrefab: {fileID: 1480027675339556, guid: 1f4d376d8ca693049abd1744e4c79fad,
+    type: 3}
+  autoCreatePlayer: 1
+  playerSpawnMethod: 1
+  spawnPrefabs:
+  - {fileID: 1139254171913846, guid: 8cec47ed46e0eff45966a5173d3aa0d3, type: 3}
+  instances: 2
+  gameScene: Assets/Mirror/Examples/MultipleAdditiveScenes/Scenes/Game.unity
+--- !u!4 &69965670
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 69965666}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &69965671
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -272,53 +372,6 @@ MonoBehaviour:
   SendWindowSize: 128
   ReceiveWindowSize: 128
   debugGUI: 0
---- !u!114 &69965669
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 69965666}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b982a1fd37427e64e8310a863d03d2c9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  dontDestroyOnLoad: 0
-  runInBackground: 1
-  autoStartServerBuild: 1
-  showDebugMessages: 0
-  serverTickRate: 30
-  offlineScene: 
-  onlineScene: 
-  transport: {fileID: 69965668}
-  networkAddress: localhost
-  maxConnections: 100
-  disconnectInactiveConnections: 0
-  disconnectInactiveTimeout: 60
-  authenticator: {fileID: 0}
-  playerPrefab: {fileID: 1480027675339556, guid: 1f4d376d8ca693049abd1744e4c79fad,
-    type: 3}
-  autoCreatePlayer: 1
-  playerSpawnMethod: 1
-  spawnPrefabs:
-  - {fileID: 1139254171913846, guid: 8cec47ed46e0eff45966a5173d3aa0d3, type: 3}
-  instances: 3
-  gameScene: Assets/Mirror/Examples/MultipleAdditiveScenes/Scenes/Game.unity
---- !u!4 &69965670
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 69965666}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &204334129
 GameObject:
   m_ObjectHideFlags: 0
@@ -473,12 +526,14 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 690741347}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 0.990566, g: 0.9496818, b: 0.82702917, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -488,6 +543,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -495,12 +568,15 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &690741349

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
@@ -19,6 +19,9 @@ namespace Mirror.Examples.MultipleAdditiveScenes
 
         #region Server System Callbacks
 
+        // Sequential index used in round-robin deployment of players into instances and score positioning
+        int clientIndex;
+
         /// <summary>
         /// Called on the server when a client adds a new player with ClientScene.AddPlayer.
         /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
@@ -26,6 +29,9 @@ namespace Mirror.Examples.MultipleAdditiveScenes
         /// <param name="conn">Connection from client.</param>
         public override void OnServerAddPlayer(NetworkConnection conn)
         {
+            // increment the index before adding the player, so first player starts at 1
+            clientIndex++;
+
             StartCoroutine(OnServerAddPlayerDelayed(conn));
         }
 
@@ -42,12 +48,12 @@ namespace Mirror.Examples.MultipleAdditiveScenes
             base.OnServerAddPlayer(conn);
 
             PlayerScore playerScore = conn.identity.GetComponent<PlayerScore>();
-            playerScore.playerNumber = conn.connectionId;
-            playerScore.scoreIndex = conn.connectionId / subScenes.Count;
-            playerScore.matchIndex = conn.connectionId % subScenes.Count;
+            playerScore.playerNumber = clientIndex;
+            playerScore.scoreIndex = clientIndex / subScenes.Count;
+            playerScore.matchIndex = clientIndex % subScenes.Count;
 
             if (subScenes.Count > 0)
-                SceneManager.MoveGameObjectToScene(conn.identity.gameObject, subScenes[conn.connectionId % subScenes.Count]);
+                SceneManager.MoveGameObjectToScene(conn.identity.gameObject, subScenes[clientIndex % subScenes.Count]);
         }
 
         #endregion

--- a/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
@@ -10,11 +10,6 @@ namespace Mirror.Examples.NetworkRoom
         [SyncVar]
         public uint score;
 
-        public override void OnStartServer()
-        {
-            index = ((NetworkRoomManager)NetworkManager.singleton).clientIndex;
-        }
-
         void OnGUI()
         {
             GUI.Box(new Rect(10f + (index * 110), 10f, 100f, 25f), $"P{index}: {score.ToString("0000000")}");

--- a/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
@@ -12,7 +12,7 @@ namespace Mirror.Examples.NetworkRoom
 
         public override void OnStartServer()
         {
-            index = connectionToClient.connectionId;
+            index = ((NetworkRoomManager)NetworkManager.singleton).clientIndex;
         }
 
         void OnGUI()


### PR DESCRIPTION
These examples all relied on connectionID being sequential from the transport (e.g. Telepathy) but KCP doesn't use sequential id's.

Changed them all to use a clientIndex instead.