### PR TITLE
fix: NetworkClient/Server: use the new custom NetworkLateUpdate instead of Unity's LateUpdate. fixes possible data races where other component's LateUpdate could be called before/after NetworkServer/Client LateUpdate causing non obvious data races.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -272,15 +272,7 @@ namespace Mirror
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkLateUpdate() {}
-
-        // obsolete to not break people's projects. Update was public.
-        [Obsolete("NetworkClient.Update was renamed to LateUpdate because that's when it actually happens.")]
-        public static void Update() => LateUpdate();
-
-        // Called from NetworkManager in LateUpdate
-        // The user should never need to pump the update loop manually.
-        internal static void LateUpdate()
+        internal static void NetworkLateUpdate()
         {
             // local connection?
             if (connection is LocalConnectionToServer localConnection)
@@ -297,6 +289,10 @@ namespace Mirror
                 }
             }
         }
+
+        // obsolete to not break people's projects. Update was public.
+        [Obsolete("NetworkClient.Update is now called internally from our custom update loop. No need to call Update manually anymore.")]
+        public static void Update() => NetworkLateUpdate();
 
         internal static void RegisterSystemHandlers(bool hostMode)
         {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -292,11 +292,6 @@ namespace Mirror
         /// </summary>
         public virtual void LateUpdate()
         {
-            // call it while the NetworkManager exists.
-            // -> we don't only call while Client/Server.Connected, because then we would stop if disconnected and the
-            //    NetworkClient wouldn't receive the last Disconnect event, result in all kinds of issues
-            NetworkServer.LateUpdate();
-            NetworkClient.LateUpdate();
             UpdateScene();
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -456,15 +456,7 @@ namespace Mirror
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkLateUpdate() {}
-
-        // obsolete to not break people's projects. Update was public.
-        [Obsolete("NetworkServer.Update was renamed to LateUpdate because that's when it actually happens.")]
-        public static void Update() => LateUpdate();
-
-        // Called from NetworkManager in LateUpdate
-        // The user should never need to pump the update loop manually.
-        internal static void LateUpdate()
+        internal static void NetworkLateUpdate()
         {
             // don't need to update server if not active
             if (!active) return;
@@ -492,6 +484,10 @@ namespace Mirror
                 conn.Update();
             }
         }
+
+        // obsolete to not break people's projects. Update was public.
+        [Obsolete("NetworkServer.Update is now called internally from our custom update loop. No need to call Update manually anymore.")]
+        public static void Update() => NetworkLateUpdate();
 
         static void CheckForInactiveConnections()
         {

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -1121,7 +1121,7 @@ namespace Mirror.Tests
 
             // update
             LogAssert.Expect(LogType.Warning, new Regex("Found 'null' entry in spawned list.*"));
-            NetworkServer.LateUpdate();
+            NetworkServer.NetworkLateUpdate();
 
             // clean up
             NetworkServer.Shutdown();
@@ -1144,7 +1144,7 @@ namespace Mirror.Tests
 
             // update
             LogAssert.Expect(LogType.Warning, new Regex("Found 'null' entry in spawned list.*"));
-            NetworkServer.LateUpdate();
+            NetworkServer.NetworkLateUpdate();
 
             // clean up
             NetworkServer.Shutdown();

--- a/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
@@ -82,8 +82,8 @@ namespace Mirror.Tests.RemoteAttrributeTest
         protected static void ProcessMessages()
         {
             // run update so message are processed
-            NetworkServer.LateUpdate();
-            NetworkClient.LateUpdate();
+            NetworkServer.NetworkLateUpdate();
+            NetworkClient.NetworkLateUpdate();
         }
     }
 }

--- a/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
@@ -69,7 +69,7 @@ namespace Mirror.Tests.Runtime
             while (Time.time < endTime)
             {
                 yield return null;
-                NetworkServer.LateUpdate();
+                NetworkServer.NetworkLateUpdate();
             }
 
             // host client connection should still be alive


### PR DESCRIPTION
baby steps