### PR TITLE
weaver: using TypeReference with comparer instead of string

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -8,22 +8,23 @@ namespace Mirror.Weaver
 {
     public static class Readers
     {
-        static Dictionary<string, MethodReference> readFuncs;
+        static Dictionary<TypeReference, MethodReference> readFuncs;
 
         public static void Init()
         {
-            readFuncs = new Dictionary<string, MethodReference>();
+            readFuncs = new Dictionary<TypeReference, MethodReference>(new TypeReferenceComparer());
         }
 
         internal static void Register(TypeReference dataType, MethodReference methodReference)
         {
-            string typeName = dataType.FullName;
-            if (readFuncs.ContainsKey(typeName))
+            if (readFuncs.ContainsKey(dataType))
             {
-                Weaver.Warning($"Registering a Read method for {typeName} when one already exists", methodReference);
+                Weaver.Warning($"Registering a Read method for {dataType.FullName} when one already exists", methodReference);
             }
 
-            readFuncs[dataType.FullName] = methodReference;
+            // we need to import type when we Initialize Readers so import here incase it is used anywhere else
+            TypeReference imported = Weaver.CurrentAssembly.MainModule.ImportReference(dataType);
+            readFuncs[imported] = methodReference;
         }
 
         static void RegisterReadFunc(TypeReference typeReference, MethodDefinition newReaderFunc)
@@ -41,7 +42,7 @@ namespace Mirror.Weaver
         /// <returns>Returns <see cref="MethodReference"/> or null</returns>
         public static MethodReference GetReadFunc(TypeReference variable)
         {
-            if (readFuncs.TryGetValue(variable.FullName, out MethodReference foundFunc))
+            if (readFuncs.TryGetValue(variable, out MethodReference foundFunc))
             {
                 return foundFunc;
             }
@@ -322,19 +323,20 @@ namespace Mirror.Weaver
             TypeReference funcRef = module.ImportReference(typeof(Func<,>));
             MethodReference funcConstructorRef = module.ImportReference(typeof(Func<,>).GetConstructors()[0]);
 
-            foreach (MethodReference readFunc in readFuncs.Values)
+            foreach (KeyValuePair<TypeReference, MethodReference> kvp in readFuncs)
             {
-                TypeReference dataType = readFunc.ReturnType;
+                TypeReference targetType = kvp.Key;
+                MethodReference readFunc = kvp.Value;
 
                 // create a Func<NetworkReader, T> delegate
                 worker.Append(worker.Create(OpCodes.Ldnull));
                 worker.Append(worker.Create(OpCodes.Ldftn, readFunc));
-                GenericInstanceType funcGenericInstance = funcRef.MakeGenericInstanceType(networkReaderRef, dataType);
+                GenericInstanceType funcGenericInstance = funcRef.MakeGenericInstanceType(networkReaderRef, targetType);
                 MethodReference funcConstructorInstance = funcConstructorRef.MakeHostInstanceGeneric(funcGenericInstance);
                 worker.Append(worker.Create(OpCodes.Newobj, funcConstructorInstance));
 
-                // save it in Writer<T>.write
-                GenericInstanceType genericInstance = genericReaderClassRef.MakeGenericInstanceType(dataType);
+                // save it in Reader<T>.read
+                GenericInstanceType genericInstance = genericReaderClassRef.MakeGenericInstanceType(targetType);
                 FieldReference specializedField = fieldRef.SpecializeField(genericInstance);
                 worker.Append(worker.Create(OpCodes.Stsfld, specializedField));
             }

--- a/Assets/Mirror/Editor/Weaver/TypeReferenceComparer.cs
+++ b/Assets/Mirror/Editor/Weaver/TypeReferenceComparer.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Mono.CecilX;
+
+namespace Mirror.Weaver
+{
+    /// <summary>
+    /// Comparers TypeReference using FullName
+    /// </summary>
+    public class TypeReferenceComparer : IEqualityComparer<TypeReference>
+    {
+        public bool Equals(TypeReference x, TypeReference y)
+        {
+            return x.FullName == y.FullName;
+        }
+
+        public int GetHashCode(TypeReference obj)
+        {
+            return obj.FullName.GetHashCode();
+        }
+    }
+}

--- a/Assets/Mirror/Editor/Weaver/TypeReferenceComparer.cs.meta
+++ b/Assets/Mirror/Editor/Weaver/TypeReferenceComparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55eb9eb8794946f4da7ad39788c9920b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/NetworkWriterCollectionTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterCollectionTest.cs
@@ -1,0 +1,26 @@
+using System;
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    public class NetworkWriterCollectionTest
+    {
+        [Test]
+        public void HasWriteFunctionForInt()
+        {
+            Assert.That(Writer<int>.write, Is.Not.Null, "int write function was not found");
+
+            Action<NetworkWriter, int> action = NetworkWriterExtensions.WriteInt32;
+            Assert.That(Writer<int>.write, Is.EqualTo(action), "int write function was incorrect value");
+        }
+
+        [Test]
+        public void HasReadFunctionForInt()
+        {
+            Assert.That(Reader<int>.read, Is.Not.Null, "int read function was not found");
+
+            Func<NetworkReader, int> action = NetworkReaderExtensions.ReadInt32;
+            Assert.That(Reader<int>.read, Is.EqualTo(action), "int read function was incorrect value");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkWriterCollectionTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterCollectionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfc7cd9211e6145418289e9c9572ce55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Using TypeReference  with IEqualityComparer instead of string to keep reference to type
* using targetType to initialize write/read functions
* test to make sure write function is set
