### PR TITLE
feat: maxConnections can now be set after the server has started

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using kcp2k;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
-using kcp2k;
 
 namespace Mirror
 {
@@ -97,13 +97,25 @@ namespace Mirror
         [Tooltip("Network Address where the client should connect to the server. Server does not use this for anything.")]
         public string networkAddress = "localhost";
 
+        [FormerlySerializedAs("m_MaxConnections")]
+        [FormerlySerializedAs("maxConnections")] // renamed 2020-11-21
+        [Tooltip("Maximum number of concurrent connections.")]
+        [SerializeField] int _maxConnections = 4;
+
         /// <summary>
         /// The maximum number of concurrent network connections to support.
         /// <para>This effects the memory usage of the network layer.</para>
+        /// <para>Setting this property will also set <see cref="NetworkServer.maxConnections"/></para>
         /// </summary>
-        [FormerlySerializedAs("m_MaxConnections")]
-        [Tooltip("Maximum number of concurrent connections.")]
-        public int maxConnections = 4;
+        public int maxConnections
+        {
+            get => _maxConnections;
+            set
+            {
+                _maxConnections = value;
+                NetworkServer.maxConnections = value;
+            }
+        }
 
         // This value is passed to NetworkServer in SetupServer
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -21,7 +21,13 @@ namespace Mirror
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkServer));
 
         static bool initialized;
-        static int maxConnections;
+
+        /// <summary>
+        /// Max number of connects NetworkServer will accept
+        /// <para>If a new client tries to connect it will be disconnected immediately</para>
+        /// <para>This limit does include the host client, but the host bypasses the check and can always connect</para>
+        /// </summary>
+        public static int maxConnections;
 
         /// <summary>
         /// The connection to the host mode client (if any).


### PR DESCRIPTION
* NetworkServer.maxConnections is now public
* NetworkManager.maxConnections is now a property that updates NetworkServer.maxConnections when set
* old field now use SerializeField so it shows up in inspector while being private. the new property should be used instead of the field when changing it via code

fixes: https://github.com/vis2k/Mirror/issues/2448