### PR TITLE
Replace & obsolete URI with Connect("IP:Port") addresses

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscovery.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscovery.cs
@@ -59,7 +59,7 @@ namespace Mirror.Discovery
                 return new ServerResponse
                 {
                     serverId = ServerId,
-                    uri = transport.ServerUri()
+                    address = transport.ServerAddress()
                 };
             }
             catch (NotImplementedException)
@@ -98,13 +98,19 @@ namespace Mirror.Discovery
 
             // although we got a supposedly valid url, we may not be able to resolve
             // the provided host
+            // TODO Y THO???????
             // However we know the real ip address of the server because we just
             // received a packet from it,  so use that as host.
-            UriBuilder realUri = new UriBuilder(response.uri)
+            //   UriBuilder realUri = new UriBuilder(response.uri)
+            //   {
+            //       Host = response.EndPoint.Address.ToString()
+            //   };
+            //   response.uri = realUri.Uri;
+
+            if (Utils.ParseHostAndPort(response.address, out string _, out ushort port))
             {
-                Host = response.EndPoint.Address.ToString()
-            };
-            response.uri = realUri.Uri;
+                response.address = $"{response.EndPoint.Address}:{port}";
+            }
 
             OnServerFound.Invoke(response);
         }

--- a/Assets/Mirror/Components/Discovery/ServerResponse.cs
+++ b/Assets/Mirror/Components/Discovery/ServerResponse.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 
 namespace Mirror.Discovery
 {
@@ -10,7 +9,8 @@ namespace Mirror.Discovery
         // client fills this up after we receive it
         public IPEndPoint EndPoint { get; set; }
 
-        public Uri uri;
+        // Transport.ServerAddress(). can be "IP:Port".
+        public string address;
 
         // Prevent duplicate server appearance when a connection can be made via LAN on multiple NICs
         public long serverId;

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -145,7 +145,7 @@ namespace Mirror
         }
 
         /// <summary>Connect client to a NetworkServer by Uri.</summary>
-        [Obsolete(Transport.UriObsoleteMessage)]
+        [Obsolete(Transport.ConnectUriObsoleteMessage)]
         public static void Connect(Uri uri)
         {
             // Debug.Log("Client Connect: " + uri);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -145,6 +145,7 @@ namespace Mirror
         }
 
         /// <summary>Connect client to a NetworkServer by Uri.</summary>
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public static void Connect(Uri uri)
         {
             // Debug.Log("Client Connect: " + uri);

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -145,7 +145,7 @@ namespace Mirror
         }
 
         /// <summary>Connect client to a NetworkServer by Uri.</summary>
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(Transport.UriObsoleteMessage)]
         public static void Connect(Uri uri)
         {
             // Debug.Log("Client Connect: " + uri);

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -362,7 +362,7 @@ namespace Mirror
         }
 
         /// <summary>Starts the client, connects it to the server via Uri</summary>
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(Transport.UriObsoleteMessage)]
         public void StartClient(Uri uri)
         {
             if (NetworkClient.active)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -362,7 +362,7 @@ namespace Mirror
         }
 
         /// <summary>Starts the client, connects it to the server via Uri</summary>
-        [Obsolete(Transport.UriObsoleteMessage)]
+        [Obsolete(Transport.ConnectUriObsoleteMessage)]
         public void StartClient(Uri uri)
         {
             if (NetworkClient.active)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -362,6 +362,7 @@ namespace Mirror
         }
 
         /// <summary>Starts the client, connects it to the server via Uri</summary>
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public void StartClient(Uri uri)
         {
             if (NetworkClient.active)

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -394,6 +394,7 @@ namespace Mirror
             return result;
         }
 
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public static Uri ReadUri(this NetworkReader reader)
         {
             return new Uri(reader.ReadString());

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -394,7 +394,7 @@ namespace Mirror
             return result;
         }
 
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(Transport.UriObsoleteMessage)]
         public static Uri ReadUri(this NetworkReader reader)
         {
             return new Uri(reader.ReadString());

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -394,7 +394,7 @@ namespace Mirror
             return result;
         }
 
