### PR TITLE
add common options for rooms, and update example to use them

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -33,6 +33,14 @@ namespace Mirror
         [Tooltip("This flag controls whether the default UI is shown for the room")]
         public bool showRoomGUI = true;
 
+        [Tooltip("Automatically starts the game when all players are ready")]
+        [SerializeField]
+        public bool StartWhenPlayersReady = true;
+
+        [Tooltip("Allows players to join when the game scene is active")]
+        [SerializeField]
+        public bool AllowJoinGameInProgress;
+
         [FormerlySerializedAs("m_MinPlayers")]
         [SerializeField]
         [Tooltip("Minimum number of players to auto-start the game")]
@@ -254,8 +262,7 @@ namespace Mirror
                 return;
             }
 
-            // cannot join game in progress
-            if (!IsSceneActive(RoomScene))
+            if (!IsSceneActive(RoomScene) && !AllowJoinGameInProgress)
             {
                 conn.Disconnect();
                 return;
@@ -609,8 +616,10 @@ namespace Mirror
         /// </summary>
         public virtual void OnRoomServerPlayersReady()
         {
-            // all players are readyToBegin, start the game
-            ServerChangeScene(GameplayScene);
+            if (StartWhenPlayersReady)
+            {
+                ServerChangeScene(GameplayScene);
+            }
         }
 
         /// <summary>

--- a/Assets/Mirror/Examples/Room/Scenes/OfflineScene.unity
+++ b/Assets/Mirror/Examples/Room/Scenes/OfflineScene.unity
@@ -258,6 +258,8 @@ MonoBehaviour:
   spawnPrefabs:
   - {fileID: 1139254171913846, guid: 52f1c9ea06cfd154cb68ff9d1b66fc13, type: 3}
   showRoomGUI: 1
+  StartWhenPlayersReady: 0
+  AllowJoinGameInProgress: 0
   minPlayers: 1
   roomPlayerPrefab: {fileID: 114033720796874720, guid: deae2134a1d77704b9c595efe69767dd,
     type: 3}

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
@@ -58,36 +58,12 @@ namespace Mirror.Examples.NetworkRoom
             base.OnRoomStopServer();
         }
 
-        /*
-            This code below is to demonstrate how to do a Start button that only appears for the Host player
-            showStartButton is a local bool that's needed because OnRoomServerPlayersReady is only fired when
-            all players are ready, but if a player cancels their ready state there's no callback to set it back to false
-            Therefore, allPlayersReady is used in combination with showStartButton to show/hide the Start button correctly.
-            Setting showStartButton false when the button is pressed hides it in the game scene since NetworkRoomManager
-            is set as DontDestroyOnLoad = true.
-        */
-
-        bool showStartButton;
-
-        public override void OnRoomServerPlayersReady()
-        {
-            // calling the base method calls ServerChangeScene as soon as all players are in Ready state.
-#if UNITY_SERVER
-            base.OnRoomServerPlayersReady();
-#else
-            showStartButton = true;
-#endif
-        }
-
         public override void OnGUI()
         {
             base.OnGUI();
 
-            if (allPlayersReady && showStartButton && GUI.Button(new Rect(150, 300, 120, 20), "START GAME"))
+            if (allPlayersReady && IsSceneActive(RoomScene) && GUI.Button(new Rect(150, 300, 120, 20), "START GAME"))
             {
-                // set to false to hide it in the game scene
-                showStartButton = false;
-
                 ServerChangeScene(GameplayScene);
             }
         }


### PR DESCRIPTION
added editor booleans for 

StartWhenPlayersReady
 - Automatically starts the game when all players are ready. 
 - defaults to true to maintain current behaviour.

AllowJoinGameInProgress
 - Allows players to join when the game scene is active
 - defaults to false to maintain current behaviour.
 
 
Room example now sets StartWhenPlayersReady to false instead of having to override code.