### PR TITLE
fix: Prevent client shutdown from running twice

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -280,6 +280,11 @@ namespace Mirror
 
         static void OnDisconnected()
         {
+            // StopClient called from user code triggers Disconnected event
+            // from transport which calls StopClient again, so check here
+            // and short circuit running the Shutdown process twice.
+            if (connectState == ConnectState.Disconnected) return;
+
             connectState = ConnectState.Disconnected;
             ready = false;
 


### PR DESCRIPTION
StopClient called from user code triggers Disconnected event from transport which calls StopClient again
Check in OnDisconnected and short circuit running the Shutdown process twice.
