### PR TITLE
feat: allow types that inherit from Networkbehaviour to be used in syncvar's

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -120,6 +120,20 @@ namespace Mirror.Weaver
             return true;
         }
 
+        /// <summary>
+        /// Makes T => Variable and imports function
+        /// </summary>
+        /// <param name="generic"></param>
+        /// <param name="variableReference"></param>
+        /// <returns></returns>
+        public static MethodReference MakeGeneric(this MethodReference generic, TypeReference variableReference)
+        {
+            GenericInstanceMethod instance = new GenericInstanceMethod(generic);
+            instance.GenericArguments.Add(variableReference);
+
+            MethodReference readFunc = Weaver.CurrentAssembly.MainModule.ImportReference(instance);
+            return readFunc;
+        }
 
         /// <summary>
         /// Given a method of a generic class such as ArraySegment`T.get_Count,

--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -90,7 +90,8 @@ namespace Mirror.Weaver
         public static bool IsNetworkIdentityField(this TypeReference tr)
         {
             return tr.Is<UnityEngine.GameObject>()
-                || tr.Is<NetworkIdentity>();
+                || tr.Is<NetworkIdentity>()
+                || tr.IsDerivedFrom<NetworkBehaviour>();
         }
 
         public static bool CanBeResolved(this TypeReference parent)

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -142,10 +142,7 @@ namespace Mirror.Weaver
             // uses generic ReadNetworkBehaviour rather than having weaver create one for each NB
             MethodReference generic = WeaverTypes.readNetworkBehaviourGeneric;
 
-            GenericInstanceMethod instance = new GenericInstanceMethod(generic);
-            instance.GenericArguments.Add(variableReference);
-
-            MethodReference readFunc = Weaver.CurrentAssembly.MainModule.ImportReference(instance);
+            MethodReference readFunc = generic.MakeGeneric(variableReference);
 
             // register function so it is added to Reader<T>
             // use Register instead of RegisterWriteFunc because this is not a generated function

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -44,6 +44,9 @@ namespace Mirror.Weaver
         public static MethodReference getSyncVarGameObjectReference;
         public static MethodReference setSyncVarNetworkIdentityReference;
         public static MethodReference getSyncVarNetworkIdentityReference;
+        public static MethodReference syncVarNetworkBehaviourEqualReference;
+        public static MethodReference setSyncVarNetworkBehaviourReference;
+        public static MethodReference getSyncVarNetworkBehaviourReference;
         public static MethodReference registerCommandDelegateReference;
         public static MethodReference registerRpcDelegateReference;
         public static MethodReference getTypeReference;
@@ -116,6 +119,10 @@ namespace Mirror.Weaver
             getSyncVarGameObjectReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "GetSyncVarGameObject");
             setSyncVarNetworkIdentityReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "SetSyncVarNetworkIdentity");
             getSyncVarNetworkIdentityReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "GetSyncVarNetworkIdentity");
+            syncVarNetworkBehaviourEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "SyncVarNetworkBehaviourEqual");
+            setSyncVarNetworkBehaviourReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "SetSyncVarNetworkBehaviour");
+            getSyncVarNetworkBehaviourReference = Resolvers.ResolveMethod(NetworkBehaviourType, currentAssembly, "GetSyncVarNetworkBehaviour");
+
             registerCommandDelegateReference = Resolvers.ResolveMethod(RemoteCallHelperType, currentAssembly, "RegisterCommandDelegate");
             registerRpcDelegateReference = Resolvers.ResolveMethod(RemoteCallHelperType, currentAssembly, "RegisterRpcDelegate");
             TypeReference unityDebug = Import(typeof(UnityEngine.Debug));

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -329,6 +329,20 @@ namespace Mirror
             return reader.ReadNetworkBehaviour() as T;
         }
 
