### PR TITLE
Pool<T>; NetworkReader/WriterPools simplified by using Pool<T>

### DIFF
--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine;
 
 namespace Mirror
 {
@@ -21,42 +20,14 @@ namespace Mirror
     /// </summary>
     public static class NetworkWriterPool
     {
-        static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkWriterPool), LogType.Error);
-
-        /// <summary>
-        /// Size of the pool
-        /// <para>If pool is too small getting writers will causes memory allocation</para>
-        /// <para>Default value: 100 </para>
-        /// </summary>
-        public static int Capacity
-        {
-            get => pool.Length;
-            set
-            {
-                // resize the array
-                Array.Resize(ref pool, value);
-
-                // if capacity is smaller than before, then we need to adjust
-                // 'next' so it doesn't point to an index out of range
-                // -> if we set '0' then next = min(_, 0-1) => -1
-                // -> if we set '2' then next = min(_, 2-1) =>  1
-                next = Mathf.Min(next, pool.Length - 1);
-            }
-        }
-
-        /// <summary>
-        /// Mirror usually only uses up to 4 writes in nested usings,
-        /// 100 is a good margin for edge cases when users need a lot writers at
-        /// the same time.
-        ///
-        /// <para>keep in mind, most entries of the pool will be null in most cases</para>
-        /// </summary>
-        ///
-        /// Note: we use an Array instead of a Stack because it's significantly
-        ///       faster: https://github.com/vis2k/Mirror/issues/1614
-        static PooledNetworkWriter[] pool = new PooledNetworkWriter[100];
-
-        static int next = -1;
+        // reuse Pool<T>
+        // we still wrap it in NetworkWriterPool.Get/Recyle so we can reset the
+        // position before reusing.
+        // this is also more consistent with NetworkReaderPool where we need to
+        // assign the internal buffer before reusing.
+        static readonly Pool<PooledNetworkWriter> pool = new Pool<PooledNetworkWriter>(
+            () => new PooledNetworkWriter()
+        );
 
         /// <summary>
         /// Get the next writer in the pool
@@ -64,16 +35,8 @@ namespace Mirror
         /// </summary>
         public static PooledNetworkWriter GetWriter()
         {
-            if (next == -1)
-            {
-                return new PooledNetworkWriter();
-            }
-
-            PooledNetworkWriter writer = pool[next];
-            pool[next] = null;
-            next--;
-
-            // reset cached writer length and position
+            // grab from from pool & reset position
+            PooledNetworkWriter writer = pool.Take();
             writer.Reset();
             return writer;
         }
@@ -84,15 +47,7 @@ namespace Mirror
         /// </summary>
         public static void Recycle(PooledNetworkWriter writer)
         {
-            if (next < pool.Length - 1)
-            {
-                next++;
-                pool[next] = writer;
-            }
-            else
-            {
-                logger.LogWarning("NetworkWriterPool.Recycle, Pool was full leaving extra writer for GC");
-            }
+            pool.Return(writer);
         }
     }
 }

--- a/Assets/Mirror/Runtime/Pool.cs
+++ b/Assets/Mirror/Runtime/Pool.cs
@@ -1,0 +1,30 @@
+﻿// Pool to avoid allocations (from libuv2k)
+using System;
+using System.Collections.Generic;
+
+namespace Mirror
+{
+    public class Pool<T>
+    {
+        // Mirror is single threaded, no need for concurrent collections
+        readonly Stack<T> objects = new Stack<T>();
+
+        // some types might need additional parameters in their constructor, so
+        // we use a Func<T> generator
+        readonly Func<T> objectGenerator;
+
+        public Pool(Func<T> objectGenerator)
+        {
+            this.objectGenerator = objectGenerator;
+        }
+
+        // take an element from the pool, or create a new one if empty
+        public T Take() => objects.Count > 0 ? objects.Pop() : objectGenerator();
+
+        // return an element to the pool
+        public void Return(T item) => objects.Push(item);
+
+        // count to see how many objects are in the pool. useful for tests.
+        public int Count => objects.Count;
+    }
+}

--- a/Assets/Mirror/Runtime/Pool.cs.meta
+++ b/Assets/Mirror/Runtime/Pool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 845bb05fa349344c3811022f4f15dfbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/NetworkReaderPoolTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderPoolTest.cs
@@ -1,25 +1,10 @@
 using System;
