### PR TITLE
feat: Add OnSpawned/OnDestroyed events to interest management

### DIFF
--- a/Assets/Mirror/Runtime/InterestManagement.cs
+++ b/Assets/Mirror/Runtime/InterestManagement.cs
@@ -77,5 +77,15 @@ namespace Mirror
             foreach (Renderer rend in identity.GetComponentsInChildren<Renderer>())
                 rend.enabled = visible;
         }
+
+        /// <summary>
+        /// This is called on the server when a new networked object is spawned
+        /// </summary>
+        public virtual void OnSpawned(NetworkIdentity identity) {}
+
+        /// <summary>
+        /// This is called on the server when a networked object is destroyed
+        /// </summary>
+        public virtual void OnDestroyed(NetworkIdentity identity) {}
     }
 }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -964,6 +964,20 @@ namespace Mirror
 
             // Debug.Log("SpawnObject instance ID " + identity.netId + " asset ID " + identity.assetId);
 
+            if (aoi)
+            {
+                // This calls user code which might throw exceptions
+                // We don't want this to leave us in bad state
+                try
+                {
+                    aoi.OnSpawned(identity);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
+            }
+
             RebuildObservers(identity, true);
         }
 
@@ -1181,6 +1195,19 @@ namespace Mirror
 
         static void DestroyObject(NetworkIdentity identity, bool destroyServerObject)
         {
+            if (aoi)
+            {
+                // This calls user code which might throw exceptions
+                // We don't want this to leave us in bad state
+                try
+                {
+                    aoi.OnDestroyed(identity);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
+            }
             // Debug.Log("DestroyObject instance:" + identity.netId);
             NetworkIdentity.spawned.Remove(identity.netId);
 


### PR DESCRIPTION
This simplifies managing per-object state in interest management a lot since you're now told when a new object is spawned/destroyed

Once this is in, we can move towards feature parity with the new interest management. 

For example, implementing something like this for the distance based aoi to override visibility ranges:
```c#
// straight forward Vector3.Distance based interest management.
using System.Collections.Generic;
using UnityEngine;

namespace Mirror
{
    public class DistanceInterestManagement : InterestManagement
    {
        [Tooltip("The maximum range that objects will be visible at.")]
        public int visRange = 10;

        [Tooltip("Rebuild all every 'rebuildInterval' seconds.")]
        public float rebuildInterval = 1;
        double lastRebuildTime;

        private Dictionary<NetworkIdentity, DistanceVisibilityOverride> _overrides =
            new Dictionary<NetworkIdentity, DistanceVisibilityOverride>();

        public override void OnSpawned(NetworkIdentity identity)
        {
            DistanceVisibilityOverride visOverride = identity.GetComponent<DistanceVisibilityOverride>();
            if (visOverride)
            {
                _overrides[identity] = visOverride;
            }
        }
        
        public override void OnDestroyed(NetworkIdentity identity)
        {
            _overrides.Remove(identity);
        }
        
        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnection newObserver)
        {
            float range = visRange;
            if (_overrides.TryGetValue(identity, out var disOverride))
            {
                range = disOverride.visRange;
            }
            return Vector3.Distance(identity.transform.position, newObserver.identity.transform.position) <= range;
        }

        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnection> newObservers, bool initialize)
        {
            // 'transform.' calls GetComponent, only do it once
            Vector3 position = identity.transform.position;

            float range = visRange;
            if (_overrides.TryGetValue(identity, out var disOverride))
            {
                range = disOverride.visRange;
            }

            // brute force distance check
            // -> only player connections can be observers, so it's enough if we
            //    go through all connections instead of all spawned identities.
            // -> compared to UNET's sphere cast checking, this one is orders of
            //    magnitude faster. if we have 10k monsters and run a sphere
            //    cast 10k times, we will see a noticeable lag even with physics
            //    layers. but checking to every connection is fast.
            foreach (NetworkConnectionToClient conn in NetworkServer.connections.Values)
            {
                // authenticated and joined world with a player?
                if (conn != null && conn.isAuthenticated && conn.identity != null)
                {

                    // check distance
                    if (Vector3.Distance(conn.identity.transform.position, position) < range)
                    {
                        newObservers.Add(conn);
                    }
                }
            }
        }

        void Update()
        {
            // only on server
            if (!NetworkServer.active) return;

            // rebuild all spawned NetworkIdentity's observers every interval
            if (NetworkTime.time >= lastRebuildTime + rebuildInterval)
            {
                RebuildAll();
                lastRebuildTime = NetworkTime.time;
            }
        }
    }
}
```