### PR TITLE
feat: adding function to check if NetworkBehaviour has any Dirtybits

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -476,6 +476,20 @@ namespace Mirror
             return false;
         }
 
+        /// <summary>
+        /// Used to check if the behaviour has a dirty bit ignoring syncInterval
+        /// </summary>
+        /// <param name="dirtyBit"></param>
+        /// <returns></returns>
+        public bool HasDirtybit()
+        {
+            return syncVarDirtyBits != 0;
+        }
+
+        /// <summary>
+        /// Checks if behaviour is dirty and has been syncInterval since last sync
+        /// </summary>
+        /// <returns></returns>
         public bool IsDirty()
         {
             if (Time.time - lastSyncTime >= syncInterval)


### PR DESCRIPTION
This is useful for doing custom OnSerialize where you only want to check if should be dirty is not already dirty.

for example 

```cs
if (!HasDirtybit() && ExpensiveCheck())
{
    SetDirtyBit(1UL);
}
```