### PR TITLE
DontDestroyOnLoad gameobjects now won't remove observers during scene change

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -136,13 +136,12 @@ namespace Mirror
         }
 
         // TODO move to server's NetworkConnectionToClient?
-        internal void RemoveObservers()
+        /// <param name="removeDontDestroyOnLoadObjects">If true, removes all observers, even when they won't be destroyed on load</param>
+        internal void RemoveObservers(bool removeDontDestroyOnLoadObjects = true)
         {
-            foreach (NetworkIdentity netIdentity in observing)
-            {
-                netIdentity.RemoveObserverInternal(this);
-            }
-            observing.Clear();
+            // only remove from observing if either removeDontDestroyOnLoadObjects is true, or if netIdentity is not in "DontDestroyOnLoad"
+            // (DontDestroyOnLoad is checked in netIdentity.RemoveObserverInternal
+            observing.RemoveWhere(netIdentity => netIdentity.RemoveObserverInternal(this, removeDontDestroyOnLoadObjects));
         }
 
         // helper function

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -267,9 +267,20 @@ namespace Mirror
         public static event ClientAuthorityCallback clientAuthorityCallback;
 
         // this is used when a connection is destroyed, since the "observers" property is read-only
-        internal void RemoveObserverInternal(NetworkConnection conn)
+        /// <param name="conn">The NetworkConnection that should be removed as observer</param>
+        /// <param name="removeEvenWhenDontDestroyOnLoad">If true, conn will always be removed as observer,
+        /// otherwise only if this gameObject is not part of DontDestroyOnLoad</param>
+        /// <returns>true if conn has been removed from observers</returns>
+        internal bool RemoveObserverInternal(NetworkConnection conn, bool removeEvenWhenDontDestroyOnLoad = true)
         {
-            observers?.Remove(conn.connectionId);
+            // only remove conn from observers if either removeEvenWhenDontDestroyOnLoad is true,
+            // or if not "DontDestroyOnLoad" (scene.buildIndex of -1 means DontDestroyOnLoad has been activated)
+            if (removeEvenWhenDontDestroyOnLoad || gameObject.scene.buildIndex != -1)
+            {
+                observers?.Remove(conn.connectionId);
+                return true;
+            }
+            return false;
         }
 
         // hasSpawned should always be false before runtime

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -687,7 +687,7 @@ namespace Mirror
             {
                 // Debug.Log("PlayerNotReady " + conn);
                 conn.isReady = false;
-                conn.RemoveObservers();
+                conn.RemoveObservers(false);
 
                 conn.Send(new NotReadyMessage());
             }


### PR DESCRIPTION

RemoveObservers in NetworkConnection now has a parameter "removeDontDestroyOnLoadObjects".
By default it is set to true. If set to false, gameObjects that are part of DontDestroyOnLoad
won't be removed from the observing set.
Because of that, updates of NetworkIdentities which have DontDestroyOnLoad activated,
will now not be lost for unready clients during scene changes.

**This pull request fixes https://github.com/vis2k/Mirror/issues/2672**