### PR TITLE
feature: add custom NetworkEarlyUpdate (before any Update/FixedUpdate), NetworkLateUpdate (after any Update/FixedUpdate/LateUpdate)

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -280,6 +280,10 @@ namespace Mirror
             //Debug.Log("NetworkClient.NetworkLateUpdate @ " + Time.time);
         }
 
+        // obsolete to not break people's projects. Update was public.
+        [Obsolete("Use NetworkClient.Update was renamed to LateUpdate because that's when it actually happens.")]
+        public static void Update() => LateUpdate();
+
         // Called from NetworkManager in LateUpdate
         // The user should never need to pump the update loop manually.
         public static void LateUpdate()

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -268,17 +268,11 @@ namespace Mirror
 
         // NetworkEarlyUpdate called before any Update/FixedUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkEarlyUpdate()
-        {
-            //Debug.Log("NetworkClient.NetworkEarlyUpdate @ " + Time.time);
-        }
+        internal static void NetworkEarlyUpdate() {}
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkLateUpdate()
-        {
-            //Debug.Log("NetworkClient.NetworkLateUpdate @ " + Time.time);
-        }
+        internal static void NetworkLateUpdate() {}
 
         // obsolete to not break people's projects. Update was public.
         [Obsolete("Use NetworkClient.Update was renamed to LateUpdate because that's when it actually happens.")]

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -266,7 +266,9 @@ namespace Mirror
             else Debug.LogError("NetworkClient Send with no connection");
         }
 
-        public static void Update()
+        // Called from NetworkManager in LateUpdate
+        // The user should never need to pump the update loop manually.
+        public static void LateUpdate()
         {
             // local connection?
             if (connection is LocalConnectionToServer localConnection)

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -266,6 +266,14 @@ namespace Mirror
             else Debug.LogError("NetworkClient Send with no connection");
         }
 
+        // NetworkEarlyUpdate called before any Update/FixedUpdate
+        // (we add this to the UnityEngine in NetworkLoop)
+        internal static void NetworkEarlyUpdate() {}
+
+        // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
+        // (we add this to the UnityEngine in NetworkLoop)
+        internal static void NetworkLateUpdate() {}
+
         // Called from NetworkManager in LateUpdate
         // The user should never need to pump the update loop manually.
         public static void LateUpdate()

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -280,7 +280,7 @@ namespace Mirror
 
         // Called from NetworkManager in LateUpdate
         // The user should never need to pump the update loop manually.
