### PR TITLE
perf: kcp Tick split into TickIncoming/Outgoing to utilize the new NetworkEarly/LateUpdate functions. minimizes latency.

### DIFF
--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -119,11 +119,8 @@ namespace kcp2k
             // process incoming in early update
             client.ProcessIncoming();
         }
-        public override void ClientLateUpdate()
-        {
-            // process outgoing in late update
-            client.ProcessOutgoing();
-        }
+        // process outgoing in late update
+        public override void ClientLateUpdate() => client.ProcessOutgoing();
 
         // scene change message will disable transports.
         // kcp processes messages in an internal loop which should be
@@ -190,11 +187,8 @@ namespace kcp2k
             // process incoming in early update
             server.ProcessIncoming();
         }
-        public override void ServerLateUpdate()
-        {
-            // process outgoing in late update
-            server.ProcessOutgoing();
-        }
+        // process outgoing in late update
+        public override void ServerLateUpdate() => server.ProcessOutgoing();
 
         // common
         public override void Shutdown() {}

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -116,13 +116,13 @@ namespace kcp2k
             if (!enabled)
                 return;
 
-            // TODO only process incoming
-            client.Tick();
+            // process incoming in early update
+            client.ProcessIncoming();
         }
         public override void ClientLateUpdate()
         {
-            // TODO only process outgoing
-            client.Tick();
+            // process outgoing in late update
+            client.ProcessOutgoing();
         }
 
         // scene change message will disable transports.
@@ -187,13 +187,13 @@ namespace kcp2k
             if (!enabled)
                 return;
 
-            // TODO only process incoming
-            server.Tick();
+            // process incoming in early update
+            server.ProcessIncoming();
         }
         public override void ServerLateUpdate()
         {
-            // TODO only process outgoing
-            server.Tick();
+            // process outgoing in late update
+            server.ProcessOutgoing();
         }
 
         // common

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -114,7 +114,7 @@ namespace kcp2k
             // -> we need to check enabled here
             // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
             // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (enabled)
+            if (!enabled)
                 return;
 
             client.ProcessIncoming();

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -106,6 +106,7 @@ namespace kcp2k
             }
         }
         public override void ClientDisconnect() => client.Disconnect();
+        // process incoming in early update
         public override void ClientEarlyUpdate()
         {
             // scene change messages disable transports to stop them from
@@ -113,10 +114,9 @@ namespace kcp2k
             // -> we need to check enabled here
             // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
             // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (!enabled)
+            if (enabled)
                 return;
 
-            // process incoming in early update
             client.ProcessIncoming();
         }
         // process outgoing in late update

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -114,10 +114,7 @@ namespace kcp2k
             // -> we need to check enabled here
             // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
             // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (!enabled)
-                return;
-
-            client.ProcessIncoming();
+            if (enabled) client.ProcessIncoming();
         }
         // process outgoing in late update
         public override void ClientLateUpdate() => client.ProcessOutgoing();
@@ -181,11 +178,7 @@ namespace kcp2k
             // -> we need to check enabled here
             // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
             // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (!enabled)
-                return;
-
-            // process incoming in early update
-            server.ProcessIncoming();
+            if (enabled) server.ProcessIncoming();
         }
         // process outgoing in late update
         public override void ServerLateUpdate() => server.ProcessOutgoing();

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -106,7 +106,6 @@ namespace kcp2k
             }
         }
         public override void ClientDisconnect() => client.Disconnect();
-
         public override void ClientEarlyUpdate()
         {
             // scene change messages disable transports to stop them from
@@ -132,32 +131,6 @@ namespace kcp2k
 
             // TODO only process outgoing
             client.Tick();
-        }
-        public override void ServerEarlyUpdate()
-        {
-            // scene change messages disable transports to stop them from
-            // processing while changing the scene.
-            // -> we need to check enabled here
-            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
-            // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (!enabled)
-                return;
-
-            // TODO only process incoming
-            server.Tick();
-        }
-        public override void ServerLateUpdate()
-        {
-            // scene change messages disable transports to stop them from
-            // processing while changing the scene.
-            // -> we need to check enabled here
-            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
-            // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (!enabled)
-                return;
-
-            // TODO only process outgoing
-            server.Tick();
         }
 
         // scene change message will disable transports.
@@ -212,6 +185,32 @@ namespace kcp2k
         }
         public override string ServerGetClientAddress(int connectionId) => server.GetClientAddress(connectionId);
         public override void ServerStop() => server.Stop();
