### PR TITLE
fix: using mathematics in commands and rpcs

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -269,8 +269,8 @@ namespace Mirror.Weaver
                 // mismatched ldloca/ldloc for struct/class combinations is invalid IL, which causes crash at runtime
                 OpCode opcode = variable.IsValueType ? OpCodes.Ldloca : OpCodes.Ldloc;
                 worker.Append(worker.Create(opcode, 0));
-
-                MethodReference readFunc = GetReadFunc(field.FieldType);
+                TypeReference fieldTypeRef = Weaver.CurrentAssembly.MainModule.ImportReference(field.FieldType);
+                MethodReference readFunc = GetReadFunc(fieldTypeRef);
                 if (readFunc != null)
                 {
                     worker.Append(worker.Create(OpCodes.Ldarg_0));

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -218,7 +218,8 @@ namespace Mirror.Weaver
             uint fields = 0;
             foreach (FieldDefinition field in variable.FindAllPublicFields())
             {
-                MethodReference writeFunc = GetWriteFunc(field.FieldType);
+                TypeReference fieldTypeRef = Weaver.CurrentAssembly.MainModule.ImportReference(field.FieldType);
+                MethodReference writeFunc = GetWriteFunc(fieldTypeRef);
                 // need this null check till later PR when GetWriteFunc throws exception instead
                 if (writeFunc == null) { return false; }
 


### PR DESCRIPTION
Generating readers and writers for structs in other assemblies
could sometimes cause a
```
System.ArgumentException: Member 'xxx' is declared in another module and needs to be imported
```

This in particular affected unity mathematics.

fixes #2406