### PR TITLE
fix: Add missing virtual update methods in MultiplexTransport

### DIFF
--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -20,6 +20,38 @@ namespace Mirror
             }
         }
 
+        public override void ClientEarlyUpdate()
+        {
+            foreach (Transport transport in transports)
+            {
+                transport.ClientEarlyUpdate();
+            }
+        }
+
+        public override void ServerEarlyUpdate()
+        {
+            foreach (Transport transport in transports)
+            {
+                transport.ServerEarlyUpdate();
+            }
+        }
+
+        public override void ClientLateUpdate()
+        {
+            foreach (Transport transport in transports)
+            {
+                transport.ClientLateUpdate();
+            }
+        }
+
+        public override void ServerLateUpdate()
+        {
+            foreach (Transport transport in transports)
+            {
+                transport.ServerLateUpdate();
+            }
+        }
+
         void OnEnable()
         {
             foreach (Transport transport in transports)


### PR DESCRIPTION
When MultiplexTransport is used with KcpTransport, SimpleWebTransport or TelepathyTransport it does not call update methods from new NetworkLoop. It breaks the transmission of any network messages.