### PR TITLE
fix: scene rename handling NullReferenceException in NetworkManager

### DIFF
--- a/Assets/Mirror/Editor/SceneDrawer.cs
+++ b/Assets/Mirror/Editor/SceneDrawer.cs
@@ -36,7 +36,7 @@ namespace Mirror
             foreach (EditorBuildSettingsScene buildScene in EditorBuildSettings.scenes)
             {
                 SceneAsset sceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(buildScene.path);
-                if (sceneAsset.name == sceneName)
+                if (sceneAsset!= null && sceneAsset.name == sceneName)
                 {
                     return sceneAsset;
                 }


### PR DESCRIPTION
When the user renamed offline scene or online scene, it will always cause editor rendering errors in `NetworkManager`. To solve it, I had to re-add the component `NetworkManager`. This is happening because the previous path to the scenes is preserved. The script tries to load it, and it can't find it, which causes `NullReferenceException`.

Sample error:
```
NullReferenceException: Object reference not set to an instance of an object
Mirror.SceneDrawer.GetBuildSettingsSceneObject (System.String sceneName) (at Assets/Mirror/Editor/SceneDrawer.cs:43)
Mirror.SceneDrawer.OnGUI (UnityEngine.Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label) (at Assets/Mirror/Editor/SceneDrawer.cs:18)
UnityEditor.PropertyDrawer.OnGUISafe (UnityEngine.Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label) (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEditor.PropertyHandler.OnGUI (UnityEngine.Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, System.Boolean includeChildren, UnityEngine.Rect visibleArea) (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEditor.PropertyHandler.OnGUI (UnityEngine.Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, System.Boolean includeChildren) (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEditor.PropertyHandler.OnGUILayout (UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, System.Boolean includeChildren, UnityEngine.GUILayoutOption[] options) (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEditor.EditorGUILayout.PropertyField (UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, System.Boolean includeChildren, UnityEngine.GUILayoutOption[] options) (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEditor.EditorGUILayout.PropertyField (UnityEditor.SerializedProperty property, System.Boolean includeChildren, UnityEngine.GUILayoutOption[] options) (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEditor.Editor.DoDrawDefaultInspector (UnityEditor.SerializedObject obj) (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEditor.Editor.DoDrawDefaultInspector () (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEditor.Editor.DrawDefaultInspector () (at <a8e33794c0064f2aa201ade069162226>:0)
Mirror.NetworkManagerEditor.OnInspectorGUI () (at Assets/Mirror/Editor/NetworkManagerEditor.cs:43)
UnityEditor.UIElements.InspectorElement+<>c__DisplayClass58_0.<CreateIMGUIInspectorFromEditor>b__0 () (at <a8e33794c0064f2aa201ade069162226>:0)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr)
```