### PR TITLE
perf: Transport.Client/Server Early/LateUpdate to fix data races and allow transports to reduce latency by doing all receiving & sending in one frame.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -268,7 +268,12 @@ namespace Mirror
 
         // NetworkEarlyUpdate called before any Update/FixedUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkEarlyUpdate() {}
+        internal static void NetworkEarlyUpdate()
+        {
+            // process all incoming messages first before updating the world
+            if (Transport.activeTransport != null)
+                Transport.activeTransport.ClientEarlyUpdate();
+        }
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
@@ -288,6 +293,10 @@ namespace Mirror
                     NetworkTime.UpdateClient();
                 }
             }
+
+            // process all incoming messages after updating the world
+            if (Transport.activeTransport != null)
+                Transport.activeTransport.ClientLateUpdate();
         }
 
         // obsolete to not break people's projects. Update was public.

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -272,15 +272,7 @@ namespace Mirror
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkLateUpdate() {}
-
-        // obsolete to not break people's projects. Update was public.
-        [Obsolete("NetworkClient.Update was renamed to LateUpdate because that's when it actually happens.")]
-        public static void Update() => LateUpdate();
-
-        // Called from NetworkManager in LateUpdate
-        // The user should never need to pump the update loop manually.
-        internal static void LateUpdate()
+        internal static void NetworkLateUpdate()
         {
             // local connection?
             if (connection is LocalConnectionToServer localConnection)
@@ -297,6 +289,10 @@ namespace Mirror
                 }
             }
         }
+
+        // obsolete to not break people's projects. Update was public.
+        [Obsolete("NetworkClient.Update is now called internally from our custom update loop. No need to call Update manually anymore.")]
+        public static void Update() => NetworkLateUpdate();
 
         internal static void RegisterSystemHandlers(bool hostMode)
         {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -292,11 +292,6 @@ namespace Mirror
         /// </summary>
         public virtual void LateUpdate()
         {
-            // call it while the NetworkManager exists.
-            // -> we don't only call while Client/Server.Connected, because then we would stop if disconnected and the
-            //    NetworkClient wouldn't receive the last Disconnect event, result in all kinds of issues
-            NetworkServer.LateUpdate();
-            NetworkClient.LateUpdate();
             UpdateScene();
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -456,15 +456,7 @@ namespace Mirror
 
         // NetworkLateUpdate called after any Update/FixedUpdate/LateUpdate
         // (we add this to the UnityEngine in NetworkLoop)
-        internal static void NetworkLateUpdate() {}
-
-        // obsolete to not break people's projects. Update was public.
-        [Obsolete("NetworkServer.Update was renamed to LateUpdate because that's when it actually happens.")]
-        public static void Update() => LateUpdate();
-
-        // Called from NetworkManager in LateUpdate
-        // The user should never need to pump the update loop manually.
-        internal static void LateUpdate()
+        internal static void NetworkLateUpdate()
         {
             // don't need to update server if not active
             if (!active) return;
@@ -492,6 +484,10 @@ namespace Mirror
                 conn.Update();
             }
         }
+
+        // obsolete to not break people's projects. Update was public.
+        [Obsolete("NetworkServer.Update is now called internally from our custom update loop. No need to call Update manually anymore.")]
+        public static void Update() => NetworkLateUpdate();
 
         static void CheckForInactiveConnections()
         {

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -218,28 +218,44 @@ namespace Mirror
         public virtual int GetMaxBatchSize(int channelId) =>
             GetMaxPacketSize(channelId);
 
+        // block Update & LateUpdate to show warnings if Transports still use
+        // them instead of using
+        //   Client/ServerEarlyUpdate: to process incoming messages
+        //   Client/ServerLateUpdate: to process outgoing messages
+        // those are called by NetworkClient/Server at the right time.
+        //
+        // allows transports to implement the proper network update order of:
+        //      process_incoming()
+        //      update_world()
+        //      process_outgoing()
+        //
+        // => see NetworkLoop.cs for detailed explanations!
+#pragma warning disable UNT0001 // Empty Unity message
+        public void Update() {}
+        public void LateUpdate() {}
+#pragma warning restore UNT0001 // Empty Unity message
+
+        /// <summary>
+        /// NetworkLoop NetworkEarly/LateUpdate were added for a proper network
+        /// update order. the goal is to:
+        ///    process_incoming()
+        ///    update_world()
+        ///    process_outgoing()
+        /// in order to avoid unnecessary latency and data races.
+        /// </summary>
+        // => split into client and server parts so that we can cleanly call
+        //    them from NetworkClient/Server
+        // => VIRTUAL for now so we can take our time to convert transports
+        //    without breaking anything.
+        public virtual void ClientEarlyUpdate() {}
+        public virtual void ServerEarlyUpdate() {}
+        public virtual void ClientLateUpdate() {}
+        public virtual void ServerLateUpdate() {}
+
         /// <summary>
         /// Shut down the transport, both as client and server
         /// </summary>
         public abstract void Shutdown();
-
-        // block Update() to force Transports to use LateUpdate to avoid race
-        // conditions. messages should be processed after all the game state
-        // was processed in Update.
-        // -> in other words: use LateUpdate!
-        // -> uMMORPG 480 CCU stress test: when bot machine stops, it causes
-        //    'Observer not ready for ...' log messages when using Update
-        // -> occupying a public Update() function will cause Warnings if a
-        //    transport uses Update.
-        //
-        // IMPORTANT: set script execution order to >1000 to call Transport's
-        //            LateUpdate after all others. Fixes race condition where
-        //            e.g. in uSurvival Transport would apply Cmds before
-        //            ShoulderRotation.LateUpdate, resulting in projectile
-        //            spawns at the point before shoulder rotation.
-#pragma warning disable UNT0001 // Empty Unity message
-        public void Update() {}
-#pragma warning restore UNT0001 // Empty Unity message
 
         /// <summary>
         /// called when quitting the application by closing the window / pressing stop in the editor

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -1121,7 +1121,7 @@ namespace Mirror.Tests
 
             // update
             LogAssert.Expect(LogType.Warning, new Regex("Found 'null' entry in spawned list.*"));
-            NetworkServer.LateUpdate();
+            NetworkServer.NetworkLateUpdate();
 
             // clean up
             NetworkServer.Shutdown();
@@ -1144,7 +1144,7 @@ namespace Mirror.Tests
 
             // update
             LogAssert.Expect(LogType.Warning, new Regex("Found 'null' entry in spawned list.*"));
-            NetworkServer.LateUpdate();
+            NetworkServer.NetworkLateUpdate();
 
             // clean up
             NetworkServer.Shutdown();

--- a/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
@@ -82,8 +82,8 @@ namespace Mirror.Tests.RemoteAttrributeTest
         protected static void ProcessMessages()
         {
             // run update so message are processed
-            NetworkServer.LateUpdate();
-            NetworkClient.LateUpdate();
+            NetworkServer.NetworkLateUpdate();
+            NetworkClient.NetworkLateUpdate();
         }
     }
 }

--- a/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerWithHostRuntimeTest.cs
@@ -69,7 +69,7 @@ namespace Mirror.Tests.Runtime
             while (Time.time < endTime)
             {
                 yield return null;
-                NetworkServer.LateUpdate();
+                NetworkServer.NetworkLateUpdate();
             }
 
             // host client connection should still be alive


### PR DESCRIPTION
merge #2604 first

all transports that still use LateUpdate will show a warning.
the new functions are virtual for now so we don't break anything.

=> everything still works, we can modify transports over time