### PR TITLE
fix: Weaver Generated Cmd/Rpc should be private

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
@@ -35,6 +35,11 @@ namespace Mirror.Weaver
             string newName = RpcPrefix + md.Name;
             MethodDefinition cmd = new MethodDefinition(newName, md.Attributes, md.ReturnType);
 
+            // force new usercode_cmd to be private.
+            // this prevents users from mistakenly calling weaver generated methods in dropdown menus (such as buttons)
+            cmd.IsPublic = false;
+            cmd.IsPrivate = true;
+
             // add parameters
             foreach (ParameterDefinition pd in md.Parameters)
             {

--- a/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
@@ -36,7 +36,8 @@ namespace Mirror.Weaver
             MethodDefinition cmd = new MethodDefinition(newName, md.Attributes, md.ReturnType);
 
             // force new usercode_cmd to be private.
-            // this prevents users from mistakenly calling weaver generated methods in dropdown menus (such as buttons)
+            // otherwise the generated User_Cmd could be assigned to UnityEvents in the Inspector
+            // (User_Cmd() is only called by Invoke_Cmd in this class)
             cmd.IsPublic = false;
             cmd.IsPrivate = true;
 


### PR DESCRIPTION
Forces the new weaver generated method to be private, preventing users from mistakenly calling weaver generated methods in dropdown menus (such as buttons) in the inspector.