### PR TITLE
perf: NetworkWriter/Reader Write/ReadBlittable<T> for 4-6x performance improvement!

### DIFF
--- a/Assets/Mirror/Runtime/Mirror.asmdef
+++ b/Assets/Mirror/Runtime/Mirror.asmdef
@@ -8,7 +8,7 @@
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace Mirror
@@ -57,13 +58,43 @@ namespace Mirror
             buffer = segment;
         }
 
-        public byte ReadByte()
+        // ReadBlittable<T> from DOTSNET
+        // this is extremely fast, but only works for blittable types.
+        //
+        // Benchmark: see NetworkWriter.WriteBlittable!
+        //
+        // Note:
+        //   ReadBlittable assumes same endianness for server & client.
+        //   All Unity 2018+ platforms are little endian.
+        public unsafe T ReadBlittable<T>()
+            where T : unmanaged
         {
-            if (Position + 1 > buffer.Count)
+            // check if blittable for safety
+#if UNITY_EDITOR
+            if (!UnsafeUtility.IsBlittable(typeof(T)))
             {
-                throw new EndOfStreamException("ReadByte out of range:" + ToString());
+                throw new ArgumentException(typeof(T) + " is not blittable!");
             }
-            return buffer.Array[buffer.Offset + Position++];
+#endif
+
+            // calculate size
+            int size = sizeof(T);
+
+            // enough data to read?
+            if (Position + size > buffer.Count)
+            {
+                throw new EndOfStreamException($"ReadBlittable<{typeof(T)}> out of range: {ToString()}");
+            }
+
+            // read blittable
+            T value;
+            fixed (byte* ptr = &buffer.Array[buffer.Offset + Position])
+            {
+                // cast buffer to a T* pointer and then read from it.
+                value = *(T*)ptr;
+            }
+            Position += size;
+            return value;
         }
 
         // read bytes into the passed buffer
@@ -128,61 +159,19 @@ namespace Mirror
         // 1000 readers after: 0.8MB GC, 18ms
         static readonly UTF8Encoding encoding = new UTF8Encoding(false, true);
 
-        public static byte ReadByte(this NetworkReader reader) => reader.ReadByte();
-        public static sbyte ReadSByte(this NetworkReader reader) => (sbyte)reader.ReadByte();
-        public static char ReadChar(this NetworkReader reader) => (char)reader.ReadUInt16();
-        public static bool ReadBoolean(this NetworkReader reader) => reader.ReadByte() != 0;
-        public static short ReadInt16(this NetworkReader reader) => (short)reader.ReadUInt16();
-        public static ushort ReadUInt16(this NetworkReader reader)
-        {
-            ushort value = 0;
-            value |= reader.ReadByte();
-            value |= (ushort)(reader.ReadByte() << 8);
-            return value;
-        }
-        public static int ReadInt32(this NetworkReader reader) => (int)reader.ReadUInt32();
-        public static uint ReadUInt32(this NetworkReader reader)
-        {
-            uint value = 0;
-            value |= reader.ReadByte();
-            value |= (uint)(reader.ReadByte() << 8);
-            value |= (uint)(reader.ReadByte() << 16);
-            value |= (uint)(reader.ReadByte() << 24);
-            return value;
-        }
-        public static long ReadInt64(this NetworkReader reader) => (long)reader.ReadUInt64();
-        public static ulong ReadUInt64(this NetworkReader reader)
-        {
-            ulong value = 0;
-            value |= reader.ReadByte();
-            value |= ((ulong)reader.ReadByte()) << 8;
-            value |= ((ulong)reader.ReadByte()) << 16;
-            value |= ((ulong)reader.ReadByte()) << 24;
-            value |= ((ulong)reader.ReadByte()) << 32;
-            value |= ((ulong)reader.ReadByte()) << 40;
-            value |= ((ulong)reader.ReadByte()) << 48;
-            value |= ((ulong)reader.ReadByte()) << 56;
-            return value;
-        }
-        public static float ReadSingle(this NetworkReader reader)
-        {
-            UIntFloat converter = new UIntFloat();
-            converter.intValue = reader.ReadUInt32();
-            return converter.floatValue;
-        }
-        public static double ReadDouble(this NetworkReader reader)
-        {
-            UIntDouble converter = new UIntDouble();
-            converter.longValue = reader.ReadUInt64();
-            return converter.doubleValue;
-        }
-        public static decimal ReadDecimal(this NetworkReader reader)
-        {
-            UIntDecimal converter = new UIntDecimal();
-            converter.longValue1 = reader.ReadUInt64();
-            converter.longValue2 = reader.ReadUInt64();
-            return converter.decimalValue;
-        }
+        public static byte ReadByte(this NetworkReader reader) => reader.ReadBlittable<byte>();
+        public static sbyte ReadSByte(this NetworkReader reader) => reader.ReadBlittable<sbyte>();
+        public static char ReadChar(this NetworkReader reader) => (char)reader.ReadBlittable<short>(); // char isn't blittable
+        public static bool ReadBoolean(this NetworkReader reader) => reader.ReadBlittable<byte>() != 0; // bool isn't blittable
+        public static short ReadInt16(this NetworkReader reader) => reader.ReadBlittable<short>();
+        public static ushort ReadUInt16(this NetworkReader reader) => reader.ReadBlittable<ushort>();
+        public static int ReadInt32(this NetworkReader reader) =>  reader.ReadBlittable<int>();
+        public static uint ReadUInt32(this NetworkReader reader) => reader.ReadBlittable<uint>();
+        public static long ReadInt64(this NetworkReader reader) => reader.ReadBlittable<long>();
+        public static ulong ReadUInt64(this NetworkReader reader) => reader.ReadBlittable<ulong>();
+        public static float ReadSingle(this NetworkReader reader) => reader.ReadBlittable<float>();
+        public static double ReadDouble(this NetworkReader reader) => reader.ReadBlittable<double>();
+        public static decimal ReadDecimal(this NetworkReader reader) => reader.ReadBlittable<decimal>();
 
         // note: this will throw an ArgumentException if an invalid utf8 string is sent
         // null support, see NetworkWriter
