### PR TITLE
MessagePacker.UnpackMessage renamed to Unpack for consistency with Pack and because the class is already named MessagePacker anyway

### DIFF
--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -43,7 +43,7 @@ namespace Mirror
         // -> pass NetworkReader so it's less strange if we create it in here
         //    and pass it upwards.
         // -> NetworkReader will point at content afterwards!
-        public static bool UnpackMessage(NetworkReader messageReader, out int msgType)
+        public static bool Unpack(NetworkReader messageReader, out int msgType)
         {
             // read message type (varint)
             try
@@ -58,7 +58,10 @@ namespace Mirror
             }
         }
 
-        // wraps a handler function with extra code
+        [Obsolete("MessagePacker.UnpackMessage was renamed to Unpack for consistency with Pack.")]
+        public static bool UnpackMessage(NetworkReader messageReader, out int msgType) =>
+            Unpack(messageReader, out msgType);
+
         internal static NetworkMessageDelegate WrapHandler<T, C>(Action<C, T> handler, bool requireAuthenication)
             where T : struct, NetworkMessage
             where C : NetworkConnection

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -242,7 +242,7 @@ namespace Mirror
             // unpack message
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(buffer))
             {
-                if (MessagePacker.UnpackMessage(networkReader, out int msgType))
+                if (MessagePacker.Unpack(networkReader, out int msgType))
                 {
                     // logging
                     if (logger.LogEnabled()) logger.Log("ConnectionRecv " + this + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));

--- a/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
@@ -99,7 +99,7 @@ namespace Mirror.Tests
             byte[] data = PackToByteArray(message);
             NetworkReader reader = new NetworkReader(data);
 
-            bool result = MessagePacker.UnpackMessage(reader, out int msgType);
+            bool result = MessagePacker.Unpack(reader, out int msgType);
             Assert.That(result, Is.EqualTo(true));
             Assert.That(msgType, Is.EqualTo(BitConverter.ToUInt16(data, 0)));
         }
@@ -109,7 +109,7 @@ namespace Mirror.Tests
         {
             // try an invalid message
             NetworkReader reader2 = new NetworkReader(new byte[0]);
-            bool result2 = MessagePacker.UnpackMessage(reader2, out int msgType2);
+            bool result2 = MessagePacker.Unpack(reader2, out int msgType2);
             Assert.That(result2, Is.EqualTo(false));
             Assert.That(msgType2, Is.EqualTo(0));
         }


### PR DESCRIPTION
rename + obsolete.
MessagePacker.Unpack is easier to use than MessagePacker.UnpackMessage, which is unnecessarily verbose.