### PR TITLE
feature: Timestamp Batching

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -10,7 +10,7 @@ namespace Mirror
     {
         internal LocalConnectionToServer connectionToServer;
 
-        public LocalConnectionToClient() : base(LocalConnectionId, false) {}
+        public LocalConnectionToClient() : base(LocalConnectionId) {}
 
         public override string address => "localhost";
 
@@ -64,9 +64,6 @@ namespace Mirror
         internal void QueueConnectedEvent() => connectedEventPending = true;
         internal void QueueDisconnectedEvent() => disconnectedEventPending = true;
 
-        // parameterless constructor that disables batching for local connections
-        public LocalConnectionToServer() : base(false) {}
-
         // Send stage two: serialized NetworkMessage as ArraySegment<byte>
         internal override void Send(ArraySegment<byte> segment, int channelId = Channels.Reliable)
         {
@@ -76,8 +73,22 @@ namespace Mirror
                 return;
             }
 
-            // handle the server's message directly
-            NetworkServer.OnTransportData(connectionId, segment, channelId);
+            // OnTransportData assumes batching.
+            // so let's make a batch with proper timestamp prefix.
+            Batcher batcher = GetBatchForChannelId(channelId);
+            batcher.AddMessage(segment);
+
+            // flush it to the server's OnTransportData immediately.
+            // local connection to server always invokes immediately.
+            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            {
+                // make a batch with our local time (double precision)
+                if (batcher.MakeNextBatch(writer, NetworkTime.localTime))
+                {
+                    NetworkServer.OnTransportData(connectionId, writer.ToArraySegment(), channelId);
+                }
+                else Debug.LogError("Local connection failed to make batch. This should never happen.");
+            }
         }
 
         internal override void Update()
@@ -96,9 +107,22 @@ namespace Mirror
             {
                 // call receive on queued writer's content, return to pool
                 PooledNetworkWriter writer = queue.Dequeue();
-                ArraySegment<byte> segment = writer.ToArraySegment();
-                //Debug.Log("Dequeue " + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
-                NetworkClient.OnTransportData(segment, Channels.Reliable);
+                ArraySegment<byte> message = writer.ToArraySegment();
+
+                // OnTransportData assumes a proper batch with timestamp etc.
+                // let's make a proper batch and pass it to OnTransportData.
+                Batcher batcher = GetBatchForChannelId(Channels.Reliable);
+                batcher.AddMessage(message);
+
+                using (PooledNetworkWriter batchWriter = NetworkWriterPool.GetWriter())
+                {
+                    // make a batch with our local time (double precision)
+                    if (batcher.MakeNextBatch(batchWriter, NetworkTime.localTime))
+                    {
+                        NetworkClient.OnTransportData(batchWriter.ToArraySegment(), Channels.Reliable);
+                    }
+                }
+
                 NetworkWriterPool.Recycle(writer);
             }
 

--- a/Assets/Mirror/Runtime/MessagePacking.cs
+++ b/Assets/Mirror/Runtime/MessagePacking.cs
@@ -14,8 +14,13 @@ namespace Mirror
         public const int HeaderSize = sizeof(ushort);
 
         // max message content size (without header) calculation for convenience
+        // -> Transport.GetMaxPacketSize is the raw maximum
+        // -> Every message gets serialized into <<id, content>>
+        // -> Every serialized message get put into a batch with a header
         public static int MaxContentSize =>