-        [Obsolete(Transport.UriObsoleteMessage)]
+        [Obsolete("ReadUri is obsolete because Transport URI support is obsolete.")]
         public static Uri ReadUri(this NetworkReader reader)
         {
             return new Uri(reader.ReadString());

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -413,6 +413,7 @@ namespace Mirror
             }
         }
 
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public static void WriteUri(this NetworkWriter writer, Uri uri)
         {
             writer.WriteString(uri.ToString());

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -413,7 +413,7 @@ namespace Mirror
             }
         }
 
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(Transport.UriObsoleteMessage)]
         public static void WriteUri(this NetworkWriter writer, Uri uri)
         {
             writer.WriteString(uri.ToString());

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -413,7 +413,7 @@ namespace Mirror
             }
         }
 
-        [Obsolete(Transport.UriObsoleteMessage)]
+        [Obsolete("WriteUri is obsolete because Transport URI support is obsolete.")]
         public static void WriteUri(this NetworkWriter writer, Uri uri)
         {
             writer.WriteString(uri.ToString());

--- a/Assets/Mirror/Runtime/Transport/FallbackTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/FallbackTransport.cs
@@ -63,7 +63,7 @@ namespace Mirror
             available.ClientConnect(address);
         }
 
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ConnectUriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {
             foreach (Transport transport in transports)
@@ -101,7 +101,7 @@ namespace Mirror
 
         // right now this just returns the first available uri,
         // should we return the list of all available uri?
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ServerUriObsoleteMessage)]
         public override Uri ServerUri() => available.ServerUri();
 
         public override bool ServerActive()

--- a/Assets/Mirror/Runtime/Transport/FallbackTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/FallbackTransport.cs
@@ -63,7 +63,7 @@ namespace Mirror
             available.ClientConnect(address);
         }
 
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {
             foreach (Transport transport in transports)
@@ -101,7 +101,7 @@ namespace Mirror
 
         // right now this just returns the first available uri,
         // should we return the list of all available uri?
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override Uri ServerUri() => available.ServerUri();
 
         public override bool ServerActive()

--- a/Assets/Mirror/Runtime/Transport/FallbackTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/FallbackTransport.cs
@@ -63,6 +63,7 @@ namespace Mirror
             available.ClientConnect(address);
         }
 
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override void ClientConnect(Uri uri)
         {
             foreach (Transport transport in transports)
@@ -100,6 +101,7 @@ namespace Mirror
 
         // right now this just returns the first available uri,
         // should we return the list of all available uri?
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override Uri ServerUri() => available.ServerUri();
 
         public override bool ServerActive()

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -139,6 +139,7 @@ namespace kcp2k
         }
 
         // server
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder();

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -139,7 +139,7 @@ namespace kcp2k
         }
 
         // server
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder();

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -88,7 +88,16 @@ namespace kcp2k
         public override bool ClientConnected() => client.connected;
         public override void ClientConnect(string address)
         {
-            client.Connect(address, Port, NoDelay, Interval, FastResend, CongestionWindow, SendWindowSize, ReceiveWindowSize);
+            // "IP:Port"
+            if (Mirror.Utils.ParseHostAndPort(address, out string parsedHost, out ushort parsedPort))
+            {
+                client.Connect(parsedHost, parsedPort, NoDelay, Interval, FastResend, CongestionWindow, SendWindowSize, ReceiveWindowSize);
+            }
+            // "IP" and default port
+            else
+            {
+                client.Connect(address, Port, NoDelay, Interval, FastResend, CongestionWindow, SendWindowSize, ReceiveWindowSize);
+            }
         }
         public override void ClientSend(ArraySegment<byte> segment, int channelId)
         {

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -139,7 +139,7 @@ namespace kcp2k
         }
 
         // server
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ServerUriObsoleteMessage)]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder();

--- a/Assets/Mirror/Runtime/Transport/LatencySimulation.cs
+++ b/Assets/Mirror/Runtime/Transport/LatencySimulation.cs
@@ -143,7 +143,7 @@ namespace Mirror
             wrap.ClientConnect(address);
         }
 
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {
             wrap.OnClientConnected = OnClientConnected;
@@ -168,7 +168,7 @@ namespace Mirror
             SimulateSend(0, segment, channelId, latency, reliableClientToServer, unreliableClientToServer);
         }
 
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override Uri ServerUri() => wrap.ServerUri();
 
         public override bool ServerActive() => wrap.ServerActive();

