### PR TITLE
fix: Fixes Batching with Scene Messages

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -88,7 +88,11 @@ namespace Mirror
                 // pack message and send allocation free
                 MessagePacking.Pack(msg, writer);
                 NetworkDiagnostics.OnSend(msg, channelId, writer.Position, 1);
-                Send(writer.ToArraySegment(), channelId);
+
+                if (msg is SceneMessage)
+                    Send(writer.ToArraySegment(), true, channelId);
+                else
+                    Send(writer.ToArraySegment(), channelId);
             }
         }
 
@@ -119,6 +123,12 @@ namespace Mirror
         // internal because no one except Mirror should send bytes directly to
         // the client. they would be detected as a message. send messages instead.
         internal abstract void Send(ArraySegment<byte> segment, int channelId = Channels.Reliable);
+
+       
+        // Special case for Scene Messages and batching, so virtual instead of abstract.
+        // This is only overridden in NetworkConnectionToClient
+        // No override needed in NetworkConnectionToServer or LocalConnection
+        internal virtual void Send(ArraySegment<byte> segment, bool isSceneMessag, int channelId = Channels.Reliable) => Send(segment, channelId);
 
         public override string ToString() => $"connection({connectionId})";
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -128,7 +128,7 @@ namespace Mirror
         // Special case for Scene Messages and batching, so virtual instead of abstract.
         // This is only overridden in NetworkConnectionToClient
         // No override needed in NetworkConnectionToServer or LocalConnection
-        internal virtual void Send(ArraySegment<byte> segment, bool isSceneMessag, int channelId = Channels.Reliable) => Send(segment, channelId);
+        internal virtual void Send(ArraySegment<byte> segment, bool isSceneMessage, int channelId = Channels.Reliable) => Send(segment, channelId);
 
         public override string ToString() => $"connection({connectionId})";
 


### PR DESCRIPTION
Fixes #2651 

Client must not process any more messages after SceneMessage while it has transport suspended and is loading the scene, so this ensures the scene message is the last one in the batch.

Subsequent messages will go into the next batch and will be processed by client after it unsuspends the transport.