### PR TITLE
Networkwriter consistency

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -63,30 +63,6 @@ namespace Mirror
             }
             return buffer.Array[buffer.Offset + Position++];
         }
-        public int ReadInt32() => (int)ReadUInt32();
-        public uint ReadUInt32()
-        {
-            uint value = 0;
-            value |= ReadByte();
-            value |= (uint)(ReadByte() << 8);
-            value |= (uint)(ReadByte() << 16);
-            value |= (uint)(ReadByte() << 24);
-            return value;
-        }
-        public long ReadInt64() => (long)ReadUInt64();
-        public ulong ReadUInt64()
-        {
-            ulong value = 0;
-            value |= ReadByte();
-            value |= ((ulong)ReadByte()) << 8;
-            value |= ((ulong)ReadByte()) << 16;
-            value |= ((ulong)ReadByte()) << 24;
-            value |= ((ulong)ReadByte()) << 32;
-            value |= ((ulong)ReadByte()) << 40;
-            value |= ((ulong)ReadByte()) << 48;
-            value |= ((ulong)ReadByte()) << 56;
-            return value;
-        }
 
         // read bytes into the passed buffer
         public byte[] ReadBytes(byte[] bytes, int count)

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -142,32 +142,6 @@ namespace Mirror
             position += count;
         }
 
-        public void WriteUInt32(uint value)
-        {
-            EnsureLength(position + 4);
-            buffer[position++] = (byte)value;
-            buffer[position++] = (byte)(value >> 8);
-            buffer[position++] = (byte)(value >> 16);
-            buffer[position++] = (byte)(value >> 24);
-        }
-
-        public void WriteInt32(int value) => WriteUInt32((uint)value);
-
-        public void WriteUInt64(ulong value)
-        {
-            EnsureLength(position + 8);
-            buffer[position++] = (byte)value;
-            buffer[position++] = (byte)(value >> 8);
-            buffer[position++] = (byte)(value >> 16);
-            buffer[position++] = (byte)(value >> 24);
-            buffer[position++] = (byte)(value >> 32);
-            buffer[position++] = (byte)(value >> 40);
-            buffer[position++] = (byte)(value >> 48);
-            buffer[position++] = (byte)(value >> 56);
-        }
-
-        public void WriteInt64(long value) => WriteUInt64((ulong)value);
-
         /// <summary>
         /// Writes any type that mirror supports
         /// </summary>
@@ -207,6 +181,30 @@ namespace Mirror
         }
 
         public static void WriteInt16(this NetworkWriter writer, short value) => writer.WriteUInt16((ushort)value);
+
+        public static void WriteUInt32(this NetworkWriter writer, uint value)
+        {
+            writer.WriteByte((byte)value);
+            writer.WriteByte((byte)(value >> 8));
+            writer.WriteByte((byte)(value >> 16));
+            writer.WriteByte((byte)(value >> 24));
+        }
+
+        public static void WriteInt32(this NetworkWriter writer, int value) => writer.WriteUInt32((uint)value);
+
+        public static void WriteUInt64(this NetworkWriter writer, ulong value)
+        {
+            writer.WriteByte((byte)value);
+            writer.WriteByte((byte)(value >> 8));
+            writer.WriteByte((byte)(value >> 16));
+            writer.WriteByte((byte)(value >> 24));
+            writer.WriteByte((byte)(value >> 32));
+            writer.WriteByte((byte)(value >> 40));
+            writer.WriteByte((byte)(value >> 48));
+            writer.WriteByte((byte)(value >> 56));
+        }
+
+        public static void WriteInt64(this NetworkWriter writer, long value) => writer.WriteUInt64((ulong)value);
 
         public static void WriteSingle(this NetworkWriter writer, float value)
         {


### PR DESCRIPTION
SQUASH!

consistent read/write(u)int functions in extensions for networkreader and writer.
makes further performance and bandwidth improvements from 'x' branch possible afterwards.

this is good no matter what, because weaver will look for all read/write(u)int functions in one place.
right now, if we were to remove the packed functions then weaver would break with strange errors because it doesn't find regular write/read(u)int functions. this costs a lot of time to debugger, and is avoided this way.