### PR TITLE
Fixing typo on Network Lerp Rigidbody

### DIFF
--- a/doc/Articles/Components/NetworkLerpRigidbody.md
+++ b/doc/Articles/Components/NetworkLerpRigidbody.md
@@ -6,7 +6,7 @@ The Network Lerp Rigidbody component synchronizes position and velocity of a rig
 
 A game object with a Network Rigidbody component must also have a Network Identity component. When you add a Network Rigidbody component to a game object, Mirror also adds a Network Identity component on that game object if it does not already have one.
 
-When using the Network Lerp Rigidbody you should have NetworkTransform on the same object as the Network Lerp Rigidbody will handle syncing the position
+When using the Network Lerp Rigidbody you should NOT have NetworkTransform on the same object as the Network Lerp Rigidbody will handle syncing the position
 
 By default, Network Lerp Rigidbody is server-authoritative unless you check the box for **Client Authority**. Client Authority applies to player objects as well as non-player objects that have been specifically assigned to a client, but only for this component. With this enabled, value changes are send from the client to the server.
 


### PR DESCRIPTION
I believe this should say you should NOT have a network transform on a gameobject with a network rigidbody.