### PR TITLE
feat(Transport): Adding method that users can call to check for new messages

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -211,23 +211,32 @@ namespace Mirror
         /// </summary>
         public abstract void Shutdown();
 
-        // block Update() to force Transports to use LateUpdate to avoid race
-        // conditions. messages should be processed after all the game state
-        // was processed in Update.
-        // -> in other words: use LateUpdate!
-        // -> uMMORPG 480 CCU stress test: when bot machine stops, it causes
-        //    'Observer not ready for ...' log messages when using Update
-        // -> occupying a public Update() function will cause Warnings if a
-        //    transport uses Update.
-        //
+        /// <summary>
+        /// Checks for new message and invokes ondata callback
+        /// </summary>
+        public abstract void CheckForMessages();
+
+        /// <summary>
+        /// Causes CheckForMessages to be called in LateUpdate
+        /// <para>
+        /// Using LateUpdate will avoid race conditions.
+        /// Message should be processed after all the game sate was processed in Update
+        /// </para>
+        /// </summary>
+        [Tooltip("Checks for new message in LateUpdate")]
+        public bool checkInLateUpdate = true;
+
+
         // IMPORTANT: set script execution order to >1000 to call Transport's
         //            LateUpdate after all others. Fixes race condition where
         //            e.g. in uSurvival Transport would apply Cmds before
         //            ShoulderRotation.LateUpdate, resulting in projectile
         //            spawns at the point before shoulder rotation.
-#pragma warning disable UNT0001 // Empty Unity message
-        public void Update() { }
-#pragma warning restore UNT0001 // Empty Unity message
+        public void LateUpdate()
+        {
+            if (checkInLateUpdate)
+                CheckForMessages();
+        }
 
         /// <summary>
         /// called when quitting the application by closing the window / pressing stop in the editor


### PR DESCRIPTION
This allows user to call `CheckForMessages` when they want incase their game want to call it multiple times per frame or from a different update loop.

* adding CheckForMessages
* adding LateUpdate that calls CheckForMessages
* adding bool to disable the LateUpdate call
* removes Empty Update method

BREAKING CHANGE: Transports now need to implement CheckForMessages

If we want to do a change like this it is worth doing it at the same time as https://github.com/vis2k/Mirror/pull/2482 so transport owners dont need to update multiple times.