### PR TITLE
breaking: perf: remove NetworkWriter.Length/SetLength/EnsureLength. Position is enough.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -92,7 +92,7 @@ namespace Mirror
                     {
                         // flush & reset writer
                         Transport.activeTransport.ServerSend(connectionId, writer.ToArraySegment(), channelId);
-                        writer.SetLength(0);
+                        writer.Position = 0;
                     }
 
                     // now add to writer in any case
@@ -114,7 +114,7 @@ namespace Mirror
                 if (writer.Position > 0)
                 {
                     Transport.activeTransport.ServerSend(connectionId, writer.ToArraySegment(), channelId);
-                    writer.SetLength(0);
+                    writer.Position = 0;
                 }
             }
 

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -24,64 +24,15 @@ namespace Mirror
         // => 1500 bytes by default because on average, most packets will be <= MTU
         byte[] buffer = new byte[1500];
 
-        // 'int' is the best type for .Position. 'short' is too small if we send >32kb which would result in negative .Position
-        // -> converting long to int is fine until 2GB of data (MAX_INT), so we don't have to worry about overflows here
-        int position;
-        int length;
-
-        /// <summary>Number of bytes writen to the buffer</summary>
-        [Obsolete("Remember .Position instead of using .Length. It's too weird and too costly.")]
-        public int Length => length;
-
         /// <summary>Next position to write to the buffer</summary>
-        public int Position
-        {
-            get => position;
-            set
-            {
-                position = value;
-                EnsureLength(value);
-            }
-        }
+        public int Position;
 
         /// <summary>Reset both the position and length of the stream</summary>
         // Leaves the capacity the same so that we can reuse this writer without
         // extra allocations
         public void Reset()
         {
-            position = 0;
-            length = 0;
-        }
-
-        /// <summary>Sets length, moves position if it is greater than new length</summary>
-        /// Zeros out any extra length created by setlength
-        [Obsolete("Set .Position instead of using .Length. It's too weird and too costly.")]
-        public void SetLength(int newLength)
-        {
-            int oldLength = length;
-
-            // ensure length & capacity
-            EnsureLength(newLength);
-
-            // zero out new length
-            if (oldLength < newLength)
-            {
-                Array.Clear(buffer, oldLength, newLength - oldLength);
-            }
-
-            length = newLength;
-            position = Mathf.Min(position, length);
-        }
-
-        // TODO remove after removing obsolete .Length and .SetLength.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void EnsureLength(int value)
-        {
-            if (length < value)
-            {
-                length = value;
-                EnsureCapacity(value);
-            }
+            Position = 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -94,33 +45,33 @@ namespace Mirror
             }
         }
 
-        /// <summary>Copies buffer to new array of size 'Length'. Ignores 'Position'.</summary>
+        /// <summary>Copies buffer until 'Position' to a new array.</summary>
         public byte[] ToArray()
         {
-            byte[] data = new byte[length];
-            Array.ConstrainedCopy(buffer, 0, data, 0, length);
+            byte[] data = new byte[Position];
+            Array.ConstrainedCopy(buffer, 0, data, 0, Position);
             return data;
         }
 
-        /// <summary>Returns allocatin-free ArraySegment which points to buffer up to 'Length' (ignores 'Position').</summary>
+        /// <summary>Returns allocation-free ArraySegment until 'Position'.</summary>
         public ArraySegment<byte> ToArraySegment()
         {
-            return new ArraySegment<byte>(buffer, 0, length);
+            return new ArraySegment<byte>(buffer, 0, Position);
         }
 
         public void WriteByte(byte value)
         {
-            EnsureLength(position + 1);
-            buffer[position++] = value;
+            EnsureCapacity(Position + 1);
+            buffer[Position++] = value;
         }
 
         // for byte arrays with consistent size, where the reader knows how many to read
         // (like a packet opcode that's always the same)
         public void WriteBytes(byte[] buffer, int offset, int count)
         {
-            EnsureLength(position + count);
-            Array.ConstrainedCopy(buffer, offset, this.buffer, position, count);
-            position += count;
+            EnsureCapacity(Position + count);
+            Array.ConstrainedCopy(buffer, offset, this.buffer, Position, count);
+            Position += count;
         }
 
         /// <summary>Writes any type that mirror supports. Uses weaver populated Writer(T).write.</summary>

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -30,6 +30,7 @@ namespace Mirror
         int length;
 
         /// <summary>Number of bytes writen to the buffer</summary>
+        [Obsolete("Remember .Position instead of using .Length. It's too weird and too costly.")]
         public int Length => length;
 
         /// <summary>Next position to write to the buffer</summary>
@@ -54,6 +55,7 @@ namespace Mirror
 
         /// <summary>Sets length, moves position if it is greater than new length</summary>
         /// Zeros out any extra length created by setlength
+        [Obsolete("Set .Position instead of using .Length. It's too weird and too costly.")]
         public void SetLength(int newLength)
         {
             int oldLength = length;
@@ -71,6 +73,7 @@ namespace Mirror
             position = Mathf.Min(position, length);
         }
 
