### PR TITLE
Obsolete ReplaceHandler

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -334,7 +334,7 @@ namespace Mirror
         }
 
         /// <summary>Replace a handler for a particular message type. Should require authentication by default.</summary>
-        // TODO does anyone even use that? consider removing
+        [Obsolete("We are considering to remove ReplaceHandler<T>. If you have a good reason why we should keep it, please let us know.")]
         public static void ReplaceHandler<T>(Action<NetworkConnection, T> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {
@@ -343,7 +343,7 @@ namespace Mirror
         }
 
         /// <summary>Replace a handler for a particular message type. Should require authentication by default.</summary>
-        // TODO does anyone even use that? consider removing
+        [Obsolete("We are considering to remove ReplaceHandler<T>. If you have a good reason why we should keep it, please let us know.")]
         public static void ReplaceHandler<T>(Action<T> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -469,6 +469,7 @@ namespace Mirror
         }
 
         /// <summary>Replace a handler for message type T. Most should require authentication.</summary>
+        [Obsolete("We are considering to remove ReplaceHandler<T>. If you have a good reason why we should keep it, please let us know.")]
         public static void ReplaceHandler<T>(Action<NetworkConnection, T> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {
@@ -477,6 +478,7 @@ namespace Mirror
         }
 
         /// <summary>Replace a handler for message type T. Most should require authentication.</summary>
+        [Obsolete("We are considering to remove ReplaceHandler<T>. If you have a good reason why we should keep it, please let us know.")]
         public static void ReplaceHandler<T>(Action<T> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {


### PR DESCRIPTION
get rid of dead weight.
this seems like an extreme edge case.
yet we support it.

looking for use cases.

from discord: https://github.com/vis2k/Mirror/pull/1775/

and:
'In a chat system that uses network messages to send messages the server has a handle that sends all messages to other players, now lets say suddenly the admin turns on allowCheats and clients can send commands in the chat then the messages have to be handled differently so you replace the handler for them.

In this case you could have one handler with an if...else... but if you have more different cases then its just cleaner and better if I can write 5 different handlers and replace them instead of having one 500 loc handler that gets really messy'