+        public static NetworkBehaviour.NetworkBehaviourSyncVar ReadNetworkBehaviourSyncVar(this NetworkReader reader)
+        {
+            uint netId = reader.ReadUInt32();
+            byte componentIndex = default;
+
+            // if netId is not 0, then index is also sent to read before returning
+            if (netId != 0)
+            {
+                componentIndex = reader.ReadByte();
+            }
+
+            return new NetworkBehaviour.NetworkBehaviourSyncVar(netId, componentIndex);
+        }
+
         public static List<T> ReadList<T>(this NetworkReader reader)
         {
             int length = reader.ReadInt32();

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -317,7 +317,7 @@ namespace Mirror
 
             if (!NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
             {
-                if (logger.WarnEnabled()) logger.LogFormat(LogType.Warning, "ReadNetworkIdentity netId:{0} not found in spawned", netId);
+                if (logger.WarnEnabled()) logger.LogFormat(LogType.Warning, "ReadNetworkBehaviour netId:{0} not found in spawned", netId);
                 return null;
             }
 

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -308,13 +308,19 @@ namespace Mirror
 
         public static NetworkBehaviour ReadNetworkBehaviour(this NetworkReader reader)
         {
-            NetworkIdentity identity = reader.ReadNetworkIdentity();
-            if (identity == null)
+            uint netId = reader.ReadUInt32();
+            if (netId == 0)
+                return null;
+
+            // if netId is not 0, then index is also sent to read before returning
+            byte componentIndex = reader.ReadByte();
+
+            if (!NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
             {
+                if (logger.WarnEnabled()) logger.LogFormat(LogType.Warning, "ReadNetworkIdentity netId:{0} not found in spawned", netId);
                 return null;
             }
 
-            byte componentIndex = reader.ReadByte();
             return identity.NetworkBehaviours[componentIndex];
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1012,15 +1012,32 @@ namespace Mirror.Tests
         [Test]
         public void ReadNetworkIdentityGivesWarningWhenNotFound()
         {
+            const uint netId = 423;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteUInt32(netId);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+
+            LogAssert.Expect(LogType.Warning, $"ReadNetworkIdentity netId:{netId} not found in spawned");
+            NetworkIdentity actual = reader.ReadNetworkIdentity();
+            Assert.That(actual, Is.Null);
+
+            Assert.That(reader.Position, Is.EqualTo(4), "should read 4 bytes");
+        }
+
+        [Test]
+        public void ReadNetworkBehaviourGivesWarningWhenNotFound()
+        {
             const uint netId = 424;
             NetworkWriter writer = new NetworkWriter();
             writer.WriteUInt32(netId);
             writer.WriteByte(0);
             NetworkReader reader = new NetworkReader(writer.ToArray());
 
-            LogAssert.Expect(LogType.Warning, $"ReadNetworkIdentity netId:{netId} not found in spawned");
-            NetworkIdentity actual = reader.ReadNetworkIdentity();
+            LogAssert.Expect(LogType.Warning, $"ReadNetworkBehaviour netId:{netId} not found in spawned");
+            NetworkBehaviour actual = reader.ReadNetworkBehaviour();
             Assert.That(actual, Is.Null);
+
+            Assert.That(reader.Position, Is.EqualTo(5), "should read 5 bytes when netId is not 0");
         }
 
         [Test]
@@ -1111,21 +1128,6 @@ namespace Mirror.Tests
                 NetworkIdentity.spawned.Remove(netId);
                 GameObject.DestroyImmediate(gameObject);
             }
-        }
-
-        [Test]
-        public void ReadNetworkBehaviourGivesWarningWhenNotFound()
-        {
-            const uint netId = 424;
-            NetworkWriter writer = new NetworkWriter();
-            writer.WriteUInt32(netId);
-            NetworkReader reader = new NetworkReader(writer.ToArray());
-
-            LogAssert.Expect(LogType.Warning, $"ReadNetworkBehaviour netId:{netId} not found in spawned");
-            NetworkBehaviour actual = reader.ReadNetworkBehaviour();
-            Assert.That(actual, Is.Null);
-
-            Assert.That(reader.Position, Is.EqualTo(5), "should read 5 bytes when netId is not 0");
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Mirror.Tests.RemoteAttrributeTest;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Mirror.Tests
 {
@@ -1009,6 +1010,20 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void ReadNetworkIdentityGivesWarningWhenNotFound()
+        {
+            const uint netId = 424;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteUInt32(netId);
+            writer.WriteByte(0);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+
+            LogAssert.Expect(LogType.Warning, $"ReadNetworkIdentity netId:{netId} not found in spawned");
+            NetworkIdentity actual = reader.ReadNetworkIdentity();
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
         public void TestNetworkBehaviour()
         {
             //setup
@@ -1056,7 +1071,9 @@ namespace Mirror.Tests
 
             NetworkReader reader = new NetworkReader(bytes);
             RpcNetworkIdentityBehaviour actual = reader.ReadNetworkBehaviour<RpcNetworkIdentityBehaviour>();
-            Assert.That(actual, Is.EqualTo(null), "Read should find the same behaviour as written");
+            Assert.That(actual, Is.Null, "should read null");
+
+            Assert.That(reader.Position, Is.EqualTo(4), "should read 4 bytes when netid is 0");
         }
 
         [Test]
@@ -1094,6 +1111,21 @@ namespace Mirror.Tests
                 NetworkIdentity.spawned.Remove(netId);
                 GameObject.DestroyImmediate(gameObject);
             }
+        }
+
+        [Test]
+        public void ReadNetworkBehaviourGivesWarningWhenNotFound()
+        {
+            const uint netId = 424;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteUInt32(netId);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+
+            LogAssert.Expect(LogType.Warning, $"ReadNetworkBehaviour netId:{netId} not found in spawned");
+            NetworkBehaviour actual = reader.ReadNetworkBehaviour();
+            Assert.That(actual, Is.Null);
+
+            Assert.That(reader.Position, Is.EqualTo(5), "should read 5 bytes when netId is not 0");
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -1,9 +1,9 @@
+using System;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Mirror.Tests
+namespace Mirror.Tests.SyncVarTests
 {
-
     class MockPlayer : NetworkBehaviour
     {
         public struct Guild
@@ -16,9 +16,29 @@ namespace Mirror.Tests
 
     }
 
-    public class SyncVarTest
+    class SyncVarGameObject : NetworkBehaviour
     {
+        [SyncVar]
+        public GameObject value;
+    }
+    class SyncVarNetworkIdentity : NetworkBehaviour
+    {
+        [SyncVar]
+        public NetworkIdentity value;
+    }
+    class SyncVarTransform : NetworkBehaviour
+    {
+        [SyncVar]
+        public Transform value;
+    }
+    class SyncVarNetworkBehaviour : NetworkBehaviour
+    {
+        [SyncVar]
+        public SyncVarNetworkBehaviour value;
+    }
 
+    public class SyncVarTest : SyncVarTestBase
+    {
         [Test]
         public void TestSettingStruct()
         {
@@ -136,6 +156,206 @@ namespace Mirror.Tests
 
             // check that the syncvars got updated
             Assert.That(player2.guild.name, Is.EqualTo("Back street boys"), "Data should be synchronized");
+        }
+
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncsGameobject(bool initialState)
+        {
+            SyncVarGameObject serverObject = CreateObject<SyncVarGameObject>();
+            SyncVarGameObject clientObject = CreateObject<SyncVarGameObject>();
+
+            GameObject serverValue = CreateNetworkIdentity(2044).gameObject;
+
+            serverObject.value = serverValue;
+            clientObject.value = null;
+
+            bool written = SyncToClient(serverObject, clientObject, initialState);
+            Assert.IsTrue(written);
+            Assert.That(clientObject.value, Is.EqualTo(serverValue));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncIdentity(bool initialState)
+        {
+            SyncVarNetworkIdentity serverObject = CreateObject<SyncVarNetworkIdentity>();
+            SyncVarNetworkIdentity clientObject = CreateObject<SyncVarNetworkIdentity>();
+
+            NetworkIdentity serverValue = CreateNetworkIdentity(2045);
+
+            serverObject.value = serverValue;
+            clientObject.value = null;
+
+            bool written = SyncToClient(serverObject, clientObject, initialState);
+            Assert.IsTrue(written);
+            Assert.That(clientObject.value, Is.EqualTo(serverValue));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncTransform(bool initialState)
+        {
+            SyncVarTransform serverObject = CreateObject<SyncVarTransform>();
+            SyncVarTransform clientObject = CreateObject<SyncVarTransform>();
+
+            Transform serverValue = CreateNetworkIdentity(2045).transform;
+
+            serverObject.value = serverValue;
+            clientObject.value = null;
+
+            bool written = SyncToClient(serverObject, clientObject, initialState);
+            Assert.IsTrue(written);
+            Assert.That(clientObject.value, Is.EqualTo(serverValue));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncsBehaviour(bool initialState)
+        {
+            SyncVarNetworkBehaviour serverObject = CreateObject<SyncVarNetworkBehaviour>();
+            SyncVarNetworkBehaviour clientObject = CreateObject<SyncVarNetworkBehaviour>();
+
+            SyncVarNetworkBehaviour serverValue = CreateNetworkIdentity(2046).gameObject.AddComponent<SyncVarNetworkBehaviour>();
+
+            serverObject.value = serverValue;
+            clientObject.value = null;
+
+            bool written = SyncToClient(serverObject, clientObject, initialState);
+            Assert.IsTrue(written);
+            Assert.That(clientObject.value, Is.EqualTo(serverValue));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncsMultipleBehaviour(bool initialState)
+        {
+            SyncVarNetworkBehaviour serverObject = CreateObject<SyncVarNetworkBehaviour>();
+            SyncVarNetworkBehaviour clientObject = CreateObject<SyncVarNetworkBehaviour>();
+
+            NetworkIdentity identity = CreateNetworkIdentity(2046);
+            SyncVarNetworkBehaviour behaviour1 = identity.gameObject.AddComponent<SyncVarNetworkBehaviour>();
+            SyncVarNetworkBehaviour behaviour2 = identity.gameObject.AddComponent<SyncVarNetworkBehaviour>();
+            // create array/set indexs
+            _ = identity.NetworkBehaviours;
+
+            int index1 = behaviour1.ComponentIndex;
+            int index2 = behaviour2.ComponentIndex;
+
+            // check components of same type have different indexes
+            Assert.That(index1, Is.Not.EqualTo(index2));
+
+            // check behaviour 1 can be synced
+            serverObject.value = behaviour1;
+            clientObject.value = null;
+
+            bool written1 = SyncToClient(serverObject, clientObject, initialState);
+            Assert.IsTrue(written1);
+            Assert.That(clientObject.value, Is.EqualTo(behaviour1));
+
+            // check that behaviour 2 can be synced
+            serverObject.value = behaviour2;
+            clientObject.value = null;
+
+            bool written2 = SyncToClient(serverObject, clientObject, initialState);
+            Assert.IsTrue(written2);
+            Assert.That(clientObject.value, Is.EqualTo(behaviour2));
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncVarCacheNetidForGameObject(bool initialState)
+        {
+            SyncVarCacheNetidForGeneric<SyncVarGameObject, GameObject>(
+                (obj) => obj.value,
+                (obj, value) => obj.value = value,
+                (identity) => identity.gameObject,
+                initialState
+            );
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncVarCacheNetidForIdentity(bool initialState)
+        {
+            SyncVarCacheNetidForGeneric<SyncVarNetworkIdentity, NetworkIdentity>(
+                (obj) => obj.value,
+                (obj, value) => obj.value = value,
+                (identity) => identity,
+                initialState
+            );
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncVarCacheNetidForTransform(bool initialState)
+        {
+            SyncVarCacheNetidForGeneric<SyncVarTransform, Transform>(
+                (obj) => obj.value,
+                (obj, value) => obj.value = value,
+                (identity) => identity.transform,
+                initialState
+            );
+        }
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SyncVarCacheNetidForBehaviour(bool initialState)
+        {
+            SyncVarCacheNetidForGeneric<SyncVarNetworkBehaviour, SyncVarNetworkBehaviour>(
+                (obj) => obj.value,
+                (obj, value) => obj.value = value,
+                (identity) => identity.gameObject.AddComponent<SyncVarNetworkBehaviour>(),
+                initialState
+            );
+        }
+
+        private void SyncVarCacheNetidForGeneric<TBehaviour, TValue>(
+            Func<TBehaviour, TValue> getField,
+            Action<TBehaviour, TValue> setField,
+            Func<NetworkIdentity, TValue> getCreatedValue,
+            bool initialState)
+            where TValue : UnityEngine.Object
+            where TBehaviour : NetworkBehaviour
+        {
+            TBehaviour serverObject = CreateObject<TBehaviour>();
+            TBehaviour clientObject = CreateObject<TBehaviour>();
+
+            NetworkIdentity identity = CreateNetworkIdentity(2047);
+            TValue serverValue = getCreatedValue(identity);
+
+            Assert.That(serverValue, Is.Not.Null, "getCreatedValue should not return null");
+
+            setField(serverObject, serverValue);
+            setField(clientObject, null);
+
+            // write server data
+            bool written = ServerWrite(serverObject, initialState, out ArraySegment<byte> data, out int writeLength);
+            Assert.IsTrue(written, "did not write");
+
+            // remove identity from collection
+            NetworkIdentity.spawned.Remove(identity.netId);
+
+            // read client data, this should be cached in field
+            ClientRead(clientObject, initialState, data, writeLength);
+
+            // check field shows as null
+            Assert.That(getField(clientObject), Is.EqualTo(null), "field should return null");
+
+            // add identity back to collection
+            NetworkIdentity.spawned.Add(identity.netId, identity);
+
+            // check field finds value
+            Assert.That(getField(clientObject), Is.EqualTo(serverValue), "fields should return serverValue");
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -297,6 +297,7 @@ namespace Mirror.Tests.SyncVarTests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
+        [Ignore("Transform backing field has not been implemented yet")]
         public void SyncVarCacheNetidForTransform(bool initialState)
         {
             SyncVarCacheNetidForGeneric<SyncVarTransform, Transform>(

--- a/Assets/Mirror/Tests/Editor/SyncVarTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTestBase.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mirror.Tests
+{
+    public class SyncVarTestBase
+    {
+        readonly List<GameObject> spawned = new List<GameObject>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (GameObject item in spawned)
+            {
+                GameObject.DestroyImmediate(item);
+            }
+            spawned.Clear();
+
+            NetworkIdentity.spawned.Clear();
+        }
+
+
+        protected T CreateObject<T>() where T : NetworkBehaviour
+        {
+            GameObject gameObject = new GameObject();
+            spawned.Add(gameObject);
+
+            gameObject.AddComponent<NetworkIdentity>();
+
+            T behaviour = gameObject.AddComponent<T>();
+            behaviour.syncInterval = 0f;
+
+            return behaviour;
+        }
+
+        protected NetworkIdentity CreateNetworkIdentity(uint netId)
+        {
+            GameObject gameObject = new GameObject();
+            spawned.Add(gameObject);
+
+            NetworkIdentity networkIdentity = gameObject.AddComponent<NetworkIdentity>();
+            networkIdentity.netId = netId;
+            NetworkIdentity.spawned[netId] = networkIdentity;
+            return networkIdentity;
+        }
+
+        /// <returns>If data was written by OnSerialize</returns>
+        public static bool SyncToClient<T>(T serverObject, T clientObject, bool initialState) where T : NetworkBehaviour
+        {
+            bool written = ServerWrite(serverObject, initialState, out ArraySegment<byte> data, out int writeLength);
+
+            ClientRead(clientObject, initialState, data, writeLength);
+
+            return written;
+        }
+
+        public static bool ServerWrite<T>(T serverObject, bool initialState, out ArraySegment<byte> data, out int writeLength) where T : NetworkBehaviour
+        {
+            NetworkWriter writer = new NetworkWriter();
+            bool written = serverObject.OnSerialize(writer, initialState);
+            writeLength = writer.Length;
+            data = writer.ToArraySegment();
+
+            return written;
+        }
+
+        public static void ClientRead<T>(T clientObject, bool initialState, ArraySegment<byte> data, int writeLength) where T : NetworkBehaviour
+        {
+            NetworkReader reader = new NetworkReader(data);
+            clientObject.OnDeserialize(reader, initialState);
+
+            int readLength = reader.Position;
+            Assert.That(writeLength == readLength,
+                $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n" +
+                $"    writeLength={writeLength}\n" +
+                $"    readLength={readLength}");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/SyncVarTestBase.cs.meta
+++ b/Assets/Mirror/Tests/Editor/SyncVarTestBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fbd8fff4a0795d49a0b122554ed6b13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Creating backing field for NetworkBehaviour syncvar so that they work the same as NetworkIdentity and GameObject syncvars

requires: 
https://github.com/vis2k/Mirror/pull/2475
https://github.com/vis2k/Mirror/pull/2476
https://github.com/vis2k/Mirror/pull/2478

