### PR TITLE
breaking: Revert WriteBlittable. Fixes Android on ARMv7 devices firing SIGBUS BUS_ADRALN error codes.

### DIFF
--- a/Assets/Mirror/Runtime/Mirror.asmdef
+++ b/Assets/Mirror/Runtime/Mirror.asmdef
@@ -8,7 +8,7 @@
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": true,
+    "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -1,8 +1,15 @@
+// Custom NetworkReader that doesn't use C#'s built in MemoryStream in order to
+// avoid allocations.
+//
+// Benchmark: 100kb byte[] passed to NetworkReader constructor 1000x
+//   before with MemoryStream
+//     0.8% CPU time, 250KB memory, 3.82ms
+//   now:
+//     0.0% CPU time,  32KB memory, 0.02ms
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace Mirror
@@ -68,59 +75,13 @@ namespace Mirror
             buffer = segment;
         }
 
-        // ReadBlittable<T> from DOTSNET
-        // Benchmark: see NetworkWriter.WriteBlittable!
-        /// <summary>
-        /// Read blittable type from buffer
-        /// <para>
-        ///     this is extremely fast, but only works for blittable types.
-        /// </para>
-        /// <para>
-        ///     Note:
-        ///     ReadBlittable assumes same endianness for server and client.
-        ///     All Unity 2018+ platforms are little endian.
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        ///     See <see href="https://docs.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types">Blittable and Non-Blittable Types</see>
-        ///     for more info.
-        /// </remarks>
-        /// <typeparam name="T">Needs to be unmanaged, see <see href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/unmanaged-types">unmanaged types</see></typeparam>
-        /// <returns></returns>
-        public unsafe T ReadBlittable<T>()
-            where T : unmanaged
+        public byte ReadByte()
         {
-            // check if blittable for safety
-#if UNITY_EDITOR
-            if (!UnsafeUtility.IsBlittable(typeof(T)))
+            if (Position + 1 > buffer.Count)
             {
-                throw new ArgumentException(typeof(T) + " is not blittable!");
+                throw new EndOfStreamException("ReadByte out of range:" + ToString());
             }
-#endif
-
-            // calculate size
-            //   sizeof(T) gets the managed size at compile time.
-            //   Marshal.SizeOf<T> gets the unmanaged size at runtime (slow).
-            // => our 1mio writes benchmark is 6x slower with Marshal.SizeOf<T>
-            // => for blittable types, sizeof(T) is even recommended:
-            // https://docs.microsoft.com/en-us/dotnet/standard/native-interop/best-practices
-            int size = sizeof(T);
-
-            // enough data to read?
-            if (Position + size > buffer.Count)
-            {
-                throw new EndOfStreamException($"ReadBlittable<{typeof(T)}> out of range: {ToString()}");
-            }
-
-            // read blittable
-            T value;
-            fixed (byte* ptr = &buffer.Array[buffer.Offset + Position])
-            {
-                // cast buffer to a T* pointer and then read from it.
-                value = *(T*)ptr;
-            }
-            Position += size;
-            return value;
+            return buffer.Array[buffer.Offset + Position++];
         }
 
         /// <summary>
@@ -183,12 +144,9 @@ namespace Mirror
         }
     }
 
-    /// <summary>
-    /// Built in Reader functions for Mirror
-    /// <para>
-    ///     Weaver automatically detects all extension methods for NetworkWriter
-    /// </para>
-    /// </summary>
+
+    // Mirror's Weaver automatically detects all NetworkReader function types,
+    // but they do all need to be extensions.
     public static class NetworkReaderExtensions
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkReaderExtensions));
@@ -198,19 +156,61 @@ namespace Mirror
         // 1000 readers after: 0.8MB GC, 18ms
         static readonly UTF8Encoding encoding = new UTF8Encoding(false, true);
 