--- a/Assets/Mirror/Runtime/Transport/LatencySimulation.cs
+++ b/Assets/Mirror/Runtime/Transport/LatencySimulation.cs
@@ -143,7 +143,7 @@ namespace Mirror
             wrap.ClientConnect(address);
         }
 
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ConnectUriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {
             wrap.OnClientConnected = OnClientConnected;
@@ -168,7 +168,7 @@ namespace Mirror
             SimulateSend(0, segment, channelId, latency, reliableClientToServer, unreliableClientToServer);
         }
 
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ServerUriObsoleteMessage)]
         public override Uri ServerUri() => wrap.ServerUri();
 
         public override bool ServerActive() => wrap.ServerActive();

--- a/Assets/Mirror/Runtime/Transport/LatencySimulation.cs
+++ b/Assets/Mirror/Runtime/Transport/LatencySimulation.cs
@@ -143,6 +143,7 @@ namespace Mirror
             wrap.ClientConnect(address);
         }
 
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override void ClientConnect(Uri uri)
         {
             wrap.OnClientConnected = OnClientConnected;
@@ -167,6 +168,7 @@ namespace Mirror
             SimulateSend(0, segment, channelId, latency, reliableClientToServer, unreliableClientToServer);
         }
 
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override Uri ServerUri() => wrap.ServerUri();
 
         public override bool ServerActive() => wrap.ServerActive();

--- a/Assets/Mirror/Runtime/Transport/MiddlewareTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MiddlewareTransport.cs
@@ -48,6 +48,7 @@ namespace Mirror
         public override void ServerSend(int connectionId, ArraySegment<byte> segment, int channelId) => inner.ServerSend(connectionId, segment, channelId);
         public override void ServerDisconnect(int connectionId) => inner.ServerDisconnect(connectionId);
         public override string ServerGetClientAddress(int connectionId) => inner.ServerGetClientAddress(connectionId);
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override Uri ServerUri() => inner.ServerUri();
         #endregion
     }

--- a/Assets/Mirror/Runtime/Transport/MiddlewareTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MiddlewareTransport.cs
@@ -48,7 +48,7 @@ namespace Mirror
         public override void ServerSend(int connectionId, ArraySegment<byte> segment, int channelId) => inner.ServerSend(connectionId, segment, channelId);
         public override void ServerDisconnect(int connectionId) => inner.ServerDisconnect(connectionId);
         public override string ServerGetClientAddress(int connectionId) => inner.ServerGetClientAddress(connectionId);
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override Uri ServerUri() => inner.ServerUri();
         #endregion
     }

--- a/Assets/Mirror/Runtime/Transport/MiddlewareTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MiddlewareTransport.cs
@@ -48,7 +48,7 @@ namespace Mirror
         public override void ServerSend(int connectionId, ArraySegment<byte> segment, int channelId) => inner.ServerSend(connectionId, segment, channelId);
         public override void ServerDisconnect(int connectionId) => inner.ServerDisconnect(connectionId);
         public override string ServerGetClientAddress(int connectionId) => inner.ServerGetClientAddress(connectionId);
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ServerUriObsoleteMessage)]
         public override Uri ServerUri() => inner.ServerUri();
         #endregion
     }

--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -101,6 +101,7 @@ namespace Mirror
             throw new ArgumentException("No transport suitable for this platform");
         }
 
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override void ClientConnect(Uri uri)
         {
             foreach (Transport transport in transports)
@@ -198,6 +199,7 @@ namespace Mirror
 
         // for now returns the first uri,
         // should we return all available uris?
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override Uri ServerUri()
         {
             return transports[0].ServerUri();

--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -101,7 +101,7 @@ namespace Mirror
             throw new ArgumentException("No transport suitable for this platform");
         }
 
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {
             foreach (Transport transport in transports)
@@ -199,7 +199,7 @@ namespace Mirror
 
         // for now returns the first uri,
         // should we return all available uris?
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override Uri ServerUri()
         {
             return transports[0].ServerUri();

--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -101,7 +101,7 @@ namespace Mirror
             throw new ArgumentException("No transport suitable for this platform");
         }
 
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ConnectUriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {
             foreach (Transport transport in transports)
@@ -199,7 +199,7 @@ namespace Mirror
 
         // for now returns the first uri,
         // should we return all available uris?
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ServerUriObsoleteMessage)]
         public override Uri ServerUri()
         {
             return transports[0].ServerUri();

--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
@@ -272,6 +272,7 @@ namespace Mirror.SimpleWeb
             return server.GetClientAddress(connectionId);
         }
 
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder

--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
@@ -272,7 +272,7 @@ namespace Mirror.SimpleWeb
             return server.GetClientAddress(connectionId);
         }
 
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder

--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
@@ -272,7 +272,7 @@ namespace Mirror.SimpleWeb
             return server.GetClientAddress(connectionId);
         }
 
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ServerUriObsoleteMessage)]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder

--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/SimpleWebTransport.cs
@@ -122,7 +122,7 @@ namespace Mirror.SimpleWeb
             return client != null && client.ConnectionState != ClientState.NotConnected;
         }
 
-        public override void ClientConnect(string hostname)
+        public override void ClientConnect(string address)
         {
             // connecting or connected
             if (ClientConnected())
@@ -131,13 +131,28 @@ namespace Mirror.SimpleWeb
                 return;
             }
 
-            UriBuilder builder = new UriBuilder
-            {
-                Scheme = GetClientScheme(),
-                Host = hostname,
-                Port = port
-            };
+            UriBuilder builder;
 
+            // "Host:Port"
+            if (Mirror.Utils.ParseHostAndPort(address, out string parsedHost, out ushort parsedPort))
+            {
+                builder = new UriBuilder
+                {
+                    Scheme = GetClientScheme(),
+                    Host = parsedHost,
+                    Port = parsedPort
+                };
+            }
+            // "Host" and default port
+            else
+            {
+                builder = new UriBuilder
+                {
+                    Scheme = GetClientScheme(),
+                    Host = address,
+                    Port = port
+                };
+            }
 
             client = SimpleWebClient.Create(maxMessageSize, clientMaxMessagesPerTick, TcpConfig);
             if (client == null) { return; }

--- a/Assets/Mirror/Runtime/Transport/Telepathy/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/TelepathyTransport.cs
@@ -123,6 +123,7 @@ namespace Mirror
         // client
         public override bool ClientConnected() => client.Connected;
         public override void ClientConnect(string address) => client.Connect(address, port);
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override void ClientConnect(Uri uri)
         {
             if (uri.Scheme != Scheme)
@@ -148,6 +149,7 @@ namespace Mirror
         }
 
         // server
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder();

--- a/Assets/Mirror/Runtime/Transport/Telepathy/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/TelepathyTransport.cs
@@ -122,7 +122,19 @@ namespace Mirror
 
         // client
         public override bool ClientConnected() => client.Connected;