-        public static void LateUpdate()
+        internal static void LateUpdate()
         {
             // local connection?
             if (connection is LocalConnectionToServer localConnection)

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -275,7 +275,7 @@ namespace Mirror
         internal static void NetworkLateUpdate() {}
 
         // obsolete to not break people's projects. Update was public.
-        [Obsolete("Use NetworkClient.Update was renamed to LateUpdate because that's when it actually happens.")]
+        [Obsolete("NetworkClient.Update was renamed to LateUpdate because that's when it actually happens.")]
         public static void Update() => LateUpdate();
 
         // Called from NetworkManager in LateUpdate

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -268,11 +268,17 @@ namespace Mirror
 
         // NetworkEarlyUpdate called before any Update/FixedUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkEarlyUpdate() {}
+        internal static void NetworkEarlyUpdate()
+        {
+            Debug.Log("NetworkClient.NetworkEarlyUpdate @ " + Time.time);
+        }
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkLateUpdate() {}
+        internal static void NetworkLateUpdate()
+        {
+            Debug.Log("NetworkClient.NetworkLateUpdate @ " + Time.time);
+        }
 
         // Called from NetworkManager in LateUpdate
         // The user should never need to pump the update loop manually.

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -270,14 +270,14 @@ namespace Mirror
         // (we add this to the UnityEngine in NetworkLoop)
         internal static void NetworkEarlyUpdate()
         {
-            Debug.Log("NetworkClient.NetworkEarlyUpdate @ " + Time.time);
+            //Debug.Log("NetworkClient.NetworkEarlyUpdate @ " + Time.time);
         }
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
         internal static void NetworkLateUpdate()
         {
-            Debug.Log("NetworkClient.NetworkLateUpdate @ " + Time.time);
+            //Debug.Log("NetworkClient.NetworkLateUpdate @ " + Time.time);
         }
 
         // Called from NetworkManager in LateUpdate

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -63,18 +63,12 @@ namespace Mirror
                     Debug.Log($"->{sys.type}");
 
                 // resize & expand subSystemList to fit one more entry
-                // TODO use Array.Resize later if it's safe
                 int oldListLength = (playerLoop.subSystemList != null) ? playerLoop.subSystemList.Length : 0;
-                PlayerLoopSystem[] newSubsystemList = new PlayerLoopSystem[oldListLength + 1];
-                for (int i = 0; i < oldListLength; ++i)
-                    newSubsystemList[i] = playerLoop.subSystemList[i];
+                Array.Resize(ref playerLoop.subSystemList, oldListLength + 1);
 
                 // append our custom loop at the end
-                newSubsystemList[oldListLength].type = ownerType;
-                newSubsystemList[oldListLength].updateDelegate = function;
-
-                // assign the new subSystemList
-                playerLoop.subSystemList = newSubsystemList;
+                playerLoop.subSystemList[oldListLength].type = ownerType;
+                playerLoop.subSystemList[oldListLength].updateDelegate = function;
 
                 // debugging
                 Debug.LogWarning($"New playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -58,9 +58,9 @@ namespace Mirror
             if (playerLoop.type == playerLoopSystemType)
             {
                 // debugging
-                Debug.LogWarning($"Found playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");
+                Debug.Log($"Found playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");
                 foreach (PlayerLoopSystem sys in playerLoop.subSystemList)
-                    Debug.Log($"->{sys.type}");
+                    Debug.Log($"  ->{sys.type}");
 
                 // resize & expand subSystemList to fit one more entry
                 int oldListLength = (playerLoop.subSystemList != null) ? playerLoop.subSystemList.Length : 0;
@@ -71,9 +71,9 @@ namespace Mirror
                 playerLoop.subSystemList[oldListLength].updateDelegate = function;
 
                 // debugging
-                Debug.LogWarning($"New playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");
+                Debug.Log($"New playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");
                 foreach (PlayerLoopSystem sys in playerLoop.subSystemList)
-                    Debug.Log($"->{sys.type}");
+                    Debug.Log($"  ->{sys.type}");
 
                 return true;
             }

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -1,0 +1,30 @@
+﻿// our ideal update looks like this:
+//   transport.process_incoming()
+//   update_world()
+//   transport.process_outgoing()
+//
+// this way we avoid unnecessary latency for low-ish server tick rates.
+// for example, if we were to use this tick:
+//   transport.process_incoming/outgoing()
+//   update_world()
+//
+// then anything sent in update_world wouldn't be actually sent out by the
+// transport until the next frame. if server runs at 60Hz, then this can add
+// 16ms latency for every single packet.
+//
+// => instead we process incoming, update world, process_outgoing in the same
+//    frame. it's more clear (no race conditions) and lower latency.
+// => we need to add custom Update functions to the Unity engine:
+//      NetworkEarlyUpdate before Update()/FixedUpdate()
+//      NetworkLateUpdate after LateUpdate()
+//    this way the user can update the world in Update/FixedUpdate/LateUpdate
+//    and networking still runs before/after those functions no matter what!
+// => see also: https://docs.unity3d.com/Manual/ExecutionOrder.html
+using UnityEngine;
+
+namespace Mirror
+{
+    internal static class NetworkLoop
+    {
+    }
+}

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -24,7 +24,6 @@
 //    PostLateUpdate. we DO NOT want to add to the end of PostLateUpdate
 //    after Unity's magic systems like MemoryFrameMaintenance ran.
 using System;
-using UnityEngine;
 using UnityEngine.Experimental.LowLevel;
 
 namespace Mirror
@@ -81,9 +80,9 @@ namespace Mirror
             if (playerLoop.type == playerLoopSystemType)
             {
                 // debugging
-                Debug.Log($"Found playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");
-                foreach (PlayerLoopSystem sys in playerLoop.subSystemList)
-                    Debug.Log($"  ->{sys.type}");
+                //Debug.Log($"Found playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");
+                //foreach (PlayerLoopSystem sys in playerLoop.subSystemList)
+                //    Debug.Log($"  ->{sys.type}");
 
                 // resize & expand subSystemList to fit one more entry
                 int oldListLength = (playerLoop.subSystemList != null) ? playerLoop.subSystemList.Length : 0;
@@ -107,9 +106,9 @@ namespace Mirror
                 }
 
                 // debugging
-                Debug.Log($"New playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");
-                foreach (PlayerLoopSystem sys in playerLoop.subSystemList)
-                    Debug.Log($"  ->{sys.type}");
+                //Debug.Log($"New playerLoop of type {playerLoop.type} with {playerLoop.subSystemList.Length} Functions:");
+                //foreach (PlayerLoopSystem sys in playerLoop.subSystemList)
+                //    Debug.Log($"  ->{sys.type}");
 
                 return true;
             }

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -132,7 +132,7 @@ namespace Mirror
         [RuntimeInitializeOnLoadMethod]
         static void RuntimeInitializeOnLoad()
         {
-            Debug.Log("NetworkLoop: adding NetworkEarly/LateUpdate to Unity... ");
+            Debug.Log("Mirror: adding Network[Early/Late]Update to Unity...");
 
             // get current loop
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -77,10 +77,11 @@ namespace Mirror
 
                 return true;
             }
+
             // recursively keep looking
             if (playerLoop.subSystemList != null)
             {
-                for(int i=0; i<playerLoop.subSystemList.Length; ++i)
+                for(int i = 0; i < playerLoop.subSystemList.Length; ++i)
                 {
                     if (AppendSystemToPlayerLoopList(function, ownerType, ref playerLoop.subSystemList[i], playerLoopSystemType))
                         return true;

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -20,6 +20,9 @@
 //    this way the user can update the world in Update/FixedUpdate/LateUpdate
 //    and networking still runs before/after those functions no matter what!
 // => see also: https://docs.unity3d.com/Manual/ExecutionOrder.html
+// => we want to add to the end of EarlyUpdate and to the beginning of
+//    PostLateUpdate. we DO NOT want to add to the end of PostLateUpdate
+//    after Unity's magic systems like MemoryFrameMaintenance ran.
 
 using System;
 using UnityEngine;
@@ -29,9 +32,10 @@ namespace Mirror
 {
     internal static class NetworkLoop
     {
-        // AddSystemToPlayerLoopList from
-        // com.unity.entities/ScriptBehaviourUpdateOrder (ECS)
-        // => adds an update function to the Unity internal update loop.
+        // helper enum to add loop to begin/end of subSystemList
+
+        // AddSystemToPlayerLoopList from Unity.Entities.ScriptBehaviourUpdateOrder (ECS)
+        // => adds an update function to the END of the Unity internal update type.
         // => Unity has different update loops:
         //    https://medium.com/@thebeardphantom/unity-2018-and-playerloop-5c46a12a677
         //      EarlyUpdate
@@ -40,20 +44,28 @@ namespace Mirror
         //      Update
         //      PreLateUpdate
         //      PostLateUpdate
-        internal static bool AddSystemToPlayerLoopList(Action CustomLoop, ref PlayerLoopSystem playerLoop, Type playerLoopSystemType)
+        internal static bool AppendSystemToPlayerLoopList(Action CustomLoop, ref PlayerLoopSystem playerLoop, Type playerLoopSystemType)
         {
             // did we find the type? e.g. EarlyUpdate/PreLateUpdate/etc.
             if (playerLoop.type == playerLoopSystemType)
             {
-                /*DummyDelegateWrapper del = new DummyDelegateWrapper(system);
+                Debug.Log($"Found playerLoop of type {playerLoop.type}");
+
+                // resize & expand subSystemList to fit one more entry
+                // TODO use Array.Resize later if it's safe
                 int oldListLength = (playerLoop.subSystemList != null) ? playerLoop.subSystemList.Length : 0;
                 PlayerLoopSystem[] newSubsystemList = new PlayerLoopSystem[oldListLength + 1];
                 for (int i = 0; i < oldListLength; ++i)
                     newSubsystemList[i] = playerLoop.subSystemList[i];
-                newSubsystemList[oldListLength].type = CustomLoop.GetType(); // TODO
-                newSubsystemList[oldListLength].updateDelegate = del.TriggerUpdate;
-                playerLoop.subSystemList = newSubsystemList;*/
-                Debug.LogWarning($"Found playerLoop of type {playerLoop.type}");
+
+                // add our custom loop at the end
+                // TODO optional 'add to beginning' for prelateupdate!
+                //DummyDelegateWrapper del = new DummyDelegateWrapper(system);
+                //newSubsystemList[oldListLength].type = CustomLoop.GetType(); // TODO
+                //newSubsystemList[oldListLength].updateDelegate = del.TriggerUpdate;
+
+                // assign the new subSystemList
+                playerLoop.subSystemList = newSubsystemList;
                 return true;
             }
             // recursively keep looking
@@ -61,7 +73,7 @@ namespace Mirror
             {
                 for(int i=0; i<playerLoop.subSystemList.Length; ++i)
                 {
-                    if (AddSystemToPlayerLoopList(CustomLoop, ref playerLoop.subSystemList[i], playerLoopSystemType))
+                    if (AppendSystemToPlayerLoopList(CustomLoop, ref playerLoop.subSystemList[i], playerLoopSystemType))
                         return true;
                 }
             }

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -153,11 +153,15 @@ namespace Mirror
         static void NetworkEarlyUpdate()
         {
             Debug.Log("NetworkEarlyUpdate @ " + Time.time);
+            NetworkServer.NetworkEarlyUpdate();
+            NetworkClient.NetworkEarlyUpdate();
         }
 
         static void NetworkLateUpdate()
         {
             Debug.Log("NetworkLateUpdate @ " + Time.time);
+            NetworkServer.NetworkLateUpdate();
+            NetworkClient.NetworkLateUpdate();
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -48,7 +48,7 @@ namespace Mirror
                 for(int i = 0; i < playerLoop.subSystemList.Length; ++i)
                 {
                     int index = FindPlayerLoopEntryIndex(function, playerLoop.subSystemList[i], playerLoopSystemType);
-                    if (index != -1)  return index;
+                    if (index != -1) return index;
                 }
             }
             return -1;

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -34,7 +34,26 @@ namespace Mirror
         // helper enum to add loop to begin/end of subSystemList
         internal enum AddMode { Beginning, End }
 
-        // helper function to find an
+        // helper function to find an update function's index in a player loop
+        // type. this is used for testing to guarantee our functions are added
+        // at the beginning/end properly.
+        internal static int FindPlayerLoopEntryIndex(PlayerLoopSystem.UpdateFunction function, PlayerLoopSystem playerLoop, Type playerLoopSystemType)
+        {
+            // did we find the type? e.g. EarlyUpdate/PreLateUpdate/etc.
+            if (playerLoop.type == playerLoopSystemType)
+                return Array.FindIndex(playerLoop.subSystemList, (elem => elem.updateDelegate == function));
+
+            // recursively keep looking
+            if (playerLoop.subSystemList != null)
+            {
+                for(int i = 0; i < playerLoop.subSystemList.Length; ++i)
+                {
+                    int index = FindPlayerLoopEntryIndex(function, playerLoop.subSystemList[i], playerLoopSystemType);
+                    if (index != -1)  return index;
+                }
+            }
+            return -1;
+        }
 
         // MODIFIED AddSystemToPlayerLoopList from Unity.Entities.ScriptBehaviourUpdateOrder (ECS)
         //

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -26,8 +26,13 @@
 //      to the beginning of PostLateUpdate doesn't actually work.
 using System;
 using UnityEngine;
+#if UNITY_2019_1_OR_NEWER
+using UnityEngine.LowLevel;
+using UnityEngine.PlayerLoop;
+#else
 using UnityEngine.Experimental.LowLevel;
 using UnityEngine.Experimental.PlayerLoop;
+#endif
 
 namespace Mirror
 {

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -139,7 +139,11 @@ namespace Mirror
         {
             Debug.Log("Mirror: adding Network[Early/Late]Update to Unity...");
 
-            // get current loop
+            // get loop
+            // TODO 2019 has GetCURRENTPlayerLoop which is safe to use without
+            // breaking other custom system's custom loops. Let's use Default
+            // for now until we upgrade to 2019 so we have the same behaviour
+            // at all times (instead of different loop behavior on 2018/2019)
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
 
             // add NetworkEarlyUpdate to the end of EarlyUpdate so it runs after

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -152,14 +152,14 @@ namespace Mirror
 
         static void NetworkEarlyUpdate()
         {
-            Debug.Log("NetworkEarlyUpdate @ " + Time.time);
+            //Debug.Log("NetworkEarlyUpdate @ " + Time.time);
             NetworkServer.NetworkEarlyUpdate();
             NetworkClient.NetworkEarlyUpdate();
         }
 
         static void NetworkLateUpdate()
         {
-            Debug.Log("NetworkLateUpdate @ " + Time.time);
+            //Debug.Log("NetworkLateUpdate @ " + Time.time);
             NetworkServer.NetworkLateUpdate();
             NetworkClient.NetworkLateUpdate();
         }

--- a/Assets/Mirror/Runtime/NetworkLoop.cs.meta
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c6cec4e279774b919386e05545317b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 7453abfe9e8b2c04a8a47eb536fe21eb, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -295,8 +295,8 @@ namespace Mirror
             // call it while the NetworkManager exists.
             // -> we don't only call while Client/Server.Connected, because then we would stop if disconnected and the
             //    NetworkClient wouldn't receive the last Disconnect event, result in all kinds of issues
-            NetworkServer.Update();
-            NetworkClient.Update();
+            NetworkServer.LateUpdate();
+            NetworkClient.LateUpdate();
             UpdateScene();
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -452,17 +452,11 @@ namespace Mirror
 
         // NetworkEarlyUpdate called before any Update/FixedUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkEarlyUpdate()
-        {
-            //Debug.Log("NetworkServer.NetworkEarlyUpdate @ " + Time.time);
-        }
+        internal static void NetworkEarlyUpdate() {}
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkLateUpdate()
-        {
-            //Debug.Log("NetworkServer.NetworkLateUpdate @ " + Time.time);
-        }
+        internal static void NetworkLateUpdate() {}
 
         // obsolete to not break people's projects. Update was public.
         [Obsolete("Use NetworkServer.Update was renamed to LateUpdate because that's when it actually happens.")]

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -454,14 +454,14 @@ namespace Mirror
         // (we add this to the UnityEngine in NetworkLoop)
         internal static void NetworkEarlyUpdate()
         {
-            Debug.Log("NetworkServer.NetworkEarlyUpdate @ " + Time.time);
+            //Debug.Log("NetworkServer.NetworkEarlyUpdate @ " + Time.time);
         }
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
         internal static void NetworkLateUpdate()
         {
-            Debug.Log("NetworkServer.NetworkLateUpdate @ " + Time.time);
+            //Debug.Log("NetworkServer.NetworkLateUpdate @ " + Time.time);
         }
 
         // Called from NetworkManager in LateUpdate

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -450,11 +450,9 @@ namespace Mirror
             return connections.Count == 0 || (connections.Count == 1 && localConnection != null);
         }
 
-        /// <summary>
-        /// Called from NetworkManager in LateUpdate
-        /// <para>The user should never need to pump the update loop manually</para>
-        /// </summary>
-        public static void Update()
+        // Called from NetworkManager in LateUpdate
+        // The user should never need to pump the update loop manually.
+        public static void LateUpdate()
         {
             // don't need to update server if not active
             if (!active) return;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -452,11 +452,17 @@ namespace Mirror
 
         // NetworkEarlyUpdate called before any Update/FixedUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkEarlyUpdate() {}
+        internal static void NetworkEarlyUpdate()
+        {
+            Debug.Log("NetworkServer.NetworkEarlyUpdate @ " + Time.time);
+        }
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkLateUpdate() {}
+        internal static void NetworkLateUpdate()
+        {
+            Debug.Log("NetworkServer.NetworkLateUpdate @ " + Time.time);
+        }
 
         // Called from NetworkManager in LateUpdate
         // The user should never need to pump the update loop manually.

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -464,6 +464,10 @@ namespace Mirror
             //Debug.Log("NetworkServer.NetworkLateUpdate @ " + Time.time);
         }
 
+        // obsolete to not break people's projects. Update was public.
+        [Obsolete("Use NetworkServer.Update was renamed to LateUpdate because that's when it actually happens.")]
+        public static void Update() => LateUpdate();
+
         // Called from NetworkManager in LateUpdate
         // The user should never need to pump the update loop manually.
         public static void LateUpdate()

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -459,7 +459,7 @@ namespace Mirror
         internal static void NetworkLateUpdate() {}
 
         // obsolete to not break people's projects. Update was public.
-        [Obsolete("Use NetworkServer.Update was renamed to LateUpdate because that's when it actually happens.")]
+        [Obsolete("NetworkServer.Update was renamed to LateUpdate because that's when it actually happens.")]
         public static void Update() => LateUpdate();
 
         // Called from NetworkManager in LateUpdate

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -450,6 +450,14 @@ namespace Mirror
             return connections.Count == 0 || (connections.Count == 1 && localConnection != null);
         }
 
+        // NetworkEarlyUpdate called before any Update/FixedUpdate
+        // (we add this to the UnityEngine in NetworkLoop)
+        internal static void NetworkEarlyUpdate() {}
+
+        // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
+        // (we add this to the UnityEngine in NetworkLoop)
+        internal static void NetworkLateUpdate() {}
+
         // Called from NetworkManager in LateUpdate
         // The user should never need to pump the update loop manually.
         public static void LateUpdate()

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -464,7 +464,7 @@ namespace Mirror
 
         // Called from NetworkManager in LateUpdate
         // The user should never need to pump the update loop manually.
-        public static void LateUpdate()
+        internal static void LateUpdate()
         {
             // don't need to update server if not active
             if (!active) return;

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -1,6 +1,11 @@
 using NUnit.Framework;
+#if UNITY_2019_1_OR_NEWER
+using UnityEngine.LowLevel;
+using UnityEngine.PlayerLoop;
+#else
 using UnityEngine.Experimental.LowLevel;
 using UnityEngine.Experimental.PlayerLoop;
+#endif
 
 namespace Mirror.Tests
 {

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -8,28 +8,52 @@ namespace Mirror.Tests
     {
         // simple test to see if it finds and adds to EarlyUpdate() loop
         [Test]
-        public void AppendSystemToPlayerLoopList_EarlyUpdate()
+        public void AddToPlayerLoop_EarlyUpdate_Beginning()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate));
+            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.Beginning);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void AddToPlayerLoop_EarlyUpdate_End()
+        {
+            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
         }
 
         // simple test to see if it finds and adds to Update() loop
         [Test]
-        public void AppendSystemToPlayerLoopList_Update()
+        public void AddToPlayerLoop_Update_Beginning()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(Update));
+            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.Beginning);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void AddToPlayerLoop_Update_End()
+        {
+            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
         }
 
         // simple test to see if it finds and adds to PostLateUpdate() loop
         [Test]
-        public void AppendSystemToPlayerLoopList_PostLateUpdate()
+        public void AddToPlayerLoop_PostLateUpdate_Beginning()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate));
+            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.Beginning);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void AddToPlayerLoop_PostLateUpdate_End()
+        {
+            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
         }
     }

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -8,28 +8,28 @@ namespace Mirror.Tests
     {
         // simple test to see if it finds and adds to EarlyUpdate() loop
         [Test]
-        public void AddSystemToPlayerLoopList_EarlyUpdate()
+        public void AppendSystemToPlayerLoopList_EarlyUpdate()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(EarlyUpdate));
+            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(EarlyUpdate));
             Assert.That(result, Is.True);
         }
 
         // simple test to see if it finds and adds to Update() loop
         [Test]
