### PR TITLE
Update Dev Server docs for Kcp Transport

### DIFF
--- a/doc/Articles/Guides/DevServer/AWS/index.md
+++ b/doc/Articles/Guides/DevServer/AWS/index.md
@@ -79,6 +79,7 @@ Create a new security group and you can give it your own name and description. A
 
 -   RDP with source "Anywhere", Description can be whatever but put it as Remote Desktop Program.
 -   Custom TCP Rule with port 7777 and source "Anywhere", Description can be whatever but put it as Mirror.
+    - If you're using the default Kcp Transport in your Network Manager instead of the Telepathy Transport, create the above rule as a Custom UDP rule instead.
 -   SSH with source "Anywhere", Description can be whatever but put it as SSH.
 
 SSH is not strictly necessary but can be used to remote connect to it through other means than the RDP.

--- a/doc/Articles/Guides/DevServer/gcloud/index.md
+++ b/doc/Articles/Guides/DevServer/gcloud/index.md
@@ -89,9 +89,8 @@ This will allow other people to connect to your server using its IP and port
     - Target tags: `mirror-demo`
     - Source filter: IP ranges
     - Source IP ranges: 0.0.0.0/0
-    - Protocols or ports: Select tcp, and then enter port 7777 into the field provided.
-
-> note tcp and port 7777 is default settings for telepathy, if you are using a different transport you will need to find out what settings that uses.
+    - Protocols or ports: Select TCP, and then enter port 7777 into the field provided.
+      - If you're using the default Kcp Transport in your Network Manager instead of the Telepathy Transport, then you will need to use UDP instead. If you are using a different transport or have configured it to use a different port then you will need to use those settings.
 
 ![Create network rule](./07-create-network-rule.jpg)
 


### PR DESCRIPTION
Now that Kcp Transport is the default for Mirror's Network Manager, let's update the docs to provide info on how setting up a dev server may be differ.