### PR TITLE
breaking: Using Events instead of Message for connect and disconnect

### DIFF
--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -30,10 +30,12 @@ namespace Mirror
 
     public struct AddPlayerMessage : NetworkMessage { }
 
-    [System.Obsolete("this message is never sent over network, replace with an event", true)]
+    // todo remove this in 3 months, Obsoleted 2020-11-07
+    [System.Obsolete("This message is never sent over network, Replaced with NetworkServer.OnDisconnected and NetworkClient.OnDisconnected events", true)]
     public struct DisconnectMessage : NetworkMessage { }
 
-    [System.Obsolete("this message is never sent over network, replace with an event", true)]
+    // todo remove this in 3 months, Obsoleted 2020-11-07
+    [System.Obsolete("This message is never sent over network, Replaced with NetworkServer.OnConnected and NetworkClient.OnConnected events", true)]
     public struct ConnectMessage : NetworkMessage { }
 
     public struct SceneMessage : NetworkMessage

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -30,8 +30,10 @@ namespace Mirror
 
     public struct AddPlayerMessage : NetworkMessage { }
 
+    [System.Obsolete("this message is never sent over network, replace with an event", true)]
     public struct DisconnectMessage : NetworkMessage { }
 
+    [System.Obsolete("this message is never sent over network, replace with an event", true)]
     public struct ConnectMessage : NetworkMessage { }
 
     public struct SceneMessage : NetworkMessage

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -153,15 +153,15 @@ namespace Mirror
                 // local connection. should we send a DisconnectMessage here too?
                 // (if we do then we get an Unknown Message ID log)
                 //NetworkServer.localConnection.Send(new DisconnectMessage());
-                NetworkServer.OnDisconnectedInternal(NetworkServer.localConnection.connectionId);
+                NetworkServer.OnDisconnectedTransport(NetworkServer.localConnection.connectionId);
             }
         }
 
         static void AddTransportHandlers()
         {
-            Transport.activeTransport.OnClientConnected = OnConnected;
+            Transport.activeTransport.OnClientConnected = OnConnectedTransport;
             Transport.activeTransport.OnClientDataReceived = OnDataReceived;
-            Transport.activeTransport.OnClientDisconnected = OnDisconnected;
+            Transport.activeTransport.OnClientDisconnected = OnDisconnectedTransport;
             Transport.activeTransport.OnClientError = OnError;
         }
 
@@ -173,7 +173,7 @@ namespace Mirror
         /// <summary>
         /// Handles OnClientDisconnected from transport
         /// </summary>