-        public void AddSystemToPlayerLoopList_Update()
+        public void AppendSystemToPlayerLoopList_Update()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(Update));
+            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(Update));
             Assert.That(result, Is.True);
         }
 
         // simple test to see if it finds and adds to PostLateUpdate() loop
         [Test]
-        public void AddSystemToPlayerLoopList_PostLateUpdate()
+        public void AppendSystemToPlayerLoopList_PostLateUpdate()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(PostLateUpdate));
+            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(PostLateUpdate));
             Assert.That(result, Is.True);
         }
     }

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using UnityEngine.Experimental.LowLevel;
+using UnityEngine.Experimental.PlayerLoop;
+
+namespace Mirror.Tests
+{
+    public class NetworkLoopTests
+    {
+        // simple test to see if it finds and adds to EarlyUpdate() loop
+        [Test]
+        public void AddSystemToPlayerLoopList_EarlyUpdate()
+        {
+            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            bool result = NetworkLoop.AddSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(EarlyUpdate));
+            Assert.That(result, Is.True);
+        }
+
+        // simple test to see if it finds and adds to Update() loop
+        [Test]
+        public void AddSystemToPlayerLoopList_Update()
+        {
+            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            bool result = NetworkLoop.AddSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(Update));
+            Assert.That(result, Is.True);
+        }
+
+        // simple test to see if it finds and adds to PostLateUpdate() loop
+        [Test]
+        public void AddSystemToPlayerLoopList_PostLateUpdate()
+        {
+            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            bool result = NetworkLoop.AddSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(PostLateUpdate));
+            Assert.That(result, Is.True);
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -11,7 +11,7 @@ namespace Mirror.Tests
         public void AppendSystemToPlayerLoopList_EarlyUpdate()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(EarlyUpdate));
