### PR TITLE
fix: Use double time everywhere

### DIFF
--- a/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
@@ -16,7 +16,7 @@ namespace Mirror.Experimental
         [Tooltip("Set to true if moves come from owner client, set to false if moves always come from server")]
         [SerializeField] bool clientAuthority = false;
 
-        float nextSyncTime;
+        double nextSyncTime;
 
 
         [SyncVar()]
@@ -61,7 +61,7 @@ namespace Mirror.Experimental
 
         void SendToServer()
         {
-            float now = Time.time;
+            double now = NetworkTime.localFrameTime;
             if (now > nextSyncTime)
             {
                 nextSyncTime = now + syncInterval;

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
@@ -204,7 +204,7 @@ namespace Mirror.Experimental
         [Client]
         void SendVelocity()
         {
-            float now = Time.time;
+            double now = NetworkTime.localFrameTime;
             if (now < previousValue.nextSyncTime)
                 return;
 
@@ -349,7 +349,7 @@ namespace Mirror.Experimental
             /// <summary>
             /// Next sync time that velocity will be synced, based on syncInterval.
             /// </summary>
-            public float nextSyncTime;
+            public double nextSyncTime;
             public Vector3 velocity;
             public Vector3 angularVelocity;
             public bool isKinematic;

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody2D.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody2D.cs
@@ -203,7 +203,7 @@ namespace Mirror.Experimental
         [Client]
         void SendVelocity()
         {
-            float now = Time.time;
+            double now = NetworkTime.localFrameTime;
             if (now < previousValue.nextSyncTime)
                 return;
 
@@ -348,7 +348,7 @@ namespace Mirror.Experimental
             /// <summary>
             /// Next sync time that velocity will be synced, based on syncInterval.
             /// </summary>
-            public float nextSyncTime;
+            public double nextSyncTime;
             public Vector2 velocity;
             public float angularVelocity;
             public bool isKinematic;

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -48,7 +48,7 @@ namespace Mirror
         int[] animationHash;
         int[] transitionHash;
         float[] layerWeight;
-        float nextSendTime;
+        double nextSendTime;
 
         bool SendMessagesAllowed
         {
@@ -196,7 +196,7 @@ namespace Mirror
 
         void CheckSendRate()
         {
-            float now = Time.time;
+            double now = NetworkTime.localFrameTime;
             if (SendMessagesAllowed && syncInterval >= 0 && now > nextSendTime)
             {
                 nextSendTime = now + syncInterval;

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -75,7 +75,7 @@ namespace Mirror
         // client
         public class DataPoint
         {
-            public float timeStamp;
+            public double timeStamp;
             // use local position/rotation for VR support
             public Vector3 localPosition;
             public Quaternion localRotation;
@@ -87,7 +87,7 @@ namespace Mirror
         DataPoint goal;
 
         // local authority send time
-        float lastClientSendTime;
+        double lastClientSendTime;
 
         // serialization is needed by OnSerialize and by manual sending from authority
         // public only for tests
@@ -125,9 +125,9 @@ namespace Mirror
         static float EstimateMovementSpeed(DataPoint from, DataPoint to, Transform transform, float sendInterval)
         {
             Vector3 delta = to.localPosition - (from != null ? from.localPosition : transform.localPosition);
-            float elapsed = from != null ? to.timeStamp - from.timeStamp : sendInterval;
+            double elapsed = from != null ? to.timeStamp - from.timeStamp : sendInterval;
             // avoid NaN
-            return elapsed > 0 ? delta.magnitude / elapsed : 0;
+            return (float) (elapsed > 0 ? delta.magnitude / elapsed : 0);
         }
 
         // serialization is needed by OnSerialize and by manual sending from authority
@@ -144,7 +144,7 @@ namespace Mirror
                                 : reader.ReadQuaternion(),
                 // use current target scale, so we can check boolean and reader later, to see if the data is actually sent.
                 localScale = targetComponent.localScale,
-                timeStamp = Time.time
+                timeStamp = NetworkTime.localFrameTime
             };
 
             if (syncScale)
@@ -168,7 +168,7 @@ namespace Mirror
             {
                 start = new DataPoint
                 {
-                    timeStamp = Time.time - syncInterval,
+                    timeStamp = NetworkTime.localFrameTime - syncInterval,
                     // local position/rotation for VR support
                     localPosition = targetComponent.localPosition,
                     localRotation = targetComponent.localRotation,
@@ -260,13 +260,13 @@ namespace Mirror
         {
             if (start != null)
             {
-                float difference = goal.timeStamp - start.timeStamp;
+                double difference = goal.timeStamp - start.timeStamp;
 
                 // the moment we get 'goal', 'start' is supposed to
                 // start, so elapsed time is based on:
-                float elapsed = Time.time - goal.timeStamp;
+                double elapsed = NetworkTime.localFrameTime - goal.timeStamp;
                 // avoid NaN
-                return difference > 0 ? elapsed / difference : 0;
+                return (float)(difference > 0 ? elapsed / difference : 0);
             }
             return 0;
         }
@@ -337,10 +337,10 @@ namespace Mirror
         bool NeedsTeleport()
         {
             // calculate time between the two data points
-            float startTime = start != null ? start.timeStamp : Time.time - syncInterval;
-            float goalTime = goal != null ? goal.timeStamp : Time.time;
-            float difference = goalTime - startTime;
-            float timeSinceGoalReceived = Time.time - goalTime;
+            double startTime = start != null ? start.timeStamp : NetworkTime.localFrameTime - syncInterval;
+            double goalTime = goal != null ? goal.timeStamp : NetworkTime.localFrameTime;
+            double difference = goalTime - startTime;
+            double timeSinceGoalReceived = NetworkTime.localFrameTime - goalTime;
             return timeSinceGoalReceived > difference * 5;
         }
 
@@ -395,7 +395,7 @@ namespace Mirror
                 if (!isServer && IsClientWithAuthority)
                 {
                     // check only each 'syncInterval'
-                    if (Time.time - lastClientSendTime >= syncInterval)
+                    if (NetworkTime.localFrameTime - lastClientSendTime >= syncInterval)
                     {
                         if (HasEitherMovedRotatedScaled())
                         {
@@ -409,7 +409,7 @@ namespace Mirror
                                 CmdClientToServerSync(writer.ToArraySegment());
                             }
                         }
-                        lastClientSendTime = Time.time;
+                        lastClientSendTime = NetworkTime.localFrameTime;
                     }
                 }
 

--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -83,7 +83,7 @@ namespace Mirror
             using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
             {
                 // make a batch with our local time (double precision)
-                if (batcher.MakeNextBatch(writer, NetworkTime.localTime))
+                if (batcher.MakeNextBatch(writer, NetworkTime.localFrameTime))
                 {
                     NetworkServer.OnTransportData(connectionId, writer.ToArraySegment(), channelId);
                 }
@@ -117,7 +117,7 @@ namespace Mirror
                 using (PooledNetworkWriter batchWriter = NetworkWriterPool.GetWriter())
                 {
                     // make a batch with our local time (double precision)
-                    if (batcher.MakeNextBatch(batchWriter, NetworkTime.localTime))
+                    if (batcher.MakeNextBatch(batchWriter, NetworkTime.localFrameTime))
                     {
                         NetworkClient.OnTransportData(batchWriter.ToArraySegment(), Channels.Reliable);
                     }

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -13,7 +13,7 @@ namespace Mirror
     [HelpURL("https://mirror-networking.gitbook.io/docs/guides/networkbehaviour")]
     public abstract class NetworkBehaviour : MonoBehaviour
     {
-        internal float lastSyncTime;
+        internal double lastSyncTime;
 
         /// <summary>sync mode for OnSerialize</summary>
         // hidden because NetworkBehaviourInspector shows it only if has OnSerialize.
@@ -478,7 +478,7 @@ namespace Mirror
         // be called manually as well.
         public void ClearAllDirtyBits()
         {
-            lastSyncTime = Time.time;
+            lastSyncTime = NetworkTime.localFrameTime;
             syncVarDirtyBits = 0L;
 
             // flush all unsynchronized changes in syncobjects
@@ -509,7 +509,7 @@ namespace Mirror
         // true if syncInterval elapsed and any SyncVar or SyncObject is dirty
         public bool IsDirty()
         {
-            if (Time.time - lastSyncTime >= syncInterval)
+            if (NetworkTime.localFrameTime - lastSyncTime >= syncInterval)
             {
                 return syncVarDirtyBits != 0L || AnySyncObjectDirty();
             }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -293,7 +293,7 @@ namespace Mirror
                     // message handler may disconnect client, making connection = null
                     // therefore must check for null to avoid NRE.
                     if (connection != null)
-                        connection.lastMessageTime = Time.time;
+                        connection.lastMessageTime = NetworkTime.localFrameTime;
 
                     return true;
                 }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -34,7 +34,7 @@ namespace Mirror
         public abstract string address { get; }
 
         /// <summary>Last time a message was received for this connection. Includes system and user messages.</summary>
-        public float lastMessageTime;
+        public double lastMessageTime;
 
         /// <summary>This connection's main object (usually the player object).</summary>
         public NetworkIdentity identity { get; internal set; }
@@ -70,7 +70,7 @@ namespace Mirror
         {
             // set lastTime to current time when creating connection to make
             // sure it isn't instantly kicked for inactivity
-            lastMessageTime = Time.time;
+            lastMessageTime = NetworkTime.localFrameTime;
         }
 
         internal NetworkConnection(int networkConnectionId) : this()
@@ -253,7 +253,7 @@ namespace Mirror
         }
 
         /// <summary>Check if we received a message within the last 'timeout' seconds.</summary>
-        internal virtual bool IsAlive(float timeout) => Time.time - lastMessageTime < timeout;
+        internal virtual bool IsAlive(float timeout) => NetworkTime.localFrameTime - lastMessageTime < timeout;
 
         internal void AddOwnedObject(NetworkIdentity obj)
         {

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -177,7 +177,7 @@ namespace Mirror
                 using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
                 {
                     // make a batch with our local time (double precision)
-                    while (batcher.MakeNextBatch(writer, NetworkTime.localTime))
+                    while (batcher.MakeNextBatch(writer, NetworkTime.localFrameTime))
                     {
                         // validate packet before handing the batch to the
                         // transport. this guarantees that we always stay

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -177,6 +177,7 @@ namespace Mirror
 
         static void NetworkEarlyUpdate()
         {
+            NetworkTime.EarlyUpdate();
             //Debug.Log("NetworkEarlyUpdate @ " + Time.time);
             NetworkServer.NetworkEarlyUpdate();
             NetworkClient.NetworkEarlyUpdate();

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -178,14 +178,14 @@ namespace Mirror
         static void NetworkEarlyUpdate()
         {
             NetworkTime.EarlyUpdate();
-            //Debug.Log("NetworkEarlyUpdate @ " + Time.time);
+            //Debug.Log("NetworkEarlyUpdate @ " + NetworkTime.localFrameTime);
             NetworkServer.NetworkEarlyUpdate();
             NetworkClient.NetworkEarlyUpdate();
         }
 
         static void NetworkLateUpdate()
         {
-            //Debug.Log("NetworkLateUpdate @ " + Time.time);
+            //Debug.Log("NetworkLateUpdate @ " + NetworkTime.localFrameTime);
             NetworkServer.NetworkLateUpdate();
             NetworkClient.NetworkLateUpdate();
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -419,7 +419,7 @@ namespace Mirror
                 if (handlers.TryGetValue(msgType, out NetworkMessageDelegate handler))
                 {
                     handler.Invoke(connection, reader, channelId);
-                    connection.lastMessageTime = Time.time;
+                    connection.lastMessageTime = NetworkTime.localFrameTime;
                     return true;
                 }
                 else

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -104,11 +104,11 @@ namespace Mirror
 
         internal static void UpdateClient()
         {
-            if (Time.time - lastPingTime >= PingFrequency)
+            if (localFrameTime - lastPingTime >= PingFrequency)
             {
                 NetworkPingMessage pingMessage = new NetworkPingMessage(localTime);
                 NetworkClient.Send(pingMessage, Channels.Unreliable);
-                lastPingTime = Time.time;
+                lastPingTime = localFrameTime;
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -38,6 +38,9 @@ namespace Mirror
         //          it changes during the frame too.
         public static double localTime => stopwatch.Elapsed.TotalSeconds;
 
+        /// <summary> returns the local time at the start of the frame. This provides a double alternative to Time.time</summary>
+        public static double localFrameTime { get; internal set; }
+
         /// <summary>The time in seconds since the server started.</summary>
         //
         // I measured the accuracy of float and I got this:
@@ -155,6 +158,11 @@ namespace Mirror
                 // new offset looks reasonable,  add to the average
                 _offset.Add(newOffset);
             }
+        }
+
+        public static void EarlyUpdate()
+        {
+            localFrameTime = localTime;
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -96,6 +96,7 @@ namespace Mirror
         public static void Reset()
         {
             stopwatch.Restart();
+            lastPingTime = 0;
             _rtt = new ExponentialMovingAverage(PingWindowSize);
             _offset = new ExponentialMovingAverage(PingWindowSize);
             offsetMin = double.MinValue;

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -587,7 +587,7 @@ namespace Mirror.Tests
 
             // remember current time & update NetworkClient IMMEDIATELY so the
             // batch is finished with timestamp.
-            double sendTime = NetworkTime.localTime;
+            double sendTime = NetworkTime.localFrameTime;
             NetworkClient.NetworkLateUpdate();
 
             // let some time pass before processing
@@ -620,7 +620,7 @@ namespace Mirror.Tests
 
             // remember current time & update NetworkClient IMMEDIATELY so the
             // batch is finished with timestamp.
-            double sendTime = NetworkTime.localTime;
+            double sendTime = NetworkTime.localFrameTime;
             NetworkServer.NetworkLateUpdate();
 
             // let some time pass before processing

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -68,7 +68,7 @@ namespace Mirror.Tests.SyncVarTests
         public void TestSyncIntervalAndClearDirtyComponents()
         {
             CreateNetworked(out GameObject gameObject, out NetworkIdentity identity, out MockPlayer player);
-            player.lastSyncTime = Time.time;
+            player.lastSyncTime = NetworkTime.localFrameTime;
             // synchronize immediately
             player.syncInterval = 1f;
 
@@ -84,7 +84,7 @@ namespace Mirror.Tests.SyncVarTests
             player.netIdentity.ClearDirtyComponentsDirtyBits();
 
             // set lastSyncTime far enough back to be ready for syncing
-            player.lastSyncTime = Time.time - player.syncInterval;
+            player.lastSyncTime = NetworkTime.localFrameTime - player.syncInterval;
 
             // should be dirty now
             Assert.That(player.IsDirty(), Is.True, "Sync interval met, should be dirty");
@@ -94,7 +94,7 @@ namespace Mirror.Tests.SyncVarTests
         public void TestSyncIntervalAndClearAllComponents()
         {
             CreateNetworked(out GameObject gameObject, out NetworkIdentity identity, out MockPlayer player);
-            player.lastSyncTime = Time.time;
+            player.lastSyncTime = NetworkTime.localFrameTime;
             // synchronize immediately
             player.syncInterval = 1f;
 
@@ -110,7 +110,7 @@ namespace Mirror.Tests.SyncVarTests
             player.netIdentity.ClearAllComponentsDirtyBits();
 
             // set lastSyncTime far enough back to be ready for syncing
-            player.lastSyncTime = Time.time - player.syncInterval;
+            player.lastSyncTime = NetworkTime.localFrameTime - player.syncInterval;
 
             // should be dirty now
             Assert.That(player.IsDirty(), Is.False, "Sync interval met, should still not be dirty");

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using NUnit.Framework;
 using UnityEngine;


### PR DESCRIPTION
This PR adds a double-based alternative to Time.time to the NetworkTime class (NetworkTime.localFrameTime). This is then used instead of Time.time for most things
Time.time is not precise enough, it will cause skipping (and since the pull->push change, dropping) of serialization updates after 5-6 days of server run time.
See the added test, it fails with the old float timestamps.

I've gone through and replaced it everywhere, even the NetworkTransform/NetworkAnimator/.. components - so this should get a thorough review before merging, don't want to break peoples projects.

The breaking changes are:
- NetworkConnection.lastMessageTime which is public and used to be a float, and now is a double
- NetworkRigidbody and NetworkRigidbody2D.nextSyncTime which is public and used to be a float, and now is a double

So nothing super bad, I'd say most people aren't touching those anyways

All tests still pass with the changes