### PR TITLE
weaver: moving IsNetworkIdentityField to extensions

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -85,13 +85,12 @@ namespace Mirror.Weaver
         }
 
         /// <summary>
-        /// Is the field a NetworkIdentity or GameObject
+        /// Does type use netId as backing field
         /// </summary>
-        public static bool IsNetworkIdentityField(this FieldDefinition fd)
+        public static bool IsNetworkIdentityField(this TypeReference tr)
         {
-            TypeReference fieldType = fd.FieldType;
-            return fieldType.Is<UnityEngine.GameObject>()
-                || fieldType.Is<NetworkIdentity>();
+            return tr.Is<UnityEngine.GameObject>()
+                || tr.Is<NetworkIdentity>();
         }
 
         public static bool CanBeResolved(this TypeReference parent)

--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -84,6 +84,16 @@ namespace Mirror.Weaver
             return tr is ArrayType arrayType && arrayType.Rank > 1;
         }
 
+        /// <summary>
+        /// Is the field a NetworkIdentity or GameObject
+        /// </summary>
+        public static bool IsNetworkIdentityField(this FieldDefinition fd)
+        {
+            TypeReference fieldType = fd.FieldType;
+            return fieldType.Is<UnityEngine.GameObject>()
+                || fieldType.Is<NetworkIdentity>();
+        }
+
         public static bool CanBeResolved(this TypeReference parent)
         {
             while (parent != null)

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -500,7 +500,7 @@ namespace Mirror.Weaver
             // check for Hook function
             MethodDefinition hookMethod = SyncVarProcessor.GetHookMethod(netBehaviourSubclass, syncVar);
 
-            if (syncVar.IsNetworkIdentityField())
+            if (syncVar.FieldType.IsNetworkIdentityField())
             {
                 DeserializeNetworkIdentityField(syncVar, worker, deserialize, hookMethod);
             }

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -500,7 +500,7 @@ namespace Mirror.Weaver
             // check for Hook function
             MethodDefinition hookMethod = SyncVarProcessor.GetHookMethod(netBehaviourSubclass, syncVar);
 
-            if (IsNetworkIdentityField(syncVar))
+            if (syncVar.IsNetworkIdentityField())
             {
                 DeserializeNetworkIdentityField(syncVar, worker, deserialize, hookMethod);
             }
@@ -508,17 +508,6 @@ namespace Mirror.Weaver
             {
                 DeserializeNormalField(syncVar, worker, deserialize, hookMethod);
             }
-        }
-
-        /// <summary>
-        /// Is the field a NetworkIdentity or GameObject
-        /// </summary>
-        /// <param name="syncVar"></param>
-        /// <returns></returns>
-        static bool IsNetworkIdentityField(FieldDefinition syncVar)
-        {
-            return syncVar.FieldType.Is<UnityEngine.GameObject>() ||
-                   syncVar.FieldType.Is<NetworkIdentity>();
         }
 
         /// <summary>

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -266,7 +266,7 @@ namespace Mirror.Weaver
 
             // GameObject/NetworkIdentity SyncVars have a new field for netId
             FieldDefinition netIdField = null;
-            if (fd.IsNetworkIdentityField())
+            if (fd.FieldType.IsNetworkIdentityField())
             {
                 netIdField = new FieldDefinition("___" + fd.Name + "NetId",
                     FieldAttributes.Private,
@@ -296,7 +296,7 @@ namespace Mirror.Weaver
             // netId instead
             // -> only for GameObjects, otherwise an int syncvar's getter would
             //    end up in recursion.
-            if (fd.IsNetworkIdentityField())
+            if (fd.FieldType.IsNetworkIdentityField())
             {
                 Weaver.WeaveLists.replacementGetterProperties[fd] = get;
             }

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -266,8 +266,7 @@ namespace Mirror.Weaver
 
             // GameObject/NetworkIdentity SyncVars have a new field for netId
             FieldDefinition netIdField = null;
-            if (fd.FieldType.Is<UnityEngine.GameObject>() ||
-                fd.FieldType.Is<NetworkIdentity>())
+            if (fd.IsNetworkIdentityField())
             {
                 netIdField = new FieldDefinition("___" + fd.Name + "NetId",
                     FieldAttributes.Private,
@@ -297,8 +296,7 @@ namespace Mirror.Weaver
             // netId instead
             // -> only for GameObjects, otherwise an int syncvar's getter would
             //    end up in recursion.
-            if (fd.FieldType.Is<UnityEngine.GameObject>() ||
-                fd.FieldType.Is<NetworkIdentity>())
+            if (fd.IsNetworkIdentityField())
             {
                 Weaver.WeaveLists.replacementGetterProperties[fd] = get;
             }


### PR DESCRIPTION
removes duplicate code in `NetworkBehaviourProcessor` and `SyncVarProcessor`

used in https://github.com/vis2k/Mirror/pull/2471

