### PR TITLE
fix: networkloop breaks other libraries that use playerloop

### DIFF
--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -140,16 +140,15 @@ namespace Mirror
             Debug.Log("Mirror: adding Network[Early/Late]Update to Unity...");
 
             // get loop
-            // TODO 2019 has GetCURRENTPlayerLoop which is safe to use without
-            // breaking other custom system's custom loops. Let's use Default
-            // for now until we upgrade to 2019 so we have the same behaviour
-            // at all times (instead of different loop behavior on 2018/2019)
+            // 2019 has GetCURRENTPlayerLoop which is safe to use without
+            // breaking other custom system's custom loops. 
+            // see also: https://github.com/vis2k/Mirror/pull/2627/files
             PlayerLoopSystem playerLoop =
-            #if UNITY_2019_3_OR_NEWER
-                            PlayerLoop.GetCurrentPlayerLoop();
-            #else
-                            PlayerLoop.GetDefaultPlayerLoop();
-            #endif
+#if UNITY_2019_3_OR_NEWER
+                PlayerLoop.GetCurrentPlayerLoop();
+#else
+                PlayerLoop.GetDefaultPlayerLoop();
+#endif
 
             // add NetworkEarlyUpdate to the end of EarlyUpdate so it runs after
             // any Unity initializations but before the first Update/FixedUpdate

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -144,7 +144,12 @@ namespace Mirror
             // breaking other custom system's custom loops. Let's use Default
             // for now until we upgrade to 2019 so we have the same behaviour
             // at all times (instead of different loop behavior on 2018/2019)
-            PlayerLoopSystem playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+            PlayerLoopSystem playerLoop =
+            #if UNITY_2019_3_OR_NEWER
+                            PlayerLoop.GetCurrentPlayerLoop();
+            #else
+                            PlayerLoop.GetDefaultPlayerLoop();
+            #endif
 
             // add NetworkEarlyUpdate to the end of EarlyUpdate so it runs after
             // any Unity initializations but before the first Update/FixedUpdate


### PR DESCRIPTION
Networkloop breaks other libraries that use playerloop (eg UniTask) so it's impossible to use Mirror with them together. 