### PR TITLE
feat(Transform): New NetworkTransform using SnapshotInterpolation

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -6,8 +6,7 @@ using UnityEngine;
 namespace Mirror
 {
     [DisallowMultipleComponent]
-    [AddComponentMenu("Network/NetworkTransform")]
-    [HelpURL("https://mirror-networking.com/docs/Articles/Components/NetworkTransform.html")]
+    [AddComponentMenu("Network/NetworkTransformSnapshotInterpolation")]
     // placeholder name, can be renamed when old component gets removed
     // when renaming name sure GUID of component stays the same
     public class NetworkTransformSnapshotInterpolation : NetworkBehaviour

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 
 namespace Mirror
 {
-    [DisallowMultipleComponent]
     [AddComponentMenu("Network/NetworkTransformSnapshotInterpolation")]
     // placeholder name, can be renamed when old component gets removed
     // when renaming name sure GUID of component stays the same
@@ -63,7 +62,7 @@ namespace Mirror
         // client
         SnapshotBuffer snapshotBuffer = new SnapshotBuffer();
 
-        private void OnGUI()
+        void OnGUI()
         {
             if (showDebugGui)
             {
@@ -73,27 +72,27 @@ namespace Mirror
             }
         }
 
-        private void OnValidate()
+        void OnValidate()
         {
             if (target == null)
                 target = transform;
         }
 
-        public bool IsControlledByServer
+        bool IsControlledByServer
         {
             // server auth or no owner
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => !clientAuthority || connectionToClient == null;
         }
 
-        public bool IsLocalClientInControl
+        bool IsLocalClientInControl
         {
             // client auth and owner
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => clientAuthority && hasAuthority;
         }
 
-        public Vector3 Position
+        Vector3 Position
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -114,7 +113,7 @@ namespace Mirror
             }
         }
 
-        public Quaternion Rotation
+        Quaternion Rotation
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -151,7 +150,7 @@ namespace Mirror
         /// Resets values, called after syncing to client
         /// <para>Called on server</para>
         /// </summary>
-        public void ClearNeedsUpdate(float interval)
+        void ClearNeedsUpdate(float interval)
         {
             _needsUpdate = false;
             _nextSyncInterval = Time.time + interval;
@@ -191,7 +190,7 @@ namespace Mirror
             return rotated;
         }
 
