### PR TITLE
Adjusted KCP tooltip typo.

### DIFF
--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -17,7 +17,7 @@ namespace kcp2k
         public ushort Port = 7777;
         [Tooltip("NoDelay is recommended to reduce latency. This also scales better without buffers getting full.")]
         public bool NoDelay = true;
-        [Tooltip("KCP internal update interval. 100ms is KCP default, but a lower interval is recommended to minimize latency and to scale to more networked entities.")]
+        [Tooltip("KCP internal update interval. 10ms is KCP default, but a lower interval is recommended to minimize latency and to scale to more networked entities.")]
         public uint Interval = 10;
         [Header("Advanced")]
         [Tooltip("KCP fastresend parameter. Faster resend for the cost of higher bandwidth.")]


### PR DESCRIPTION
Changed the default 100ms to 10ms
Double checked with Vis in Discord  "tooltip is meant to say 10ms."
Already seen one screenshot of a Discord user that set this from 10 to 100, due to the typo, believing 100 was meant to be default and not 10.