### PR TITLE
Network Transform Sync Scale boolean.

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -51,7 +51,6 @@ namespace Mirror
         //Users in most scenarios are best to send change of scale via cmd/rpc, syncvar/hooks, only when required.
         [Tooltip("True syncs scale data over the network. Set false to not continuously sync scale which saves bandwidth.")]
         public bool syncScale = false;
-        //static bool syncScale = false;
 
         // target transform to sync. can be on a child.
         protected abstract Transform targetComponent { get; }

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -233,5 +233,18 @@ namespace Mirror
             float outValue = valueRelative * rangeFloat + minFloat;
             return outValue;
         }
+        
+        //rounds to 2 decimal places, and turns a float into a short ( -32,768 to 32,767 )
+        public static short CompressPosition(float value)
+        {
+            value = (Mathf.Round(value * 100f) / 100f) * 100;
+            return (short)value;
+        }
+        
+        //turns the 3 short position values back to a decimal float
+        public static Vector3 DecompressPosition(short valueX,short valueY,short valueZ)
+        {
+            return new Vector3((float)valueX / 100.0f, (float)valueY / 100.0f, (float)valueZ / 100.0f);
+        }
     }
 }

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -233,18 +233,5 @@ namespace Mirror
             float outValue = valueRelative * rangeFloat + minFloat;
             return outValue;
         }
-        
-        //rounds to 2 decimal places, and turns a float into a short ( -32,768 to 32,767 )
-        public static short CompressPosition(float value)
-        {
-            value = (Mathf.Round(value * 100f) / 100f) * 100;
-            return (short)value;
-        }
-        
-        //turns the 3 short position values back to a decimal float
-        public static Vector3 DecompressPosition(short valueX,short valueY,short valueZ)
-        {
-            return new Vector3((float)valueX / 100.0f, (float)valueY / 100.0f, (float)valueZ / 100.0f);
-        }
     }
 }


### PR DESCRIPTION
Optimisation for default NetworkTransform, a boolean to stop scale being sent over the network, instantly saves ~25% bandwidth (12 bytes).
Sync Scale false results:
(Player to server cmd) 50 to 38 bytes
(Server to players OnSerialize) 43 to 31 bytes

Used the naming conventions of Network Transform Experimental for when/if they become one component.
NTE still sends the data across network, its current syncScale boolean just stops the sent results from being applied to player transform.

**NetworkTransformBase.cs**

public bool syncScale = false; 

// Off by default, it should be very rare cases that people want continuous sync scale, instantly saves ~25% bandwidth (12 bytes)
// Users in most scenarios are best to send change of scale via cmd/rpc, syncvar/hooks, only when required.

[Tooltip("True syncs scale data over the network. Set false to not continuously sync scale which saves bandwidth.")]