+        // TODO remove after removing obsolete .Length and .SetLength.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         void EnsureLength(int value)
         {

--- a/Assets/Mirror/Tests/Editor/EnumReadWriteTests.cs
+++ b/Assets/Mirror/Tests/Editor/EnumReadWriteTests.cs
@@ -52,7 +52,7 @@ namespace Mirror.Tests
             writer.Write(msg);
 
             // should be 1 byte for data
-            Assert.That(writer.Length, Is.EqualTo(1));
+            Assert.That(writer.Position, Is.EqualTo(1));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace Mirror.Tests
             writer.Write(msg);
 
             // should be 2 bytes for data
-            Assert.That(writer.Length, Is.EqualTo(2));
+            Assert.That(writer.Position, Is.EqualTo(2));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/MessageInheritanceTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessageInheritanceTest.cs
@@ -58,7 +58,7 @@ namespace Mirror.Tests.MessageTests
             Assert.AreEqual(3, received.parentValue);
             Assert.AreEqual(4, received.childValue);
 
-            int writeLength = writer.Length;
+            int writeLength = writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }
@@ -87,7 +87,7 @@ namespace Mirror.Tests.MessageTests
             Assert.AreEqual(message, received.message);
             Assert.AreEqual(responseId, received.responseId);
 
-            int writeLength = writer.Length;
+            int writeLength = writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }
@@ -116,7 +116,7 @@ namespace Mirror.Tests.MessageTests
             Assert.AreEqual(message, received.message);
             Assert.AreEqual(responseId, received.responseId);
 
-            int writeLength = writer.Length;
+            int writeLength = writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -105,36 +105,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void TestSetLengthZeroes()
-        {
-            NetworkWriter writer = new NetworkWriter();
-            writer.WriteString("I saw");
-            writer.WriteInt64(0xA_FADED_DEAD_EEL);
-            writer.WriteString("and ate it");
-            int position = writer.Position;
-
-            writer.SetLength(10);
-            Assert.That(writer.Position, Is.EqualTo(10), "Decreasing length should move position");
-
-            // lets grow it back and check there's zeroes now.
-            writer.SetLength(position);
-            byte[] data = writer.ToArray();
-            for (int i = 10; i < data.Length; i++)
-            {
-                Assert.That(data[i], Is.EqualTo(0), $"index {i} should have value 0");
-            }
-        }
-
-        [Test]
-        public void TestSetLengthInitialization()
-        {
-            NetworkWriter writer = new NetworkWriter();
-
-            writer.SetLength(10);
-            Assert.That(writer.Position, Is.EqualTo(0), "Increasing length should not move position");
-        }
-
-        [Test]
         public void TestResetSetsPotionAndLength()
         {
             NetworkWriter writer = new NetworkWriter();
@@ -144,7 +114,6 @@ namespace Mirror.Tests
             writer.Reset();
 
             Assert.That(writer.Position, Is.EqualTo(0));
-            Assert.That(writer.Length, Is.EqualTo(0));
 
             byte[] data = writer.ToArray();
             Assert.That(data, Is.Empty);

--- a/Assets/Mirror/Tests/Editor/StructMessagesTests.cs
+++ b/Assets/Mirror/Tests/Editor/StructMessagesTests.cs
@@ -28,7 +28,7 @@ namespace Mirror.Tests.StructMessages
 
             Assert.AreEqual(someValue, received.someValue);
 
-            int writeLength = writer.Length;
+            int writeLength = writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -17,7 +17,7 @@ namespace Mirror.Tests
             NetworkReader reader = new NetworkReader(writer.ToArray());
             toList.OnDeserializeAll(reader);
 
-            int writeLength = writer.Length;
+            int writeLength = writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
 
@@ -31,7 +31,7 @@ namespace Mirror.Tests
             toList.OnDeserializeDelta(reader);
             fromList.Flush();
 
-            int writeLength = writer.Length;
+            int writeLength = writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeDelta and OnDeserializeDelta calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }

--- a/Assets/Mirror/Tests/Editor/SyncVarTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTestBase.cs
@@ -60,7 +60,7 @@ namespace Mirror.Tests
         {
             NetworkWriter writer = new NetworkWriter();
             bool written = serverObject.OnSerialize(writer, initialState);
-            writeLength = writer.Length;
+            writeLength = writer.Position;
             data = writer.ToArraySegment();
 
             return written;


### PR DESCRIPTION
**NetworkWriter currently has:**
.Position
.Length
.Capacity

**Which is super confusing.**
EnsureLength is always called when writing anything, which is super unnecessary.
SetLength(0) behaves different than Position=0, which is confusing.
ToArray/Segment works up to 'Length', not up to 'Position' which is confusing and error prone.

**In DOTSNET I only have .Position.**
That's totally enough and way easier to use.
We can't expect anyone to remember that .ToArray is until 'Length', not until 'Position', etc.
Bitpacking won't have this anyway.

**Can't Obsolete**
We can't obsolete and tell people to only use .Position instead, because .ToArray previously copied until .Length.
This is (and should be) a breaking change.
Pretty sure nobody uses Length anyway, we only used it in NetworkConnection.