### PR TITLE
IP Information boolean to display LAN and WAN

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -32,11 +32,10 @@ namespace Mirror
         public int offsetY;
         
         /// <summary>
-        /// Outputs the current devices IP to gui input, useful if your are host/server.
-        /// Only use the WAN check when necessary, as it uses an external service.
+        /// Outputs the current devices IP to gui input, only use the WAN check when necessary, as it uses an external service.
         /// For further connection information, visit: https://mirror-networking.com/docs/Articles/FAQ.html#how-to-connect
         /// </summary>
-        [Tooltip("localhost for games on same device, LAN for different devices same wifi, WAN for external connections. See summary for more information.")]
+        [Tooltip("Localhost for games on same device, LAN for different devices same wifi, WAN for external connections. See summary for more information.")]
         [SerializeField]
         private IPType _IPType = IPType.localhost;
         private string inputField; 

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -34,6 +34,7 @@ namespace Mirror
         /// <summary>
         /// Displays this devices IP information, useful if your are host/server.
         /// Only use this check when necessary, as it uses an external service for WAN.
+        /// For further connection information, visit: https://mirror-networking.com/docs/Articles/FAQ.html#how-to-connect
         /// </summary>
         [Tooltip("True displays your LAN and WAN IP address for debugging purposes in console log. See summary for more information.")]
         public bool getIPInformation = false;

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -1,6 +1,5 @@
 // vis2k: GUILayout instead of spacey += ...; removed Update hotkeys to avoid
 // confusion if someone accidentally presses one.
-using System.Collections;
 using UnityEngine;
 
 namespace Mirror
@@ -165,9 +164,8 @@ namespace Mirror
             }
         }
         