-        public static byte ReadByte(this NetworkReader reader) => reader.ReadBlittable<byte>();
-        public static sbyte ReadSByte(this NetworkReader reader) => reader.ReadBlittable<sbyte>();
-        public static char ReadChar(this NetworkReader reader) => (char)reader.ReadBlittable<short>(); // char isn't blittable
-        public static bool ReadBoolean(this NetworkReader reader) => reader.ReadBlittable<byte>() != 0; // bool isn't blittable
-        public static short ReadInt16(this NetworkReader reader) => reader.ReadBlittable<short>();
-        public static ushort ReadUInt16(this NetworkReader reader) => reader.ReadBlittable<ushort>();
-        public static int ReadInt32(this NetworkReader reader) => reader.ReadBlittable<int>();
-        public static uint ReadUInt32(this NetworkReader reader) => reader.ReadBlittable<uint>();
-        public static long ReadInt64(this NetworkReader reader) => reader.ReadBlittable<long>();
-        public static ulong ReadUInt64(this NetworkReader reader) => reader.ReadBlittable<ulong>();
-        public static float ReadSingle(this NetworkReader reader) => reader.ReadBlittable<float>();
-        public static double ReadDouble(this NetworkReader reader) => reader.ReadBlittable<double>();
-        public static decimal ReadDecimal(this NetworkReader reader) => reader.ReadBlittable<decimal>();
+        public static byte ReadByte(this NetworkReader reader) => reader.ReadByte();
+        public static sbyte ReadSByte(this NetworkReader reader) => (sbyte)reader.ReadByte();
+        public static char ReadChar(this NetworkReader reader) => (char)reader.ReadUInt16();
+        public static bool ReadBoolean(this NetworkReader reader) => reader.ReadByte() != 0;
+        public static short ReadInt16(this NetworkReader reader) => (short)reader.ReadUInt16();
+        public static ushort ReadUInt16(this NetworkReader reader)
+        {
+            ushort value = 0;
+            value |= reader.ReadByte();
+            value |= (ushort)(reader.ReadByte() << 8);
+            return value;
+        }
+        public static int ReadInt32(this NetworkReader reader) => (int)reader.ReadUInt32();
+        public static uint ReadUInt32(this NetworkReader reader)
+        {
+            uint value = 0;
+            value |= reader.ReadByte();
+            value |= (uint)(reader.ReadByte() << 8);
+            value |= (uint)(reader.ReadByte() << 16);
+            value |= (uint)(reader.ReadByte() << 24);
+            return value;
+        }
+        public static long ReadInt64(this NetworkReader reader) => (long)reader.ReadUInt64();
+        public static ulong ReadUInt64(this NetworkReader reader)
+        {
+            ulong value = 0;
+            value |= reader.ReadByte();
+            value |= ((ulong)reader.ReadByte()) << 8;
+            value |= ((ulong)reader.ReadByte()) << 16;
+            value |= ((ulong)reader.ReadByte()) << 24;
+            value |= ((ulong)reader.ReadByte()) << 32;
+            value |= ((ulong)reader.ReadByte()) << 40;
+            value |= ((ulong)reader.ReadByte()) << 48;
+            value |= ((ulong)reader.ReadByte()) << 56;
+            return value;
+        }
+        public static float ReadSingle(this NetworkReader reader)
+        {
+            UIntFloat converter = new UIntFloat();
+            converter.intValue = reader.ReadUInt32();
+            return converter.floatValue;
+        }
+        public static double ReadDouble(this NetworkReader reader)
+        {
+            UIntDouble converter = new UIntDouble();
+            converter.longValue = reader.ReadUInt64();
+            return converter.doubleValue;
+        }
+        public static decimal ReadDecimal(this NetworkReader reader)
+        {
+            UIntDecimal converter = new UIntDecimal();
+            converter.longValue1 = reader.ReadUInt64();
+            converter.longValue2 = reader.ReadUInt64();
+            return converter.decimalValue;
+        }
 
         /// <exception cref="T:System.ArgumentException">if an invalid utf8 string is sent</exception>
         public static string ReadString(this NetworkReader reader)
@@ -256,18 +256,40 @@ namespace Mirror
             return count == 0 ? default : reader.ReadBytesSegment(checked((int)(count - 1u)));
         }
 