@@ -226,40 +215,18 @@ namespace Mirror
             return count == 0 ? default : reader.ReadBytesSegment(checked((int)(count - 1u)));
         }
 
-        public static Vector2 ReadVector2(this NetworkReader reader) => new Vector2(reader.ReadSingle(), reader.ReadSingle());
-        public static Vector3 ReadVector3(this NetworkReader reader) => new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-        public static Vector4 ReadVector4(this NetworkReader reader) => new Vector4(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-        public static Vector2Int ReadVector2Int(this NetworkReader reader) => new Vector2Int(reader.ReadInt32(), reader.ReadInt32());
-        public static Vector3Int ReadVector3Int(this NetworkReader reader) => new Vector3Int(reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32());
-        public static Color ReadColor(this NetworkReader reader) => new Color(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-        public static Color32 ReadColor32(this NetworkReader reader) => new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
-        public static Quaternion ReadQuaternion(this NetworkReader reader) => new Quaternion(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-        public static Rect ReadRect(this NetworkReader reader) => new Rect(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-        public static Plane ReadPlane(this NetworkReader reader) => new Plane(reader.ReadVector3(), reader.ReadSingle());
-        public static Ray ReadRay(this NetworkReader reader) => new Ray(reader.ReadVector3(), reader.ReadVector3());
-
-        public static Matrix4x4 ReadMatrix4x4(this NetworkReader reader)
-        {
-            return new Matrix4x4
-            {
-                m00 = reader.ReadSingle(),
-                m01 = reader.ReadSingle(),
-                m02 = reader.ReadSingle(),
-                m03 = reader.ReadSingle(),
-                m10 = reader.ReadSingle(),
-                m11 = reader.ReadSingle(),
-                m12 = reader.ReadSingle(),
-                m13 = reader.ReadSingle(),
-                m20 = reader.ReadSingle(),
-                m21 = reader.ReadSingle(),
-                m22 = reader.ReadSingle(),
-                m23 = reader.ReadSingle(),
-                m30 = reader.ReadSingle(),
-                m31 = reader.ReadSingle(),
-                m32 = reader.ReadSingle(),
-                m33 = reader.ReadSingle()
-            };
-        }
+        public static Vector2 ReadVector2(this NetworkReader reader) => reader.ReadBlittable<Vector2>();
+        public static Vector3 ReadVector3(this NetworkReader reader) => reader.ReadBlittable<Vector3>();
+        public static Vector4 ReadVector4(this NetworkReader reader) => reader.ReadBlittable<Vector4>();
+        public static Vector2Int ReadVector2Int(this NetworkReader reader) => reader.ReadBlittable<Vector2Int>();
+        public static Vector3Int ReadVector3Int(this NetworkReader reader) => reader.ReadBlittable<Vector3Int>();
+        public static Color ReadColor(this NetworkReader reader) => reader.ReadBlittable<Color>();
+        public static Color32 ReadColor32(this NetworkReader reader) => reader.ReadBlittable<Color32>();
+        public static Quaternion ReadQuaternion(this NetworkReader reader) => reader.ReadBlittable<Quaternion>();
+        public static Rect ReadRect(this NetworkReader reader) => reader.ReadBlittable<Rect>();
+        public static Plane ReadPlane(this NetworkReader reader) => reader.ReadBlittable<Plane>();
+        public static Ray ReadRay(this NetworkReader reader) => reader.ReadBlittable<Ray>();
+        public static Matrix4x4 ReadMatrix4x4(this NetworkReader reader) => reader.ReadBlittable<Matrix4x4>();
 
         public static byte[] ReadBytes(this NetworkReader reader, int count)
         {

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -78,6 +78,11 @@ namespace Mirror
 #endif
 
             // calculate size
+            //   sizeof(T) gets the managed size at compile time.
+            //   Marshal.SizeOf<T> gets the unmanaged size at runtime (slow).
+            // => our 1mio writes benchmark is 6x slower with Marshal.SizeOf<T>
+            // => for blittable types, sizeof(T) is even recommended:
+            // https://docs.microsoft.com/en-us/dotnet/standard/native-interop/best-practices
             int size = sizeof(T);
 
             // enough data to read?

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace Mirror
@@ -128,10 +129,55 @@ namespace Mirror
             return new ArraySegment<byte>(buffer, 0, length);
         }
 
-        public void WriteByte(byte value)
+        // WriteBlittable<T> from DOTSNET.
+        // this is extremely fast, but only works for blittable types.
+        //
+        // Benchmark:
+        //   WriteQuaternion x 100k, Macbook Pro 2015 @ 2.2Ghz, Unity 2018 LTS (debug mode)
+        //
+        //                | Median |  Min  |  Max  |  Avg  |  Std  | (ms)
+        //     before     |  30.35 | 29.86 | 48.99 | 32.54 |  4.93 |
+        //     blittable* |   5.69 |  5.52 | 27.51 |  7.78 |  5.65 |
+        //
+        //     * without IsBlittable check
+        //     => 4-6x faster!
+        //
+        //   WriteQuaternion x 100k, Macbook Pro 2015 @ 2.2Ghz, Unity 2020.1 (release mode)
+        //
+        //                | Median |  Min  |  Max  |  Avg  |  Std  | (ms)
+        //     before     |   9.41 |  8.90 | 23.02 | 10.72 |  3.07 |
+        //     blittable* |   1.48 |  1.40 | 16.03 |  2.60 |  2.71 |
+        //
+        //     * without IsBlittable check
+        //     => 6x faster!
+        //
+        // Note:
+        //   WriteBlittable assumes same endianness for server & client.
+        //   All Unity 2018+ platforms are little endian.
+        public unsafe void WriteBlittable<T>(T value)
+            where T : unmanaged
         {
-            EnsureLength(position + 1);
-            buffer[position++] = value;
+            // check if blittable for safety
+#if UNITY_EDITOR
+            if (!UnsafeUtility.IsBlittable(typeof(T)))
+            {
+                Debug.LogError(typeof(T) + " is not blittable!");
+                return;
+            }
+#endif
+            // calculate size
+            int size = sizeof(T);
+
+            // ensure length
+            EnsureLength(position + size);
+
+            // write blittable
+            fixed (byte* ptr = &buffer[Position])
+            {
+                // cast buffer to T* pointer, then assign value to the area
+                *(T*)ptr = value;
+            }
+            Position += size;
         }
 
         // for byte arrays with consistent size, where the reader knows how many to read
@@ -175,76 +221,19 @@ namespace Mirror
         static readonly UTF8Encoding encoding = new UTF8Encoding(false, true);
         static readonly byte[] stringBuffer = new byte[NetworkWriter.MaxStringLength];
 
-        public static void WriteByte(this NetworkWriter writer, byte value) => writer.WriteByte(value);
-
-        public static void WriteSByte(this NetworkWriter writer, sbyte value) => writer.WriteByte((byte)value);
-
-        public static void WriteChar(this NetworkWriter writer, char value) => writer.WriteUInt16(value);
-
-        public static void WriteBoolean(this NetworkWriter writer, bool value) => writer.WriteByte((byte)(value ? 1 : 0));
-
-        public static void WriteUInt16(this NetworkWriter writer, ushort value)
-        {
-            writer.WriteByte((byte)value);
-            writer.WriteByte((byte)(value >> 8));
-        }
-
+        public static void WriteByte(this NetworkWriter writer, byte value) => writer.WriteBlittable(value);
+        public static void WriteSByte(this NetworkWriter writer, sbyte value) => writer.WriteBlittable(value);
+        public static void WriteChar(this NetworkWriter writer, char value) => writer.WriteBlittable((short)value); // char isn't blittable
+        public static void WriteBoolean(this NetworkWriter writer, bool value) => writer.WriteBlittable((byte)(value ? 1 : 0)); // bool isn't blittable
+        public static void WriteUInt16(this NetworkWriter writer, ushort value) => writer.WriteBlittable(value);
         public static void WriteInt16(this NetworkWriter writer, short value) => writer.WriteUInt16((ushort)value);
-
-        public static void WriteUInt32(this NetworkWriter writer, uint value)
-        {
-            writer.WriteByte((byte)value);
-            writer.WriteByte((byte)(value >> 8));
-            writer.WriteByte((byte)(value >> 16));
-            writer.WriteByte((byte)(value >> 24));
-        }
-
-        public static void WriteInt32(this NetworkWriter writer, int value) => writer.WriteUInt32((uint)value);
-
-        public static void WriteUInt64(this NetworkWriter writer, ulong value)
-        {
-            writer.WriteByte((byte)value);
-            writer.WriteByte((byte)(value >> 8));
-            writer.WriteByte((byte)(value >> 16));
-            writer.WriteByte((byte)(value >> 24));
-            writer.WriteByte((byte)(value >> 32));
-            writer.WriteByte((byte)(value >> 40));
-            writer.WriteByte((byte)(value >> 48));
-            writer.WriteByte((byte)(value >> 56));
-        }
-
-        public static void WriteInt64(this NetworkWriter writer, long value) => writer.WriteUInt64((ulong)value);
-
-        public static void WriteSingle(this NetworkWriter writer, float value)
-        {
-            UIntFloat converter = new UIntFloat
-            {
-                floatValue = value
-            };
-            writer.WriteUInt32(converter.intValue);
-        }
-
-        public static void WriteDouble(this NetworkWriter writer, double value)
-        {
-            UIntDouble converter = new UIntDouble
-            {
-                doubleValue = value
-            };
-            writer.WriteUInt64(converter.longValue);
-        }
-
-        public static void WriteDecimal(this NetworkWriter writer, decimal value)
-        {
-            // the only way to read it without allocations is to both read and
-            // write it with the FloatConverter (which is not binary compatible
-            // to writer.Write(decimal), hence why we use it here too)
-            UIntDecimal converter = new UIntDecimal
-            {
-                decimalValue = value
-            };
-            writer.WriteUInt64(converter.longValue1);
-            writer.WriteUInt64(converter.longValue2);
-        }
+        public static void WriteUInt32(this NetworkWriter writer, uint value) => writer.WriteBlittable(value);
+        public static void WriteInt32(this NetworkWriter writer, int value) => writer.WriteBlittable(value);
+        public static void WriteUInt64(this NetworkWriter writer, ulong value) => writer.WriteBlittable(value);
+        public static void WriteInt64(this NetworkWriter writer, long value) => writer.WriteBlittable(value);
+        public static void WriteSingle(this NetworkWriter writer, float value) => writer.WriteBlittable(value);
+        public static void WriteDouble(this NetworkWriter writer, double value) => writer.WriteBlittable(value);
+        public static void WriteDecimal(this NetworkWriter writer, decimal value) => writer.WriteBlittable(value);
 
         public static void WriteString(this NetworkWriter writer, string value)
         {
@@ -302,103 +291,18 @@ namespace Mirror
             writer.WriteBytesAndSize(buffer.Array, buffer.Offset, buffer.Count);
         }
 
-        public static void WriteVector2(this NetworkWriter writer, Vector2 value)
-        {
-            writer.WriteSingle(value.x);
-            writer.WriteSingle(value.y);
-        }
-
-        public static void WriteVector3(this NetworkWriter writer, Vector3 value)
-        {
-            writer.WriteSingle(value.x);
-            writer.WriteSingle(value.y);
-            writer.WriteSingle(value.z);
-        }
-
-        public static void WriteVector4(this NetworkWriter writer, Vector4 value)
-        {
-            writer.WriteSingle(value.x);
-            writer.WriteSingle(value.y);
-            writer.WriteSingle(value.z);
-            writer.WriteSingle(value.w);
-        }
-
-        public static void WriteVector2Int(this NetworkWriter writer, Vector2Int value)
-        {
-            writer.WriteInt32(value.x);
-            writer.WriteInt32(value.y);
-        }
-
-        public static void WriteVector3Int(this NetworkWriter writer, Vector3Int value)
-        {
-            writer.WriteInt32(value.x);
-            writer.WriteInt32(value.y);
-            writer.WriteInt32(value.z);
-        }
-
-        public static void WriteColor(this NetworkWriter writer, Color value)
-        {
-            writer.WriteSingle(value.r);
-            writer.WriteSingle(value.g);
-            writer.WriteSingle(value.b);
-            writer.WriteSingle(value.a);
-        }
-
-        public static void WriteColor32(this NetworkWriter writer, Color32 value)
-        {
-            writer.WriteByte(value.r);
-            writer.WriteByte(value.g);
-            writer.WriteByte(value.b);
-            writer.WriteByte(value.a);
-        }
-
-        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value)
-        {
-            writer.WriteSingle(value.x);
-            writer.WriteSingle(value.y);
-            writer.WriteSingle(value.z);
-            writer.WriteSingle(value.w);
-        }
-
-        public static void WriteRect(this NetworkWriter writer, Rect value)
-        {
-            writer.WriteSingle(value.xMin);
-            writer.WriteSingle(value.yMin);
-            writer.WriteSingle(value.width);
-            writer.WriteSingle(value.height);
-        }
-
-        public static void WritePlane(this NetworkWriter writer, Plane value)
-        {
-            writer.WriteVector3(value.normal);
-            writer.WriteSingle(value.distance);
-        }
-
-        public static void WriteRay(this NetworkWriter writer, Ray value)
-        {
-            writer.WriteVector3(value.origin);
-            writer.WriteVector3(value.direction);
-        }
-
-        public static void WriteMatrix4x4(this NetworkWriter writer, Matrix4x4 value)
-        {
-            writer.WriteSingle(value.m00);
-            writer.WriteSingle(value.m01);
-            writer.WriteSingle(value.m02);
-            writer.WriteSingle(value.m03);
-            writer.WriteSingle(value.m10);
-            writer.WriteSingle(value.m11);
-            writer.WriteSingle(value.m12);
-            writer.WriteSingle(value.m13);
-            writer.WriteSingle(value.m20);
-            writer.WriteSingle(value.m21);
-            writer.WriteSingle(value.m22);
-            writer.WriteSingle(value.m23);
-            writer.WriteSingle(value.m30);
-            writer.WriteSingle(value.m31);
-            writer.WriteSingle(value.m32);
-            writer.WriteSingle(value.m33);
-        }
+        public static void WriteVector2(this NetworkWriter writer, Vector2 value) => writer.WriteBlittable(value);
+        public static void WriteVector3(this NetworkWriter writer, Vector3 value) => writer.WriteBlittable(value);
+        public static void WriteVector4(this NetworkWriter writer, Vector4 value) => writer.WriteBlittable(value);
+        public static void WriteVector2Int(this NetworkWriter writer, Vector2Int value) => writer.WriteBlittable(value);
+        public static void WriteVector3Int(this NetworkWriter writer, Vector3Int value) => writer.WriteBlittable(value);
+        public static void WriteColor(this NetworkWriter writer, Color value) => writer.WriteBlittable(value);
+        public static void WriteColor32(this NetworkWriter writer, Color32 value) => writer.WriteBlittable(value);
+        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value) => writer.WriteBlittable(value);
+        public static void WriteRect(this NetworkWriter writer, Rect value) => writer.WriteBlittable(value);
+        public static void WritePlane(this NetworkWriter writer, Plane value) => writer.WriteBlittable(value);
+        public static void WriteRay(this NetworkWriter writer, Ray value) => writer.WriteBlittable(value);
+        public static void WriteMatrix4x4(this NetworkWriter writer, Matrix4x4 value) => writer.WriteBlittable(value);
 
         public static void WriteGuid(this NetworkWriter writer, Guid value)
         {

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -154,6 +154,7 @@ namespace Mirror
         // Note:
         //   WriteBlittable assumes same endianness for server & client.
         //   All Unity 2018+ platforms are little endian.
+        //   => run NetworkWriterTests.BlittableOnThisPlatform() to verify!
         public unsafe void WriteBlittable<T>(T value)
             where T : unmanaged
         {

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -166,6 +166,11 @@ namespace Mirror
             }
 #endif
             // calculate size
+            //   sizeof(T) gets the managed size at compile time.
+            //   Marshal.SizeOf<T> gets the unmanaged size at runtime (slow).
+            // => our 1mio writes benchmark is 6x slower with Marshal.SizeOf<T>
+            // => for blittable types, sizeof(T) is even recommended:
+            // https://docs.microsoft.com/en-us/dotnet/standard/native-interop/best-practices
             int size = sizeof(T);
 
             // ensure length

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -32,38 +32,4 @@ namespace Mirror
         public const int DefaultReliable = 0;
         public const int DefaultUnreliable = 1;
     }
-
-    // -- helpers for float conversion without allocations --
-    [StructLayout(LayoutKind.Explicit)]
-    internal struct UIntFloat
-    {
-        [FieldOffset(0)]
-        public float floatValue;
-
-        [FieldOffset(0)]
-        public uint intValue;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    internal struct UIntDouble
-    {
-        [FieldOffset(0)]
-        public double doubleValue;
-
-        [FieldOffset(0)]
-        public ulong longValue;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    internal struct UIntDecimal
-    {
-        [FieldOffset(0)]
-        public ulong longValue1;
-
-        [FieldOffset(8)]
-        public ulong longValue2;
-
-        [FieldOffset(0)]
-        public decimal decimalValue;
-    }
 }

--- a/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
+++ b/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
@@ -14,7 +14,7 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": true,
     "precompiledReferences": [
         "NSubstitute.dll",

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -23,6 +23,43 @@ namespace Mirror.Tests
         }
         */
 
+        struct TestStruct
+        {
+            public int data;
+            public byte data2;
+        }
+
+        [Test]
+        public unsafe void BlittableOnThisPlatform()
+        {
+            // we assume NetworkWriter.WriteBlittable<T> to behave the same on
+            // all platforms:
+            // - need to be little endian (atm all Unity platforms are)
+            // - padded structs need to be same size across all platforms
+            //   (C# int, byte, etc. should be same on all platforms, and
+            //    C# should do the same padding on all platforms)
+            //   https://kalapos.net/Blog/ShowPost/DotNetConceptOfTheWeek13_DotNetMemoryLayout
+            // => let's have a test that we can run on different platforms to
+            //    be 100% sure
+
+            // let's assume little endian.
+            // it would also be ok if server and client are both big endian,
+            // but that's extremely unlikely.
+            Assert.That(BitConverter.IsLittleEndian, Is.True);
+
+            // TestStruct biggest member is 'int' = 4 bytes.
+            // so C# aligns it to 4 bytes, hence does padding for the byte:
+            //   0 int
+            //   1 int
+            //   2 int
+            //   3 int
+            //   4 byte
+            //   5 padding
+            //   6 padding
+            //   7 padding
+            Assert.That(sizeof(TestStruct), Is.EqualTo(8));
+        }
+
         [Test]
         public void TestWritingSmallMessage()
         {


### PR DESCRIPTION
Write/ReadBlittable<T> from DOTSNET.

**Benchmark:**
<img width="689" alt="2020-11-17_21-36-54@2x" src="https://user-images.githubusercontent.com/16416509/99396719-0d5e3400-291d-11eb-9953-4f02930cb65d.png">

**Reasons to use Blittable**
+ 4-6x faster within Unity versions
+ (2020.1 + Blittable is 10x faster than 2018.4 without Blittable)
+ The code is a lot cleaner.
+ Removes 160 LOC
+ All Unity 2018+ platforms are little endian
+ This has been heavily tested in DOTSNET
+ Non-Blittable types still work fine
+ Invisible change to the user
+ No more UIntFloat etc. conversion structs
+ The more complex the type, the more significant the performance gain compared to serializing each member manually
+ Will allow us to reduce generated weaver code later. All blittable types can simply use WriteBlittable.

It's 4-6x performance for free. Would be silly not to use it.

**Unity Platform Endianness**
  [Little] Windows
  [Little] Mac(Intel)
  [Little] Mac(Apple Silicon)
  [Little] Linux(Intel)
  [Little] Android
  [Little] iOS
  [Little] UWP
  [Little] PS4
  [Little] XBOX ONE
  [Little] Nintendo Switch
  [Little] WebGL
  [Little] Android TV
  [Little] tvOS @ Apple A10