### PR TITLE
Stopped client address showing for server.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -106,7 +106,7 @@ namespace Mirror
         void StatusLabels()
         {
             // server / client status message
-            if (NetworkServer.active)
+            if (NetworkClient.isConnected && !NetworkServer.active)
             {
                 GUILayout.Label("Server: active. Transport: " + Transport.activeTransport);
             }

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -106,7 +106,7 @@ namespace Mirror
         void StatusLabels()
         {
             // server / client status message
-            if (NetworkClient.isConnected)
+            if (NetworkServer.active)
             {
                 GUILayout.Label("Server: active. Transport: " + Transport.activeTransport);
             }

--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -106,11 +106,11 @@ namespace Mirror
         void StatusLabels()
         {
             // server / client status message
-            if (NetworkClient.isConnected && !NetworkServer.active)
+            if (NetworkClient.isConnected)
             {
                 GUILayout.Label("Server: active. Transport: " + Transport.activeTransport);
             }
-            if (NetworkClient.isConnected)
+            if (NetworkClient.isConnected && !NetworkServer.active)
             {
                 GUILayout.Label("Client: address=" + manager.networkAddress);
             }


### PR DESCRIPTION
"We’re upto our 5th person in 2 days that thinks mirrors localhost only.
- presumably due to it saying localhost on screen when pressing start host/start server."

Shown on hosts screen Before:
![Screenshot 2021-05-14 at 09 36 02](https://user-images.githubusercontent.com/57072365/118244978-1e38ce00-b498-11eb-912e-adb81a37a4ce.jpg)

Now it doesn't give the impression their host/server is localhost only, After:
![Screenshot 2021-05-14 at 09 33 25](https://user-images.githubusercontent.com/57072365/118244995-209b2800-b498-11eb-971d-13aabc76ed46.jpg)