-        public static Vector2 ReadVector2(this NetworkReader reader) => reader.ReadBlittable<Vector2>();
-        public static Vector3 ReadVector3(this NetworkReader reader) => reader.ReadBlittable<Vector3>();
-        public static Vector4 ReadVector4(this NetworkReader reader) => reader.ReadBlittable<Vector4>();
-        public static Vector2Int ReadVector2Int(this NetworkReader reader) => reader.ReadBlittable<Vector2Int>();
-        public static Vector3Int ReadVector3Int(this NetworkReader reader) => reader.ReadBlittable<Vector3Int>();
-        public static Color ReadColor(this NetworkReader reader) => reader.ReadBlittable<Color>();
-        public static Color32 ReadColor32(this NetworkReader reader) => reader.ReadBlittable<Color32>();
-        public static Quaternion ReadQuaternion(this NetworkReader reader) => reader.ReadBlittable<Quaternion>();
-        public static Rect ReadRect(this NetworkReader reader) => reader.ReadBlittable<Rect>();
-        public static Plane ReadPlane(this NetworkReader reader) => reader.ReadBlittable<Plane>();
-        public static Ray ReadRay(this NetworkReader reader) => reader.ReadBlittable<Ray>();
-        public static Matrix4x4 ReadMatrix4x4(this NetworkReader reader) => reader.ReadBlittable<Matrix4x4>();
+        public static Vector2 ReadVector2(this NetworkReader reader) => new Vector2(reader.ReadSingle(), reader.ReadSingle());
+        public static Vector3 ReadVector3(this NetworkReader reader) => new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        public static Vector4 ReadVector4(this NetworkReader reader) => new Vector4(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        public static Vector2Int ReadVector2Int(this NetworkReader reader) => new Vector2Int(reader.ReadInt32(), reader.ReadInt32());
+        public static Vector3Int ReadVector3Int(this NetworkReader reader) => new Vector3Int(reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32());
+        public static Color ReadColor(this NetworkReader reader) => new Color(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        public static Color32 ReadColor32(this NetworkReader reader) => new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
+        public static Quaternion ReadQuaternion(this NetworkReader reader) => new Quaternion(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        public static Rect ReadRect(this NetworkReader reader) => new Rect(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        public static Plane ReadPlane(this NetworkReader reader) => new Plane(reader.ReadVector3(), reader.ReadSingle());
+        public static Ray ReadRay(this NetworkReader reader) => new Ray(reader.ReadVector3(), reader.ReadVector3());
+
+        public static Matrix4x4 ReadMatrix4x4(this NetworkReader reader)
+        {
+            return new Matrix4x4
+            {
+                m00 = reader.ReadSingle(),
+                m01 = reader.ReadSingle(),
+                m02 = reader.ReadSingle(),
+                m03 = reader.ReadSingle(),
+                m10 = reader.ReadSingle(),
+                m11 = reader.ReadSingle(),
+                m12 = reader.ReadSingle(),
+                m13 = reader.ReadSingle(),
+                m20 = reader.ReadSingle(),
+                m21 = reader.ReadSingle(),
+                m22 = reader.ReadSingle(),
+                m23 = reader.ReadSingle(),
+                m30 = reader.ReadSingle(),
+                m31 = reader.ReadSingle(),
+                m32 = reader.ReadSingle(),
+                m33 = reader.ReadSingle()
+            };
+        }
 
         public static byte[] ReadBytes(this NetworkReader reader, int count)
         {

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using UnityEngine;
 
 namespace Mirror
@@ -30,5 +31,39 @@ namespace Mirror
     {
         public const int DefaultReliable = 0;
         public const int DefaultUnreliable = 1;
+    }
+
+    // -- helpers for float conversion without allocations --
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct UIntFloat
+    {
+        [FieldOffset(0)]
+        public float floatValue;
+
+        [FieldOffset(0)]
+        public uint intValue;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct UIntDouble
+    {
+        [FieldOffset(0)]
+        public double doubleValue;
+
+        [FieldOffset(0)]
+        public ulong longValue;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct UIntDecimal
+    {
+        [FieldOffset(0)]
+        public ulong longValue1;
+
+        [FieldOffset(8)]
+        public ulong longValue2;
+
+        [FieldOffset(0)]
+        public decimal decimalValue;
     }
 }

--- a/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
+++ b/Assets/Mirror/Tests/Editor/Mirror.Tests.asmdef
@@ -15,7 +15,7 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": true,
+    "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
         "NSubstitute.dll",

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -26,45 +26,6 @@ namespace Mirror.Tests
         }
         */
 
-        struct TestStruct
-        {
-#pragma warning disable 649
-            public int data;
-            public byte data2;
-#pragma warning restore 649
-        }
-
-        [Test]
-        public unsafe void BlittableOnThisPlatform()
-        {
-            // we assume NetworkWriter.WriteBlittable<T> to behave the same on
-            // all platforms:
-            // - need to be little endian (atm all Unity platforms are)
-            // - padded structs need to be same size across all platforms
-            //   (C# int, byte, etc. should be same on all platforms, and
-            //    C# should do the same padding on all platforms)
-            //   https://kalapos.net/Blog/ShowPost/DotNetConceptOfTheWeek13_DotNetMemoryLayout
-            // => let's have a test that we can run on different platforms to
-            //    be 100% sure
-
-            // let's assume little endian.
-            // it would also be ok if server and client are both big endian,
-            // but that's extremely unlikely.
-            Assert.That(BitConverter.IsLittleEndian, Is.True);
-
-            // TestStruct biggest member is 'int' = 4 bytes.
-            // so C# aligns it to 4 bytes, hence does padding for the byte:
-            //   0 int
-            //   1 int
-            //   2 int
-            //   3 int
-            //   4 byte
-            //   5 padding
-            //   6 padding
-            //   7 padding
-            Assert.That(sizeof(TestStruct), Is.EqualTo(8));
-        }
-
         [Test]
         public void TestWritingSmallMessage()
         {


### PR DESCRIPTION
This PR Fixes #2511, #2518 (confirmed in private DMs on Discord) and any other developers' issues about Mirror randomly crashing on ARMv7 devices running on Mono backend with **SIGBUS BUS_ADRALN** codes. This PR reverts commit 1947f061add00b9a8b02a8778f5bd9bc2b7cd158 and brings both NetworkReader and NetworkWriter up to date in a no-Blittable branch.

This PR removes WriteBlittable, which was a supposedly 4x - 6x performance increase from DOTSNET. Unfortunately it bugs out on Android devices. It also reverts it back to a slower but stable Write method.

**Now tested and confirmed working. No more NullPointerExceptions on Mono ARMv7.**

Quoting vis:
> imho let's just revert. who knows where else it'll fail.