-using System.Linq;
 using NUnit.Framework;
 
 namespace Mirror.Tests
 {
     public class NetworkReaderPoolTest
     {
-        int defaultCapacity;
-
-        [SetUp]
-        public void SetUp()
-        {
-            defaultCapacity = NetworkReaderPool.Capacity;
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            NetworkReaderPool.Capacity = defaultCapacity;
-        }
-
         [Test]
         public void TestPoolRecycling()
         {
@@ -34,95 +19,6 @@ namespace Mirror.Tests
             {
                 Assert.That(Reader, Is.SameAs(firstReader), "Pool should reuse the Reader");
             }
-        }
-
-        [Test]
-        public void PoolCanGetMoreReadersThanPoolSize()
-        {
-            NetworkReaderPool.Capacity = 5;
-
-            const int testReaderCount = 10;
-            PooledNetworkReader[] Readers = new PooledNetworkReader[testReaderCount];
-
-            for (int i = 0; i < testReaderCount; i++)
-            {
-                Readers[i] = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            }
-
-            // Make sure all Readers are different
-            Assert.That(Readers.Distinct().Count(), Is.EqualTo(testReaderCount));
-        }
-
-        [Test]
-        public void PoolReUsesReadersUpToSizeLimit()
-        {
-            NetworkReaderPool.Capacity = 1;
-
-            // get 2 Readers
-            PooledNetworkReader a = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            PooledNetworkReader b = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-
-            // recycle all
-            NetworkReaderPool.Recycle(a);
-            NetworkReaderPool.Recycle(b);
-
-            // get 2 new ones
-            PooledNetworkReader c = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            PooledNetworkReader d = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-
-            // exactly one should be reused, one should be new
-            bool cReused = c == a || c == b;
-            bool dReused = d == a || d == b;
-            Assert.That((cReused && !dReused) ||
-                        (!cReused && dReused));
-        }
-
-        // if we shrink the capacity, the internal 'next' needs to be adjusted
-        // to the new capacity so we don't get a IndexOutOfRangeException
-        [Test]
-        public void ShrinkCapacity()
-        {
-            NetworkReaderPool.Capacity = 2;
-
-            // get Reader and recycle so we have 2 in there, hence 'next' is at limit
-            PooledNetworkReader a = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            PooledNetworkReader b = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            NetworkReaderPool.Recycle(a);
-            NetworkReaderPool.Recycle(b);
-
-            // shrink
-            NetworkReaderPool.Capacity = 1;
-
-            // get one. should return the only one which is still in there.
-            PooledNetworkReader c = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            Assert.That(c, !Is.Null);
-            Assert.That(c == a || c == b);
-        }
-
-        // if we grow the capacity, things should still work fine
-        [Test]
-        public void GrowCapacity()
-        {
-            NetworkReaderPool.Capacity = 1;
-
-            // create and recycle one
-            PooledNetworkReader a = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            NetworkReaderPool.Recycle(a);
-
-            // grow capacity
-            NetworkReaderPool.Capacity = 2;
-
-            // get two
-            PooledNetworkReader b = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            PooledNetworkReader c = NetworkReaderPool.GetReader(default(ArraySegment<byte>));
-            Assert.That(b, !Is.Null);
-            Assert.That(c, !Is.Null);
-
-            // exactly one should be reused, one should be new
-            bool bReused = b == a;
-            bool cReused = c == a;
-            Assert.That((bReused && !cReused) ||
-                        (!bReused && cReused));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkWriterPoolTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterPoolTest.cs
@@ -1,24 +1,9 @@
-using System.Linq;
 using NUnit.Framework;
 
 namespace Mirror.Tests
 {
     public class NetworkWriterPoolTest
     {
-        int defaultCapacity;
-
-        [SetUp]
-        public void SetUp()
-        {
-            defaultCapacity = NetworkWriterPool.Capacity;
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            NetworkWriterPool.Capacity = defaultCapacity;
-        }
-
         [Test]
         public void TestPoolRecycling()
         {
@@ -33,95 +18,6 @@ namespace Mirror.Tests
             {
                 Assert.That(writer, Is.SameAs(firstWriter), "Pool should reuse the writer");
             }
-        }
-
-        [Test]
-        public void PoolCanGetMoreWritersThanPoolSize()
-        {
-            NetworkWriterPool.Capacity = 5;
-
-            const int testWriterCount = 10;
-            PooledNetworkWriter[] writers = new PooledNetworkWriter[testWriterCount];
-
-            for (int i = 0; i < testWriterCount; i++)
-            {
-                writers[i] = NetworkWriterPool.GetWriter();
-            }
-
-            // Make sure all writers are different
-            Assert.That(writers.Distinct().Count(), Is.EqualTo(testWriterCount));
-        }
-
-        [Test]
-        public void PoolReUsesWritersUpToSizeLimit()
-        {
-            NetworkWriterPool.Capacity = 1;
-
-            // get 2 writers
-            PooledNetworkWriter a = NetworkWriterPool.GetWriter();
-            PooledNetworkWriter b = NetworkWriterPool.GetWriter();
-
-            // recycle all
-            NetworkWriterPool.Recycle(a);
-            NetworkWriterPool.Recycle(b);
-
-            // get 2 new ones
-            PooledNetworkWriter c = NetworkWriterPool.GetWriter();
-            PooledNetworkWriter d = NetworkWriterPool.GetWriter();
-
-            // exactly one should be reused, one should be new
-            bool cReused = c == a || c == b;
-            bool dReused = d == a || d == b;
-            Assert.That((cReused && !dReused) ||
-                        (!cReused && dReused));
-        }
-
-        // if we shrink the capacity, the internal 'next' needs to be adjusted
-        // to the new capacity so we don't get a IndexOutOfRangeException
-        [Test]
-        public void ShrinkCapacity()
-        {
-            NetworkWriterPool.Capacity = 2;
-
-            // get writer and recycle so we have 2 in there, hence 'next' is at limit
-            PooledNetworkWriter a = NetworkWriterPool.GetWriter();
-            PooledNetworkWriter b = NetworkWriterPool.GetWriter();
-            NetworkWriterPool.Recycle(a);
-            NetworkWriterPool.Recycle(b);
-
-            // shrink
-            NetworkWriterPool.Capacity = 1;
-
-            // get one. should return the only one which is still in there.
-            PooledNetworkWriter c = NetworkWriterPool.GetWriter();
-            Assert.That(c, !Is.Null);
-            Assert.That(c == a || c == b);
-        }
-
-        // if we grow the capacity, things should still work fine
-        [Test]
-        public void GrowCapacity()
-        {
-            NetworkWriterPool.Capacity = 1;
-
-            // create and recycle one
-            PooledNetworkWriter a = NetworkWriterPool.GetWriter();
-            NetworkWriterPool.Recycle(a);
-
-            // grow capacity
-            NetworkWriterPool.Capacity = 2;
-
-            // get two
-            PooledNetworkWriter b = NetworkWriterPool.GetWriter();
-            PooledNetworkWriter c = NetworkWriterPool.GetWriter();
-            Assert.That(b, !Is.Null);
-            Assert.That(c, !Is.Null);
-
-            // exactly one should be reused, one should be new
-            bool bReused = b == a;
-            bool cReused = c == a;
-            Assert.That((bReused && !cReused) ||
-                        (!bReused && cReused));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/PoolTests.cs
+++ b/Assets/Mirror/Tests/Editor/PoolTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    public class PoolTests
+    {
+        Pool<string> pool;
+
+        [SetUp]
+        public void SetUp()
+        {
+            pool = new Pool<string>(() => "new string");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            pool = null;
+        }
+
+        [Test]
+        public void TakeFromEmpty()
+        {
+            // taking from an empty pool should give us a completely new string
+            Assert.That(pool.Take(), Is.EqualTo("new string"));
+        }
+
+        [Test]
+        public void ReturnAndTake()
+        {
+            // returning and then taking should get the returned one, not a
+            // newly generated one.
+            pool.Return("returned");
+            Assert.That(pool.Take(), Is.EqualTo("returned"));
+        }
+
+        [Test]
+        public void Count()
+        {
+            Assert.That(pool.Count, Is.EqualTo(0));
+            pool.Return("returned");
+            Assert.That(pool.Count, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/PoolTests.cs.meta
+++ b/Assets/Mirror/Tests/Editor/PoolTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 566efeb4786e4449bb70c041baf39b42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
keep it simple & stupid.
Stack<T> has already been built into C#, might as well use it.
same functionality while removing 200 LOC that we won't have to worry about anymore.