### PR TITLE
breaking(Transports): splitting transports to 2 monobehaviours

### DIFF
--- a/Assets/Mirror/Runtime/Transport/ClientTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/ClientTransport.cs
@@ -76,7 +76,7 @@ namespace Mirror
         /// but some transports might want to provide unreliable, encrypted, compressed, or any other feature
         /// as new channels</param>
         /// <param name="segment">The data to send to the server. Will be recycled after returning, so either use it directly or copy it internally. This allows for allocation-free sends!</param>
-        public abstract void ClientSend(int channelId, ArraySegment<byte> segment);
+        public abstract void Send(int channelId, ArraySegment<byte> segment);
 
         /// <summary>
         /// Disconnect this client from the server

--- a/Assets/Mirror/Runtime/Transport/ClientTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/ClientTransport.cs
@@ -81,7 +81,7 @@ namespace Mirror
         /// <summary>
         /// Disconnect this client from the server
         /// </summary>
-        public abstract void ClientDisconnect();
+        public abstract void Disconnect();
 
         /// <summary>
         /// The maximum packet size for a given channel.  Unreliable transports

--- a/Assets/Mirror/Runtime/Transport/ClientTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/ClientTransport.cs
@@ -97,11 +97,6 @@ namespace Mirror
         /// <returns>the size in bytes that can be sent via the provided channel</returns>
         public abstract int GetMaxPacketSize(int channelId = Channels.DefaultReliable);
 
-        /// <summary>
-        /// Shut down the transport, both as client and server
-        /// </summary>
-        public abstract void Shutdown();
-
         // block Update() to force Transports to use LateUpdate to avoid race
         // conditions. messages should be processed after all the game state
         // was processed in Update.
@@ -130,7 +125,7 @@ namespace Mirror
             // (when pressing Stop in the Editor, Unity keeps threads alive
             //  until we press Start again. so if Transports use threads, we
             //  really want them to end now and not after next start)
-            Shutdown();
+            Disconnect();
         }
     }
 }

