### PR TITLE
fix: prevent allocation of massive array

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -359,7 +359,7 @@ namespace Mirror
         public static T[] ReadArray<T>(this NetworkReader reader)
         {
             int length = reader.ReadInt32();
-            if (length < 0)
+            if (length < 0 || length + reader.Position > reader.Length)
                 return null;
             T[] result = new T[length];
             for (int i = 0; i < length; i++)

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -359,15 +359,21 @@ namespace Mirror
         public static T[] ReadArray<T>(this NetworkReader reader)
         {
             int length = reader.ReadInt32();
+
+            //  we write -1 for null
+            if (length < 0)
+                return null;
+            
+            // todo throw an exception for other negative values (we never write them, likely to be attacker)
+
             // this assumes that a reader for T reads atleast 1 bytes
             // we can't know the exact size of T because it could have a user created reader
             // NOTE: dont add to length as it could overflow if value is int.max
             if (length > reader.Length - reader.Position)
             {
-                throw new EndOfStreamException($"Received array that is too large {length}");
+                throw new EndOfStreamException($"Received array that is too large: {length}");
             }
-            if (length < 0)
-                return null;
+
             T[] result = new T[length];
             for (int i = 0; i < length; i++)
             {

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -361,10 +361,11 @@ namespace Mirror
             int length = reader.ReadInt32();
             // this assumes that a reader for T reads atleast 1 bytes
             // we can't know the exact size of T because it could have a user created reader
-            if (reader.Position + length > reader.Length)
+            // NOTE: dont add to length as it could overflow if value is int.max
+            if (length > reader.Length - reader.Position)
             {
                 throw new EndOfStreamException($"Received array that is too large {length}");
-            }            
+            }
             if (length < 0)
                 return null;
             T[] result = new T[length];

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -359,7 +359,11 @@ namespace Mirror
         public static T[] ReadArray<T>(this NetworkReader reader)
         {
             int length = reader.ReadInt32();
-            if (length < 0 || length + reader.Position > reader.Length)
+            if (reader.Position + length > reader.Length)
+            {
+                throw new EndOfStreamException($"Received array that is too large {length}");
+            }            
+            if (length < 0)
                 return null;
             T[] result = new T[length];
             for (int i = 0; i < length; i++)

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -359,6 +359,8 @@ namespace Mirror
         public static T[] ReadArray<T>(this NetworkReader reader)
         {
             int length = reader.ReadInt32();
+            // this assumes that a reader for T reads atleast 1 bytes
+            // we can't know the exact size of T because it could have a user created reader
             if (reader.Position + length > reader.Length)
             {
                 throw new EndOfStreamException($"Received array that is too large {length}");

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Mirror.Tests.RemoteAttrributeTest;
 using NUnit.Framework;
 using UnityEngine;
@@ -1007,6 +1008,32 @@ namespace Mirror.Tests
             NetworkReader reader = new NetworkReader(writer.ToArray());
             List<int> readList = reader.Read<List<int>>();
             Assert.That(readList, Is.Null);
+        }
+
+        [Test]
+        [Description("ReadArray should throw if it is trying to read more than length of segement, this is to stop allocation attacks")]
+        [TestCase(sizeof(int) * 4 + 1, Description = "min read count is 1 byte, 16 array bytes are writen so 17 should throw error")]
+        [TestCase(20_000)]
+        [TestCase(int.MaxValue)]
+        public void TestArrayThrowsIfLengthIsTooBig(int badLength)
+        {
+            NetworkWriter writer = new NetworkWriter();
+            WriteBadArray();
+
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            EndOfStreamException exception = Assert.Throws<EndOfStreamException>(() =>
+            {
+                _ = reader.ReadArray<int>();
+            });
+            Assert.That(exception, Has.Message.EqualTo($"Received array that is too large {badLength}"));
+
+            void WriteBadArray()
+            {
+                writer.WriteInt32(badLength);
+                int[] array = new int[] { 1, 2, 3, 4 };
+                for (int i = 0; i < array.Length; i++)
+                    writer.Write(array[i]);
+            }
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1015,6 +1015,7 @@ namespace Mirror.Tests
         [TestCase(sizeof(int) * 4 + 1, Description = "min read count is 1 byte, 16 array bytes are writen so 17 should throw error")]
         [TestCase(20_000)]
         [TestCase(int.MaxValue)]
+        [TestCase(int.MaxValue - 1)]
         // todo add fuzzy testing to check more values
         public void TestArrayThrowsIfLengthIsTooBig(int badLength)
         {

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1015,6 +1015,7 @@ namespace Mirror.Tests
         [TestCase(sizeof(int) * 4 + 1, Description = "min read count is 1 byte, 16 array bytes are writen so 17 should throw error")]
         [TestCase(20_000)]
         [TestCase(int.MaxValue)]
+        // todo add fuzzy testing to check more values
         public void TestArrayThrowsIfLengthIsTooBig(int badLength)
         {
             NetworkWriter writer = new NetworkWriter();

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1077,7 +1077,7 @@ namespace Mirror.Tests
             {
                 _ = reader.ReadArray<int>();
             });
-            Assert.That(exception, Has.Message.EqualTo($"Received array that is too large {badLength}"));
+            Assert.That(exception, Has.Message.EqualTo($"Received array that is too large: {badLength}"));
 
             void WriteBadArray()
             {


### PR DESCRIPTION
A poison message could contain an invalid length causing us to allocate massive arrays