### PR TITLE
fix: stopping values being reset before OnDestory is called

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -951,22 +951,29 @@ namespace Mirror
             {
                 localObject.OnStopClient();
 
-                if (!InvokeUnSpawnHandler(localObject.assetId, localObject.gameObject))
+                // user handling
+                if (InvokeUnSpawnHandler(localObject.assetId, localObject.gameObject))
                 {
-                    // default handling
-                    if (localObject.sceneId == 0)
-                    {
-                        Object.Destroy(localObject.gameObject);
-                    }
-                    else
-                    {
-                        // scene object.. disable it in scene instead of destroying
-                        localObject.gameObject.SetActive(false);
-                        spawnableObjects[localObject.sceneId] = localObject;
-                    }
+                    // reset object after user's handler
+                    localObject.Reset();
                 }
+                // default handling
+                else if (localObject.sceneId == 0)
+                {
+                    // dont call reset before destroy so that values are still set in OnDestroy
+                    Object.Destroy(localObject.gameObject);
+                }
+                else
+                {
+                    // scene object.. disable it in scene instead of destroying
+                    localObject.gameObject.SetActive(false);
+                    spawnableObjects[localObject.sceneId] = localObject;
+                    // reset for scene objects
+                    localObject.Reset();
+                }
+
+                // remove from dictionary no matter how it is unspawned
                 NetworkIdentity.spawned.Remove(netId);
-                localObject.Reset();
             }
             else
             {

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -963,9 +963,9 @@ namespace Mirror
                     // dont call reset before destroy so that values are still set in OnDestroy
                     Object.Destroy(localObject.gameObject);
                 }
+                // scene object.. disable it in scene instead of destroying
                 else
                 {
-                    // scene object.. disable it in scene instead of destroying
                     localObject.gameObject.SetActive(false);
                     spawnableObjects[localObject.sceneId] = localObject;
                     // reset for scene objects


### PR DESCRIPTION
* matches server side logic
* if an object is being fully destroyed it doesn't need its values to be reset


flipping logic so it is:
```
if user handler
else if not scene object
else scene object 
```

reset should be called for userhandler and scene object, not destroyed objects (so that value arn't reset in OnDestroy)