### PR TITLE
feat: Check NetworkManager gameobject for NI and NBs

### DIFF
--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -32,7 +32,7 @@ namespace Mirror
                 foreach (NetworkManager netManager in netManagers)
                 {
                     // NetworkBehaviour check.
-                    NetworkBehaviour[] checkForNetBehaviours = netManager.gameObject.GetComponents<NetworkBehaviour>();
+                    NetworkBehaviour[] checkForNetBehaviours = netManager.gameObject.GetComponentsInChildren<NetworkBehaviour>();
                     if (checkForNetBehaviours.Length > 0)
                     {
                         // Throw an error saying that this is not supported.
@@ -41,8 +41,8 @@ namespace Mirror
                     }
 
                     // NetworkIdentity check.
-                    NetworkIdentity checkForNetIdentity = netManager.gameObject.GetComponent<NetworkIdentity>();
-                    if (checkForNetIdentity != null)
+                    NetworkIdentity[] checkForNetIdentities = netManager.gameObject.GetComponentsInChildren<NetworkIdentity>();
+                    if (checkForNetIdentities.Length > 0)
                     {
                         // Throw an error saying this will cause problems. Mirror later checks to see if the NetworkManager has a NetworkIdentity, but this one pin-points the issue.
                         Debug.LogError("Detected a NetworkIdentity on the same GameObject as the NetworkManager. A NetworkIdentity should never be added to a " +


### PR DESCRIPTION
This hopefully makes it apparent to newcomers that wonder why NetworkManager isn't working correctly that they can't put NetworkIdentities on NetworkManager objects. Same thing applies for NetworkBehaviours on NetworkManager objects. 

This idea started out by MrGadget or James in the Discord mentioning about the fact people were stacking NetworkBehaviours on the Network Manager game object and complaining why it wasn't working, which is a really bad practice. We should instead detect this, alert the user with an error so they don't come into the Discord really upset and/or lashing out at us because they put all their network logic on the same game object as Network Manager, instead of others. I also added in a check to ensure if you have two network managers that it alerts you preemptively to avoid the shock of the "duplicate network manager, will be destroyed" warning.

I originally wanted to try to block the Scene from playback mode so it's a show-stopper error, but it seems Exceptions thrown in either OnValidate or PostProcessScene are not major show-stoppers.

Tested and working. As for maintainability, it copy-pasted a chunk from the function below it, so it'll be pretty easy to update. Yeah yeah, the code contained inside PR will survive the next 10 years.