### PR TITLE
Calling Register from RegisterWriteFunc and adding comments

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -26,6 +26,13 @@ namespace Mirror.Weaver
             readFuncs[dataType.FullName] = methodReference;
         }
 
+        static void RegisterReadFunc(TypeReference typeReference, MethodDefinition newReaderFunc)
+        {
+            Register(typeReference, newReaderFunc);
+
+            Weaver.WeaveLists.generateContainerClass.Methods.Add(newReaderFunc);
+        }
+
         /// <summary>
         /// Finds existing reader for type, if non exists trys to create one
         /// <para>This method is recursive</para>
@@ -122,13 +129,6 @@ namespace Mirror.Weaver
             }
 
             return GenerateClassOrStructReadFunction(variableReference);
-        }
-
-        static void RegisterReadFunc(TypeReference typeReference, MethodDefinition newReaderFunc)
-        {
-            readFuncs[typeReference.FullName] = newReaderFunc;
-
-            Weaver.WeaveLists.generateContainerClass.Methods.Add(newReaderFunc);
         }
 
         static MethodDefinition GenerateEnumReadFunc(TypeReference variable)

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -28,7 +28,7 @@ namespace Mirror.Weaver
 
         static void RegisterWriteFunc(TypeReference typeReference, MethodDefinition newWriterFunc)
         {
-            writeFuncs[typeReference.FullName] = newWriterFunc;
+            Register(typeReference, newWriterFunc);
 
             Weaver.WeaveLists.generateContainerClass.Methods.Add(newWriterFunc);
         }


### PR DESCRIPTION
Having near identical lines in these functions is confusing at first glace. Having RegisterWriteFunc call Register makes it more clear exactly what is going on

Adding doc comments to explain when each method should be called