-        public override void ClientConnect(string address) => client.Connect(address, port);
+        public override void ClientConnect(string address)
+        {
+            // "IP:Port"
+            if (Utils.ParseHostAndPort(address, out string parsedHost, out ushort parsedPort))
+            {
+                client.Connect(parsedHost, parsedPort);
+            }
+            // "IP" and default port
+            else
+            {
+                client.Connect(address, port);
+            }
+        }
         [Obsolete(ConnectUriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {

--- a/Assets/Mirror/Runtime/Transport/Telepathy/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/TelepathyTransport.cs
@@ -123,7 +123,7 @@ namespace Mirror
         // client
         public override bool ClientConnected() => client.Connected;
         public override void ClientConnect(string address) => client.Connect(address, port);
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ConnectUriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {
             if (uri.Scheme != Scheme)
@@ -149,7 +149,7 @@ namespace Mirror
         }
 
         // server
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ServerUriObsoleteMessage)]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder();

--- a/Assets/Mirror/Runtime/Transport/Telepathy/TelepathyTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Telepathy/TelepathyTransport.cs
@@ -123,7 +123,7 @@ namespace Mirror
         // client
         public override bool ClientConnected() => client.Connected;
         public override void ClientConnect(string address) => client.Connect(address, port);
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override void ClientConnect(Uri uri)
         {
             if (uri.Scheme != Scheme)
@@ -149,7 +149,7 @@ namespace Mirror
         }
 
         // server
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override Uri ServerUri()
         {
             UriBuilder builder = new UriBuilder();

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -51,7 +51,10 @@ namespace Mirror
         /// <summary>True if the client is currently connected to the server.</summary>
         public abstract bool ClientConnected();
 
-        /// <summary>Connects the client to the server at the address.</summary>
+        /// <summary>Connects the client to the server at address. Can be "IP" or "IP:Port" etc. depending on the Transport.</summary>
+        // IMPORTANT: Transports should support both "IP" and "IP:Port" for
+        //            NetworkDiscovery, list servers, etc.
+        //            (easier than supporting Uris)
         public abstract void ClientConnect(string address);
 
         /// <summary>Connects the client to the server at the Uri.</summary>

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -87,6 +87,16 @@ namespace Mirror
         [Obsolete(UriObsoleteMessage)]
         public abstract Uri ServerUri();
 
+        /// <summary>Returns full server address like "IP:Port". Useful for clients to connect.</summary>
+        // => reuse obsolete ServerUri() by default. Give transports time to upgrade.
+        public virtual string ServerAddress()
+        {
+#pragma warning disable 618
+            Uri uri = ServerUri();
+#pragma warning restore 618
+            return $"{uri.Host}:{uri.Port}";
+        }
+
         /// <summary>Called by Transport when a new client connected to the server.</summary>
         public Action<int> OnServerConnected = (connId) => Debug.LogWarning("OnServerConnected called with no handler");
 

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -55,6 +55,7 @@ namespace Mirror
         public abstract void ClientConnect(string address);
 
         /// <summary>Connects the client to the server at the Uri.</summary>
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public virtual void ClientConnect(Uri uri)
         {
             // By default, to keep backwards compatibility, just connect to the host

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -60,7 +60,7 @@ namespace Mirror
 
         /// <summary>Connects the client to the server at the Uri.</summary>
         // DEPRECATED 2021-05-27
-        public const string ConnectUriObsoleteMessage = "We are considering to remove Uri support, unless someone has a good reason to keep it.";
+        public const string ConnectUriObsoleteMessage = "Uri support will be removed. Use Connect('IP:Port') instead of Connect(Uri).";
         [Obsolete(ConnectUriObsoleteMessage)]
         public virtual void ClientConnect(Uri uri)
         {
@@ -88,7 +88,7 @@ namespace Mirror
         /// <summary>Returns server address as Uri.</summary>
         // Useful for NetworkDiscovery.
         // DEPRECATED 2021-05-27
-        public const string ServerUriObsoleteMessage = "We are considering to remove Uri support, unless someone has a good reason to keep it.";
+        public const string ServerUriObsoleteMessage = "Uri support will be removed. Use ServerAddress() instead, which can be 'IP:Port' too.";
         [Obsolete(ServerUriObsoleteMessage)]
         public abstract Uri ServerUri();
 

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -30,6 +30,9 @@ namespace Mirror
     /// <summary>Abstract transport layer component</summary>
     public abstract class Transport : MonoBehaviour
     {
+        // DEPRECATED 2021-05-27
+        public const string UriObsoleteMessage = "We are considering to remove Uri support, unless someone has a good reason to keep it.";
+
         /// <summary>The current transport used by Mirror.</summary>
         public static Transport activeTransport;
 
@@ -55,7 +58,7 @@ namespace Mirror
         public abstract void ClientConnect(string address);
 
         /// <summary>Connects the client to the server at the Uri.</summary>
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public virtual void ClientConnect(Uri uri)
         {
             // By default, to keep backwards compatibility, just connect to the host
@@ -81,6 +84,7 @@ namespace Mirror
 
         /// <summary>Returns server address as Uri.</summary>
         // Useful for NetworkDiscovery.
+        [Obsolete(UriObsoleteMessage)]
         public abstract Uri ServerUri();
 
         /// <summary>Called by Transport when a new client connected to the server.</summary>

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -55,6 +55,7 @@ namespace Mirror
         // IMPORTANT: Transports should support both "IP" and "IP:Port" for
         //            NetworkDiscovery, list servers, etc.
         //            (easier than supporting Uris)
+        //            => use Utils.SplitNetworkAddress() to split "IP:Port"!
         public abstract void ClientConnect(string address);
 
         /// <summary>Connects the client to the server at the Uri.</summary>

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -30,9 +30,6 @@ namespace Mirror
     /// <summary>Abstract transport layer component</summary>
     public abstract class Transport : MonoBehaviour
     {
-        // DEPRECATED 2021-05-27
-        public const string UriObsoleteMessage = "We are considering to remove Uri support, unless someone has a good reason to keep it.";
-
         /// <summary>The current transport used by Mirror.</summary>
         public static Transport activeTransport;
 
@@ -58,7 +55,9 @@ namespace Mirror
         public abstract void ClientConnect(string address);
 
         /// <summary>Connects the client to the server at the Uri.</summary>
-        [Obsolete(UriObsoleteMessage)]
+        // DEPRECATED 2021-05-27
+        public const string ConnectUriObsoleteMessage = "We are considering to remove Uri support, unless someone has a good reason to keep it.";
+        [Obsolete(ConnectUriObsoleteMessage)]
         public virtual void ClientConnect(Uri uri)
         {
             // By default, to keep backwards compatibility, just connect to the host
@@ -84,7 +83,9 @@ namespace Mirror
 
         /// <summary>Returns server address as Uri.</summary>
         // Useful for NetworkDiscovery.
-        [Obsolete(UriObsoleteMessage)]
+        // DEPRECATED 2021-05-27
+        public const string ServerUriObsoleteMessage = "We are considering to remove Uri support, unless someone has a good reason to keep it.";
+        [Obsolete(ServerUriObsoleteMessage)]
         public abstract Uri ServerUri();
 
         /// <summary>Returns full server address like "IP:Port". Useful for clients to connect.</summary>

--- a/Assets/Mirror/Runtime/Utils.cs
+++ b/Assets/Mirror/Runtime/Utils.cs
@@ -122,5 +122,23 @@ namespace Mirror
             }
             return true;
         }
+
+        // split network address of "IP:Port" or "Hostname:Port".
+        // can be used by several Transport's ClientConnect() for convenience.
+        // => returns true if of "IP:Port".
+        //            false if of "IP" only.
+        public static bool ParseHostAndPort(string address, out string host, out ushort port)
+        {
+            string[] parts = address.Split(':');
+            if (parts.Length == 2)
+            {
+                host = parts[0];
+                port = Convert.ToUInt16(parts[1]);
+                return true;
+            }
+            host = "";
+            port = 0;
+            return false;
+        }
     }
 }

--- a/Assets/Mirror/Tests/Common/MemoryTransport.cs
+++ b/Assets/Mirror/Tests/Common/MemoryTransport.cs
@@ -113,6 +113,7 @@ namespace Mirror.Tests
         }
 
         public override bool ServerActive() => serverActive;
+        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
         public override Uri ServerUri() => throw new NotImplementedException();
         public override void ServerStart() { serverActive = true; }
         public override void ServerSend(int connectionId, ArraySegment<byte> segment, int channelId)

--- a/Assets/Mirror/Tests/Common/MemoryTransport.cs
+++ b/Assets/Mirror/Tests/Common/MemoryTransport.cs
@@ -113,7 +113,7 @@ namespace Mirror.Tests
         }
 
         public override bool ServerActive() => serverActive;
-        [Obsolete("We are considering to remove Uri support, unless someone has a good reason to keep it.")]
+        [Obsolete(UriObsoleteMessage)]
         public override Uri ServerUri() => throw new NotImplementedException();
         public override void ServerStart() { serverActive = true; }
         public override void ServerSend(int connectionId, ArraySegment<byte> segment, int channelId)

--- a/Assets/Mirror/Tests/Common/MemoryTransport.cs
+++ b/Assets/Mirror/Tests/Common/MemoryTransport.cs
@@ -113,7 +113,7 @@ namespace Mirror.Tests
         }
 
         public override bool ServerActive() => serverActive;
-        [Obsolete(UriObsoleteMessage)]
+        [Obsolete(ServerUriObsoleteMessage)]
         public override Uri ServerUri() => throw new NotImplementedException();
         public override void ServerStart() { serverActive = true; }
         public override void ServerSend(int connectionId, ArraySegment<byte> segment, int channelId)

--- a/Assets/Mirror/Tests/Editor/MiddlewareTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/MiddlewareTransportTest.cs
@@ -176,6 +176,7 @@ namespace Mirror.Tests
         [Test]
         [TestCase("tcp4://localhost:7777")]
         [TestCase("tcp4://example.com:7777")]
+#pragma warning disable 618
         public void TestServerUri(string address)
         {
             Uri uri = new Uri(address);
@@ -185,6 +186,7 @@ namespace Mirror.Tests
 
             inner.Received(1).ServerUri();
         }
+#pragma warning restore 618
 
         [Test]
         public void TestClientConnectedCallback()

--- a/Assets/Mirror/Tests/Editor/MultiplexTest.cs
+++ b/Assets/Mirror/Tests/Editor/MultiplexTest.cs
@@ -64,6 +64,7 @@ namespace Mirror.Tests
         }
 
         // A Test behaves as an ordinary method