+        public override void ServerEarlyUpdate()
+        {
+            // scene change messages disable transports to stop them from
+            // processing while changing the scene.
+            // -> we need to check enabled here
+            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
+            // (see also: https://github.com/vis2k/Mirror/pull/379)
+            if (!enabled)
+                return;
+
+            // TODO only process incoming
+            server.Tick();
+        }
+        public override void ServerLateUpdate()
+        {
+            // scene change messages disable transports to stop them from
+            // processing while changing the scene.
+            // -> we need to check enabled here
+            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
+            // (see also: https://github.com/vis2k/Mirror/pull/379)
+            if (!enabled)
+                return;
+
+            // TODO only process outgoing
+            server.Tick();
+        }
 
         // common
         public override void Shutdown() {}

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -121,14 +121,6 @@ namespace kcp2k
         }
         public override void ClientLateUpdate()
         {
-            // scene change messages disable transports to stop them from
-            // processing while changing the scene.
-            // -> we need to check enabled here
-            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
-            // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (!enabled)
-                return;
-
             // TODO only process outgoing
             client.Tick();
         }
@@ -200,14 +192,6 @@ namespace kcp2k
         }
         public override void ServerLateUpdate()
         {
-            // scene change messages disable transports to stop them from
-            // processing while changing the scene.
-            // -> we need to check enabled here
-            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
-            // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (!enabled)
-                return;
-
             // TODO only process outgoing
             server.Tick();
         }

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -107,12 +107,7 @@ namespace kcp2k
         }
         public override void ClientDisconnect() => client.Disconnect();
 
-        // IMPORTANT: set script execution order to >1000 to call Transport's
-        //            LateUpdate after all others. Fixes race condition where
-        //            e.g. in uSurvival Transport would apply Cmds before
-        //            ShoulderRotation.LateUpdate, resulting in projectile
-        //            spawns at the point before shoulder rotation.
-        public void LateUpdate()
+        public override void ClientEarlyUpdate()
         {
             // scene change messages disable transports to stop them from
             // processing while changing the scene.
@@ -122,8 +117,47 @@ namespace kcp2k
             if (!enabled)
                 return;
 
-            server.Tick();
+            // TODO only process incoming
             client.Tick();
+        }
+        public override void ClientLateUpdate()
+        {
+            // scene change messages disable transports to stop them from
+            // processing while changing the scene.
+            // -> we need to check enabled here
+            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
+            // (see also: https://github.com/vis2k/Mirror/pull/379)
+            if (!enabled)
+                return;
+
+            // TODO only process outgoing
+            client.Tick();
+        }
+        public override void ServerEarlyUpdate()
+        {
+            // scene change messages disable transports to stop them from
+            // processing while changing the scene.
+            // -> we need to check enabled here
+            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
+            // (see also: https://github.com/vis2k/Mirror/pull/379)
+            if (!enabled)
+                return;
+
+            // TODO only process incoming
+            server.Tick();
+        }
+        public override void ServerLateUpdate()
+        {
+            // scene change messages disable transports to stop them from
+            // processing while changing the scene.
+            // -> we need to check enabled here
+            // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
+            // (see also: https://github.com/vis2k/Mirror/pull/379)
+            if (!enabled)
+                return;
+
+            // TODO only process outgoing
+            server.Tick();
         }
 
         // scene change message will disable transports.

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -114,10 +114,10 @@ namespace kcp2k
             // -> we need to check enabled here
             // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
             // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (enabled) client.ProcessIncoming();
+            if (enabled) client.TickIncoming();
         }
         // process outgoing in late update
-        public override void ClientLateUpdate() => client.ProcessOutgoing();
+        public override void ClientLateUpdate() => client.TickOutgoing();
 
         // scene change message will disable transports.
         // kcp processes messages in an internal loop which should be
@@ -178,10 +178,10 @@ namespace kcp2k
             // -> we need to check enabled here
             // -> and in kcp's internal loops, see Awake() OnCheckEnabled setup!
             // (see also: https://github.com/vis2k/Mirror/pull/379)
-            if (enabled) server.ProcessIncoming();
+            if (enabled) server.TickIncoming();
         }
         // process outgoing in late update
