### PR TITLE
Use Debug.LogException for NetworkBehaviour error messages

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -651,7 +651,7 @@ namespace Mirror
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("Exception in OnStartServer:" + e.Message + " " + e.StackTrace);
+                    Debug.LogException(e, comp);
                 }
             }
         }
@@ -671,7 +671,7 @@ namespace Mirror
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("Exception in OnStopServer:" + e.Message + " " + e.StackTrace);
+                    Debug.LogException(e, comp);
                 }
             }
         }
@@ -709,7 +709,7 @@ namespace Mirror
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("Exception in OnStartClient:" + e.Message + " " + e.StackTrace);
+                    Debug.LogException(e, comp);
                 }
             }
         }
@@ -729,7 +729,7 @@ namespace Mirror
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("Exception in OnStopClient:" + e.Message + " " + e.StackTrace);
+                    Debug.LogException(e, comp);
                 }
             }
         }
@@ -767,7 +767,7 @@ namespace Mirror
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("Exception in OnStartLocalPlayer:" + e.Message + " " + e.StackTrace);
+                    Debug.LogException(e, comp);
                 }
             }
         }
@@ -797,7 +797,7 @@ namespace Mirror
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("Exception in OnStartAuthority:" + e.Message + " " + e.StackTrace);
+                    Debug.LogException(e, comp);
                 }
             }
         }
@@ -817,7 +817,7 @@ namespace Mirror
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("Exception in OnStopAuthority:" + e.Message + " " + e.StackTrace);
+                    Debug.LogException(e, comp);
                 }
             }
         }


### PR DESCRIPTION
This is a small QoL change.

NetworkBehaviour error messages currently use Debug.LogError.
`Debug.LogError("Exception in OnStopAuthority:" + e.Message + " " + e.StackTrace);`
Call stacks are unclickable in console, which is kinda annoying. Also slightly less readable than normal stack traces.
![before](https://user-images.githubusercontent.com/41206458/123975687-7e5be300-d9f8-11eb-85e8-880750c9c3ed.png)


Unity has a variant of Debug.Log specifically for logging exceptions, might as well use it.
`Debug.LogException(e, comp);`
Call stacks are now clickable, and they tell you enough that it came from OnStartServer.
![after](https://user-images.githubusercontent.com/41206458/123975699-8025a680-d9f8-11eb-9479-671d76cf4948.png)
By providing context parameter this comes with an additional benefit of highlighting relevant object when clicked.
![after2](https://user-images.githubusercontent.com/41206458/123975706-81ef6a00-d9f8-11eb-9cce-0d4024a46d9c.png)