+#pragma warning disable 618
         [Test]
         public void TestConnectFirstUri()
         {
@@ -76,9 +77,10 @@ namespace Mirror.Tests
             transport1.Received().ClientConnect(uri);
             transport2.DidNotReceive().ClientConnect(uri);
         }
-
+#pragma warning restore 61
 
         // A Test behaves as an ordinary method
+#pragma warning disable 618
         [Test]
         public void TestConnectSecondUri()
         {
@@ -96,6 +98,7 @@ namespace Mirror.Tests
             transport.ClientConnect(uri);
             transport2.Received().ClientConnect(uri);
         }
+#pragma warning restore 618
 
         [Test]
         public void TestConnected()

--- a/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
@@ -36,6 +36,7 @@ namespace Mirror.Tests
             Assert.That(NetworkClient.isConnected, Is.True);
         }
 
+#pragma warning disable 618
         [Test]
         public void ConnectUri()
         {
@@ -44,6 +45,7 @@ namespace Mirror.Tests
             UpdateTransport();
             Assert.That(NetworkClient.isConnected, Is.True);
         }
+#pragma warning restore 618
 
         [Test]
         public void DisconnectInHostMode()

--- a/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
@@ -133,6 +133,7 @@ namespace Mirror.Tests
         }
 
         [Test]
