### PR TITLE
Finding handler inside TransportReceive so we dont need to check bool

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -245,10 +245,12 @@ namespace Mirror
                 if (MessagePacker.Unpack(reader, out int msgType))
                 {
                     // try to invoke the handler for that message
-                    if (InvokeHandler(msgType, reader, channelId))
+                    if (messageHandlers.TryGetValue(msgType, out NetworkMessageDelegate msgDelegate))
                     {
+                        msgDelegate.Invoke(this, reader, channelId);
                         lastMessageTime = Time.time;
                     }
+                    else if (logger.LogEnabled()) logger.Log("Unknown message ID " + msgType + " " + this + ". May be due to no existing RegisterHandler for this message.");
                 }
                 else
                 {


### PR DESCRIPTION
Planning to remove `InvokeHandler<T>` in https://github.com/vis2k/Mirror/pull/2397 so the code in InvokeHandler is only done in 1 place. Moving it to TransportReceive avoids the need for the return true/false