+            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate));
             Assert.That(result, Is.True);
         }
 
@@ -20,7 +20,7 @@ namespace Mirror.Tests
         public void AppendSystemToPlayerLoopList_Update()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(Update));
+            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(Update));
             Assert.That(result, Is.True);
         }
 
@@ -29,7 +29,7 @@ namespace Mirror.Tests
         public void AppendSystemToPlayerLoopList_PostLateUpdate()
         {
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, ref playerLoop, typeof(PostLateUpdate));
+            bool result = NetworkLoop.AppendSystemToPlayerLoopList(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate));
             Assert.That(result, Is.True);
         }
     }

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -10,50 +10,67 @@ namespace Mirror.Tests
         [Test]
         public void AddToPlayerLoop_EarlyUpdate_Beginning()
         {
+            void Function() {}
+
+            // get and add to loop, without calling PlayerLoop.SetLoop.
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.Beginning);
+            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
+
         }
 
         [Test]
         public void AddToPlayerLoop_EarlyUpdate_End()
         {
+            void Function() {}
+
+            // get and add to loop, without calling PlayerLoop.SetLoop.
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.End);
+            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
         }
 
-        // simple test to see if it finds and adds to Update() loop
         [Test]
         public void AddToPlayerLoop_Update_Beginning()
         {
+            void Function() {}
+
+            // get and add to loop, without calling PlayerLoop.SetLoop.
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.Beginning);
+            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
         }
 
         [Test]
         public void AddToPlayerLoop_Update_End()
         {
+            void Function() {}
+
+            // get and add to loop, without calling PlayerLoop.SetLoop.
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.End);
+            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
         }
 
