### PR TITLE
perf: PartialWorldState message step 1: UpdateVarsMessage replaced with PartialWorldState

### DIFF
--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -87,12 +87,15 @@ namespace Mirror
         public uint netId;
     }
 
-    public struct UpdateVarsMessage : NetworkMessage
+    // a snapshot for the part of the world that a connection sees
+    public struct PartialWorldStateMessage : NetworkMessage
     {
-        public uint netId;
-        // the serialized component data
-        // -> ArraySegment to avoid unnecessary allocations
-        public ArraySegment<byte> payload;
+        // serialized entities <<netid, payloadsize, payload, ...>
+        public ArraySegment<byte> entitiesPayload;
+
+        // calculate total size
+        // TODO include Rpcs etc. later
+        public int TotalSize() => entitiesPayload.Count;
     }
 
     // A client sends this message to the server

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1498,6 +1498,7 @@ namespace Mirror
                             {
                                 // TODO SEND without batching
                                 connection.Send(world);
+                                //Debug.Log($"Sending {world.TotalSize()} bytes World to connId={connection.connectionId}");
                             }
                             else
                             {

--- a/Assets/Mirror/Tests/Editor/BuiltInMessages.cs
+++ b/Assets/Mirror/Tests/Editor/BuiltInMessages.cs
@@ -177,23 +177,5 @@ namespace Mirror.Tests.MessageTests
                         Is.EqualTo(message.payload.Array[message.payload.Offset + i]));
             }
         }
-
-        [Test]
-        public void UpdateVarsMessage()
-        {
-            // try setting value with constructor
-            UpdateVarsMessage message = new UpdateVarsMessage
-            {
-                netId = 42,
-                payload = new ArraySegment<byte>(new byte[] { 0x01, 0x02 })
-            };
-            byte[] arr = MessagePackingTest.PackToByteArray(message);
-            UpdateVarsMessage fresh = MessagePackingTest.UnpackFromByteArray<UpdateVarsMessage>(arr);
-            Assert.That(fresh.netId, Is.EqualTo(message.netId));
-            Assert.That(fresh.payload.Count, Is.EqualTo(message.payload.Count));
-            for (int i = 0; i < fresh.payload.Count; ++i)
-                Assert.That(fresh.payload.Array[fresh.payload.Offset + i],
-                    Is.EqualTo(message.payload.Array[message.payload.Offset + i]));
-        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
@@ -60,7 +60,7 @@ namespace Mirror.Tests
 
             Assert.Throws<FormatException>(() =>
             {
-                UpdateVarsMessage unpacked = UnpackFromByteArray<UpdateVarsMessage>(data);
+                SceneMessage unpacked = UnpackFromByteArray<SceneMessage>(data);
             });
         }
 


### PR DESCRIPTION
**previously we send one UpdateVarsMessage per NetworkIdentity per Connection.
now we send one PartialWorldStateMessage per Connection.**

less bandwidth.
more simple.

**will allow for several improvements like:**
- removing batching
- putting rpcs into the worldstate
- snapshot interpolation
- delta compression by default
etc.

**this is the first step.**
=> partial world around a player is put into a message
=> message is sent if small enough to fit into transport
=> otherwise disconnect

**we need to add more strategies to handle large worlds, for example:**
- bitpacking
- priority sorting: put as many entities as possible into the message. drop the rest.

**IMPORTANT:**
the 10k benchmark uses around 200KB if we send all 10k to a single connection.
which currently disconnects that connection, since that's the only strategy atm.