-            Transport.activeTransport.GetMaxPacketSize() - HeaderSize;
+            Transport.activeTransport.GetMaxPacketSize()
+            - HeaderSize
+            - Batcher.HeaderSize;
 
         public static ushort GetId<T>() where T : struct, NetworkMessage
         {

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -57,19 +57,23 @@ namespace Mirror
         // Dictionary<channelId, batch> because we have multiple channels.
         protected Dictionary<int, Batcher> batches = new Dictionary<int, Batcher>();
 
-        // batch messages and send them out in LateUpdate (or after batchInterval)
-        protected bool batching;
+        /// <summary>last batch's remote timestamp. not interpolated. useful for NetworkTransform etc.</summary>
+        // for any given NetworkMessage/Rpc/Cmd/OnSerialize, this was the time
+        // on the REMOTE END when it was sent.
+        //
+        // NOTE: this is NOT in NetworkTime, it needs to be per-connection
+        //       because the server receives different batch timestamps from
+        //       different connections.
+        public double remoteTimeStamp { get; internal set; }
 
-        internal NetworkConnection(bool batching)
+        internal NetworkConnection()
         {
-            this.batching = batching;
-
             // set lastTime to current time when creating connection to make
             // sure it isn't instantly kicked for inactivity
             lastMessageTime = Time.time;
         }
 
-        internal NetworkConnection(int networkConnectionId, bool batching) : this(batching)
+        internal NetworkConnection(int networkConnectionId) : this()
         {
             connectionId = networkConnectionId;
             // TODO why isn't lastMessageTime set in here like in the other ctor?
@@ -139,27 +143,23 @@ namespace Mirror
         {
             //Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
-            // validate packet size first.
-            if (ValidatePacketSize(segment, channelId))
-            {
-                // batching enabled?
-                if (batching)
-                {
-                    // add to batch no matter what.
-                    // batching will try to fit as many as possible into MTU.
-                    // but we still allow > MTU, e.g. kcp max packet size 144kb.
-                    // those are simply sent as single batches.
-                    //
-                    // IMPORTANT: do NOT send > batch sized messages directly:
-                    // - data race: large messages would be sent directly. small
-                    //   messages would be sent in the batch at the end of frame
-                    // - timestamps: if batching assumes a timestamp, then large
-                    //   messages need that too.
-                    GetBatchForChannelId(channelId).AddMessage(segment);
-                }
-                // otherwise send directly to minimize latency
-                else SendToTransport(segment, channelId);
-            }
+            // add to batch no matter what.
+            // batching will try to fit as many as possible into MTU.
+            // but we still allow > MTU, e.g. kcp max packet size 144kb.
+            // those are simply sent as single batches.
+            //
+            // IMPORTANT: do NOT send > batch sized messages directly:
+            // - data race: large messages would be sent directly. small
+            //   messages would be sent in the batch at the end of frame
+            // - timestamps: if batching assumes a timestamp, then large
+            //   messages need that too.
+            //
+            // NOTE: we ALWAYS batch. it's not optional, because the
+            //       receiver needs timestamps for NT etc.
+            //
+            // NOTE: we do NOT ValidatePacketSize here yet. the final packet
+            //       will be the full batch, including timestamp.
+            GetBatchForChannelId(channelId).AddMessage(segment);
         }
 
         // Send stage three: hand off to transport
@@ -168,34 +168,31 @@ namespace Mirror
         // flush batched messages at the end of every Update.
         internal virtual void Update()
         {
-            // batching?
-            if (batching)
+            // go through batches for all channels
+            foreach (KeyValuePair<int, Batcher> kvp in batches)
             {
-                // go through batches for all channels
-                foreach (KeyValuePair<int, Batcher> kvp in batches)
+                // make and send as many batches as necessary from the stored
+                // messages.
+                Batcher batcher = kvp.Value;
+                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
                 {
-                    // make and send as many batches as necessary from the stored
-                    // messages.
-                    Batcher batcher = kvp.Value;
-                    using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                    // make a batch with our local time (double precision)
+                    while (batcher.MakeNextBatch(writer, NetworkTime.localTime))
                     {
-                        while (batcher.MakeNextBatch(writer))
+                        // validate packet before handing the batch to the
+                        // transport. this guarantees that we always stay
+                        // within transport's max message size limit.
+                        // => just in case transport forgets to check it
+                        // => just in case mirror miscalulated it etc.
+                        ArraySegment<byte> segment = writer.ToArraySegment();
+                        if (ValidatePacketSize(segment, kvp.Key))
                         {
-                            // validate packet before handing the batch to the
-                            // transport. this guarantees that we always stay
-                            // within transport's max message size limit.
-                            // => just in case transport forgets to check it
-                            // => just in case mirror miscalulated it etc.
-                            ArraySegment<byte> segment = writer.ToArraySegment();
-                            if (ValidatePacketSize(segment, kvp.Key))
-                            {
-                                // send to transport
-                                SendToTransport(segment, kvp.Key);
-                                //UnityEngine.Debug.Log($"sending batch of {writer.Position} bytes for channel={kvp.Key} connId={connectionId}");
+                            // send to transport
+                            SendToTransport(segment, kvp.Key);
+                            //UnityEngine.Debug.Log($"sending batch of {writer.Position} bytes for channel={kvp.Key} connId={connectionId}");
 
-                                // reset writer for each new batch
-                                writer.Position = 0;
-                            }
+                            // reset writer for each new batch
+                            writer.Position = 0;
                         }
                     }
                 }

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -10,8 +10,8 @@ namespace Mirror
         // unbatcher
         public Unbatcher unbatcher = new Unbatcher();
 
-        public NetworkConnectionToClient(int networkConnectionId, bool batching)
-            : base(networkConnectionId, batching) {}
+        public NetworkConnectionToClient(int networkConnectionId)
+            : base(networkConnectionId) {}
 
         // Send stage three: hand off to transport
         protected override void SendToTransport(ArraySegment<byte> segment, int channelId = Channels.Reliable) =>

--- a/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
@@ -6,8 +6,6 @@ namespace Mirror
     {
         public override string address => "";
 
-        public NetworkConnectionToServer(bool batching) : base(batching) {}
-
         // Send stage three: hand off to transport
         protected override void SendToTransport(ArraySegment<byte> segment, int channelId = Channels.Reliable) =>
             Transport.activeTransport.ClientSend(segment, channelId);

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -45,6 +45,8 @@ namespace Mirror
         // after 60 days, accuracy is 454 ms
         // in other words,  if the server is running for 2 months,
         // and you cast down to float,  then the time will jump in 0.4s intervals.
+        //
+        // TODO consider using Unbatcher's remoteTime for NetworkTime
         public static double time => localTime - _offset.Value;
 
         /// <summary>Time measurement variance. The higher, the less accurate the time is.</summary>

--- a/Assets/Mirror/Tests/Common/FakeNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Common/FakeNetworkConnection.cs
@@ -4,7 +4,7 @@ namespace Mirror.Tests
 {
     public class FakeNetworkConnection : NetworkConnectionToClient
     {
-        public FakeNetworkConnection() : base(1, false) {}
+        public FakeNetworkConnection() : base(1) {}
         public override string address => "Test";
         public override void Disconnect() {}
         internal override void Send(ArraySegment<byte> segment, int channelId = 0) {}

--- a/Assets/Mirror/Tests/Editor/InterestManagementTests_Common.cs
+++ b/Assets/Mirror/Tests/Editor/InterestManagementTests_Common.cs
@@ -21,7 +21,7 @@ namespace Mirror.Tests
 
             // A with connectionId = 0x0A, netId = 0xAA
             CreateNetworked(out gameObjectA, out identityA);
-            connectionA = new NetworkConnectionToClient(0x0A, false);
+            connectionA = new NetworkConnectionToClient(0x0A);
             connectionA.isAuthenticated = true;
             connectionA.isReady = true;
             connectionA.identity = identityA;
@@ -29,7 +29,7 @@ namespace Mirror.Tests
 
             // B
             CreateNetworked(out gameObjectB, out identityB);
-            connectionB = new NetworkConnectionToClient(0x0B, false);
+            connectionB = new NetworkConnectionToClient(0x0B);
             connectionB.isAuthenticated = true;
             connectionB.isReady = true;
             connectionB.identity = identityB;

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -445,7 +445,7 @@ namespace Mirror.Tests
 
             // calling rpc on connectionToServer shouldn't work
             LogAssert.Expect(LogType.Error, $"TargetRPC {nameof(NetworkBehaviourSendTargetRPCInternalComponent.TargetRPCGenerated)} requires a NetworkConnectionToClient but was given {typeof(NetworkConnectionToServer).Name}");
-            comp.CallSendTargetRPCInternal(new NetworkConnectionToServer(false));
+            comp.CallSendTargetRPCInternal(new NetworkConnectionToServer());
             Assert.That(comp.called, Is.EqualTo(0));
 
             // set proper connection to client

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -414,11 +414,11 @@ namespace Mirror.Tests
             identity.OnStartServer();
 
             // add an observer connection
-            NetworkConnectionToClient connection = new NetworkConnectionToClient(42, false);
+            NetworkConnectionToClient connection = new NetworkConnectionToClient(42);
             identity.observers[connection.connectionId] = connection;
 
             // RemoveObserverInternal with invalid connection should do nothing
-            identity.RemoveObserverInternal(new NetworkConnectionToClient(43, false));
+            identity.RemoveObserverInternal(new NetworkConnectionToClient(43));
             Assert.That(identity.observers.Count, Is.EqualTo(1));
 
             // RemoveObserverInternal with existing connection should remove it
@@ -622,7 +622,7 @@ namespace Mirror.Tests
             // another connection
             // error log is expected
             LogAssert.ignoreFailingMessages = true;
-            result = identity.AssignClientAuthority(new NetworkConnectionToClient(43, false));
+            result = identity.AssignClientAuthority(new NetworkConnectionToClient(43));
             LogAssert.ignoreFailingMessages = false;
             Assert.That(result, Is.False);
             Assert.That(identity.connectionToClient, Is.EqualTo(owner));
@@ -987,8 +987,8 @@ namespace Mirror.Tests
             CreateNetworked(out GameObject _, out NetworkIdentity identity);
 
             // create some connections
-            NetworkConnectionToClient connection1 = new NetworkConnectionToClient(42, false);
-            NetworkConnectionToClient connection2 = new NetworkConnectionToClient(43, false);
+            NetworkConnectionToClient connection1 = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient connection2 = new NetworkConnectionToClient(43);
 
             // AddObserver should return early if called before .observers was
             // created
@@ -1012,7 +1012,7 @@ namespace Mirror.Tests
             Assert.That(identity.observers[connection2.connectionId], Is.EqualTo(connection2));
 
             // adding a duplicate connectionId shouldn't overwrite the original
-            NetworkConnectionToClient duplicate = new NetworkConnectionToClient(connection1.connectionId, false);
+            NetworkConnectionToClient duplicate = new NetworkConnectionToClient(connection1.connectionId);
             identity.AddObserver(duplicate);
             Assert.That(identity.observers.Count, Is.EqualTo(2));
             Assert.That(identity.observers.ContainsKey(connection1.connectionId));
@@ -1030,8 +1030,8 @@ namespace Mirror.Tests
             identity.OnStartServer();
 
             // add some observers
-            identity.observers[42] = new NetworkConnectionToClient(42, false);
-            identity.observers[43] = new NetworkConnectionToClient(43, false);
+            identity.observers[42] = new NetworkConnectionToClient(42);
+            identity.observers[43] = new NetworkConnectionToClient(43);
 
             // call ClearObservers
             identity.ClearObservers();
@@ -1111,9 +1111,9 @@ namespace Mirror.Tests
             identity.isClient = true;
             // creates .observers and generates a netId
             identity.OnStartServer();
-            identity.connectionToClient = new NetworkConnectionToClient(1, false);
-            identity.connectionToServer = new NetworkConnectionToServer(false);
-            identity.observers[43] = new NetworkConnectionToClient(2, false);
+            identity.connectionToClient = new NetworkConnectionToClient(1);
+            identity.connectionToServer = new NetworkConnectionToServer();
+            identity.observers[43] = new NetworkConnectionToClient(2);
 
             // mark for reset and reset
             identity.Reset();

--- a/Assets/Mirror/Tests/Editor/NetworkMatchCheckerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkMatchCheckerTest.cs
@@ -43,7 +43,7 @@ namespace Mirror.Tests
 
         static NetworkConnection CreateNetworkConnection(GameObject player)
         {
-            NetworkConnectionToClient connection = new NetworkConnectionToClient(++nextConnectionId, false);
+            NetworkConnectionToClient connection = new NetworkConnectionToClient(++nextConnectionId);
             connection.identity = player.GetComponent<NetworkIdentity>();
             connection.identity.connectionToClient = connection;
             connection.identity.observers = new Dictionary<int, NetworkConnection>();

--- a/Assets/Mirror/Tests/Editor/TargetRpcTest.cs
+++ b/Assets/Mirror/Tests/Editor/TargetRpcTest.cs
@@ -112,7 +112,6 @@ namespace Mirror.Tests.RemoteAttrributeTest
         class FakeConnection : NetworkConnection
         {
             public override string address => throw new NotImplementedException();
-            public FakeConnection() : base(false) {}
             public override void Disconnect() => throw new NotImplementedException();
             internal override void Send(ArraySegment<byte> segment, int channelId = 0) => throw new NotImplementedException();
             protected override void SendToTransport(ArraySegment<byte> segment, int channelId = Channels.Reliable) => throw new NotImplementedException();

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -29,7 +29,7 @@ namespace Mirror.Tests.Runtime
         public IEnumerator DestroyPlayerForConnectionTest()
         {
             GameObject player = new GameObject("testPlayer", typeof(NetworkIdentity));
-            NetworkConnectionToClient conn = new NetworkConnectionToClient(1, false);
+            NetworkConnectionToClient conn = new NetworkConnectionToClient(1);
 
             NetworkServer.AddPlayerForConnection(conn, player);
 
@@ -48,7 +48,7 @@ namespace Mirror.Tests.Runtime
         public IEnumerator RemovePlayerForConnectionTest()
         {
             GameObject player = new GameObject("testPlayer", typeof(NetworkIdentity));
-            NetworkConnectionToClient conn = new NetworkConnectionToClient(1, false);
+            NetworkConnectionToClient conn = new NetworkConnectionToClient(1);
 
             NetworkServer.AddPlayerForConnection(conn, player);
 


### PR DESCRIPTION
- force enables batching at all times
- every batch includes a remote timestamp
- can be used for snapshot interpolation without sending one timestamp per message etc.

=> NetworkConnection.remoteTimeStamp can be used by the end user. for any given message/rpc/cmd, this was the time on the remote end when it was sent.

TESTS:
+ all unit tests run
+ works in ummorpg finally: https://gyazo.com/466fdb86ec9c3b53907a18c27eb78fd5