### PR TITLE
feat: Provide user friendly error with undefined reader/writer

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -35,6 +35,8 @@ namespace Mirror
     /// </summary>
     public class NetworkReader
     {
+        private static readonly ILogger logger = LogFactory.GetLogger<NetworkReader>();
+
         // internal buffer
         // byte[] pointer would work, but we use ArraySegment to also support
         // the ArraySegment constructor
@@ -105,7 +107,13 @@ namespace Mirror
         /// <returns></returns>
         public T Read<T>()
         {
-            return Reader<T>.read(this);
+            Func<NetworkReader, T> readerDelegate = Reader<T>.read;
+            if (readerDelegate == null)
+            {
+                logger.LogError($"No reader found for {typeof(T)}. Use a type supported by Mirror or define a custom reader");
+                return default;
+            }
+            return readerDelegate(this);
         }
     }
 

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -35,7 +35,7 @@ namespace Mirror
     /// </summary>
     public class NetworkReader
     {
-        private static readonly ILogger logger = LogFactory.GetLogger<NetworkReader>();
+        static readonly ILogger logger = LogFactory.GetLogger<NetworkReader>();
 
         // internal buffer
         // byte[] pointer would work, but we use ArraySegment to also support

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -24,6 +24,8 @@ namespace Mirror
     /// </summary>
     public class NetworkWriter
     {
+        private ILogger logger = LogFactory.GetLogger<NetworkWriter>();
+
         public const int MaxStringLength = 1024 * 32;
 
         // create writer immediately with it's own buffer so no one can mess with it and so that we can resize it.
@@ -149,7 +151,15 @@ namespace Mirror
         /// <param name="value"></param>
         public void Write<T>(T value)
         {
-            Writer<T>.write(this, value);
+            Action<NetworkWriter, T> writeDelegate = Writer<T>.write;
+            if (writeDelegate == null)
+            {
+                logger.LogError($"No writer found for {typeof(T)}. Use a type supported by Mirror or define a custom writer");
+            }
+            else
+            {
+                writeDelegate(this, value);
+            }
         }
     }
 

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -24,7 +24,7 @@ namespace Mirror
     /// </summary>
     public class NetworkWriter
     {
-        private ILogger logger = LogFactory.GetLogger<NetworkWriter>();
+        private static readonly ILogger logger = LogFactory.GetLogger<NetworkWriter>();
 
         public const int MaxStringLength = 1024 * 32;
 

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -24,7 +24,7 @@ namespace Mirror
     /// </summary>
     public class NetworkWriter
     {
-        private static readonly ILogger logger = LogFactory.GetLogger<NetworkWriter>();
+       static readonly ILogger logger = LogFactory.GetLogger<NetworkWriter>();
 
         public const int MaxStringLength = 1024 * 32;
 


### PR DESCRIPTION
Previously this just gave NRE, which does not help the user address the problem.

provides a better error for #2411 