### PR TITLE
fix: NetworkManager: Removed #if UNITY_EDITOR

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -208,9 +208,7 @@ namespace Mirror
                     transport = gameObject.AddComponent<KcpTransport>();
                     logger.Log("NetworkManager: added default Transport because there was none yet.");
                 }
-#if UNITY_EDITOR
                 UnityEditor.Undo.RecordObject(gameObject, "Added default Transport");
-#endif
             }
 
             // always >= 0


### PR DESCRIPTION
- Not needed in `OnValidate`
- Per Unity docs, it's only called in the editor

![image](https://user-images.githubusercontent.com/9826063/105440999-a3704c80-5c35-11eb-8ab2-a713038ccf01.png)

