### PR TITLE
Add 'Manual' value to the Visibility enum

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -17,8 +17,7 @@ namespace Mirror
     // ForceHidden = useful to hide monsters while they respawn etc.
     // ForceShown = useful to have score NetworkIdentities that always broadcast
     //              to everyone etc.
-    // Manual = manually set visibility on this NetworkIdentity somewhere else in code
-    public enum Visibility { Default, ForceHidden, ForceShown, Manual }
+    public enum Visibility { Default, ForceHidden, ForceShown }
 
     /// <summary>NetworkIdentity identifies objects across the network.</summary>
     [DisallowMultipleComponent]
@@ -170,7 +169,6 @@ namespace Mirror
         // ForceHidden = useful to hide monsters while they respawn etc.
         // ForceShown = useful to have score NetworkIdentities that always broadcast
         //              to everyone etc.
-        // Manual = manually set visibility on this NetworkIdentity somewhere else in code
         //
         // TODO rename to 'visibility' after removing .visibility some day!
         [Tooltip("Visibility can overwrite interest management. ForceHidden can be useful to hide monsters while they respawn. ForceShown can be useful for score NetworkIdentities that should always broadcast to everyone in the world.")]
@@ -803,10 +801,6 @@ namespace Mirror
         //    directly in NetworkIdentity.
         internal void OnSetHostVisibility(bool visible)
         {
-            if (this.visible == Visibility.Manual) {
-                return;
-            }
-
             foreach (Renderer rend in GetComponentsInChildren<Renderer>())
                 rend.enabled = visible;
         }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -17,7 +17,8 @@ namespace Mirror
     // ForceHidden = useful to hide monsters while they respawn etc.
     // ForceShown = useful to have score NetworkIdentities that always broadcast
     //              to everyone etc.
-    public enum Visibility { Default, ForceHidden, ForceShown }
+    // Manual = manually set visibility on this NetworkIdentity somewhere else in code
+    public enum Visibility { Default, ForceHidden, ForceShown, Manual }
 
     /// <summary>NetworkIdentity identifies objects across the network.</summary>
     [DisallowMultipleComponent]
@@ -169,6 +170,7 @@ namespace Mirror
         // ForceHidden = useful to hide monsters while they respawn etc.
         // ForceShown = useful to have score NetworkIdentities that always broadcast
         //              to everyone etc.
+        // Manual = manually set visibility on this NetworkIdentity somewhere else in code
         //
         // TODO rename to 'visibility' after removing .visibility some day!
         [Tooltip("Visibility can overwrite interest management. ForceHidden can be useful to hide monsters while they respawn. ForceShown can be useful for score NetworkIdentities that should always broadcast to everyone in the world.")]
@@ -801,6 +803,10 @@ namespace Mirror
         //    directly in NetworkIdentity.
         internal void OnSetHostVisibility(bool visible)
         {
+            if (this.visible == Visibility.Manual) {
+                return;
+            }
+
             foreach (Renderer rend in GetComponentsInChildren<Renderer>())
                 rend.enabled = visible;
         }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -174,6 +174,9 @@ namespace Mirror
         [Tooltip("Visibility can overwrite interest management. ForceHidden can be useful to hide monsters while they respawn. ForceShown can be useful for score NetworkIdentities that should always broadcast to everyone in the world.")]
         public Visibility visible = Visibility.Default;
 
+        [Tooltip("Whether or not OnSetHostVisibility() should affect the status of renderers based on the visibility.")]
+        public bool updateRenderersInOnSetHostVisibility = true;
+
         /// <summary>Prefab GUID used to spawn prefabs across the network.</summary>
         //
         // The AssetId trick:
@@ -801,8 +804,13 @@ namespace Mirror
         //    directly in NetworkIdentity.
         internal void OnSetHostVisibility(bool visible)
         {
-            foreach (Renderer rend in GetComponentsInChildren<Renderer>())
-                rend.enabled = visible;
+            if (updateRenderersInOnSetHostVisibility)
+            {
+                foreach (Renderer rend in GetComponentsInChildren<Renderer>())
+                {
+                    rend.enabled = visible;
+                }
+            }
         }
 
         // vis2k: readstring bug prevention: https://github.com/vis2k/Mirror/issues/2617


### PR DESCRIPTION
Added a 'Manual' value to Visibility Enum that when used will prevent `NetworkIdentity#OnSetHostVisibility()` from modifying renderers.