-        static void OnDisconnectedInternal()
+        static void OnDisconnectedTransport()
         {
             connectState = ConnectState.Disconnected;
 
@@ -194,7 +194,7 @@ namespace Mirror
         /// <summary>
         /// Handles OnClientConnected from transport
         /// </summary>
-        internal static void OnConnectedInternal()
+        internal static void OnConnectedTransport()
         {
             if (connection != null)
             {

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -194,7 +194,7 @@ namespace Mirror
         /// <summary>
         /// Handles OnClientConnected from transport
         /// </summary>
-        static void OnConnectedInternal()
+        internal static void OnConnectedInternal()
         {
             if (connection != null)
             {
@@ -393,7 +393,11 @@ namespace Mirror
             // we do NOT call Transport.Shutdown, because someone only called
             // NetworkClient.Shutdown. we can't assume that the server is
             // supposed to be shut down too!
-            Transport.activeTransport.ClientDisconnect();
+            Transport.activeTransport?.ClientDisconnect();
+
+            // clear event listeners
+            OnConnected = null;
+            OnDisconnected = null;
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -137,6 +137,7 @@ namespace Mirror
             NetworkServer.OnConnectedInternal(NetworkServer.localConnection);
 
             Debug.Assert(connection is ULocalConnectionToServer, "Connection should be local connection");
+            // OnConnected should be called with connToServer
             OnConnected?.Invoke(connection);
         }
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -204,7 +204,7 @@ namespace Mirror
         /// <param name="msg">The message object to process.</param>
         /// <returns>Returns true if the handler was successfully invoked</returns>
         // todo remove this in 3 months, Obsoleted 2020-11-07
-        [Obsolete("InvokeHandler is only used to invoke messages locally, instead call the methods directly. see https://github.com/vis2k/Mirror/pull/2397")]
+        [Obsolete("InvokeHandler is only used to invoke messages locally and will be removed soon, instead call the methods directly. see https://github.com/vis2k/Mirror/pull/2397")]
         public bool InvokeHandler<T>(T msg, int channelId)
             where T : struct, NetworkMessage
         {

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -203,6 +203,8 @@ namespace Mirror
         /// <typeparam name="T">The message type to unregister.</typeparam>
         /// <param name="msg">The message object to process.</param>
         /// <returns>Returns true if the handler was successfully invoked</returns>
+        // todo remove this in 3 months, Obsoleted 2020-11-07
+        [Obsolete("InvokeHandler is only used to invoke messages locally, instead call the methods directly. see https://github.com/vis2k/Mirror/pull/2397")]
         public bool InvokeHandler<T>(T msg, int channelId)
             where T : struct, NetworkMessage
         {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -750,8 +750,8 @@ namespace Mirror
 
         void RegisterServerMessages()
         {
-            NetworkServer.OnConnectedEvent += OnServerConnectInternal;
-            NetworkServer.OnDisconnectEvent += OnServerDisconnectInternal;
+            NetworkServer.OnConnected += OnServerConnectInternal;
+            NetworkServer.OnDisconnected += OnServerDisconnectInternal;
             NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerInternal);
             NetworkServer.RegisterHandler<ErrorMessage>(OnServerErrorInternal, false);
 
@@ -761,8 +761,8 @@ namespace Mirror
 
         void RegisterClientMessages()
         {
-            NetworkClient.OnConnectedEvent += OnClientConnectInternal;
-            NetworkClient.OnDisconnectEvent += OnClientDisconnectInternal;
+            NetworkClient.OnConnected += OnClientConnectInternal;
+            NetworkClient.OnDisconnected += OnClientDisconnectInternal;
             NetworkClient.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal);
             NetworkClient.RegisterHandler<ErrorMessage>(OnClientErrorInternal, false);
             NetworkClient.RegisterHandler<SceneMessage>(OnClientSceneInternal, false);

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using kcp2k;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
-using kcp2k;
 
 namespace Mirror
 {
@@ -623,6 +623,8 @@ namespace Mirror
 
             logger.Log("NetworkManager StopServer");
             isNetworkActive = false;
+            NetworkServer.OnConnected -= OnServerConnectInternal;
+            NetworkServer.OnDisconnected -= OnServerDisconnectInternal;
             NetworkServer.Shutdown();
 
             // set offline mode BEFORE changing scene so that FinishStartScene
@@ -656,6 +658,8 @@ namespace Mirror
             isNetworkActive = false;
 
             // shutdown client
+            NetworkClient.OnConnected -= OnClientConnectInternal;
+            NetworkClient.OnDisconnected -= OnClientDisconnectInternal;
             NetworkClient.Disconnect();
             NetworkClient.Shutdown();
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -750,8 +750,8 @@ namespace Mirror
 
         void RegisterServerMessages()
         {
-            NetworkServer.RegisterHandler<ConnectMessage>(OnServerConnectInternal, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>(OnServerDisconnectInternal, false);
+            NetworkServer.OnConnectedEvent += OnServerConnectInternal;
+            NetworkServer.OnDisconnectEvent += OnServerDisconnectInternal;
             NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerInternal);
             NetworkServer.RegisterHandler<ErrorMessage>(OnServerErrorInternal, false);
 
@@ -761,8 +761,8 @@ namespace Mirror
 
         void RegisterClientMessages()
         {
-            NetworkClient.RegisterHandler<ConnectMessage>(OnClientConnectInternal, false);
-            NetworkClient.RegisterHandler<DisconnectMessage>(OnClientDisconnectInternal, false);
+            NetworkClient.OnConnectedEvent += OnClientConnectInternal;
+            NetworkClient.OnDisconnectEvent += OnClientDisconnectInternal;
             NetworkClient.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal);
             NetworkClient.RegisterHandler<ErrorMessage>(OnClientErrorInternal, false);
             NetworkClient.RegisterHandler<SceneMessage>(OnClientSceneInternal, false);
@@ -1149,7 +1149,7 @@ namespace Mirror
 
         #region Server Internal Message Handlers
 
-        void OnServerConnectInternal(NetworkConnection conn, ConnectMessage connectMsg)
+        void OnServerConnectInternal(NetworkConnection conn)
         {
             logger.Log("NetworkManager.OnServerConnectInternal");
 
@@ -1183,7 +1183,7 @@ namespace Mirror
             OnServerConnect(conn);
         }
 
-        void OnServerDisconnectInternal(NetworkConnection conn, DisconnectMessage msg)
+        void OnServerDisconnectInternal(NetworkConnection conn)
         {
             logger.Log("NetworkManager.OnServerDisconnectInternal");
             OnServerDisconnect(conn);
@@ -1230,7 +1230,7 @@ namespace Mirror
 
         #region Client Internal Message Handlers
 
-        void OnClientConnectInternal(NetworkConnection conn, ConnectMessage message)
+        void OnClientConnectInternal(NetworkConnection conn)
         {
             logger.Log("NetworkManager.OnClientConnectInternal");
 
@@ -1268,7 +1268,7 @@ namespace Mirror
             }
         }
 
-        void OnClientDisconnectInternal(NetworkConnection conn, DisconnectMessage msg)
+        void OnClientDisconnectInternal(NetworkConnection conn)
         {
             logger.Log("NetworkManager.OnClientDisconnectInternal");
             OnClientDisconnect(conn);

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -108,6 +108,9 @@ namespace Mirror
 
             CleanupNetworkIdentities();
             NetworkIdentity.ResetNextNetworkId();
+
+            OnConnected = null;
+            OnDisconnected = null;
         }
 
         static void CleanupNetworkIdentities()
@@ -437,7 +440,7 @@ namespace Mirror
                 conn.Disconnect();
                 // call OnDisconnected unless local player in host mode
                 if (conn.connectionId != NetworkConnection.LocalConnectionId)
-                    OnDisconnected(conn);
+                    OnDisconnectedInternal(conn);
             }
             connections.Clear();
         }
@@ -534,7 +537,7 @@ namespace Mirror
             {
                 // add connection
                 NetworkConnectionToClient conn = new NetworkConnectionToClient(connectionId);
-                OnConnected(conn);
+                OnConnectedInternal(conn);
             }
             else
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -502,13 +502,13 @@ namespace Mirror
 
         static void AddTransportHandlers()
         {
-            Transport.activeTransport.OnServerConnected = OnConnected;
+            Transport.activeTransport.OnServerConnected = OnConnectedTransport;
             Transport.activeTransport.OnServerDataReceived = OnDataReceived;
-            Transport.activeTransport.OnServerDisconnected = OnDisconnected;
+            Transport.activeTransport.OnServerDisconnected = OnDisconnectedTransport;
             Transport.activeTransport.OnServerError = OnError;
         }
 
-        static void OnConnectedInternal(int connectionId)
+        static void OnConnectedTransport(int connectionId)
         {
             if (logger.LogEnabled()) logger.Log("Server accepted client:" + connectionId);
 
@@ -556,7 +556,7 @@ namespace Mirror
             OnConnected?.Invoke(conn);
         }
 
-        internal static void OnDisconnectedInternal(int connectionId)
+        internal static void OnDisconnectedTransport(int connectionId)
         {
             if (logger.LogEnabled()) logger.Log("Server disconnect client:" + connectionId);
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -73,6 +73,15 @@ namespace Mirror
         public static float disconnectInactiveTimeout = 60f;
 
         /// <summary>
+        /// Called after new connection is set up on server
+        /// </summary>
+        public static event ConnectionEvent OnConnectedEvent;
+        /// <summary>
+        /// Called after connection disconnects from server
+        /// </summary>
+        public static event ConnectionEvent OnDisconnectEvent;
+
+        /// <summary>
         /// This shuts down the server and disconnects all clients.
         /// </summary>
         public static void Shutdown()
@@ -540,7 +549,7 @@ namespace Mirror
 
             // add connection and invoke connected event
             AddConnection(conn);
-            conn.InvokeHandler(new ConnectMessage(), -1);
+            OnConnectedEvent?.Invoke(conn);
         }
 
         internal static void OnDisconnected(int connectionId)
@@ -559,7 +568,8 @@ namespace Mirror
 
         static void OnDisconnected(NetworkConnection conn)
         {
-            conn.InvokeHandler(new DisconnectMessage(), -1);
+            // todo change to event instead of message
+            OnDisconnectEvent?.Invoke(conn);
             if (logger.LogEnabled()) logger.Log("Server lost client:" + conn);
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -75,11 +75,12 @@ namespace Mirror
         /// <summary>
         /// Called after new connection is set up on server
         /// </summary>
-        public static event ConnectionEvent OnConnectedEvent;
+        public static event ConnectionEvent OnConnected;
+
         /// <summary>
         /// Called after connection disconnects from server
         /// </summary>
-        public static event ConnectionEvent OnDisconnectEvent;
+        public static event ConnectionEvent OnDisconnected;
 
         /// <summary>
         /// This shuts down the server and disconnects all clients.
@@ -504,7 +505,7 @@ namespace Mirror
             Transport.activeTransport.OnServerError = OnError;
         }
 
-        static void OnConnected(int connectionId)
+        static void OnConnectedInternal(int connectionId)
         {
             if (logger.LogEnabled()) logger.Log("Server accepted client:" + connectionId);
 
@@ -543,16 +544,16 @@ namespace Mirror
             }
         }
 
-        internal static void OnConnected(NetworkConnectionToClient conn)
+        internal static void OnConnectedInternal(NetworkConnectionToClient conn)
         {
             if (logger.LogEnabled()) logger.Log("Server accepted client:" + conn);
 
             // add connection and invoke connected event
             AddConnection(conn);
-            OnConnectedEvent?.Invoke(conn);
+            OnConnected?.Invoke(conn);
         }
 
-        internal static void OnDisconnected(int connectionId)
+        internal static void OnDisconnectedInternal(int connectionId)
         {
             if (logger.LogEnabled()) logger.Log("Server disconnect client:" + connectionId);
 
@@ -562,14 +563,14 @@ namespace Mirror
                 RemoveConnection(connectionId);
                 if (logger.LogEnabled()) logger.Log("Server lost client:" + connectionId);
 
-                OnDisconnected(conn);
+                OnDisconnectedInternal(conn);
             }
         }
 
-        static void OnDisconnected(NetworkConnection conn)
+        static void OnDisconnectedInternal(NetworkConnection conn)
         {
             // todo change to event instead of message
-            OnDisconnectEvent?.Invoke(conn);
+            OnDisconnected?.Invoke(conn);
             if (logger.LogEnabled()) logger.Log("Server lost client:" + conn);
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -109,6 +109,7 @@ namespace Mirror
             CleanupNetworkIdentities();
             NetworkIdentity.ResetNextNetworkId();
 
+            // clear event listeners
             OnConnected = null;
             OnDisconnected = null;
         }
@@ -508,6 +509,9 @@ namespace Mirror
             Transport.activeTransport.OnServerError = OnError;
         }
 
+        /// <summary>
+        /// Handles OnServerConnected from transport
+        /// </summary>
         static void OnConnectedTransport(int connectionId)
         {
             if (logger.LogEnabled()) logger.Log("Server accepted client:" + connectionId);
@@ -547,6 +551,9 @@ namespace Mirror
             }
         }
 
+        /// <summary>
+        /// Handles OnConnectedTransport and host connection
+        /// </summary>
         internal static void OnConnectedInternal(NetworkConnectionToClient conn)
         {
             if (logger.LogEnabled()) logger.Log("Server accepted client:" + conn);
@@ -556,6 +563,9 @@ namespace Mirror
             OnConnected?.Invoke(conn);
         }
 
+        /// <summary>
+        /// Handles OnServerDisconnected from transport
+        /// </summary>
         internal static void OnDisconnectedTransport(int connectionId)
         {
             if (logger.LogEnabled()) logger.Log("Server disconnect client:" + connectionId);
@@ -570,9 +580,11 @@ namespace Mirror
             }
         }
 
+        /// <summary>
+        /// Handles OnDisconnectedTransport and host connection
+        /// </summary>
         static void OnDisconnectedInternal(NetworkConnection conn)
         {
-            // todo change to event instead of message
             OnDisconnected?.Invoke(conn);
             if (logger.LogEnabled()) logger.Log("Server lost client:" + conn);
         }

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -15,6 +15,10 @@ namespace Mirror
     // Handles requests to unspawn objects on the client
     public delegate void UnSpawnDelegate(GameObject spawned);
 
+
+    public delegate void ConnectionEvent(NetworkConnection conn);
+
+
     // invoke type for Cmd/Rpc
     public enum MirrorInvokeType
     {

--- a/Assets/Mirror/Tests/Common/MemoryTransport.cs
+++ b/Assets/Mirror/Tests/Common/MemoryTransport.cs
@@ -124,19 +124,11 @@ namespace Mirror.Tests
 
         public override bool ServerDisconnect(int connectionId)
         {
-            // clear all pending messages that we may have received.
-            // over the wire, we wouldn't receive any more pending messages
-            // ether after calling disconnect.
-            serverIncoming.Clear();
-
             // add client disconnected message with connectionId
             clientIncoming.Enqueue(new Message(connectionId, EventType.Disconnected, null));
 
             // add server disconnected message with connectionId
             serverIncoming.Enqueue(new Message(connectionId, EventType.Disconnected, null));
-
-            // not active anymore
-            serverActive = false;
 
             return false;
         }

--- a/Assets/Mirror/Tests/Editor/BuiltInMessages.cs
+++ b/Assets/Mirror/Tests/Editor/BuiltInMessages.cs
@@ -31,30 +31,6 @@ namespace Mirror.Tests.MessageTests
         }
 
         [Test]
-        public void ConnectMessage()
-        {
-            // try setting value with constructor
-            ConnectMessage message = new ConnectMessage();
-            byte[] arr = MessagePackerTest.PackToByteArray(message);
-            Assert.DoesNotThrow(() =>
-            {
-                MessagePackerTest.UnpackFromByteArray<ConnectMessage>(arr);
-            });
-        }
-
-        [Test]
-        public void DisconnectMessage()
-        {
-            // try setting value with constructor
-            DisconnectMessage message = new DisconnectMessage();
-            byte[] arr = MessagePackerTest.PackToByteArray(message);
-            Assert.DoesNotThrow(() =>
-            {
-                MessagePackerTest.UnpackFromByteArray<DisconnectMessage>(arr);
-            });
-        }
-
-        [Test]
         public void ErrorMessage()
         {
             // try setting value with constructor

--- a/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
@@ -63,7 +63,7 @@ namespace Mirror.Tests
 
             Assert.Throws<FormatException>(() =>
             {
-                Message2 unpacked = MessagePacker.Unpack<Message2>(data);
+                Message2 unpacked = UnpackFromByteArray<Message2>(data);
             });
         }
 

--- a/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
@@ -51,16 +51,19 @@ namespace Mirror.Tests
             Assert.That(unpacked.sceneOperation, Is.EqualTo(SceneOperation.LoadAdditive));
         }
 