-        // simple test to see if it finds and adds to PostLateUpdate() loop
         [Test]
         public void AddToPlayerLoop_PostLateUpdate_Beginning()
         {
+            void Function() {}
+
+            // get and add to loop, without calling PlayerLoop.SetLoop.
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.Beginning);
+            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
         }
 
         [Test]
         public void AddToPlayerLoop_PostLateUpdate_End()
         {
+            void Function() {}
+
+            // get and add to loop, without calling PlayerLoop.SetLoop.
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
-            bool result = NetworkLoop.AddToPlayerLoop(() => {}, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.End);
+            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
         }
     }

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -6,14 +6,24 @@ namespace Mirror.Tests
 {
     public class NetworkLoopTests
     {
+        // all tests need a PlayerLoopSystem to work with
+        PlayerLoopSystem playerLoop;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // we get the main player loop to work with.
+            // we don't actually set it. no need to.
+            playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+        }
+
         // simple test to see if it finds and adds to EarlyUpdate() loop
         [Test]
         public void AddToPlayerLoop_EarlyUpdate_Beginning()
         {
             void Function() {}
 
-            // get the loop and add our function
-            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            // add our function
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
 
@@ -27,8 +37,7 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get the loop and add our function
-            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            // add our function
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
 
@@ -42,8 +51,7 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get the loop and add our function
-            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            // add our function
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
 
@@ -57,8 +65,7 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get the loop and add our function
-            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            // add our function
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
 
@@ -72,8 +79,7 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get the loop and add our function
-            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            // add our function
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
 
@@ -87,8 +93,7 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get the loop and add our function
-            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            // add our function
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
 

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -12,11 +12,14 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get and add to loop, without calling PlayerLoop.SetLoop.
+            // get the loop and add our function
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
 
+            // was it added to the beginning?
+            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(EarlyUpdate));
+            Assert.That(index, Is.EqualTo(0));
         }
 
         [Test]
