### PR TITLE
perf: NetworkSceneChecker: Added MoveGameObjectToScene

### DIFF
--- a/Assets/Mirror/Components/NetworkSceneChecker.cs
+++ b/Assets/Mirror/Components/NetworkSceneChecker.cs
@@ -50,7 +50,7 @@ namespace Mirror
                 RebuildSceneObservers();
         }
 
-        // Deprecated 2021/05/28 - Remove Update in September 2021
+        // Deprecated 2021-05-28 - Remove Update in September 2021
         // Eliminating the Update loop will improve performance of the component.
         [ServerCallback]
         void Update()

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
@@ -66,7 +66,7 @@ namespace Mirror.Examples.MultipleAdditiveScenes
             // This is what allows the NetworkSceneChecker on player and scene objects
             // to isolate matches per scene instance on server.
             if (subScenes.Count > 0)
-                SceneManager.MoveGameObjectToScene(conn.identity.gameObject, subScenes[clientIndex % subScenes.Count]);
+                conn.identity.GetComponent<NetworkSceneChecker>().MoveGameObjectToScene(subScenes[clientIndex % subScenes.Count]);
         }
 
         #endregion

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/Spawner.cs
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/Spawner.cs
@@ -19,7 +19,7 @@ namespace Mirror.Examples.MultipleAdditiveScenes
 
             Vector3 spawnPosition = new Vector3(Random.Range(-19, 20), 1, Random.Range(-19, 20));
             GameObject reward = Object.Instantiate(((MultiSceneNetManager)NetworkManager.singleton).rewardPrefab, spawnPosition, Quaternion.identity);
-            SceneManager.MoveGameObjectToScene(reward, scene);
+            reward.GetComponent<NetworkSceneChecker>().MoveGameObjectToScene(scene);
             NetworkServer.Spawn(reward);
         }
     }


### PR DESCRIPTION
Update now detects when an object has been moved to another scene by `SceneManager.MoveGameObjectToScene` outside of `NetworkSceneChecker` and logs a warning on the server telling users to use this new method instead.

![image](https://user-images.githubusercontent.com/9826063/120039230-8d530e00-bfd2-11eb-90fd-c3fdc1219d63.png)

Update is effectively deprecated in this component and can be removed after 3 months, and that's where the performance gain will ultimately come from.

Multiple Additive Scenes example is also updated, and illustrates what users will have to change in their own code.
