### PR TITLE
fix: Fixes collection modified error

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1363,7 +1363,7 @@ namespace Mirror
             if (active)
             {
                 // go through all connections
-                foreach (NetworkConnectionToClient connection in connections.Values)
+                foreach (NetworkConnectionToClient connection in connections.Values.ToList())
                 {
                     // check for inactivity
 #pragma warning disable 618


### PR DESCRIPTION
- Verified by Discord user `ruploz` that got the error below:
```
InvalidOperationException: Collection was modified; enumeration operation may not execute.
System.Collections.Generic.Dictionary`2+ValueCollection+Enumerator[TKey,TValue].MoveNext () (at <695d1cc93cca45069c528c15c9fdd749>:0)
Mirror.NetworkServer.NetworkLateUpdate () (at Assets/z_Imported/Mirror/Runtime/NetworkServer.cs:1345)
Mirror.NetworkLoop.NetworkLateUpdate () (at Assets/z_Imported/Mirror/Runtime/NetworkLoop.cs:188)
```