### PR TITLE
fix: weave assembly only once when restarting

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Mono.CecilX;
 
 namespace Mirror.Weaver
@@ -173,6 +174,11 @@ namespace Mirror.Weaver
                         asmResolver.AddSearchDirectory(path);
                     }
                 }
+
+                // When unity restarts, it may try to weave an assembly that has
+                // already been weaved.
+                if (CurrentAssembly.MainModule.GetTypes().Any(td => td.FullName == "Mirror.GeneratedNetworkCode"))
+                    return true;
 
                 WeaverTypes.SetupTargetTypes(CurrentAssembly);
                 // WeaverList depends on WeaverTypes setup because it uses Import

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -177,7 +177,7 @@ namespace Mirror.Weaver
 
                 // When unity restarts, it may try to weave an assembly that has
                 // already been weaved.
-                if (CurrentAssembly.MainModule.GetTypes().Any(td => td.FullName == "Mirror.GeneratedNetworkCode"))
+                if (CurrentAssembly.MainModule.GetTypes().Any(td => td.FullName.StartsWith("Mirror.GeneratedNetworkCode")))
                     return true;
 
                 WeaverTypes.SetupTargetTypes(CurrentAssembly);


### PR DESCRIPTION
when restarting unity, check if an assembly has already been weaved instead of adding a duplicate Mirror.GeneratedNetworkCode class