@@ -24,10 +27,14 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get and add to loop, without calling PlayerLoop.SetLoop.
+            // get the loop and add our function
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(EarlyUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
+
+            // was it added to the end? we don't know the exact index, but it should be >0
+            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(EarlyUpdate));
+            Assert.That(index, Is.GreaterThan(0));
         }
 
         [Test]
@@ -35,10 +42,14 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get and add to loop, without calling PlayerLoop.SetLoop.
+            // get the loop and add our function
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
+
+            // was it added to the beginning?
+            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(Update));
+            Assert.That(index, Is.EqualTo(0));
         }
 
         [Test]
@@ -46,10 +57,14 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get and add to loop, without calling PlayerLoop.SetLoop.
+            // get the loop and add our function
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(Update), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
+
+            // was it added to the end? we don't know the exact index, but it should be >0
+            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(Update));
+            Assert.That(index, Is.GreaterThan(0));
         }
 
         [Test]
@@ -57,10 +72,14 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get and add to loop, without calling PlayerLoop.SetLoop.
+            // get the loop and add our function
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
+
+            // was it added to the beginning?
+            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(PostLateUpdate));
+            Assert.That(index, Is.EqualTo(0));
         }
 
         [Test]
@@ -68,10 +87,14 @@ namespace Mirror.Tests
         {
             void Function() {}
 
-            // get and add to loop, without calling PlayerLoop.SetLoop.
+            // get the loop and add our function
             PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
             bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
+
+            // was it added to the end? we don't know the exact index, but it should be >0
+            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(PostLateUpdate));
+            Assert.That(index, Is.GreaterThan(0));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -75,30 +75,30 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void AddToPlayerLoop_PostLateUpdate_Beginning()
+        public void AddToPlayerLoop_PreLateUpdate_Beginning()
         {
             void Function() {}
 
             // add our function
-            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.Beginning);
+            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PreLateUpdate), NetworkLoop.AddMode.Beginning);
             Assert.That(result, Is.True);
 
             // was it added to the beginning?