-        private void Update()
+        void Update()
         {
             if (isServer)
             {
@@ -212,7 +211,7 @@ namespace Mirror
         }
 
         #region Server Sync Update
-        private void ServerSyncUpdate()
+        void ServerSyncUpdate()
         {
             if (ServerNeedsToSendUpdate())
             {
@@ -244,14 +243,14 @@ namespace Mirror
         void SendMessageToClient()
         {
             // if client has send update, then we want to use the state it gave us
-            // this is to make sure we are not sending host's interoplations position as the snapshot insteading sending the client auth snapshot
+            // this is to make sure we are not sending host's interpolations position as the snapshot insteading sending the client auth snapshot
             TransformState state = IsControlledByServer ? State : _latestState;
             // todo is this correct time?
             RpcServerSync(state, NetworkTime.time);
         }
 
         [ClientRpc]
-        public void RpcServerSync(TransformState state, double time)
+        void RpcServerSync(TransformState state, double time)
         {
             // not host
             // host will have already handled movement in servers code
@@ -278,7 +277,7 @@ namespace Mirror
 
 
         #region Client Sync Update 
-        private void ClientAuthorityUpdate()
+        void ClientAuthorityUpdate()
         {
             if (TimeToUpdate && (HasMoved() || HasRotated()))
             {
@@ -295,21 +294,21 @@ namespace Mirror
         }
 
         [Command]
-        public void CmdClientAuthoritySync(TransformState state, double time)
+        void CmdClientAuthoritySync(TransformState state, double time)
         {
             // this should not happen, Exception to disconnect attacker
             if (!clientAuthority) { throw new Exception("Client is not allowed to send updated when clientAuthority is false"); }
 
             _latestState = state;
 
-            // if host apply using interoplation otherwise apply exact 
+            // if host apply using interpolation otherwise apply exact 
             if (isClient)
             {
                 AddSnapShotToBuffer(state, time);
             }
             else
             {
-                ApplyStateNoInteroplation(state);
+                ApplyStateNoInterpolation(state);
             }
         }
 
@@ -318,17 +317,17 @@ namespace Mirror
         /// <para>no need to interpolate on server</para>
         /// </summary>
         /// <param name="state"></param>
-        void ApplyStateNoInteroplation(TransformState state)
+        void ApplyStateNoInterpolation(TransformState state)
         {
             Position = state.position;
             Rotation = state.rotation;
             _needsUpdate = true;
         }
-
         #endregion
 
+
         #region Client Interpolation
-        private void ClientInterpolation()
+        void ClientInterpolation()
         {
             if (snapshotBuffer.IsEmpty) { return; }
 

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -48,14 +48,16 @@ namespace Mirror
         /// Set when client with authority updates the server
         /// </summary>
         bool _needsUpdate;
+
         /// <summary>
         /// latest values from client
         /// </summary>
         TransformState _latestState;
+
         // todo does this need to be a double, it uses Time.time
         float _nextSyncInterval;
 
-        // server
+        // values for HasMoved/Rotated
         Vector3 lastPosition;
         Quaternion lastRotation;
 
@@ -67,7 +69,7 @@ namespace Mirror
             if (showDebugGui)
             {
                 GUILayout.Label($"ServerTime: {NetworkTime.time}");
-                GUILayout.Label($"LocalTime: {NetworkTime.time - NetworkTime.rtt / 2}");
+                GUILayout.Label($"LocalTime: {localTime}");
                 GUILayout.Label(snapshotBuffer.ToString());
             }
         }

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -31,7 +31,7 @@ namespace Mirror
 
         [Header("Snapshot Interpolation")]
         [Tooltip("Delay to add to client time to make sure there is always a snapshot to interpolate towards. High delay can handle more jitter, but adds latancy to the position.")]
-        [SerializeField] float clientDelay = 0.1f;
+        [SerializeField] float clientDelay = 0.2f;
 
         [Tooltip("Client Authority Sync Interval")]
         [SerializeField] float clientSyncInterval = 0.1f;

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -50,7 +50,7 @@ namespace Mirror
         /// </summary>
         TransformState _latestState;
 
-        // todo does this need to be a double, it uses Time.time
+        // todo does this need to be a double, it uses NetworkTime.time
         float _nextSyncInterval;
 
         // values for HasMoved/Rotated

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -58,7 +58,7 @@ namespace Mirror
         Quaternion lastRotation;
 
         // client
-        SnapshotBuffer snapshotBuffer = new SnapshotBuffer();
+        readonly SnapshotBuffer snapshotBuffer = new SnapshotBuffer();
 
         void OnGUI()
         {

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Runtime.CompilerServices;
+using Mirror.TransformSyncing;
+using UnityEngine;
+
+namespace Mirror
+{
+    [DisallowMultipleComponent]
+    [AddComponentMenu("Network/NetworkTransform")]
+    [HelpURL("https://mirror-networking.com/docs/Articles/Components/NetworkTransform.html")]
+    // placeholder name, can be renamed when old component gets removed
+    // when renaming name sure GUID of component stays the same
+    public class NetworkTransformSnapshotInterpolation : NetworkBehaviour
+    {
+        static readonly ILogger logger = LogFactory.GetLogger<NetworkTransformSnapshotInterpolation>(LogType.Error);
+
+        [Tooltip("Which transform to sync")]
+        [SerializeField] Transform target;
+
+        [Header("Authority")]
+        [Tooltip("Set to true if moves come from owner client, set to false if moves always come from server")]
+        [SerializeField] bool clientAuthority = false;
+
+        [Tooltip("If true uses local position and rotation, if value uses world position and rotation")]
+        [SerializeField] bool useLocalSpace = true;
+
+        // todo make 0 Sensitivity always send (and avoid doing distance/angle check)
+        [Tooltip("How far position has to move before it is synced")]
+        [SerializeField] float positionSensitivity = 0.1f;
+
+        [Tooltip("How far rotation has to move before it is synced")]
+        [SerializeField] float rotationSensitivity = 0.1f;
+
+        [Header("Snapshot Interpolation")]
+        [Tooltip("Delay to add to client time to make sure there is always a snapshot to interpolate towards. High delay can handle more jitter, but adds latancy to the position.")]
+        [SerializeField] float clientDelay = 0.1f;
+
+        [Tooltip("Client Authority Sync Interval")]
+        [SerializeField] float clientSyncInterval = 0.1f;
+        [Tooltip("remove old snapshots from buffer older than SyncInterval * this value")]
+        [SerializeField] float snapshotRemoveTime = 1;
+        [Tooltip("How many snapshots to leave in buffer")]
+        [SerializeField] int minimumSnapsots = 1;
+
+        [SerializeField] bool showDebugGui;
+
+        double localTime;
+
+        /// <summary>
+        /// Set when client with authority updates the server
+        /// </summary>
+        bool _needsUpdate;
+        /// <summary>
+        /// latest values from client
+        /// </summary>
+        TransformState _latestState;
+        float _nextSyncInterval;
+
+        // server
+        Vector3 lastPosition;
+        Quaternion lastRotation;
+
+        // client
+        SnapshotBuffer snapshotBuffer = new SnapshotBuffer();
+
+        private void OnGUI()
+        {
+            if (showDebugGui)
+            {
+                GUILayout.Label($"ServerTime: {NetworkTime.time}");
+                GUILayout.Label($"LocalTime: {NetworkTime.time - NetworkTime.rtt / 2}");
+                GUILayout.Label(snapshotBuffer.ToString());
+            }
+        }
+
+        private void OnValidate()
+        {
+            if (target == null)
+                target = transform;
+        }
+
+        public bool IsControlledByServer
+        {
+            // server auth or no owner
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !clientAuthority || connectionToClient == null;
+        }
+        public bool IsLocalClientInControl
+        {
+            // client auth and owner
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => clientAuthority && hasAuthority;
+        }
+
+        public Vector3 Position
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return useLocalSpace ? target.localPosition : target.position;
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                if (useLocalSpace)
+                {
+                    target.localPosition = value;
+                }
+                else
+                {
+                    target.position = value;
+                }
+            }
+        }
+        public Quaternion Rotation
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return useLocalSpace ? target.localRotation : target.rotation;
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                if (useLocalSpace)
+                {
+                    target.localRotation = value;
+                }
+                else
+                {
+                    target.rotation = value;
+                }
+            }
+        }
+
+        TransformState State
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new TransformState(Position, Rotation);
+        }
+
+
+
+
+        bool TimeToUpdate
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Time.time > _nextSyncInterval;
+        }
+
+        /// <summary>
+        /// Resets values, called after syncing to client
+        /// <para>Called on server</para>
+        /// </summary>
+        public void ClearNeedsUpdate(float interval)
+        {
+            _needsUpdate = false;
+            _nextSyncInterval = Time.time + interval;
+            lastPosition = Position;
+            lastRotation = Rotation;
+        }
+
+
+        /// <summary>
+        /// Applies values to target transform on server
+        /// <para>no need to interpolate on server</para>
+        /// </summary>
+        /// <param name="state"></param>
+        void ApplyOnServer(TransformState state)
+        {
+            Position = state.position;
+            Rotation = state.rotation;
+            _needsUpdate = true;
+        }
+
+
+
+
+        /// <summary>
+        /// Has target moved since we last checked
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        bool HasMoved()
+        {
+            bool moved = Vector3.Distance(lastPosition, Position) > positionSensitivity;
+
+            if (moved)
+            {
+                lastPosition = Position;
+            }
+            return moved;
+        }
+
+        /// <summary>
+        /// Has target moved since we last checked
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        bool HasRotated()
+        {
+            bool rotated = Quaternion.Angle(lastRotation, Rotation) > rotationSensitivity;
+
+            if (rotated)
+            {
+                lastRotation = Rotation;
+            }
+            return rotated;
+        }
+
+        private void Update()
+        {
+            if (isServer)
+            {
+                ServerSyncUpdate();
+            }
+
+            if (isClient)
+            {
+                if (IsLocalClientInControl)
+                {
+                    ClientAuthorityUpdate();
+                }
+                else
+                {
+                    ClientInterpolation();
+                }
+            }
+        }
+
+        #region Server Sync Update
+        private void ServerSyncUpdate()
+        {
+            if (ServerNeedsToSendUpdate())
+            {
+                SendMessageToClient();
+                ClearNeedsUpdate(clientSyncInterval);
+            }
+        }
+
+        /// <summary>
+        /// Checks if object needs syncing to clients
+        /// <para>Called on server</para>
+        /// </summary>
+        /// <returns></returns>
+        bool ServerNeedsToSendUpdate()
+        {
+            if (IsControlledByServer)
+            {
+                return TimeToUpdate && (HasMoved() || HasRotated());
+            }
+            else
+            {
+                // dont care about time here, if client authority has sent snapshot then always relay it to other clients
+                // todo do we need a check for attackers sending too many snapshots?
+                return _needsUpdate;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void SendMessageToClient()
+        {
+            // if client has send update, then we want to use the state it gave us
+            // this is to make sure we are not sending host's interoplations position as the snapshot insteading sending the client auth snapshot
+            TransformState state = IsControlledByServer ? State : _latestState;
+            // todo is this correct time?
+            RpcServerSync(state, NetworkTime.time);
+        }
+
+        [ClientRpc]
+        public void RpcServerSync(TransformState state, double time)
+        {
+            // not host
+            // host will have already handled movement in servers code
+            if (isServer)
+                return;
+
+            ApplyOnClient(state, time);
+        }
+
+        /// <summary>
+        /// Applies values to target transform on client
+        /// <para>Adds to buffer for interpolation</para>
+        /// </summary>
+        /// <param name="state"></param>
+        void ApplyOnClient(TransformState state, double serverTime)
+        {
+            // dont apply on local owner
+            if (IsLocalClientInControl)
+                return;
+
+            snapshotBuffer.AddSnapShot(state, serverTime);
+        }
+        #endregion
+
+
+        #region Client Sync Update 
+        private void ClientAuthorityUpdate()
+        {
+            if (TimeToUpdate && (HasMoved() || HasRotated()))
+            {
+                SendMessageToServer();
+                ClearNeedsUpdate(clientSyncInterval);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void SendMessageToServer()
+        {
+            // todo, is this the correct time?
+            CmdClientAuthoritySync(State, NetworkTime.time);
+        }
+
+        [Command]
+        public void CmdClientAuthoritySync(TransformState state, double time)
+        {
+            // this should not happen, Exception to disconnect attacker
+            if (!clientAuthority) { throw new Exception("Client is not allowed to send updated when clientAuthority is false"); }
+
+            _latestState = state;
+
+            // if host apply using interoplation otherwise apply exact 
+            if (isClient)
+            {
+                ApplyOnClient(state, time);
+            }
+            else
+            {
+                ApplyOnServer(state);
+            }
+        }
+        #endregion
+
+        #region Client Interpolation
+        private void ClientInterpolation()
+        {
+            if (snapshotBuffer.IsEmpty) { return; }
+
+            // we want to set local time to the estimated time that the server was when it send the snapshot
+            double serverTime = NetworkTime.time;
+            localTime = serverTime - NetworkTime.rtt / 2;
+
+            // we then subtract clientDelay to handle any jitter
+
+            TransformState state = snapshotBuffer.GetLinearInterpolation(localTime - clientDelay);
+            if (logger.LogEnabled()) { logger.Log($"p1:{Position.x} p2:{state.position.x} delta:{Position.x - state.position.x}"); }
+            Position = state.position;
+            Rotation = state.rotation;
+
+            snapshotBuffer.RemoveOldSnapshots((float)(localTime - snapshotRemoveTime), minimumSnapsots);
+        }
+        #endregion
+
+
+
+    }
+}

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -348,7 +348,8 @@ namespace Mirror
             Rotation = state.rotation;
 
             // remove snapshots older than 2times sync interval, they will never be used by Interpolation
-            snapshotBuffer.RemoveOldSnapshots((float)(snapshotTime - (clientSyncInterval * 2)), 0);
+            float removeTime = (float)(snapshotTime - (clientSyncInterval * 2));
+            snapshotBuffer.RemoveOldSnapshots(removeTime);
         }
         #endregion
     }

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -37,8 +37,8 @@ namespace Mirror
         [SerializeField] float clientSyncInterval = 0.1f;
         [Tooltip("remove old snapshots from buffer older than SyncInterval * this value")]
         [SerializeField] float snapshotRemoveTime = 1;
-        [Tooltip("How many snapshots to leave in buffer")]
-        [SerializeField] int minimumSnapsots = 1;
+        [Tooltip("How many snapshots older than RemoveTIme to leave in buffer")]
+        [SerializeField] int minimumOldSnapsots = 2;
 
         [SerializeField] bool showDebugGui;
 
@@ -344,7 +344,7 @@ namespace Mirror
             Position = state.position;
             Rotation = state.rotation;
 
-            snapshotBuffer.RemoveOldSnapshots((float)(localTime - snapshotRemoveTime), minimumSnapsots);
+            snapshotBuffer.RemoveOldSnapshots((float)(localTime - snapshotRemoveTime), minimumOldSnapsots);
         }
         #endregion
     }

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -82,9 +82,9 @@ namespace Mirror
 
         bool IsControlledByServer
         {
-            // server auth or no owner
+            // server auth or no owner, or host
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => !clientAuthority || connectionToClient == null;
+            get => !clientAuthority || connectionToClient == null || connectionToClient == NetworkServer.localConnection;
         }
 
         bool IsLocalClientInControl

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs
@@ -36,7 +36,7 @@ namespace Mirror
         [Tooltip("Client Authority Sync Interval")]
         [SerializeField] float clientSyncInterval = 0.1f;
 
