### PR TITLE
fix: NetworkIdentity.isLocalPlayer is only set, but never reset. fixes a bug where isLocalPlayer would be false in OnDestroy, so some components couldn't rely on it in OnDestroy. fixes #2615 (this is also faster than comparing ClientScene.localPlayer each time)

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -701,6 +701,15 @@ namespace Mirror
             // set isServer flag
             isServer = true;
 
+            // set isLocalPlayer earlier, in case OnStartLocalplayer is called
+            // AFTER OnStartClient, in which case it would still be falsse here.
+            // many projects will check isLocalPlayer in OnStartClient though.
+            // TODO ideally set isLocalPlayer when ClientScene.localPlayer is set?
+            if (ClientScene.localPlayer == this)
+            {
+                isLocalPlayer = true;
+            }
+
             // If the instance/net ID is invalid here then this is an object instantiated from a prefab and the server should assign a valid ID
             // NOTE: this might not be necessary because the above m_IsServer
             //       check already checks netId. BUT this case here checks only
@@ -776,6 +785,15 @@ namespace Mirror
             clientStarted = true;
 
             isClient = true;
+
+            // set isLocalPlayer earlier, in case OnStartLocalplayer is called
+            // AFTER OnStartClient, in which case it would still be falsse here.
+            // many projects will check isLocalPlayer in OnStartClient though.
+            // TODO ideally set isLocalPlayer when ClientScene.localPlayer is set?
+            if (ClientScene.localPlayer == this)
+            {
+                isLocalPlayer = true;
+            }
 
             // Debug.Log("OnStartClient " + gameObject + " netId:" + netId);
             foreach (NetworkBehaviour comp in NetworkBehaviours)


### PR DESCRIPTION
benchmark scene, host mode, OnDestroy now has all the right values:

<img width="470" alt="2021-03-06_18-44-32@2x" src="https://user-images.githubusercontent.com/16416509/110204076-1d8a2700-7eac-11eb-8709-19d7bf376062.png">

finally, if isClient/isServer/isLocalPlayer was true once, then it always remains true.

NOTE: adds two extra checks in OnStartServer/OnStartClient in case they are called early. we have something on our roadmap to do this more elegantly. for now, at least the bug is fixed and isLocalPlayer behaves deterministically.

=> if it's set once, it's never reset again.