### PR TITLE
obsolete NetworkManagerHUD.showGUI

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -1,5 +1,7 @@
 // vis2k: GUILayout instead of spacey += ...; removed Update hotkeys to avoid
 // confusion if someone accidentally presses one.
+
+using System;
 using UnityEngine;
 
 namespace Mirror
@@ -19,6 +21,7 @@ namespace Mirror
         /// <summary>
         /// Whether to show the default control HUD at runtime.
         /// </summary>
+        [Obsolete("showGUI will be removed unless someone has a valid use case. Simply use or don't use the HUD component.")]
         public bool showGUI = true;
 
         /// <summary>
@@ -38,8 +41,9 @@ namespace Mirror
 
         void OnGUI()
         {
-            if (!showGUI)
-                return;
+#pragma warning disable 618
+            if (!showGUI) return;
+#pragma warning restore 618
 
             GUILayout.BeginArea(new Rect(10 + offsetX, 40 + offsetY, 215, 9999));
             if (!NetworkClient.isConnected && !NetworkServer.active)


### PR DESCRIPTION
remove unnecessary complexity.
use, or don't use the component.