+        struct Message1 : NetworkMessage { }
+        struct Message2 : NetworkMessage { }
+
         [Test]
         public void UnpackWrongMessage()
         {
-            ConnectMessage message = new ConnectMessage();
+            Message1 message = new Message1();
 
             byte[] data = PackToByteArray(message);
 
             Assert.Throws<FormatException>(() =>
             {
-                DisconnectMessage unpacked = UnpackFromByteArray<DisconnectMessage>(data);
+                Message2 unpacked = MessagePacker.Unpack<Message2>(data);
             });
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -300,8 +300,6 @@ namespace Mirror.Tests
             // we need to start a server and connect a client in order to be
             // able to send commands
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<SpawnMessage>((conn, msg) => { }, false);
             NetworkServer.Listen(1);
@@ -413,8 +411,6 @@ namespace Mirror.Tests
             // we need to start a server and connect a client in order to be
             // able to send commands
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<SpawnMessage>((conn, msg) => { }, false);
             NetworkServer.Listen(1);
@@ -499,8 +495,6 @@ namespace Mirror.Tests
             // we need to start a server and connect a client in order to be
             // able to send commands
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<SpawnMessage>((conn, msg) => { }, false);
             NetworkServer.Listen(1);

--- a/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -17,13 +17,8 @@ namespace Mirror.Tests
             Transport.activeTransport = transportGO.AddComponent<MemoryTransport>();
 
             // we need a server to connect to
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
             NetworkServer.Listen(10);
-
-            // setup client handlers too
-            NetworkClient.RegisterHandler<ConnectMessage>(msg => { }, false);
         }
 
         [TearDown]