-            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(PostLateUpdate));
+            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(PreLateUpdate));
             Assert.That(index, Is.EqualTo(0));
         }
 
         [Test]
-        public void AddToPlayerLoop_PostLateUpdate_End()
+        public void AddToPlayerLoop_PreLateUpdate_End()
         {
             void Function() {}
 
             // add our function
-            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PostLateUpdate), NetworkLoop.AddMode.End);
+            bool result = NetworkLoop.AddToPlayerLoop(Function, typeof(NetworkLoopTests), ref playerLoop, typeof(PreLateUpdate), NetworkLoop.AddMode.End);
             Assert.That(result, Is.True);
 
             // was it added to the end? we don't know the exact index, but it should be >0
-            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(PostLateUpdate));
+            int index = NetworkLoop.FindPlayerLoopEntryIndex(Function, playerLoop, typeof(PreLateUpdate));
             Assert.That(index, Is.GreaterThan(0));
         }
     }

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: eedb822be9a941428259caf9f707bb45
+timeCreated: 1614573407

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -1121,7 +1121,7 @@ namespace Mirror.Tests
 
             // update
             LogAssert.Expect(LogType.Warning, new Regex("Found 'null' entry in spawned list.*"));
-            NetworkServer.Update();
+            NetworkServer.LateUpdate();
 
             // clean up
             NetworkServer.Shutdown();