-        public override void ServerLateUpdate() => server.ProcessOutgoing();
+        public override void ServerLateUpdate() => server.TickOutgoing();
 
         // common
         public override void Shutdown() {}

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/VERSION
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/VERSION
@@ -1,3 +1,16 @@
+V1.9 [2021-03-02]
+- Tick() split into TickIncoming()/TickOutgoing() to use in Mirror's new update
+  functions. allows to minimize latency.
+  => original Tick() is still supported for convenience. simply processes both!
+
+V1.8 [2021-02-14]
+- fix: Unity IPv6 errors on Nintendo Switch
+- fix: KcpConnection now disconnects if data message was received without content.
+  previously it would call OnData with an empty ArraySegment, causing all kinds of
+  weird behaviour in Mirror/DOTSNET. Added tests too.
+- fix: KcpConnection.SendData: don't allow sending empty messages anymore. disconnect
+  and log a warning to make it completely obvious.
+
 V1.7 [2021-01-13]
 - fix: unreliable messages reset timeout now too
 - perf: KcpConnection OnCheckEnabled callback changed to a simple 'paused' boolean.

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
@@ -82,14 +82,11 @@ namespace kcp2k
         // process incoming messages. should be called before updating the world.
         public void ProcessIncoming()
         {
-            // tick client connection
-            if (connection != null)
-            {
-                // recv on socket first, then process incoming
-                // (even if we didn't receive anything. need to tick ping etc.)
-                connection.RawReceive();
-                connection.ProcessIncoming();
-            }
+            // recv on socket first, then process incoming
+            // (even if we didn't receive anything. need to tick ping etc.)
+            // (connection is null if not active)
+            connection?.RawReceive();
+            connection?.ProcessIncoming();
         }
 
         // process outgoing messages. should be called after updating the world.

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
@@ -79,16 +79,37 @@ namespace kcp2k
             }
         }
 
-        public void Tick()
+        // process incoming messages. should be called before updating the world.
+        public void ProcessIncoming()
         {
             // tick client connection
             if (connection != null)
             {
-                // recv on socket first
+                // recv on socket first, then process incoming
+                // (even if we didn't receive anything. need to tick ping etc.)
                 connection.RawReceive();
-                // then update
-                connection.Tick();
+                connection.ProcessIncoming();
             }
+        }
+
+        // process outgoing messages. should be called after updating the world.
+        public void ProcessOutgoing()
+        {
+            // tick client connection
+            if (connection != null)
+            {
+                // process outgoing
+                connection.ProcessOutgoing();
+            }
+        }
+
+        // process incoming and outgoing
+        // => ideally call ProcessIncoming() before updating the world and
+        //    ProcessOutgoing() after updating the world for minimum latency
+        public void Tick()
+        {
+            ProcessIncoming();
+            ProcessOutgoing();
         }
 
         // pause/unpause to safely support mirror scene handling and to

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
@@ -95,12 +95,9 @@ namespace kcp2k
         // process outgoing messages. should be called after updating the world.
         public void ProcessOutgoing()
         {
-            // tick client connection
-            if (connection != null)
-            {
-                // process outgoing
-                connection.ProcessOutgoing();
-            }
+            // process outgoing
+            // (connection is null if not active)
+            connection?.ProcessOutgoing();
         }
 
         // process incoming and outgoing for convenience

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
@@ -103,14 +103,17 @@ namespace kcp2k
             }
         }
 
-        // process incoming and outgoing
+        // process incoming and outgoing for convenience
         // => ideally call ProcessIncoming() before updating the world and
         //    ProcessOutgoing() after updating the world for minimum latency
-        public void Tick()
+        public void ProcessIncomingAndOutgoing()
         {
             ProcessIncoming();
             ProcessOutgoing();
         }
+
+        [Obsolete("Tick was renamed to ProcessIncomingAndOutgoing")]
+        public void Tick() => ProcessIncomingAndOutgoing();
 
         // pause/unpause to safely support mirror scene handling and to
         // immediately pause the receive while loop if needed.

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpClient.cs
@@ -80,34 +80,31 @@ namespace kcp2k
         }
 
         // process incoming messages. should be called before updating the world.
-        public void ProcessIncoming()
+        public void TickIncoming()
         {
             // recv on socket first, then process incoming
             // (even if we didn't receive anything. need to tick ping etc.)
             // (connection is null if not active)
             connection?.RawReceive();
-            connection?.ProcessIncoming();
+            connection?.TickIncoming();
         }
 
         // process outgoing messages. should be called after updating the world.
-        public void ProcessOutgoing()
+        public void TickOutgoing()
         {
             // process outgoing
             // (connection is null if not active)
-            connection?.ProcessOutgoing();
+            connection?.TickOutgoing();
         }
 
         // process incoming and outgoing for convenience
         // => ideally call ProcessIncoming() before updating the world and
         //    ProcessOutgoing() after updating the world for minimum latency
-        public void ProcessIncomingAndOutgoing()
+        public void Tick()
         {
-            ProcessIncoming();
-            ProcessOutgoing();
+            TickIncoming();
+            TickOutgoing();
         }
