### PR TITLE
fix: max message size

### DIFF
--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -120,7 +120,7 @@ namespace kcp2k
         public override void Shutdown() {}
 
         // MTU
-        public override int GetMaxPacketSize(int channelId = Channels.DefaultReliable) => Kcp.MTU_DEF;
+        public override int GetMaxPacketSize(int channelId = Channels.DefaultReliable) => Kcp.MTU_DEF * ReceiveWindowSize;
 
         public override string ToString()
         {


### PR DESCRIPTION
KCP can send messages up to MTU * Receive window.

KCP has fragmentation,  it will split up large messages into multiple packets and reassemble them in the other end.