--- a/Assets/Mirror/Runtime/Transport/ClientTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/ClientTransport.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using UnityEngine;
+
+namespace Mirror
+{
+    /// <summary>
+    /// Abstract transport layer component for client side
+    /// </summary>
+    public abstract class ClientTransport : MonoBehaviour
+    {
+        /// <summary>
+        /// The current transport used by Mirror.
+        /// </summary>
+        public static ClientTransport activeTransport;
+
+        /// <summary>
+        /// Is this transport available in the current platform?
+        /// <para>Some transports might only be available in mobile</para>
+        /// <para>Many will not work in webgl</para>
+        /// <para>Example usage: return Application.platform == RuntimePlatform.WebGLPlayer</para>
+        /// </summary>
+        /// <returns>True if this transport works in the current platform</returns>
+        public abstract bool Available();
+
+        /// <summary>
+        /// Notify subscribers when when this client establish a successful connection to the server
+        /// <para>callback()</para>
+        /// </summary>
+        public Action OnConnected = () => Debug.LogWarning("OnConnected called with no handler");
+
+        /// <summary>
+        /// Notify subscribers when this client receive data from the server
+        /// <para>callback(ArraySegment&lt;byte&gt; data, int channel)</para>
+        /// </summary>
+        public Action<ArraySegment<byte>, int> OnDataReceived = (data, channel) => Debug.LogWarning("OnDataReceived called with no handler");
+
+        /// <summary>
+        /// Notify subscribers when this client encounters an error communicating with the server
+        /// <para>callback(Exception e)</para>
+        /// </summary>
+        public Action<Exception> OnError = (error) => Debug.LogWarning("OnError called with no handler");
+
+        /// <summary>
+        /// Notify subscribers when this client disconnects from the server
+        /// <para>callback()</para>
+        /// </summary>
+        public Action OnDisconnected = () => Debug.LogWarning("OnDisconnected called with no handler");
+
+        /// <summary>
+        /// Determines if we are currently connected to the server
+        /// </summary>
+        /// <returns>True if a connection has been established to the server</returns>
+        public abstract bool Connected();
+
+        /// <summary>
+        /// Establish a connection to a server
+        /// </summary>
+        /// <param name="address">The IP address or FQDN of the server we are trying to connect to</param>
+        public abstract void Connect(string address);
+
+        /// <summary>
+        /// Establish a connection to a server
+        /// </summary>
+        /// <param name="uri">The address of the server we are trying to connect to</param>
+        public virtual void Connect(Uri uri)
+        {
+            // By default, to keep backwards compatibility, just connect to the host
+            // in the uri
+            Connect(uri.Host);
+        }
+
+        /// <summary>
+        /// Send data to the server
+        /// </summary>
+        /// <param name="channelId">The channel to use.  0 is the default channel,
+        /// but some transports might want to provide unreliable, encrypted, compressed, or any other feature
+        /// as new channels</param>
+        /// <param name="segment">The data to send to the server. Will be recycled after returning, so either use it directly or copy it internally. This allows for allocation-free sends!</param>
+        public abstract void ClientSend(int channelId, ArraySegment<byte> segment);
+
+        /// <summary>
+        /// Disconnect this client from the server
+        /// </summary>
+        public abstract void ClientDisconnect();
+
+        /// <summary>
+        /// The maximum packet size for a given channel.  Unreliable transports
+        /// usually can only deliver small packets. Reliable fragmented channels
+        /// can usually deliver large ones.
+        ///
+        /// GetMaxPacketSize needs to return a value at all times. Even if the
+        /// Transport isn't running, or isn't Available(). This is because
+        /// Fallback and Multiplex transports need to find the smallest possible
+        /// packet size at runtime.
+        /// </summary>
+        /// <param name="channelId">channel id</param>
+        /// <returns>the size in bytes that can be sent via the provided channel</returns>
+        public abstract int GetMaxPacketSize(int channelId = Channels.DefaultReliable);
+
+        /// <summary>
+        /// Shut down the transport, both as client and server
+        /// </summary>
+        public abstract void Shutdown();
+
+        // block Update() to force Transports to use LateUpdate to avoid race
+        // conditions. messages should be processed after all the game state
+        // was processed in Update.
+        // -> in other words: use LateUpdate!
+        // -> uMMORPG 480 CCU stress test: when bot machine stops, it causes
+        //    'Observer not ready for ...' log messages when using Update
+        // -> occupying a public Update() function will cause Warnings if a
+        //    transport uses Update.
+        //
+        // IMPORTANT: set script execution order to >1000 to call Transport's
+        //            LateUpdate after all others. Fixes race condition where
+        //            e.g. in uSurvival Transport would apply Cmds before
+        //            ShoulderRotation.LateUpdate, resulting in projectile
+        //            spawns at the point before shoulder rotation.
+#pragma warning disable UNT0001 // Empty Unity message
+        public void Update() { }
+#pragma warning restore UNT0001 // Empty Unity message
+
+        /// <summary>
+        /// called when quitting the application by closing the window / pressing stop in the editor
+        /// <para>virtual so that inheriting classes' OnApplicationQuit() can call base.OnApplicationQuit() too</para>
+        /// </summary>
+        public virtual void OnApplicationQuit()
+        {
+            // stop transport (e.g. to shut down threads)
+            // (when pressing Stop in the Editor, Unity keeps threads alive
+            //  until we press Start again. so if Transports use threads, we
+            //  really want them to end now and not after next start)
+            Shutdown();
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/Transport/ClientTransport.cs.meta
+++ b/Assets/Mirror/Runtime/Transport/ClientTransport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 099caf9cf0b1cea4aa07516206436abf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/Transport/ServerTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/ServerTransport.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using UnityEngine;
+
+namespace Mirror
+{
+    /// <summary>
+    /// Abstract transport layer component for server side
+    /// </summary>
+    public abstract class ServerTransport : MonoBehaviour
+    {
+        /// <summary>
+        /// The current transport used by Mirror.
+        /// </summary>
+        public static ServerTransport activeTransport;
+
+        /// <summary>
+        /// Is this transport available in the current platform?
+        /// <para>Some transports might only be available in mobile</para>
+        /// <para>Many will not work in webgl</para>
+        /// <para>Example usage: return Application.platform == RuntimePlatform.WebGLPlayer</para>
+        /// </summary>
+        /// <returns>True if this transport works in the current platform</returns>
+        public abstract bool Available();
+
+        /// <summary>
+        /// Retrieves the address of this server.
+        /// Useful for network discovery
+        /// </summary>
+        /// <returns>the url at which this server can be reached</returns>
+        public abstract Uri ServerUri();
+
+        /// <summary>
+        /// Notify subscribers when a client connects to this server
+        /// <para>callback(int connId)</para>
+        /// </summary>
+        public Action<int> OnConnected = (connId) => Debug.LogWarning("OnConnected called with no handler");
+
+        /// <summary>
+        /// Notify subscribers when this server receives data from the client
+        /// <para>callback(int connId, ArraySegment&lt;byte&gt; data, int channel)</para>
+        /// </summary>
+        public Action<int, ArraySegment<byte>, int> OnDataReceived = (connId, data, channel) => Debug.LogWarning("OnDataReceived called with no handler");
+
+        /// <summary>
+        /// Notify subscribers when this server has some problem communicating with the client
+        /// <para>callback(int connId, Exception e)</para>
+        /// </summary>
+        public Action<int, Exception> OnError = (connId, error) => Debug.LogWarning("OnError called with no handler");
+
+        /// <summary>
+        /// Notify subscribers when a client disconnects from this server
+        /// <para>callback(int connId)</para>
+        /// </summary>
+        public Action<int> OnDisconnected = (connId) => Debug.LogWarning("OnDisconnected called with no handler");
+
+        /// <summary>
+        /// Determines if the server is up and running
+        /// </summary>
+        /// <returns>true if the transport is ready for connections from clients</returns>
+        public abstract bool Active();
+
+        /// <summary>
+        /// Start listening for clients
+        /// </summary>
+        public abstract void Listen();
+
+        /// <summary>
+        /// Send data to a client.
+        /// </summary>
+        /// <param name="connectionId">The client connection id to send the data to</param>
+        /// <param name="channelId">The channel to be used.  Transports can use channels to implement
+        /// other features such as unreliable, encryption, compression, etc...</param>
+        /// <param name="data"></param>
+        public abstract void Send(int connectionId, int channelId, ArraySegment<byte> segment);
+
+        /// <summary>
+        /// Disconnect a client from this server.  Useful to kick people out.
+        /// </summary>
+        /// <param name="connectionId">the id of the client to disconnect</param>
+        /// <returns>true if the client was kicked</returns>
+        public abstract bool Disconnect(int connectionId);
+
+        /// <summary>
+        /// Get the client address
+        /// </summary>
+        /// <param name="connectionId">id of the client</param>
+        /// <returns>address of the client</returns>
+        public abstract string GetClientAddress(int connectionId);
+
+        /// <summary>
+        /// Stop listening for clients and disconnect all existing clients
+        /// </summary>
+        public abstract void Stop();
+
+        /// <summary>
+        /// The maximum packet size for a given channel.  Unreliable transports
+        /// usually can only deliver small packets. Reliable fragmented channels
+        /// can usually deliver large ones.
+        ///
+        /// GetMaxPacketSize needs to return a value at all times. Even if the
+        /// Transport isn't running, or isn't Available(). This is because
+        /// Fallback and Multiplex transports need to find the smallest possible
+        /// packet size at runtime.
+        /// </summary>
+        /// <param name="channelId">channel id</param>
+        /// <returns>the size in bytes that can be sent via the provided channel</returns>
+        public abstract int GetMaxPacketSize(int channelId = Channels.DefaultReliable);
+
+        /// <summary>
+        /// Shut down the transport, both as client and server
+        /// </summary>
+        public abstract void Shutdown();
+
+        // block Update() to force Transports to use LateUpdate to avoid race
+        // conditions. messages should be processed after all the game state
+        // was processed in Update.
+        // -> in other words: use LateUpdate!
+        // -> uMMORPG 480 CCU stress test: when bot machine stops, it causes
+        //    'Observer not ready for ...' log messages when using Update
+        // -> occupying a public Update() function will cause Warnings if a
+        //    transport uses Update.
+        //
+        // IMPORTANT: set script execution order to >1000 to call Transport's
+        //            LateUpdate after all others. Fixes race condition where
+        //            e.g. in uSurvival Transport would apply Cmds before
+        //            ShoulderRotation.LateUpdate, resulting in projectile
+        //            spawns at the point before shoulder rotation.
+#pragma warning disable UNT0001 // Empty Unity message
+        public void Update() { }
+#pragma warning restore UNT0001 // Empty Unity message
+
+        /// <summary>
+        /// called when quitting the application by closing the window / pressing stop in the editor
+        /// <para>virtual so that inheriting classes' OnApplicationQuit() can call base.OnApplicationQuit() too</para>
+        /// </summary>
+        public virtual void OnApplicationQuit()
+        {
+            // stop transport (e.g. to shut down threads)
+            // (when pressing Stop in the Editor, Unity keeps threads alive
+            //  until we press Start again. so if Transports use threads, we
+            //  really want them to end now and not after next start)
+            Shutdown();
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/Transport/ServerTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/ServerTransport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 namespace Mirror
@@ -106,11 +106,6 @@ namespace Mirror
         /// <returns>the size in bytes that can be sent via the provided channel</returns>
         public abstract int GetMaxPacketSize(int channelId = Channels.DefaultReliable);
 
-        /// <summary>
-        /// Shut down the transport, both as client and server
-        /// </summary>
-        public abstract void Shutdown();
-
         // block Update() to force Transports to use LateUpdate to avoid race
         // conditions. messages should be processed after all the game state
         // was processed in Update.
@@ -139,7 +134,7 @@ namespace Mirror
             // (when pressing Stop in the Editor, Unity keeps threads alive
             //  until we press Start again. so if Transports use threads, we
             //  really want them to end now and not after next start)
-            Shutdown();
+            Stop();
         }
     }
 }

--- a/Assets/Mirror/Runtime/Transport/ServerTransport.cs.meta
+++ b/Assets/Mirror/Runtime/Transport/ServerTransport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7bb65062ab0ed946b388793e55c4da3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -37,6 +37,7 @@ namespace Mirror
     ///   </description></item>
     /// </list>
     /// </remarks>
+    [Obsolete("Use ClientTransport and ServerTransport instead")]
     public abstract class Transport : MonoBehaviour
     {
         /// <summary>


### PR DESCRIPTION
* Allows Available and GetMaxPacketSize to be different for server/client
* Drops prefix from methods

BREAKING CHANGE: Transports will need to use the new base classes