-        [SerializeField] bool showDebugGui;
+        [SerializeField] bool showDebugGui = false;
 
         double localTime;
 

--- a/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs.meta
+++ b/Assets/Mirror/Components/NetworkTransformSnapshotInterpolation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ad408b25fc5a054ba28ca1f9dd57371
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 7453abfe9e8b2c04a8a47eb536fe21eb, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Components/SnapshotBuffer.cs
+++ b/Assets/Mirror/Components/SnapshotBuffer.cs
@@ -94,6 +94,15 @@ namespace Mirror.TransformSyncing
                 return only.state;
             }
 
+            // if first snapshot is after now, there is no from, so return same as first snapshot
+            if (buffer[0].time > now)
+            {
+                if (logger.LogEnabled()) logger.Log($"No snapshots for t={now:0.000}, using earliest t={buffer[0].time:0.000}");
+
+                Snapshot first = buffer[0];
+                return first.state;
+            }
+
             for (int i = 0; i < buffer.Count - 1; i++)
             {
                 Snapshot from = buffer[i];
@@ -116,7 +125,7 @@ namespace Mirror.TransformSyncing
             // this can happen if server hasn't sent new data
             // there could be no new data from either lag or because object hasn't moved
             Snapshot last = buffer[buffer.Count - 1];
-            if (logger.WarnEnabled()) logger.LogWarning($"No snapshot for t={now} using first t={buffer[0].time} last t={last.time}");
+            if (logger.WarnEnabled()) logger.LogWarning($"No snapshots for t={now:0.000}, using first t={buffer[0].time:0.000} last t={last.time:0.000}");
             return last.state;
         }
 