-        IEnumerator GetIPInformation()
+        System.Collections.IEnumerator GetIPInformation()
         {
-            
             using (UnityEngine.Networking.UnityWebRequest webRequest = UnityEngine.Networking.UnityWebRequest.Get("https://api.ipify.org/"))
             {
                 yield return webRequest.SendWebRequest();

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -40,7 +40,7 @@ namespace Mirror
         /// Only use the WAN check when necessary, as it uses an external service.
         /// For further connection information, visit: https://mirror-networking.com/docs/Articles/FAQ.html#how-to-connect
         /// </summary>
-        [Tooltip("localhost for games on same device, LAN for different devices same wifi, WAN for external connections. See summary for more information.")]
+        [Tooltip("localhost for games on same device, LAN for different devices same network, WAN for external connections. See summary for more information.")]
         [SerializeField]
         private IPType _IPType = IPType.localhost;
         private string inputField;

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -1,5 +1,7 @@
 // vis2k: GUILayout instead of spacey += ...; removed Update hotkeys to avoid
 // confusion if someone accidentally presses one.
+using System.Collections;
+using System.Net;
 using UnityEngine;
 
 namespace Mirror
@@ -189,17 +191,17 @@ namespace Mirror
 
         private void GetLanAddress()
         {
-            string hostName = System.Net.Dns.GetHostName();
-            System.Net.IPAddress iPAddress = System.Net.Dns.GetHostEntry(hostName).AddressList[0];
+            string hostName = Dns.GetHostName();
+            IPAddress iPAddress = Dns.GetHostEntry(hostName).AddressList[0];
             
             if (hostName != "" && iPAddress != null && iPAddress.ToString() != "")
             {
-                inputField = System.Net.Dns.GetHostEntry(hostName).AddressList[0].ToString();
+                inputField = Dns.GetHostEntry(hostName).AddressList[0].ToString();
                 manager.networkAddress = inputField;
             }
         }
         
-        System.Collections.IEnumerator GetWanAddress()
+        IEnumerator GetWanAddress()
         {
             using (UnityEngine.Networking.UnityWebRequest webRequest = UnityEngine.Networking.UnityWebRequest.Get("https://api.ipify.org/"))
             {

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -100,31 +100,40 @@ namespace Mirror
         {
             if (!NetworkClient.active)
             {
+            
+                GUILayout.BeginHorizontal();
+                {
+                    GUILayout.Label($"IP Type : {_ipType[_ipTypeSelectedIndex]}");
+                    {
+                        if (GUILayout.Button("▼"))
+                        {
+                            _ShowIpTypeDropdown = !_ShowIpTypeDropdown;
+                        }
+                    }
+                }
+                GUILayout.EndHorizontal();
+
                 if (_ShowIpTypeDropdown)
                 {
-                      using (var scope = new GUILayout.ScrollViewScope(scrollViewVector))
-                      {
+                    using (GUILayout.ScrollViewScope scope = new GUILayout.ScrollViewScope(scrollViewVector))
+                    {
                         scrollViewVector = scope.scrollPosition;
-
-                        GUILayout.Box("");
+                        for (int index = 0; index < _ipType.Length; index++)
                         {
-                            for (int index = 0; index < _ipType.Length; index++)
+                            if (!GUILayout.Button(_ipType[index]))
                             {
-                                if (!GUILayout.Button(_ipType[index]))
-                                {
-                                    continue;
-                                }
-                                else
-                                {
-                                    if (index == 0) { _IPType = IPType.localhost; }
-                                    else if (index == 1) { _IPType = IPType.LAN; }
-                                    else if (index == 2) { _IPType = IPType.WAN; }
-                                    SetIPInformation();
-                                }
-
-                                _ShowIpTypeDropdown = false;
-                                _ipTypeSelectedIndex = index;
+                                continue;
                             }
+                            else
+                            {
+                                if (index == 0) { _IPType = IPType.localhost; }
+                                else if (index == 1) { _IPType = IPType.LAN; }
+                                else if (index == 2) { _IPType = IPType.WAN; }
+                                SetIPInformation();
+                            }
+
+                            _ShowIpTypeDropdown = false;
+                            _ipTypeSelectedIndex = index;
                         }
                     }
                 }
@@ -142,10 +151,12 @@ namespace Mirror
                 GUILayout.BeginHorizontal();
                 if (GUILayout.Button("Client"))
                 {
+                    manager.networkAddress = inputField;
                     manager.StartClient();
                 }
-                inputField = manager.networkAddress;
-                manager.networkAddress = GUILayout.TextField(inputField);
+                
+                inputField = GUILayout.TextField(inputField);
+                
                 GUILayout.EndHorizontal();
 
                 // Server Only
@@ -158,16 +169,11 @@ namespace Mirror
                 {
                     if (GUILayout.Button("Server Only")) manager.StartServer();
                 }
-                
-                if (GUILayout.Button($"IP Type : {_ipType[_ipTypeSelectedIndex]}"))
-                {
-                    _ShowIpTypeDropdown = !_ShowIpTypeDropdown;
-                }
             }
             else
             {
                 // Connecting
-                GUILayout.Label("Connecting to " + manager.networkAddress + "..");
+                GUILayout.Label("Connecting to " + inputField + "..");
                 if (GUILayout.Button("Cancel Connection Attempt"))
                 {
                     manager.StopClient();
@@ -182,9 +188,13 @@ namespace Mirror
             {
                 GUILayout.Label("Server: active. Transport: " + Transport.activeTransport);
             }
-            if (NetworkClient.isConnected)
+            if (NetworkServer.active)
             {
-                GUILayout.Label("Client: address=" + manager.networkAddress);
+                GUILayout.Label("Server address: " + inputField);
+            }
+            else if (NetworkClient.isConnected)
+            {
+                GUILayout.Label("Connected to: " + manager.networkAddress);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -100,11 +100,6 @@ namespace Mirror
         {
             if (!NetworkClient.active)
             {
-                if (GUILayout.Button($"IP Type : {_ipType[_ipTypeSelectedIndex]}"))
-                {
-                    _ShowIpTypeDropdown = !_ShowIpTypeDropdown;
-                }
-
                 if (_ShowIpTypeDropdown)
                 {
                       using (var scope = new GUILayout.ScrollViewScope(scrollViewVector))
@@ -162,6 +157,11 @@ namespace Mirror
                 else
                 {
                     if (GUILayout.Button("Server Only")) manager.StartServer();
+                }
+                
+                if (GUILayout.Button($"IP Type : {_ipType[_ipTypeSelectedIndex]}"))
+                {
+                    _ShowIpTypeDropdown = !_ShowIpTypeDropdown;
                 }
             }
             else


### PR DESCRIPTION
Added to NetworkManagerHUD

True displays your LAN and WAN IP address for debugging purposes in console log, useful if you are host/server.
Should especially help with new Mirror users, and for debugging connection problems with them.
(many struggle to know how to get the IP's or the differences between them)

Tooltip and Summary included, boolean is false by default, and this feature is completely optional.
Feel free to offer any code improvements and grammar changes.

![Screenshot 2020-11-26 at 11 34 32](https://user-images.githubusercontent.com/57072365/100347538-71e45780-2fdd-11eb-8cd1-2fd0b0fafe73.jpg)

Related to this thread:
https://github.com/vis2k/Mirror/issues/2404

Edit: A few hours after posting this, and Punfish commenting that its not needed ( cheeky bugger :D  ), we had another trying to connect PC and Android device via localhost
https://discord.com/channels/343440455738064897/467961162558865408/781547322327826443
Honestly its a frequent thing, people not knowing the difference, the above HUD mod should help us say, okay now click start host/server on one device, that LAN/WAN IP it says in debug log, is what you type in the other devices client box, job done  :D