### PR TITLE
fix: Clear observers from other clients

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1117,6 +1117,7 @@ namespace Mirror
         {
             // destroy all objects owned by this connection, including the player object
             conn.DestroyOwnedObjects();
+            conn.RemoveFromObservingsObservers();
             conn.identity = null;
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1117,6 +1117,11 @@ namespace Mirror
         {
             // destroy all objects owned by this connection, including the player object
             conn.DestroyOwnedObjects();
+            // remove connection from all of its observing entities observers
+            // fixes https://github.com/vis2k/Mirror/issues/2737
+            // -> cleaning those up in NetworkConnection.Disconnect is NOT enough
+            //    because voluntary disconnects from the other end don't call
+            //    NetworkConnectionn.Disconnect()
             conn.RemoveFromObservingsObservers();
             conn.identity = null;
         }


### PR DESCRIPTION
Fixes #2737

Added call to RemoveFromObservingsObservers in NetworkServer.DestroyPlayerForConnection