### PR TITLE
weaver: adding IsDerivedFrom for TypeReference

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -18,11 +18,11 @@ namespace Mirror.Weaver
 
         public static bool Is<T>(this TypeReference td) => Is(td, typeof(T));
 
-        public static bool IsDerivedFrom<T>(this TypeDefinition td) => IsDerivedFrom(td, typeof(T));
+        public static bool IsDerivedFrom<T>(this TypeReference tr) => IsDerivedFrom(tr, typeof(T));
 
-        public static bool IsDerivedFrom(this TypeDefinition td, Type baseClass)
+        public static bool IsDerivedFrom(this TypeReference tr, Type baseClass)
         {
-
+            TypeDefinition td = tr.Resolve();
             if (!td.IsClass)
                 return false;
 


### PR DESCRIPTION
Avoids the need to do `td.Resolve().IsDerivedFrom`, `TypeDefinition` inherits from `TypeReference`.  

this now matches `public static bool Is<T>(this TypeReference td) => Is(td, typeof(T));`

used in https://github.com/vis2k/Mirror/pull/2471