### PR TITLE
fix: Don't call FinishLoadScene when customHandling

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -802,6 +802,7 @@ namespace Mirror
             // scene handling will happen in overrides of OnClientChangeScene and/or OnClientSceneChanged
             // Do not call FinishLoadScene here. Custom handler will assign loadingSceneAsync and we need
             // to wait for that to finish. UpdateScene already checks for that to be not null and isDone.
+            // (in other words, custom loading needs to call FinishLoadScene when they are done)
             if (customHandling)
                 return;
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -800,11 +800,10 @@ namespace Mirror
             OnClientChangeScene(newSceneName, sceneOperation, customHandling);
 
             // scene handling will happen in overrides of OnClientChangeScene and/or OnClientSceneChanged
+            // Do not call FinishLoadScene here. Custom handler will assign loadingSceneAsync and we need
+            // to wait for that to finish. UpdateScene already checks for that to be not null and isDone.
             if (customHandling)
-            {
-                FinishLoadScene();
                 return;
-            }
 
             switch (sceneOperation)
             {


### PR DESCRIPTION
`FinishLoadScene` will be called from `UpdateScene`  if `loadingSceneAsync != null && loadingSceneAsync.isDone` and it's the responsibility of the user in their custom handler to assign `loadingSceneAsync` to something to block `FinishLoadScene` until that completes. If they don't, `UpdateScene` will call `FinishLoadScene` in the next frame.

Original issue was discussed in [Discord](https://discord.com/channels/343440455738064897/656822943384469504/836508781423755284).