--- a/Assets/Mirror/Components/SnapshotBuffer.cs
+++ b/Assets/Mirror/Components/SnapshotBuffer.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using UnityEngine;
+
+namespace Mirror.TransformSyncing
+{
+    public struct TransformState
+    {
+        public readonly Vector3 position;
+        public readonly Quaternion rotation;
+
+        public TransformState(Vector3 position, Quaternion rotation)
+        {
+            this.position = position;
+            this.rotation = rotation;
+        }
+
+        public override string ToString()
+        {
+            return $"[{position}, {rotation}]";
+        }
+    }
+    public static class TransformStateWriter
+    {
+        public static void WriteTransformState(this NetworkWriter writer, TransformState value)
+        {
+            writer.WriteVector3(value.position);
+            writer.WriteUInt32(Compression.CompressQuaternion(value.rotation));
+        }
+        public static TransformState ReadTransformState(this NetworkReader reader)
+        {
+            Vector3 position = reader.ReadVector3();
+            Quaternion rotation = Compression.DecompressQuaternion(reader.ReadUInt32());
+
+            return new TransformState(position, rotation);
+        }
+    }
+
+    public class SnapshotBuffer
+    {
+        static readonly ILogger logger = LogFactory.GetLogger<SnapshotBuffer>(LogType.Error);
+        struct Snapshot
+        {
+            /// <summary>
+            /// Server Time
+            /// </summary>
+            public readonly double time;
+            public readonly TransformState state;
+
+            public Snapshot(TransformState state, double time) : this()
+            {
+                this.state = state;
+                this.time = time;
+            }
+        }
+
+        readonly List<Snapshot> buffer = new List<Snapshot>();
+
+        public bool IsEmpty
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => buffer.Count == 0;
+        }
+
+        public void AddSnapShot(TransformState state, double serverTime)
+        {
+            buffer.Add(new Snapshot(state, serverTime));
+        }
+
+        /// <summary>
+        /// Gets snapshot to use for interoplation
+        /// <para>this method should not be called when there are no snapshots in buffer</para>
+        /// </summary>
+        /// <param name="now"></param>
+        /// <returns></returns>
+        public TransformState GetLinearInterpolation(double now)
+        {
+            if (buffer.Count == 0)
+            {
+                logger.LogError("No snapshots, returning default");
+                return default;
+            }
+
+            // first snapshot
+            if (buffer.Count == 1)
+            {
+                if (logger.LogEnabled()) logger.Log("First snapshot");
+
+                Snapshot only = buffer[0];
+                return only.state;
+            }
+
+            for (int i = 0; i < buffer.Count - 1; i++)
+            {
+                Snapshot from = buffer[i];
+                Snapshot to = buffer[i + 1];
+                double fromTime = buffer[i].time;
+                double toTime = buffer[i + 1].time;
+
+                // if between times, then use from/to
+                if (fromTime < now && now < toTime)
+                {
+                    float alpha = (float)Clamp01((now - fromTime) / (toTime - fromTime));
+                    if (logger.LogEnabled()) { logger.Log($"alpha:{alpha}"); }
+                    Vector3 pos = Vector3.Lerp(from.state.position, to.state.position, alpha);
+                    Quaternion rot = Quaternion.Slerp(from.state.rotation, to.state.rotation, alpha);
+                    return new TransformState(pos, rot);
+                }
+            }
+
+            // if no valid snapshot use last
+            // this can happen if server hasn't sent new data
+            // there could be no new data from either lag or because object hasn't moved
+            Snapshot last = buffer[buffer.Count - 1];
+            if (logger.WarnEnabled()) logger.LogWarning($"No snapshot for t={now} using first t={buffer[0].time} last t={last.time}");
+            return last.state;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private double Clamp01(double v)
+        {
+            if (v < 0) { return 0; }
+            if (v > 1) { return 1; }
+            else { return v; }
+        }
+
+        /// <summary>
+        /// removes snapshots older than <paramref name="oldTime"/>, but keeps atleast <paramref name="keepCount"/> snapshots in buffer
+        /// </summary>
+        /// <param name="oldTime"></param>
+        /// <param name="keepCount">minium number of snapshots to keep in buffer</param>
+        public void RemoveOldSnapshots(float oldTime, int keepCount)
+        {
+            for (int i = buffer.Count - 1 - keepCount; i >= 0; i--)
+            {
+                // older than oldTime
+                if (buffer[i].time < oldTime)
+                {
+                    buffer.RemoveAt(i);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.AppendLine($"count:{buffer.Count}, minTime:{buffer[0].time}, maxTime:{buffer[buffer.Count - 1].time}");
+            for (int i = 0; i < buffer.Count; i++)
+            {
+                builder.AppendLine($"  {i}: {buffer[i].time}");
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/Assets/Mirror/Components/SnapshotBuffer.cs
+++ b/Assets/Mirror/Components/SnapshotBuffer.cs
@@ -21,6 +21,7 @@ namespace Mirror.TransformSyncing
             return $"[{position}, {rotation}]";
         }
     }
+
     public static class TransformStateWriter
     {
         public static void WriteTransformState(this NetworkWriter writer, TransformState value)
@@ -28,6 +29,7 @@ namespace Mirror.TransformSyncing
             writer.WriteVector3(value.position);
             writer.WriteUInt32(Compression.CompressQuaternion(value.rotation));
         }
+
         public static TransformState ReadTransformState(this NetworkReader reader)
         {
             Vector3 position = reader.ReadVector3();
@@ -40,6 +42,7 @@ namespace Mirror.TransformSyncing
     public class SnapshotBuffer
     {
         static readonly ILogger logger = LogFactory.GetLogger<SnapshotBuffer>(LogType.Error);
+
         struct Snapshot
         {
             /// <summary>
@@ -69,7 +72,7 @@ namespace Mirror.TransformSyncing
         }
 
         /// <summary>
-        /// Gets snapshot to use for interoplation
+        /// Gets snapshot to use for interpolation
         /// <para>this method should not be called when there are no snapshots in buffer</para>
         /// </summary>
         /// <param name="now"></param>

--- a/Assets/Mirror/Components/SnapshotBuffer.cs
+++ b/Assets/Mirror/Components/SnapshotBuffer.cs
@@ -129,18 +129,30 @@ namespace Mirror.TransformSyncing
         }
 
         /// <summary>
-        /// removes snapshots older than <paramref name="oldTime"/>, but keeps atleast <paramref name="keepCount"/> snapshots in buffer
+        /// removes snapshots older than <paramref name="oldTime"/>, but keeps atleast <paramref name="keepCount"/> snapshots in buffer that are older than oldTime
+        /// <para>
+        /// Keep atleast 1 snapshot older than old time so there is something to interoplate from
+        /// </para>
         /// </summary>
         /// <param name="oldTime"></param>
         /// <param name="keepCount">minium number of snapshots to keep in buffer</param>
         public void RemoveOldSnapshots(float oldTime, int keepCount)
         {
-            for (int i = buffer.Count - 1 - keepCount; i >= 0; i--)
+            int kept = 0;
+            // loop from newest to oldest
+            for (int i = buffer.Count - 1; i >= 0; i--)
             {
                 // older than oldTime
                 if (buffer[i].time < oldTime)
                 {
-                    buffer.RemoveAt(i);
+                    if (kept < keepCount)
+                    {
+                        kept++;
+                    }
+                    else
+                    {
+                        buffer.RemoveAt(i);
+                    }
                 }
             }
         }

--- a/Assets/Mirror/Components/SnapshotBuffer.cs
+++ b/Assets/Mirror/Components/SnapshotBuffer.cs
@@ -147,6 +147,8 @@ namespace Mirror.TransformSyncing
 
         public override string ToString()
         {
+            if (buffer.Count == 0) { return "Buffer Empty"; }
+
             StringBuilder builder = new StringBuilder();
             builder.AppendLine($"count:{buffer.Count}, minTime:{buffer[0].time}, maxTime:{buffer[buffer.Count - 1].time}");
             for (int i = 0; i < buffer.Count; i++)

--- a/Assets/Mirror/Components/SnapshotBuffer.cs.meta
+++ b/Assets/Mirror/Components/SnapshotBuffer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dcff336bb00a26b42a2d78518335a071
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/SnapshotBufferTests.cs
+++ b/Assets/Mirror/Tests/Editor/SnapshotBufferTests.cs
@@ -1,0 +1,175 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using RangeAttribute = NUnit.Framework.RangeAttribute;
+
+namespace Mirror.TransformSyncing.Tests
+{
+    public class SnapshotBufferTests
+    {
+        public class IsEmpty
+        {
+            [Test]
+            public void ShouldBeTrueOnNewBuffer()
+            {
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                Assert.That(buffer.IsEmpty, Is.True);
+            }
+
+            [Test]
+            public void ShouldBeFalseAfterAddingToBuffer()
+            {
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                buffer.AddSnapShot(default, default);
+                Assert.That(buffer.IsEmpty, Is.False);
+            }
+
+            [Test]
+            public void ShouldBeTrueAfterRemovingFromBuffer()
+            {
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                buffer.AddSnapShot(default, 0);
+                buffer.RemoveOldSnapshots(1);
+                Assert.That(buffer.IsEmpty, Is.True);
+            }
+        }
+
+        public class RemoveSnapshots
+        {
+            [Test]
+            public void ShouldOnlyRemoveOld()
+            {
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                buffer.AddSnapShot(default, 0);
+                buffer.AddSnapShot(default, 1);
+                Assert.That(buffer.SnapshotCount, Is.EqualTo(2));
+
+                buffer.RemoveOldSnapshots(0.5f);
+                Assert.That(buffer.SnapshotCount, Is.EqualTo(1));
+
+                buffer.RemoveOldSnapshots(1.5f);
+                Assert.That(buffer.SnapshotCount, Is.EqualTo(0));
+            }
+        }
+
+        public class AddSnapshot
+        {
+            [Test]
+            public void ShouldIncreaseCount([Range(1, 5)] int count)
+            {
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.That(buffer.SnapshotCount, Is.EqualTo(i));
+                    buffer.AddSnapShot(default, i);
+                    Assert.That(buffer.SnapshotCount, Is.EqualTo(i + 1));
+                }
+            }
+
+            [Test]
+            public void ShouldGiveErrorIfOutOfOrder()
+            {
+                const float time1 = 1.1f;
+                const float time2 = 0.9f;
+
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                buffer.AddSnapShot(default, time1);
+                LogAssert.Expect(LogType.Error, $"Adding Snapshot to buffer out of order, last t={time1:0.000}, new t={time2:0.000}");
+                buffer.AddSnapShot(default, time2);
+            }
+        }
+
+        public class GetInterpolation
+        {
+            private ILogger logger;
+            private LogType oldFilterLogType;
+
+            // set and reset log level so tests can validate
+            [SetUp]
+            public void SetUp()
+            {
+                logger = LogFactory.GetLogger<SnapshotBuffer>(LogType.Error);
+                oldFilterLogType = logger.filterLogType;
+                logger.filterLogType = LogType.Log;
+            }
+            [TearDown]
+            public void TearDown()
+            {
+                logger.filterLogType = oldFilterLogType;
+            }
+
+            [Test]
+            public void ShouldGiveErrorWhenEmpty()
+            {
+                SnapshotBuffer buffer = new SnapshotBuffer();
+
+                LogAssert.Expect(LogType.Error, "No snapshots, returning default");
+                TransformState value = buffer.GetLinearInterpolation(default);
+                Assert.That(value, Is.EqualTo(default(TransformState)));
+            }
+
+            [Test]
+            public void ShouldReturnFirstIfOnly1Snapshot([Range(0, 10, 1f)] float now)
+            {
+                TransformState state = new TransformState(Vector3.one, Quaternion.identity);
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                buffer.AddSnapShot(state, default);
+
+                LogAssert.Expect(LogType.Log, "First snapshot");
+                TransformState value = buffer.GetLinearInterpolation(now);
+                Assert.That(value, Is.EqualTo(state));
+            }
+
+            [Test]
+            public void ShouldReturnFirstIfNowIsBeforeFirst([Range(0, 1, 0.1f)] float now)
+            {
+                const float time1 = 1.1f;
+                const float time2 = 1.5f;
+                TransformState state1 = new TransformState(Vector3.one, Quaternion.identity);
+                TransformState state2 = new TransformState(Vector3.one * 2, Quaternion.identity);
+
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                buffer.AddSnapShot(state1, time1);
+                buffer.AddSnapShot(state2, time2);
+
+                LogAssert.Expect(LogType.Log, $"No snapshots for t={now:0.000}, using earliest t={time1:0.000}");
+                TransformState value = buffer.GetLinearInterpolation(now);
+                Assert.That(value, Is.EqualTo(state1));
+            }
+
+            [Test]
+            public void ShouldReturnLastIfNowIsAfterLast([Range(1.6f, 2.6f, 0.1f)] float now)
+            {
+                const float time1 = 1.1f;
+                const float time2 = 1.5f;
+                TransformState state1 = new TransformState(Vector3.one, Quaternion.identity);
+                TransformState state2 = new TransformState(Vector3.one * 2, Quaternion.identity);
+
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                buffer.AddSnapShot(state1, time1);
+                buffer.AddSnapShot(state2, time2);
+
+                LogAssert.Expect(LogType.Warning, $"No snapshots for t={now:0.000}, using first t={time1:0.000} last t={time2:0.000}");
+                TransformState value = buffer.GetLinearInterpolation(now);
+                Assert.That(value, Is.EqualTo(state2));
+            }
+
+            [Test]
+            public void ShouldReturnInterpolationForNowBetween2Snapshots([Range(1f, 2f, 0.1f)] float now)
+            {
+                const float time1 = 1f;
+                const float time2 = 2f;
+                TransformState state1 = new TransformState(Vector3.one, Quaternion.identity);
+                TransformState state2 = new TransformState(Vector3.one * 2, Quaternion.identity);
+                TransformState expected = new TransformState(Vector3.Lerp(state1.position, state2.position, now - time1), Quaternion.identity);
+
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                buffer.AddSnapShot(state1, time1);
+                buffer.AddSnapShot(state2, time2);
+
+                TransformState value = buffer.GetLinearInterpolation(now);
+                Assert.That(value, Is.EqualTo(expected));
+            }
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/SnapshotBufferTests.cs
+++ b/Assets/Mirror/Tests/Editor/SnapshotBufferTests.cs
@@ -171,5 +171,23 @@ namespace Mirror.TransformSyncing.Tests
                 Assert.That(value, Is.EqualTo(expected));
             }
         }
+
+        public class DebugToString
+        {
+            [Test]
+            public void ShouldSayEmptyBuffer()
+            {
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                string str = buffer.ToString();
+                Assert.That(str, Is.EqualTo("Buffer Empty"));
+            }
+            [Test]
+            public void ShouldListSnapshotsInBuffer()
+            {
+                SnapshotBuffer buffer = new SnapshotBuffer();
+                string str = buffer.ToString();
+                Assert.Ignore("NotImplemented");
+            }
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SnapshotBufferTests.cs.meta
+++ b/Assets/Mirror/Tests/Editor/SnapshotBufferTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8c1b5e67eab50940855a393baabff78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Runtime/HostSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/HostSetup.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -15,6 +14,9 @@ namespace Mirror.Tests.Runtime
         protected NetworkIdentity identity;
 
         protected virtual bool AutoAddPlayer => true;
+
+        protected virtual void afterStartHost() { }
+        protected virtual void beforeStopHost() { }
 
         [UnitySetUp]
         public IEnumerator SetupHost()
@@ -32,14 +34,28 @@ namespace Mirror.Tests.Runtime
             manager.autoStartServerBuild = false;
             manager.autoCreatePlayer = AutoAddPlayer;
 
+            if (Application.isBatchMode)
+            {
+                Application.targetFrameRate = 60;
+            }
+
             yield return null;
 
             manager.StartHost();
+
+            yield return null;
+
+            afterStartHost();
         }
 
-        [TearDown]
-        public void ShutdownHost()
+
+        [UnityTearDown]
+        public IEnumerator ShutdownHost()
         {
+            beforeStopHost();
+
+            yield return null;
+
             Object.DestroyImmediate(playerGO);
             manager.StopHost();
             Object.DestroyImmediate(networkManagerGo);

--- a/Assets/Mirror/Tests/Runtime/HostSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/HostSetup.cs
@@ -14,6 +14,8 @@ namespace Mirror.Tests.Runtime
         protected GameObject playerGO;
         protected NetworkIdentity identity;
 
+        protected virtual bool AutoAddPlayer => true;
+
         [UnitySetUp]
         public IEnumerator SetupHost()
         {
@@ -28,6 +30,7 @@ namespace Mirror.Tests.Runtime
 
             manager.playerPrefab = playerGO;
             manager.autoStartServerBuild = false;
+            manager.autoCreatePlayer = AutoAddPlayer;
 
             yield return null;
 

--- a/Assets/Mirror/Tests/Runtime/NetworkTransformSnapshotInterpolationTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkTransformSnapshotInterpolationTest.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using System.Collections.Generic;
+using Mirror.Tests.Runtime;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Mirror.TransformSyncing.Tests.Runtime
+{
+    public class NetworkTransformSnapshotInterpolationTest : HostSetup
+    {
+        readonly List<GameObject> spawned = new List<GameObject>();
+
+        private NetworkTransformSnapshotInterpolation serverNT;
+        private NetworkTransformSnapshotInterpolation clientNT;
+
+        [SetUp]
+        public void SetUp()
+        {
+            GameObject serverGO = new GameObject("server object");
+            GameObject clientGO = new GameObject("client object");
+            spawned.Add(serverGO);
+            spawned.Add(clientGO);
+
+            NetworkIdentity serverNI = serverGO.AddComponent<NetworkIdentity>();
+            NetworkIdentity clientNI = clientGO.AddComponent<NetworkIdentity>();
+
+            serverNT = serverGO.AddComponent<NetworkTransformSnapshotInterpolation>();
+            clientNT = clientGO.AddComponent<NetworkTransformSnapshotInterpolation>();
+
+            // set up Identitys so that server object can send message to client object in host mode
+            serverNI.OnStartServer();
+            serverNI.RebuildObservers(true);
+
+            clientNI.netId = serverNI.netId;
+            NetworkIdentity.spawned[serverNI.netId] = clientNI;
+            clientNI.OnStartClient();
+
+            // reset both transforms
+            serverGO.transform.position = Vector3.zero;
+            clientGO.transform.position = Vector3.zero;
+        }
+
+        [UnityTest]
+        public IEnumerator SyncPositionFromServerToClient()
+        {
+            Vector3[] positions = new Vector3[] {
+                new Vector3(1, 2, 3),
+                new Vector3(2, 2, 3),
+                new Vector3(2, 3, 5),
+                new Vector3(2, 3, 5),
+            };
+
+            for (int i = 0; i < positions.Length; i++)
+            {
+                serverNT.transform.position = positions[i];
+                // wait more than needed to check end position is reached
+                yield return new WaitForSeconds(0.5f);
+
+                Assert.That(clientNT.transform.position, Is.EqualTo(positions[i]));
+            }
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Runtime/NetworkTransformSnapshotInterpolationTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkTransformSnapshotInterpolationTest.cs
@@ -16,8 +16,7 @@ namespace Mirror.TransformSyncing.Tests.Runtime
 
         protected override bool AutoAddPlayer => false;
 
-        [SetUp]
-        public void SetUp()
+        protected override void afterStartHost()
         {
             GameObject serverGO = new GameObject("server object");
             GameObject clientGO = new GameObject("client object");
@@ -43,6 +42,14 @@ namespace Mirror.TransformSyncing.Tests.Runtime
             clientGO.transform.position = Vector3.zero;
         }
 
+        protected override void beforeStopHost()
+        {
+            foreach (GameObject obj in spawned)
+            {
+                Object.Destroy(obj);
+            }
+        }
+
         [UnityTest]
         public IEnumerator SyncPositionFromServerToClient()
         {
@@ -53,13 +60,13 @@ namespace Mirror.TransformSyncing.Tests.Runtime
                 new Vector3(2, 3, 5),
             };
 
-            for (int i = 0; i < positions.Length; i++)
+            foreach (Vector3 position in positions)
             {
-                serverNT.transform.position = positions[i];
+                serverNT.transform.position = position;
                 // wait more than needed to check end position is reached
                 yield return new WaitForSeconds(0.5f);
 
-                Assert.That(clientNT.transform.position, Is.EqualTo(positions[i]));
+                Assert.That(clientNT.transform.position, Is.EqualTo(position));
             }
         }
     }

--- a/Assets/Mirror/Tests/Runtime/NetworkTransformSnapshotInterpolationTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkTransformSnapshotInterpolationTest.cs
@@ -14,6 +14,8 @@ namespace Mirror.TransformSyncing.Tests.Runtime
         private NetworkTransformSnapshotInterpolation serverNT;
         private NetworkTransformSnapshotInterpolation clientNT;
 
+        protected override bool AutoAddPlayer => false;
+
         [SetUp]
         public void SetUp()
         {

--- a/Assets/Mirror/Tests/Runtime/NetworkTransformSnapshotInterpolationTest.cs.meta
+++ b/Assets/Mirror/Tests/Runtime/NetworkTransformSnapshotInterpolationTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8579b02e7de035c47b5227f58900b574
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Placeholder name for testing, later PR can replace old NT with this component

This is MVP of Snapshot Interpolation, something that should be better that the old NT but is not perfect yet.

Differences vs old NT
- no longer syncs scale
- now has local space vs world space option
- has target field instead of 2 components, field defaults to current object

Future improvements
- dynamically adjusting client delay (minimize latency) (https://www.twitch.tv/videos/867486481)
- unreliable sends
    - handle packets being received out of order
- batching+bitpacking for cpu and bandwidth savings

Other Features
- Add teleport function (eg dont interpolate when going from one side of map to the other)
- Sync parent


**For feedback, it would be helpful to know if suggestions are for this MVP or for Future improvements**