### PR TITLE
Disable KCP console logging when debugLog flag is off

### DIFF
--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -41,8 +41,7 @@ namespace kcp2k
         void Awake()
         {
             // logging
-            if (debugLog) Log.Info = Debug.Log;
-            else Log.Info = (_) => { };
+            Log.Info = debugLog ? Debug.Log : (_) => {};
             Log.Warning = Debug.LogWarning;
             Log.Error = Debug.LogError;
 

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -42,6 +42,7 @@ namespace kcp2k
         {
             // logging
             if (debugLog) Log.Info = Debug.Log;
+            else Log.Info = (_) => { };
             Log.Warning = Debug.LogWarning;
             Log.Error = Debug.LogError;
 

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -41,7 +41,10 @@ namespace kcp2k
         void Awake()
         {
             // logging
-            Log.Info = debugLog ? Debug.Log : (_) => {};
+            if (debugLog)
+                Log.Info = Debug.Log;
+            else
+                Log.Info = _ => {};
             Log.Warning = Debug.LogWarning;
             Log.Error = Debug.LogError;
 


### PR DESCRIPTION
Setting the debugLog flag off on KCP transport does not remove such logs from console (e.g. when you have a headless server).

This PR overwrites the default Console.Log function when the flag is off.