@@ -1144,7 +1144,7 @@ namespace Mirror.Tests
 
             // update
             LogAssert.Expect(LogType.Warning, new Regex("Found 'null' entry in spawned list.*"));
-            NetworkServer.Update();
+            NetworkServer.LateUpdate();
 
             // clean up
             NetworkServer.Shutdown();

--- a/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
@@ -82,8 +82,8 @@ namespace Mirror.Tests.RemoteAttrributeTest
         protected static void ProcessMessages()
         {
             // run update so message are processed
-            NetworkServer.Update();
-            NetworkClient.Update();
+            NetworkServer.LateUpdate();
+            NetworkClient.LateUpdate();
         }
     }
 }

--- a/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
@@ -69,7 +69,7 @@ namespace Mirror.Tests.Runtime
             while (Time.time < endTime)
             {
                 yield return null;
-                NetworkServer.Update();
+                NetworkServer.LateUpdate();
             }
 
             // host client connection should still be alive


### PR DESCRIPTION
simply adds NetworkEarly/LateUpdate functions.
they aren't being used yet.
step by step.

unit tests:
<img width="302" alt="2021-03-01_13-58-14@2x" src="https://user-images.githubusercontent.com/16416509/109457622-2dfa6600-7a96-11eb-910b-124612f57bc7.png">

pressing play multiple times still only adds one early/lateupdate each time
![image](https://user-images.githubusercontent.com/16416509/109457588-1cb15980-7a96-11eb-9bd5-ba0c2d140330.png)