### PR TITLE
fix: KCP Stat UI OverflowException w/ many clients

### DIFF
--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -215,11 +215,11 @@ namespace kcp2k
         // server statistics
         public int GetAverageMaxSendRate() =>
             server.connections.Count > 0
-                ? server.connections.Values.Sum(conn => (int)conn.MaxSendRate) / server.connections.Count
+                ? (int)(server.connections.Values.Sum(conn => conn.MaxSendRate) / server.connections.Count)
                 : 0;
         public int GetAverageMaxReceiveRate() =>
             server.connections.Count > 0
-                ? server.connections.Values.Sum(conn => (int)conn.MaxReceiveRate) / server.connections.Count
+                ? (int)(server.connections.Values.Sum(conn => conn.MaxReceiveRate) / server.connections.Count)
                 : 0;
         int GetTotalSendQueue() =>
             server.connections.Values.Sum(conn => conn.SendQueueCount);


### PR DESCRIPTION
```
OverflowException: Arithmetic operation resulted in an overflow.
System.Linq.Enumerable.Sum[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] selector) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
kcp2k.KcpTransport.GetAverageMaxSendRate () (at Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs:217)
kcp2k.KcpTransport.OnGUI () (at Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs:263)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr)
```
Still returning int so it's not a breaking change