### PR TITLE
Add (failing) test for large timestamp serialization

### DIFF
--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
@@ -55,6 +56,21 @@ namespace Mirror.Tests.Runtime
             yield return null;
             // Confirm it has been destroyed
             Assert.That(identity == null, Is.True);
+        }
+
+        [UnityTest]
+        public IEnumerator TestSerializationWithLargeTimestamps()
+        {
+            // 14 * 24 hours per day * 60 minutes per hour * 60 seconds per minute = 14 days
+            float time = 14 * 24 * 60 * 60 ;
+            NetworkIdentitySerialization serialization = identity.GetSerializationAtTick(time);
+            // advance time by 50ms (20 fps)
+            time += 0.05f;
+            NetworkIdentitySerialization serializationNew = identity.GetSerializationAtTick(time);
+
+            // if the serialization has been changed the tickTimeStamp should have moved
+            Assert.That(serialization.tickTimeStamp == serializationNew.tickTimeStamp, Is.False);
+            yield break;
         }
     }
 }

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -58,6 +58,8 @@ namespace Mirror.Tests.Runtime
             Assert.That(identity == null, Is.True);
         }
 
+        // imer: There's currently an issue with dropped/skipped serializations once a server
+        // has been running for around a week, this test should highlight the potential cause
         [UnityTest]
         public IEnumerator TestSerializationWithLargeTimestamps()
         {


### PR DESCRIPTION
There's currently an issue with dropped/skipped serializations once a server has been running for around a week, this test should highlight the potential cause