### PR TITLE
fix: serialization precision over days by using frameCount instead of single precision time

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -24,8 +24,8 @@ namespace Mirror
 
     public struct NetworkIdentitySerialization
     {
-        // IMPORTANT: double precision to avoid inaccuracies after several days
-        public double tickTimeStamp;
+        // IMPORTANT: int tick avoids floating point inaccuracy over days/weeks
+        public int tick;
         public NetworkWriter ownerWriter;
         public NetworkWriter observersWriter;
         // TODO there is probably a more simple way later
@@ -941,13 +941,12 @@ namespace Mirror
         }
 
         // get cached serialization for this tick (or serialize if none yet)
-        // IMPORTANT: needs FRAME TIME which doesn't change during THIS FRAME!
-        // IMPORTANT: DOUBLE PRECISION to avoid inaccuracies after several days.
-        //            see test: TestSerializationWithLargeTimestamps()
-        internal NetworkIdentitySerialization GetSerializationAtTick(double tickTimeStamp)
+        // IMPORTANT: int tick avoids floating point inaccuracy over days/weeks
+        internal NetworkIdentitySerialization GetSerializationAtTick(int tick)
         {
-            // serialize fresh if tick is newer than last one
-            if (lastSerialization.tickTimeStamp < tickTimeStamp)
+            // reserialize if tick is different than last changed.
+            // NOTE: != instead of < because int.max+1 overflows at some point.
+            if (lastSerialization.tick != tick)
             {
                 // reset
                 lastSerialization.ownerWriter.Position = 0;
@@ -960,8 +959,8 @@ namespace Mirror
                                      lastSerialization.observersWriter,
                                      out lastSerialization.observersWritten);
 
-                // set timestamp
-                lastSerialization.tickTimeStamp = tickTimeStamp;
+                // set tick
+                lastSerialization.tick = tick;
                 //Debug.Log($"{name} (netId={netId}) serialized for tick={tickTimeStamp}");
             }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -24,7 +24,8 @@ namespace Mirror
 
     public struct NetworkIdentitySerialization
     {
-        public float tickTimeStamp;
+        // IMPORTANT: double precision to avoid inaccuracies after several days
+        public double tickTimeStamp;
         public NetworkWriter ownerWriter;
         public NetworkWriter observersWriter;
         // TODO there is probably a more simple way later
@@ -941,7 +942,9 @@ namespace Mirror
 
         // get cached serialization for this tick (or serialize if none yet)
         // IMPORTANT: needs FRAME TIME which doesn't change during THIS FRAME!
-        internal NetworkIdentitySerialization GetSerializationAtTick(float tickTimeStamp)
+        // IMPORTANT: DOUBLE PRECISION to avoid inaccuracies after several days.
+        //            see test: TestSerializationWithLargeTimestamps()
+        internal NetworkIdentitySerialization GetSerializationAtTick(double tickTimeStamp)
         {
             // serialize fresh if tick is newer than last one
             if (lastSerialization.tickTimeStamp < tickTimeStamp)

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -64,7 +64,7 @@ namespace Mirror.Tests.Runtime
         public IEnumerator TestSerializationWithLargeTimestamps()
         {
             // 14 * 24 hours per day * 60 minutes per hour * 60 seconds per minute = 14 days
-            float time = 14 * 24 * 60 * 60;
+            double time = 14 * 24 * 60 * 60;
             NetworkIdentitySerialization serialization = identity.GetSerializationAtTick(time);
             // advance time by 50ms (20 fps)
             time += 0.05f;

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -64,14 +64,15 @@ namespace Mirror.Tests.Runtime
         public IEnumerator TestSerializationWithLargeTimestamps()
         {
             // 14 * 24 hours per day * 60 minutes per hour * 60 seconds per minute = 14 days
-            double time = 14 * 24 * 60 * 60;
-            NetworkIdentitySerialization serialization = identity.GetSerializationAtTick(time);
-            // advance time by 50ms (20 fps)
-            time += 0.05f;
-            NetworkIdentitySerialization serializationNew = identity.GetSerializationAtTick(time);
+            // NOTE: change this to 'float' to see the tests fail
+            int tick = 14 * 24 * 60 * 60;
+            NetworkIdentitySerialization serialization = identity.GetSerializationAtTick(tick);
+            // advance tick
+            ++tick;
+            NetworkIdentitySerialization serializationNew = identity.GetSerializationAtTick(tick);
 
             // if the serialization has been changed the tickTimeStamp should have moved
-            Assert.That(serialization.tickTimeStamp == serializationNew.tickTimeStamp, Is.False);
+            Assert.That(serialization.tick == serializationNew.tick, Is.False);
             yield break;
         }
     }


### PR DESCRIPTION
risk free alternative to https://github.com/vis2k/Mirror/pull/2811