### PR TITLE
Channels: use shorter names to prepare for enum

### DIFF
--- a/Assets/Mirror/Runtime/Utils.cs
+++ b/Assets/Mirror/Runtime/Utils.cs
@@ -38,8 +38,13 @@ namespace Mirror
     // add custom channels anymore.
     public static class Channels
     {
-        public const int DefaultReliable = 0;
-        public const int DefaultUnreliable = 1;
+        public const int Reliable = 0; // ordered
+        public const int Unreliable = 1; // unordered
+
+        [Obsolete("Use Channels.Reliable instead")]
+        public const int DefaultReliable = Reliable;
+        [Obsolete("Use Channels.Unreliable instead")]
+        public const int DefaultUnreliable = Unreliable;
     }
 
     // -- helpers for float conversion without allocations --


### PR DESCRIPTION
in the long run, Mirror will only ever need two channels:
- Reliable for handshake
- Unreliable for quake style world sync

Channels.DefaultReliable sounds kinda silly.
It's always the Reliable one.

let's use shorter names for now, and obsolete the long names.
then some day we change it to an enum and don't allow people to add more channels.