-
-        [Obsolete("Tick was renamed to ProcessIncomingAndOutgoing")]
-        public void Tick() => ProcessIncomingAndOutgoing();
 
         // pause/unpause to safely support mirror scene handling and to
         // immediately pause the receive while loop if needed.

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpConnection.cs
@@ -244,7 +244,7 @@ namespace kcp2k
             return false;
         }
 
-        void ProcessIncoming_Connected(uint time)
+        void TickIncoming_Connected(uint time)
         {
             // detect common events & ping
             HandleTimeout(time);
@@ -284,7 +284,7 @@ namespace kcp2k
             }
         }
 
-        void ProcessIncoming_Authenticated(uint time)
+        void TickIncoming_Authenticated(uint time)
         {
             // detect common events & ping
             HandleTimeout(time);
@@ -349,7 +349,7 @@ namespace kcp2k
             }
         }
 
-        public void ProcessIncoming()
+        public void TickIncoming()
         {
             uint time = (uint)refTime.ElapsedMilliseconds;
 
@@ -359,12 +359,12 @@ namespace kcp2k
                 {
                     case KcpState.Connected:
                     {
-                        ProcessIncoming_Connected(time);
+                        TickIncoming_Connected(time);
                         break;
                     }
                     case KcpState.Authenticated:
                     {
-                        ProcessIncoming_Authenticated(time);
+                        TickIncoming_Authenticated(time);
                         break;
                     }
                     case KcpState.Disconnected:
@@ -394,7 +394,7 @@ namespace kcp2k
             }
         }
 
-        public void ProcessOutgoing()
+        public void TickOutgoing()
         {
             uint time = (uint)refTime.ElapsedMilliseconds;
 

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpConnection.cs
@@ -403,11 +403,6 @@ namespace kcp2k
                 switch (state)
                 {
                     case KcpState.Connected:
-                    {
-                        // update flushes out messages
-                        kcp.Update(time);
-                        break;
-                    }
                     case KcpState.Authenticated:
                     {
                         // update flushes out messages

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpServer.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpServer.cs
@@ -125,7 +125,7 @@ namespace kcp2k
 
         // process incoming messages. should be called before updating the world.
         HashSet<int> connectionsToRemove = new HashSet<int>();
-        public void ProcessIncoming()
+        public void TickIncoming()
         {
             while (socket != null && socket.Poll(0, SelectMode.SelectRead))
             {
@@ -216,7 +216,7 @@ namespace kcp2k
                             // tick will process the first message and adds the
                             // connection if it was the handshake.
                             connection.RawInput(rawReceiveBuffer, msgLength);
-                            connection.ProcessIncoming();
+                            connection.TickIncoming();
 
                             // again, do not add to connections.
                             // if the first message wasn't the kcp handshake then
@@ -242,7 +242,7 @@ namespace kcp2k
             // (even if we didn't receive anything. need to tick ping etc.)
             foreach (KcpServerConnection connection in connections.Values)
             {
-                connection.ProcessIncoming();
+                connection.TickIncoming();
             }
 
             // remove disconnected connections
@@ -256,24 +256,21 @@ namespace kcp2k
         }
 
         // process outgoing messages. should be called after updating the world.
-        public void ProcessOutgoing()
+        public void TickOutgoing()
         {
             // flush all server connections
             foreach (KcpServerConnection connection in connections.Values)
             {
-                connection.ProcessOutgoing();
+                connection.TickOutgoing();
             }
         }
 
         // process incoming and outgoing for convenience
-        public void ProcessIncomingAndOutgoing()
+        public void Tick()
         {
-            ProcessIncoming();
-            ProcessOutgoing();
+            TickIncoming();
+            TickOutgoing();
         }
-
-        [Obsolete("Tick was renamed to ProcessIncomingAndOutgoing")]
-        public void Tick() => ProcessIncomingAndOutgoing();
 
         public void Stop()
         {

--- a/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpServer.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/kcp2k/highlevel/KcpServer.cs
@@ -265,6 +265,16 @@ namespace kcp2k
             }
         }
 
+        // process incoming and outgoing for convenience
+        public void ProcessIncomingAndOutgoing()
+        {
+            ProcessIncoming();
+            ProcessOutgoing();
+        }
+
+        [Obsolete("Tick was renamed to ProcessIncomingAndOutgoing")]
+        public void Tick() => ProcessIncomingAndOutgoing();
+
         public void Stop()
         {
             socket?.Close();


### PR DESCRIPTION
kcp before: ~30ms
kcp after: 17-20ms
telepathy: 15ms (faster because send() sends immediately. kcp sends in lateupdate. minimal difference)

TODO
- apply split to kcp2k repo first
- test carefully