### PR TITLE
fix: clientAuthority access

### DIFF
--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
@@ -10,7 +10,7 @@ namespace Mirror.Experimental
         [SerializeField] internal Rigidbody target = null;
 
         [Tooltip("Set to true if moves come from owner client, set to false if moves always come from server")]
-        [SerializeField] bool clientAuthority = false;
+        public bool clientAuthority = false;
 
         [Header("Velocity")]
 

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody2D.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody2D.cs
@@ -9,7 +9,7 @@ namespace Mirror.Experimental
         [SerializeField] internal Rigidbody2D target = null;
 
         [Tooltip("Set to true if moves come from owner client, set to false if moves always come from server")]
-        [SerializeField] bool clientAuthority = false;
+        public  bool clientAuthority = false;
 
         [Header("Velocity")]
 


### PR DESCRIPTION
Provide the same interface access for runtime changes like the NetworkTransform class.