### PR TITLE
fix: Increase log level of full server

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -555,9 +555,9 @@ namespace Mirror
             }
             else
             {
-                // kick
+                // kick because full
                 Transport.activeTransport.ServerDisconnect(connectionId);
-                if (logger.LogEnabled()) logger.Log("Server full, kicked client:" + connectionId);
+                if (logger.WarnEnabled()) logger.LogWarning($"Server full, kicked client: {connectionId}");
             }
         }
 


### PR DESCRIPTION
- This message should be a warning so that it is logged by default.
- Server being full is something the developer should look into, therefor should be a warning