### PR TITLE
NetworkServer/NetworkClient: add/remove from transport events instead of overwriting them. This allows addons to hook into Transport OnConnect/OnData/etc.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -147,10 +147,18 @@ namespace Mirror
 
         static void AddTransportHandlers()
         {
-            Transport.activeTransport.OnClientConnected = OnConnected;
-            Transport.activeTransport.OnClientDataReceived = OnDataReceived;
-            Transport.activeTransport.OnClientDisconnected = OnDisconnected;
-            Transport.activeTransport.OnClientError = OnError;
+            Transport.activeTransport.OnClientConnected += OnConnected;
+            Transport.activeTransport.OnClientDataReceived += OnDataReceived;
+            Transport.activeTransport.OnClientDisconnected += OnDisconnected;
+            Transport.activeTransport.OnClientError += OnError;
+        }
+
+        static void RemoveTransportHandlers()
+        {
+            Transport.activeTransport.OnClientConnected -= OnConnected;
+            Transport.activeTransport.OnClientDataReceived -= OnDataReceived;
+            Transport.activeTransport.OnClientDisconnected -= OnDisconnected;
+            Transport.activeTransport.OnClientError -= OnError;
         }
 
         static void OnError(Exception exception)
@@ -218,6 +226,8 @@ namespace Mirror
                     connection = null;
                 }
             }
+
+            RemoveTransportHandlers();
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -98,6 +98,7 @@ namespace Mirror
 
             CleanupNetworkIdentities();
             NetworkIdentity.ResetNextNetworkId();
+            RemoveTransportHandlers();
         }
 
         static void CleanupNetworkIdentities()
@@ -489,10 +490,18 @@ namespace Mirror
 
         static void AddTransportHandlers()
         {
-            Transport.activeTransport.OnServerConnected = OnConnected;
-            Transport.activeTransport.OnServerDataReceived = OnDataReceived;
-            Transport.activeTransport.OnServerDisconnected = OnDisconnected;
-            Transport.activeTransport.OnServerError = OnError;
+            Transport.activeTransport.OnServerConnected += OnConnected;
+            Transport.activeTransport.OnServerDataReceived += OnDataReceived;
+            Transport.activeTransport.OnServerDisconnected += OnDisconnected;
+            Transport.activeTransport.OnServerError += OnError;
+        }
+
+        static void RemoveTransportHandlers()
+        {
+            Transport.activeTransport.OnServerConnected -= OnConnected;
+            Transport.activeTransport.OnServerDataReceived -= OnDataReceived;
+            Transport.activeTransport.OnServerDisconnected -= OnDisconnected;
+            Transport.activeTransport.OnServerError -= OnError;
         }
 
         static void OnConnected(int connectionId)

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -8,7 +8,7 @@ namespace Mirror
     /// </summary>
     /// <remarks>
     /// <h2>
-    ///   Transport Rules 
+    ///   Transport Rules
     /// </h2>
     /// <list type="bullet">
     ///   <listheader><description>
@@ -58,25 +58,25 @@ namespace Mirror
         /// Notify subscribers when when this client establish a successful connection to the server
         /// <para>callback()</para>
         /// </summary>
-        public Action OnClientConnected = () => Debug.LogWarning("OnClientConnected called with no handler");
+        public Action OnClientConnected;
 
         /// <summary>
         /// Notify subscribers when this client receive data from the server
         /// <para>callback(ArraySegment&lt;byte&gt; data, int channel)</para>
         /// </summary>
-        public Action<ArraySegment<byte>, int> OnClientDataReceived = (data, channel) => Debug.LogWarning("OnClientDataReceived called with no handler");
+        public Action<ArraySegment<byte>, int> OnClientDataReceived;
 
         /// <summary>
         /// Notify subscribers when this client encounters an error communicating with the server
         /// <para>callback(Exception e)</para>
         /// </summary>
-        public Action<Exception> OnClientError = (error) => Debug.LogWarning("OnClientError called with no handler");
+        public Action<Exception> OnClientError;
 
         /// <summary>
         /// Notify subscribers when this client disconnects from the server
         /// <para>callback()</para>
         /// </summary>
-        public Action OnClientDisconnected = () => Debug.LogWarning("OnClientDisconnected called with no handler");
+        public Action OnClientDisconnected;
 
         /// <summary>
         /// Determines if we are currently connected to the server
@@ -131,25 +131,25 @@ namespace Mirror
         /// Notify subscribers when a client connects to this server
         /// <para>callback(int connId)</para>
         /// </summary>
-        public Action<int> OnServerConnected = (connId) => Debug.LogWarning("OnServerConnected called with no handler");
+        public Action<int> OnServerConnected;
 
         /// <summary>
         /// Notify subscribers when this server receives data from the client
         /// <para>callback(int connId, ArraySegment&lt;byte&gt; data, int channel)</para>
         /// </summary>
-        public Action<int, ArraySegment<byte>, int> OnServerDataReceived = (connId, data, channel) => Debug.LogWarning("OnServerDataReceived called with no handler");
+        public Action<int, ArraySegment<byte>, int> OnServerDataReceived;
 
         /// <summary>
         /// Notify subscribers when this server has some problem communicating with the client
         /// <para>callback(int connId, Exception e)</para>
         /// </summary>
-        public Action<int, Exception> OnServerError = (connId, error) => Debug.LogWarning("OnServerError called with no handler");
+        public Action<int, Exception> OnServerError;
 
         /// <summary>
         /// Notify subscribers when a client disconnects from this server
         /// <para>callback(int connId)</para>
         /// </summary>
-        public Action<int> OnServerDisconnected = (connId) => Debug.LogWarning("OnServerDisconnected called with no handler");
+        public Action<int> OnServerDisconnected;
 
         /// <summary>
         /// Determines if the server is up and running


### PR DESCRIPTION
prepare for networkstatistics.
cleaner.
allows addons to hook into transport events too.

IMPORTANT: need to test with all transports.
some might need to invoke events lazily so they always use the 'current' events.
- kcp?
- telepathy?
- libuv?
- litenet?
- ignorance?
- websockets?
- epic?