### PR TITLE
feat: Added bool to Discovery to disable automatic active discovery

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -32,8 +32,8 @@ namespace Mirror.Discovery
         protected int serverBroadcastListenPort = 47777;
 
         [SerializeField]
-        [Tooltip("Time in seconds between multi-cast messages")]
-        [Range(1, 60)]
+        [Tooltip("Time in seconds between multi-cast messages. Use a negative value to disable automatic broadcasting.")]
+        [Range(-1, 60)]
         float ActiveDiscoveryInterval = 3;
 
         protected UdpClient serverUdpClient;
@@ -251,7 +251,7 @@ namespace Mirror.Discovery
 
             _ = ClientListenAsync();
 
-            InvokeRepeating(nameof(BroadcastDiscoveryRequest), 0, ActiveDiscoveryInterval);
+            if (ActiveDiscoveryInterval >= 0) InvokeRepeating(nameof(BroadcastDiscoveryRequest), 0, ActiveDiscoveryInterval);
         }
 
         /// <summary>

--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -30,10 +30,14 @@ namespace Mirror.Discovery
         [SerializeField]
         [Tooltip("The UDP port the server will listen for multi-cast messages")]
         protected int serverBroadcastListenPort = 47777;
-
+        
         [SerializeField]
-        [Tooltip("Time in seconds between multi-cast messages. Use a negative value to disable automatic broadcasting.")]
-        [Range(-1, 60)]
+        [Tooltip("")]
+        bool enableActiveDiscovery = true;
+        
+        [SerializeField]
+        [Tooltip("Time in seconds between multi-cast messages")]
+        [Range(1, 60)]
         float ActiveDiscoveryInterval = 3;
 
         protected UdpClient serverUdpClient;
@@ -251,7 +255,7 @@ namespace Mirror.Discovery
 
             _ = ClientListenAsync();
 
-            if (ActiveDiscoveryInterval >= 0) InvokeRepeating(nameof(BroadcastDiscoveryRequest), 0, ActiveDiscoveryInterval);
+            if (enableActiveDiscovery) InvokeRepeating(nameof(BroadcastDiscoveryRequest), 0, ActiveDiscoveryInterval);
         }
 
         /// <summary>

--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -32,8 +32,8 @@ namespace Mirror.Discovery
         protected int serverBroadcastListenPort = 47777;
         
         [SerializeField]
-        [Tooltip("")]
-        bool enableActiveDiscovery = true;
+        [Tooltip("If true, broadcasts a discovery request every ActiveDiscoveryInterval seconds")]
+        public bool enableActiveDiscovery = true;
         
         [SerializeField]
         [Tooltip("Time in seconds between multi-cast messages")]


### PR DESCRIPTION
If you want to extend NetworkDiscoveryBase using the templates, you may hit this problem where you want to disable the automatic discovery. But you can't without modifying the base class. This is a proposition that is not breaking for users of the NetworkDiscovery.