+#pragma warning disable 618
         public void StartClientUriTest()
         {
             UriBuilder uriBuilder = new UriBuilder
@@ -146,5 +147,6 @@ namespace Mirror.Tests
             Assert.That(manager.isNetworkActive, Is.EqualTo(true));
             Assert.That(manager.networkAddress, Is.EqualTo(uriBuilder.Uri.Host));
         }
+#pragma warning restore 618
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -904,6 +904,7 @@ namespace Mirror.Tests
         }
 
         [Test]
+#pragma warning disable 618
         public void TestWritingUri()
         {
 
@@ -915,6 +916,7 @@ namespace Mirror.Tests
             NetworkReader reader = new NetworkReader(writer.ToArray());
             Assert.That(reader.ReadUri(), Is.EqualTo(testUri));
         }
+#pragma warning restore 618
 
         [Test]
         public void TestList()

--- a/Assets/Mirror/Tests/Editor/UtilsTest.cs
+++ b/Assets/Mirror/Tests/Editor/UtilsTest.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    public class UtilsTest
+    {
+        [Test]
+        public void ParseHostAndPort()
+        {
+            // just IP. can't split.
+            bool result = Utils.ParseHostAndPort("127.0.0.1", out string _, out ushort _);
+            Assert.That(result, Is.False);
+
+            // just Host. can't split.
+            result = Utils.ParseHostAndPort("mirror-networking.com", out string _, out ushort _);
+            Assert.That(result, Is.False);
+
+            // IP & Port
+            result = Utils.ParseHostAndPort("127.0.0.1:42", out string host, out ushort port);
+            Assert.That(result, Is.True);
+            Assert.That(host, Is.EqualTo("127.0.0.1"));
+            Assert.That(port, Is.EqualTo(42));
+
+            // Hostname & Port
+            result = Utils.ParseHostAndPort("mirror-networking.com:42", out host, out port);
+            Assert.That(result, Is.True);
+            Assert.That(host, Is.EqualTo("mirror-networking.com"));
+            Assert.That(port, Is.EqualTo(42));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/UtilsTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/UtilsTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 044ad5f93c34b486fbc779905f9930f7
+timeCreated: 1621762116


### PR DESCRIPTION
FakeByte's connect string idea.
This seems to be what Counter-Strike, Minecraft etc. do as well:
Connect("127.0.0.1:42") etc.

URI obsoleted.
Connect(address) can be of "IP:Port" instead.
works: https://gyazo.com/4809cbe8ebfba2d3735d08fbeb6a75b5

makes insight addon easier too:
<img width="961" alt="2021-05-27_19-19-23@2x" src="https://user-images.githubusercontent.com/16416509/119817364-794ed400-bf20-11eb-81ca-bc937ba7fadf.png">


TODO networkdiscovery