### PR TITLE
Fix clear pointers of first element

### DIFF
--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -103,7 +103,12 @@ namespace Mirror
                 // prepend our custom loop to the beginning
                 if (addMode == AddMode.Beginning)
                 {
-                    // copy to the right and clear the first element
+                    // shift to the right and write into the first element
+                    // IMPORTANT: PlayerLoopSystem struct has IntPtrs for native loops:
+                    //   * updateFunction IntPtr
+                    //   * loopConditionFunction IntPtr
+                    // we need to clear them, otherwise our custom loop causes undefined
+                    // behaviour (https://github.com/vis2k/Mirror/pull/2652)
                     Array.Copy(playerLoop.subSystemList, 0, playerLoop.subSystemList, 1, playerLoop.subSystemList.Length - 1);
                     playerLoop.subSystemList[0].updateFunction = IntPtr.Zero;
                     playerLoop.subSystemList[0].loopConditionFunction = IntPtr.Zero;

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -103,16 +103,14 @@ namespace Mirror
                 // prepend our custom loop to the beginning
                 if (addMode == AddMode.Beginning)
                 {
-                    // shift to the right and write into the first element
-                    // IMPORTANT: PlayerLoopSystem struct has IntPtrs for native loops:
-                    //   * updateFunction IntPtr
-                    //   * loopConditionFunction IntPtr
-                    // we need to clear them, otherwise our custom loop causes undefined
-                    // behaviour (https://github.com/vis2k/Mirror/pull/2652)
+                    // shift to the right, write into the first element
+                    // 
+                    // IMPORTANT: PlayerLoopSystem struct has IntPtrs for native loops.
+                    // => clear them so our added loop doesn't contain old IntPtr loops!
+                    //    https://github.com/vis2k/Mirror/pull/2652
                     Array.Copy(playerLoop.subSystemList, 0, playerLoop.subSystemList, 1, playerLoop.subSystemList.Length - 1);
                     playerLoop.subSystemList[0].updateFunction = IntPtr.Zero;
                     playerLoop.subSystemList[0].loopConditionFunction = IntPtr.Zero;
-                    // write into first array element
                     playerLoop.subSystemList[0].type = ownerType;
                     playerLoop.subSystemList[0].updateDelegate = function;
 

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -103,8 +103,11 @@ namespace Mirror
                 // prepend our custom loop to the beginning
                 if (addMode == AddMode.Beginning)
                 {
-                    // shift to the right, write into first array element
+                    // copy to the right and clear the first element
                     Array.Copy(playerLoop.subSystemList, 0, playerLoop.subSystemList, 1, playerLoop.subSystemList.Length - 1);
+                    playerLoop.subSystemList[0].updateFunction = IntPtr.Zero;
+                    playerLoop.subSystemList[0].loopConditionFunction = IntPtr.Zero;
+                    // write into first array element
                     playerLoop.subSystemList[0].type = ownerType;
                     playerLoop.subSystemList[0].updateDelegate = function;
 
@@ -145,7 +148,7 @@ namespace Mirror
 
             // get loop
             // 2019 has GetCURRENTPlayerLoop which is safe to use without
-            // breaking other custom system's custom loops. 
+            // breaking other custom system's custom loops.
             // see also: https://github.com/vis2k/Mirror/pull/2627/files
             PlayerLoopSystem playerLoop =
 #if UNITY_2019_3_OR_NEWER


### PR DESCRIPTION
This is necessary, since it is not a shift, but a copy. The first element stays as it was, and non cleared pointers result in the function not being called (happens for me on 2020.3.0f1)

The functionality is currently not used, that's why the bug probably was undetected.