### PR TITLE
fix: Network Authentators: Removed NetworkConnection parameter

### DIFF
--- a/Assets/Mirror/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/BasicAuthenticator.cs
@@ -150,7 +150,7 @@ namespace Mirror.Authenticators
         /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
         /// </summary>
         /// <param name="conn">Connection of the client.</param>
-        public override void OnClientAuthenticate(NetworkConnection conn)
+        public override void OnClientAuthenticate()
         {
             AuthRequestMessage authRequestMessage = new AuthRequestMessage
             {
@@ -158,13 +158,15 @@ namespace Mirror.Authenticators
                 authPassword = password
             };
 
-            conn.Send(authRequestMessage);
+            NetworkClient.connection.Send(authRequestMessage);
         }
+
+        [Obsolete("Call OnAuthResponseMessage without the NetworkConnection parameter. It always points to NetworkClient.connection anyway.")]
+        public void OnAuthResponseMessage(NetworkConnection conn, AuthResponseMessage msg) => OnAuthResponseMessage(msg);
 
         /// <summary>
         /// Called on client when the server's AuthResponseMessage arrives
         /// </summary>
-        /// <param name="conn">Connection to client.</param>
         /// <param name="msg">The message payload</param>
         public void OnAuthResponseMessage(AuthResponseMessage msg)
         {
@@ -173,19 +175,16 @@ namespace Mirror.Authenticators
                 // Debug.LogFormat(LogType.Log, "Authentication Response: {0}", msg.message);
 
                 // Authentication has been accepted
-                ClientAccept(NetworkClient.connection);
+                ClientAccept();
             }
             else
             {
                 Debug.LogError($"Authentication Response: {msg.message}");
 
                 // Authentication has been rejected
-                ClientReject(NetworkClient.connection);
+                ClientReject();
             }
         }
-
-        [Obsolete("Call OnAuthResponseMessage without the NetworkConnection parameter. It always points to NetworkClient.connection anyway.")]
-        public void OnAuthResponseMessage(NetworkConnection conn, AuthResponseMessage msg) => OnAuthResponseMessage(msg);
 
         #endregion
     }

--- a/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
@@ -48,23 +48,21 @@ namespace Mirror.Authenticators
                 StartCoroutine(BeginAuthentication(conn));
         }
 
-        public override void OnClientAuthenticate(NetworkConnection conn)
+        public override void OnClientAuthenticate()
         {
-            authenticator.OnClientAuthenticate(conn);
+            authenticator.OnClientAuthenticate();
             if (timeout > 0)
-                StartCoroutine(BeginAuthentication(conn));
+                StartCoroutine(BeginAuthentication(NetworkClient.connection));
         }
 
         IEnumerator BeginAuthentication(NetworkConnection conn)
         {
             // Debug.Log($"Authentication countdown started {conn} {timeout}");
-
             yield return new WaitForSecondsRealtime(timeout);
 
             if (!conn.isAuthenticated)
             {
                 // Debug.Log($"Authentication Timeout {conn}");
-
                 conn.Disconnect();
             }
         }

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -44,24 +44,30 @@ namespace Mirror
         /// <summary>Called when client stops, used to unregister message handlers if needed.</summary>
         public virtual void OnStopClient() {}
 
-        /// <summary>Called on client from OnClientAuthenticateInternal when a client needs to authenticate</summary>
-        // TODO client callbacks don't need NetworkConnection parameter. use NetworkClient.connection!
-        public abstract void OnClientAuthenticate(NetworkConnection conn);
+        [Obsolete("Deprecated: Remove the NetworkConnection parameter from your override and use NetworkClient.connection instead")]
+        public virtual void OnClientAuthenticate(NetworkConnection conn) => OnClientAuthenticate();
 
-        // TODO client callbacks don't need NetworkConnection parameter. use NetworkClient.connection!
-        protected void ClientAccept(NetworkConnection conn)
+        /// <summary>Called on client from OnClientAuthenticateInternal when a client needs to authenticate</summary>
+        public abstract void OnClientAuthenticate();
+
+        [Obsolete("Deprecated: Remove the NetworkConnection parameter from your override and use NetworkClient.connection instead")]
+        protected void ClientAccept(NetworkConnection conn) => ClientAccept();
+
+        protected void ClientAccept()
         {
-            OnClientAuthenticated.Invoke(conn);
+            OnClientAuthenticated.Invoke(NetworkClient.connection);
         }
 
-        // TODO client callbacks don't need NetworkConnection parameter. use NetworkClient.connection!
-        protected void ClientReject(NetworkConnection conn)
+        [Obsolete("Deprecated: Remove the NetworkConnection parameter from your override and use NetworkClient.connection instead")]
+        protected void ClientReject(NetworkConnection conn) => ClientReject();
+
+        protected void ClientReject()
         {
             // Set this on the client for local reference
-            conn.isAuthenticated = false;
+            NetworkClient.connection.isAuthenticated = false;
 
             // disconnect the client
-            conn.Disconnect();
+            NetworkClient.connection.Disconnect();
         }
 
         void OnValidate()

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1140,7 +1140,7 @@ namespace Mirror
             if (authenticator != null)
             {
                 // we have an authenticator - let it handle authentication
-                authenticator.OnClientAuthenticate(NetworkClient.connection);
+                authenticator.OnClientAuthenticate();
             }
             else
             {

--- a/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
+++ b/Assets/ScriptTemplates/51-Mirror__Network Authenticator-NewNetworkAuthenticator.cs.txt
@@ -67,8 +67,7 @@ public class #SCRIPTNAME# : NetworkAuthenticator
     /// <summary>
     /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
     /// </summary>
-    /// <param name="conn">Connection of the client.</param>
-    public override void OnClientAuthenticate(NetworkConnection conn)
+    public override void OnClientAuthenticate()
     {
         AuthRequestMessage authRequestMessage = new AuthRequestMessage();
 
@@ -78,12 +77,11 @@ public class #SCRIPTNAME# : NetworkAuthenticator
     /// <summary>
     /// Called on client when the server's AuthResponseMessage arrives
     /// </summary>
-    /// <param name="conn">Connection to client.</param>
     /// <param name="msg">The message payload</param>
     public void OnAuthResponseMessage(AuthResponseMessage msg)
     {
         // Authentication has been accepted
-        ClientAccept(NetworkClient.connection);
+        ClientAccept();
     }
 
     #endregion


### PR DESCRIPTION
As was done in other areas, now using `NetworkClient.connection` instead of passing a `conn` parameter around.
- Abstract NetworkAuthenticator now has obsoletes.
- Basic and Timeout Authenticators Updated
- Network Manager Updated
- Script Template Updated