### PR TITLE
sync scale and interpolation adjustments

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -55,7 +55,7 @@ namespace Mirror
         public bool interpolateScale = true;
         [Tooltip("Set to true if rotation should be interpolated, false is ideal for instant turning, common in retro 2d style games")]
         public bool interpolateRotation = true;
-        [Tooltip("Set to true if rotation should be interpolated, false is ideal for grid bassed movement")]
+        [Tooltip("Set to true if position should be interpolated, false is ideal for grid bassed movement")]
         public bool interpolatePosition = true;
 
 

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -53,6 +53,11 @@ namespace Mirror
         [Header("Interpolation")]
         [Tooltip("Set to true if scale should be interpolated, false is ideal for instant sprite flipping.")]
         public bool interpolateScale = true;
+        [Tooltip("Set to true if rotation should be interpolated, false is ideal for instant turning, common in retro 2d style games")]
+        public bool interpolateRotation = true;
+        [Tooltip("Set to true if rotation should be interpolated, false is ideal for grid bassed movement")]
+        public bool interpolatePosition = true;
+
 
         [Header("Synchronization")]
         // It should be very rare cases that people want to continuously sync scale, true by default to not break previous projects that use it
@@ -265,9 +270,13 @@ namespace Mirror
             return 0;
         }
 
-        static Vector3 InterpolatePosition(DataPoint start, DataPoint goal, Vector3 currentPosition)
+        Vector3 InterpolatePosition(DataPoint start, DataPoint goal, Vector3 currentPosition)
         {
-            if (start != null)
+            if (!interpolatePosition)
+            {
+                return goal.localPosition;
+            }
+            else if (start != null)
             {
                 // Option 1: simply interpolate based on time. but stutter
                 // will happen, it's not that smooth. especially noticeable if
@@ -284,9 +293,13 @@ namespace Mirror
             return currentPosition;
         }
 
-        static Quaternion InterpolateRotation(DataPoint start, DataPoint goal, Quaternion defaultRotation)
+        Quaternion InterpolateRotation(DataPoint start, DataPoint goal, Quaternion defaultRotation)
         {
-            if (start != null)
+            if (!interpolateRotation)
+            {
+                return goal.localRotation;
+            }
+            else if (start != null)
             {
                 float t = CurrentInterpolationFactor(start, goal);
                 return Quaternion.Slerp(start.localRotation, goal.localRotation, t);
@@ -296,7 +309,15 @@ namespace Mirror
 
         Vector3 InterpolateScale(DataPoint start, DataPoint goal, Vector3 currentScale)
         {
-            if (start != null && interpolateScale)
+            if (!syncScale)
+            {
+                return currentScale;
+            }
+            else if (!interpolateScale)
+            {
+                return goal.localScale;
+            }
+            else if (interpolateScale && start != null )
             {
                 float t = CurrentInterpolationFactor(start, goal);
                 return Vector3.Lerp(start.localScale, goal.localScale, t);


### PR DESCRIPTION
Tidied up sync scale / interpolate scale.
Added interpolate rotation and position booleans.
Tooltips with use-case for both.

Rotation option was added for a discord user, who was experiencing strangeness with his retro snake-like character movement.
Seemed ideal to also add Position boolean for grid based/movement snapping users at the same time.

Tested all cases, but double checking from anyone else would be greatly appreciate too ;)

![Screenshot 2021-05-02 at 21 34 30](https://user-images.githubusercontent.com/57072365/116827502-1e2ff880-ab91-11eb-8ec2-20e3dd228f32.jpg)

![Screenshot 2021-05-02 at 21 35 19](https://user-images.githubusercontent.com/57072365/116827496-183a1780-ab91-11eb-873f-8f4d24c11d37.jpg)


