### PR TITLE
perf: NetworkTransform compresses rotation from 16 to 4 bytes.

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -75,11 +75,10 @@ namespace Mirror
         public static void SerializeIntoWriter(NetworkWriter writer, Vector3 position, Quaternion rotation, Vector3 scale)
         {
             // serialize position, rotation, scale
-            // note: we do NOT compress rotation.
-            //       we are CPU constrained, not bandwidth constrained.
-            //       the code needs to WORK for the next 5-10 years of development.
+            // => compress rotation from 4*4=16 to 4 bytes
+            // => less bandwidth = better CCU tests / scale
             writer.WriteVector3(position);
-            writer.WriteQuaternion(rotation);
+            writer.WriteUInt32(Compression.CompressQuaternion(rotation));
             writer.WriteVector3(scale);
         }
 
@@ -110,8 +109,9 @@ namespace Mirror
             DataPoint temp = new DataPoint
             {
                 // deserialize position, rotation, scale
+                // (rotation is compressed)
                 localPosition = reader.ReadVector3(),
-                localRotation = reader.ReadQuaternion(),
+                localRotation = Compression.DecompressQuaternion(reader.ReadUInt32()),
                 localScale = reader.ReadVector3(),
                 timeStamp = Time.time
             };

--- a/Assets/Mirror/Tests/Editor/NetworkTransformTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransformTest.cs
@@ -17,7 +17,7 @@ namespace Mirror.Tests
             NetworkTransformBase.SerializeIntoWriter(writer, position, rotation, scale);
             NetworkReader reader = new NetworkReader(writer.ToArray());
             Assert.That(reader.ReadVector3(), Is.EqualTo(position));
-            Assert.That(reader.ReadQuaternion(), Is.EqualTo(rotation));
+            Assert.That(reader.ReadUInt32(), Is.EqualTo(Compression.CompressQuaternion(rotation)));
             Assert.That(reader.ReadVector3(), Is.EqualTo(scale));
         }
     }


### PR DESCRIPTION
1024 entity rotations=> 4KB instead of 16KB

@James-Frowen implemented quaternion compression, might as well use it :)