### PR TITLE
fix: NetworkWriterTest.cs failing due to Blittable removal

### DIFF
--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1009,8 +1009,8 @@ namespace Mirror.Tests
             {
                 _ = reader.ReadArray<int>();
             });
-            // todo inprove this message check
-            Assert.That(exception, Has.Message.Contains($"ReadBlittable<{typeof(int)}> out of range"));
+            // todo improve this message check
+            Assert.That(exception, Has.Message.Contains($"ReadByte out of range"));
 
             void WriteBadArray()
             {


### PR DESCRIPTION
I'm dumb, forgot to patch NetworkWriterTest.cs in last PR. It's patched now.