--- a/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
@@ -89,5 +89,42 @@ namespace Mirror.Tests
             // received it on server?
             Assert.That(called, Is.EqualTo(1));
         }
+
+        [Test]
+        public void ShutdownClearsEvents()
+        {
+            int called = 0;
+            NetworkClient.OnConnected += (c) => { called++; };
+
+            NetworkClient.Connect("localhost");
+            ((MemoryTransport)Transport.activeTransport).LateUpdate();
+
+            Assert.That(called, Is.EqualTo(1));
+
+            // remove events
+            NetworkClient.Disconnect();
+            NetworkClient.Shutdown();
+
+            NetworkClient.Connect("localhost");
+            ((MemoryTransport)Transport.activeTransport).LateUpdate();
+
+            Assert.That(called, Is.EqualTo(1), "Call count should still be 1");
+
+            // reset
+            NetworkClient.Disconnect();
+            NetworkClient.Shutdown();
+
+
+            // add event again
+            NetworkClient.OnConnected += (c) =>
+            {
+                called++;
+            };
+
+            NetworkClient.Connect("localhost");
+            ((MemoryTransport)Transport.activeTransport).LateUpdate();
+
+            Assert.That(called, Is.EqualTo(2), "Call count should now be 2");
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -845,7 +845,6 @@ namespace Mirror.Tests
             // call client connect so that internals are set up
             // (it won't actually successfully connect)
             // -> also set up connectmessage handler to avoid unhandled msg error
-            NetworkClient.RegisterHandler<ConnectMessage>(msg => { }, false);
             NetworkClient.Connect("localhost");
 
             // manually invoke transport.OnConnected so that NetworkClient.active is set to true

--- a/Assets/Mirror/Tests/Editor/NetworkManagerStopHostOnServerDisconnectTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerStopHostOnServerDisconnectTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+using System;
+using NUnit.Framework;
 using UnityEngine;
 
 namespace Mirror.Tests
@@ -13,6 +14,7 @@ namespace Mirror.Tests
     public class NetworkManagerStopHostOnServerDisconnectTest
     {
         GameObject gameObject;
+        GameObject playerPrefab;
         NetworkManagerOnServerDisconnect manager;
         MemoryTransport transport;
 
@@ -22,12 +24,18 @@ namespace Mirror.Tests
             gameObject = new GameObject();
             transport = gameObject.AddComponent<MemoryTransport>();
             manager = gameObject.AddComponent<NetworkManagerOnServerDisconnect>();
+            playerPrefab = new GameObject("player");
+            NetworkIdentity id = playerPrefab.AddComponent<NetworkIdentity>();
+            id.assetId = Guid.NewGuid();
+            id.sceneId = 0;
+            manager.playerPrefab = playerPrefab;
         }
 
         [TearDown]
         public void TearDown()
         {
             GameObject.DestroyImmediate(gameObject);
+            GameObject.DestroyImmediate(playerPrefab);
         }
 
         // test to prevent https://github.com/vis2k/Mirror/issues/1515

--- a/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
@@ -14,13 +14,15 @@ namespace Mirror.Tests
         public void SetupNetworkManager()
         {
             gameObject = new GameObject();
-            gameObject.AddComponent<MemoryTransport>();
+            Transport.activeTransport = gameObject.AddComponent<MemoryTransport>();
             manager = gameObject.AddComponent<NetworkManager>();
         }
 
         [TearDown]
         public void TearDownNetworkManager()
         {
+            NetworkServer.Shutdown();
+            NetworkClient.Shutdown();
             GameObject.DestroyImmediate(gameObject);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -119,8 +119,6 @@ namespace Mirror.Tests
         public void MaxConnectionsTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen with maxconnections=1
@@ -141,8 +139,7 @@ namespace Mirror.Tests
         {
             // message handlers
             bool connectCalled = false;
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { connectCalled = true; }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
+            NetworkServer.OnConnectedEvent += (conn) => { connectCalled = true; };
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -159,8 +156,7 @@ namespace Mirror.Tests
         {
             // message handlers
             bool disconnectCalled = false;
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { disconnectCalled = true; }, false);
+            NetworkServer.OnDisconnectEvent += (conn) => { disconnectCalled = true; };
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -180,8 +176,6 @@ namespace Mirror.Tests
         public void ConnectionsDictTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -216,8 +210,6 @@ namespace Mirror.Tests
             // <0 is never used
 
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -240,8 +232,6 @@ namespace Mirror.Tests
         public void ConnectDuplicateConnectionIdsTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -315,8 +305,6 @@ namespace Mirror.Tests
         public void AddConnectionTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -356,8 +344,6 @@ namespace Mirror.Tests
         public void RemoveConnectionTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -382,8 +368,6 @@ namespace Mirror.Tests
         public void DisconnectAllConnectionsTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -404,8 +388,6 @@ namespace Mirror.Tests
         public void DisconnectAllTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -432,8 +414,6 @@ namespace Mirror.Tests
         public void OnDataReceivedTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // add one custom message handler
@@ -478,8 +458,6 @@ namespace Mirror.Tests
         public void OnDataReceivedInvalidConnectionIdTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // add one custom message handler
@@ -722,8 +700,6 @@ namespace Mirror.Tests
         public void SendToAllTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -758,8 +734,6 @@ namespace Mirror.Tests
         public void RegisterUnregisterClearHandlerTest()
         {
             // message handlers that are needed for the test
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
 
@@ -806,7 +780,6 @@ namespace Mirror.Tests
             // unregister second handler via ClearHandlers to test that one too. send, should fail
             NetworkServer.ClearHandlers();
             // (only add this one to avoid disconnect error)
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             writer = new NetworkWriter();
             MessagePacker.Pack(new TestMessage1(), writer);
             // log error messages are expected
@@ -821,8 +794,6 @@ namespace Mirror.Tests
         public void SendToClientOfPlayer()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -899,8 +870,6 @@ namespace Mirror.Tests
         public void ShowForConnection()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -951,8 +920,6 @@ namespace Mirror.Tests
         public void HideForConnection()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -1089,8 +1056,6 @@ namespace Mirror.Tests
         public void ShutdownCleanupTest()
         {
             // message handlers
-            NetworkServer.RegisterHandler<ConnectMessage>((conn, msg) => { }, false);
-            NetworkServer.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -139,7 +139,7 @@ namespace Mirror.Tests
         {
             // message handlers
             bool connectCalled = false;
-            NetworkServer.OnConnectedEvent += (conn) => { connectCalled = true; };
+            NetworkServer.OnConnected += (conn) => { connectCalled = true; };
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen
@@ -156,7 +156,7 @@ namespace Mirror.Tests
         {
             // message handlers
             bool disconnectCalled = false;
-            NetworkServer.OnDisconnectEvent += (conn) => { disconnectCalled = true; };
+            NetworkServer.OnDisconnected += (conn) => { disconnectCalled = true; };
             NetworkServer.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
 
             // listen

--- a/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
@@ -13,6 +13,11 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             Transport.activeTransport = new GameObject().AddComponent<MemoryTransport>();
 
+            // shutdown has to be called after activeTransport is set
+            // make sure shutdown correctly before running test
+            NetworkClient.Shutdown();
+            NetworkServer.Shutdown();
+
             // start server/client
             NetworkServer.Listen(1);
             NetworkClient.ConnectHost();

--- a/Assets/Mirror/Tests/Runtime/NetworkManagerStopHostOnServerDisconnectTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkManagerStopHostOnServerDisconnectTest.cs
@@ -36,6 +36,8 @@ namespace Mirror.Tests
         {
             GameObject.DestroyImmediate(gameObject);
             GameObject.DestroyImmediate(playerPrefab);
+            NetworkServer.Shutdown();
+            NetworkClient.Shutdown();
         }
 
         // test to prevent https://github.com/vis2k/Mirror/issues/1515

--- a/Assets/Mirror/Tests/Runtime/NetworkManagerStopHostOnServerDisconnectTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkManagerStopHostOnServerDisconnectTest.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
-namespace Mirror.Tests
+namespace Mirror.Tests.Runtime
 {
     class NetworkManagerOnServerDisconnect : NetworkManager
     {
@@ -22,7 +24,7 @@ namespace Mirror.Tests
         public void SetUp()
         {
             gameObject = new GameObject();
-            transport = gameObject.AddComponent<MemoryTransport>();
+            transport= gameObject.AddComponent<MemoryTransport>();
             manager = gameObject.AddComponent<NetworkManagerOnServerDisconnect>();
             playerPrefab = new GameObject("player");
             NetworkIdentity id = playerPrefab.AddComponent<NetworkIdentity>();
@@ -38,12 +40,17 @@ namespace Mirror.Tests
             GameObject.DestroyImmediate(playerPrefab);
             NetworkServer.Shutdown();
             NetworkClient.Shutdown();
+            Transport.activeTransport = null;
         }
 
         // test to prevent https://github.com/vis2k/Mirror/issues/1515
-        [Test]
-        public void StopHostCallsOnServerDisconnectForHostClient()
+        [UnityTest]
+        public IEnumerator StopHostCallsOnServerDisconnectForHostClient()
         {
+            // wait for awake to be called before setting activeTransport
+            yield return null;
+            Transport.activeTransport = transport;
+
             // OnServerDisconnect is always called when a client disconnects.
             // it should also be called for the host client when we stop the host
             Assert.That(manager.called, Is.EqualTo(0));

--- a/Assets/Mirror/Tests/Runtime/NetworkManagerStopHostOnServerDisconnectTest.cs.meta
+++ b/Assets/Mirror/Tests/Runtime/NetworkManagerStopHostOnServerDisconnectTest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2f583081473a64b92b971678e571382a
+guid: 63a3472b4e4641342b092337b5065b1b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -56,7 +56,7 @@ namespace Mirror.Tests.Runtime
             const int remoteConnectionId = 1;
             const int localConnectionId = 0;
             NetworkConnectionToClient remoteConnection = new NetworkConnectionToClient(remoteConnectionId);
-            NetworkServer.OnConnected(remoteConnection);
+            NetworkServer.OnConnectedInternal(remoteConnection);
             NetworkServer.AddPlayerForConnection(remoteConnection, remotePlayer);
 
             // There's a host player from HostSetup + remotePlayer


### PR DESCRIPTION
* Using events is simpler to understand than InvokeHandler
* Allows multiple objects to listen for connected events to add/remove message handlers to NetworkClient/Server
* Stops attackers from sending Connect/Disconnect Message 

this change does cause client OnClientConnect in host mode to be called the same

BREAKING CHANGE: use events in NetworkServer/Client instead of handlers for Connect/DisconnectMessage