### PR TITLE
NetworkBehaviour.SendCommandInternal: use connectionToServer instead of NetworkClient.readyConnection. reduces dependencies on NetworkClient.readyConnection (which is redundant) and reduces static states.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -145,14 +145,21 @@ namespace Mirror
                 return;
             }
 
-            // TODO use connectionToServer directly?
-            if (NetworkClient.readyConnection == null)
+            // originally we checked if NetworkClient.readyConnection == null
+            // instead check connectionToServer and isReady.
+            if (connectionToServer == null)
             {
                 Debug.LogError("Send command attempted with no client running [client=" + connectionToServer + "].");
                 return;
             }
 
-            // construct the message
+            if (!connectionToServer.isReady)
+            {
+                Debug.LogError("Trying to send command, but connectionToServer isn't ready");
+                return;
+            }
+
+            // send CommandMessage to the server
             CommandMessage message = new CommandMessage
             {
                 netId = netId,
@@ -163,8 +170,7 @@ namespace Mirror
                 payload = writer.ToArraySegment()
             };
 
-            // TODO use connectionToServer directly?
-            NetworkClient.readyConnection.Send(message, channelId);
+            connectionToServer.Send(message, channelId);
         }
 
         protected void SendRPCInternal(Type invokeClass, string rpcName, NetworkWriter writer, int channelId, bool includeOwner)

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -362,12 +362,16 @@ namespace Mirror.Tests
             // won't find it
             NetworkIdentity.spawned[identity.netId] = identity;
 
-            // calling command before clientscene has ready connection shouldn't work
+            // calling command if connection isn't ready should not work
             // error log is expected
             LogAssert.ignoreFailingMessages = true;
+            identity.connectionToServer.isReady = false;
             comp.CallSendCommandInternal();
             LogAssert.ignoreFailingMessages = false;
             Assert.That(comp.called, Is.EqualTo(0));
+
+            // reset ready
+            identity.connectionToServer.isReady = true;
 
             // clientscene.readyconnection needs to be set for commands
             NetworkClient.Ready(connection.connectionToServer);


### PR DESCRIPTION
less state = less complexity = less bugs