### PR TITLE
feat: Fix SyncList<NetworkIdentity/GameObject/NetworkBehaviour> fragility by caching network IDs

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviourCache.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviourCache.cs
@@ -1,0 +1,52 @@
+namespace Mirror
+{
+    /// <summary>
+    /// <para>Data type for storing NetworkBehaviour's network ID and component index.</para>
+    /// <para>Use <see cref="Get"/> to get reference to the stored NetworkBehaviour.</para>
+    /// </summary>
+    public struct NetworkBehaviourCache
+    {
+        public uint netId;
+        public byte componentIndex;
+
+        public NetworkBehaviourCache(uint netId, int componentIndex) : this()
+        {
+            this.netId = netId;
+            this.componentIndex = (byte)componentIndex;
+        }
+
+        public NetworkBehaviourCache(NetworkBehaviour behaviour) : this()
+        {
+            if (behaviour == null)
+            {
+                this.netId = 0;
+                this.componentIndex = 0;
+                return;
+            }
+            this.netId = behaviour.netId;
+            this.componentIndex = (byte)behaviour.ComponentIndex;
+        }
+
+        public bool Equals(NetworkBehaviourCache other)
+        {
+            return other.netId == netId && other.componentIndex == componentIndex;
+        }
+
+        public bool Equals(uint netId, int componentIndex)
+        {
+            return this.netId == netId && this.componentIndex == componentIndex;
+        }
+
+        public NetworkBehaviour Get()
+        {
+            if (!NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
+                return null;
+            return identity.NetworkBehaviours[componentIndex];
+        }
+
+        public override string ToString()
+        {
+            return $"[netId:{netId} compIndex:{componentIndex}]";
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/NetworkBehaviourCache.cs.meta
+++ b/Assets/Mirror/Runtime/NetworkBehaviourCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04a9f19073c5f6a438940e1d1fe38ee8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 7453abfe9e8b2c04a8a47eb536fe21eb, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -416,5 +416,12 @@ namespace Mirror
             string uriString = reader.ReadString();
             return (string.IsNullOrEmpty(uriString) ? null : new Uri(uriString));
         }
+
+        public static NetworkBehaviourCache ReadNetworkBehaviourCache(this NetworkReader reader)
+        {
+            uint netId = reader.ReadUInt();
+            byte componentIndex = netId == 0 ? (byte)0 : reader.ReadByte();
+            return new NetworkBehaviourCache(netId, componentIndex);
+        }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -451,5 +451,12 @@ namespace Mirror
                 writer.Write(segment.Array[segment.Offset + i]);
             }
         }
+
+        public static void WriteNetworkBehaviourCache(this NetworkWriter writer, NetworkBehaviourCache cache)
+        {
+            writer.WriteUInt(cache.netId);
+            if (cache.netId != 0)
+                writer.WriteByte(cache.componentIndex);
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SyncListCacheNetIdTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListCacheNetIdTest.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    public class SyncListCacheNetIdTest : MirrorEditModeTest
+    {
+        public static void SerializeAllTo<T>(T fromList, T toList) where T : SyncObject
+        {
+            NetworkWriter writer = new NetworkWriter();
+            fromList.OnSerializeAll(writer);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            toList.OnDeserializeAll(reader);
+
+            int writeLength = writer.Position;
+            int readLength = reader.Position;
+            Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
+
+        }
+
+        class DerivedBehaviour : NetworkBehaviour { }
+
+        [Test]
+        public void SyncListCacheNetIdForNetworkIdentity()
+        {
+            CreateNetworked(out GameObject _, out NetworkIdentity oldA);
+            oldA.netId = 1001;
+            NetworkIdentity.spawned[oldA.netId] = oldA;
+
+            CreateNetworked(out GameObject _, out NetworkIdentity oldB);
+            oldB.netId = 1002;
+            NetworkIdentity.spawned[oldB.netId] = oldB;
+
+            var serverList = new SyncList<NetworkIdentity>();
+            var clientList = new SyncList<NetworkIdentity>();
+
+            serverList.Add(oldA);
+            serverList.Add(oldB);
+
+            SerializeAllTo(serverList, clientList);
+
+            // check if client points to right value
+            Assert.That(clientList, Is.EquivalentTo(new[] { oldA, oldB }), "Should be synced correctly");
+
+            // objects hidden from client
+            NetworkIdentity.spawned.Remove(oldA.netId);
+            NetworkIdentity.spawned.Remove(oldB.netId);
+
+            // check if client points to null
+            Assert.That(clientList, Is.EquivalentTo(new NetworkIdentity[] { null, null }), "Should point to null for hidden objects");
+
+            // objects shown to client
+            CreateNetworked(out GameObject _, out NetworkIdentity newA);
+            newA.netId = 1001;
+            NetworkIdentity.spawned[newA.netId] = newA;
+
+            CreateNetworked(out GameObject _, out NetworkIdentity newB);
+            newB.netId = 1002;
+            NetworkIdentity.spawned[newB.netId] = newB;
+
+            // check if client points to new objects
+            Assert.That(clientList, Is.EquivalentTo(new[] { newA, newB }), "Should point to new objects");
+        }
+
+        [Test]
+        public void SyncListCacheNetIdForGameObject()
+        {
+            CreateNetworked(out GameObject _, out NetworkIdentity oldA);
+            oldA.netId = 1001;
+            NetworkIdentity.spawned[oldA.netId] = oldA;
+
+            CreateNetworked(out GameObject _, out NetworkIdentity oldB);
+            oldB.netId = 1002;
+            NetworkIdentity.spawned[oldB.netId] = oldB;
+
+            var serverList = new SyncList<GameObject>();
+            var clientList = new SyncList<GameObject>();
+
+            serverList.Add(oldA.gameObject);
+            serverList.Add(oldB.gameObject);
+
+            SerializeAllTo(serverList, clientList);
+
+            // check if client points to right value
+            Assert.That(clientList, Is.EquivalentTo(new[] { oldA.gameObject, oldB.gameObject }), "Should be synced correctly");
+
+            // objects hidden from client
+            NetworkIdentity.spawned.Remove(oldA.netId);
+            NetworkIdentity.spawned.Remove(oldB.netId);
+
+            // check if client points to null
+            Assert.That(clientList, Is.EquivalentTo(new NetworkIdentity[] { null, null }), "Should point to null for hidden objects");
+
+            // objects shown to client
+            CreateNetworked(out GameObject _, out NetworkIdentity newA);
+            newA.netId = 1001;
+            NetworkIdentity.spawned[newA.netId] = newA;
+
+            CreateNetworked(out GameObject _, out NetworkIdentity newB);
+            newB.netId = 1002;
+            NetworkIdentity.spawned[newB.netId] = newB;
+
+            // check if client points to new objects
+            Assert.That(clientList, Is.EquivalentTo(new[] { newA.gameObject, newB.gameObject }), "Should point to new objects");
+        }
+
+        [Test]
+        public void SyncListCacheNetIdForNetworkBehaviour()
+        {
+            CreateNetworked(out GameObject _, out NetworkIdentity _, out DerivedBehaviour oldA);
+            oldA.netIdentity.netId = 1001;
+            NetworkIdentity.spawned[oldA.netId] = oldA.netIdentity;
+
+            CreateNetworked(out GameObject _, out NetworkIdentity _, out DerivedBehaviour oldB);
+            oldB.netIdentity.netId = 1002;
+            NetworkIdentity.spawned[oldB.netId] = oldB.netIdentity;
+
+            var serverList = new SyncList<DerivedBehaviour>();
+            var clientList = new SyncList<DerivedBehaviour>();
+
+            serverList.Add(oldA);
+            serverList.Add(oldB);
+
+            SerializeAllTo(serverList, clientList);
+
+            // check if client points to right value
+            Assert.That(clientList, Is.EquivalentTo(new[] { oldA, oldB }), "Should be synced correctly");
+
+            // objects hidden from client
+            NetworkIdentity.spawned.Remove(oldA.netId);
+            NetworkIdentity.spawned.Remove(oldB.netId);
+
+            // check if client points to null
+            Assert.That(clientList, Is.EquivalentTo(new NetworkIdentity[] { null, null }), "Should point to null for hidden objects");
+
+            // objects shown to client
+            CreateNetworked(out GameObject _, out NetworkIdentity _, out DerivedBehaviour newA);
+            newA.netIdentity.netId = 1001;
+            NetworkIdentity.spawned[newA.netId] = newA.netIdentity;
+
+            CreateNetworked(out GameObject _, out NetworkIdentity _, out DerivedBehaviour newB);
+            newB.netIdentity.netId = 1002;
+            NetworkIdentity.spawned[newB.netId] = newB.netIdentity;
+
+            // check if client points to new objects
+            Assert.That(clientList, Is.EquivalentTo(new[] { newA, newB }), "Should point to new objects");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/SyncListCacheNetIdTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/SyncListCacheNetIdTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f430103b5daedb44a90ef318823386a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
SyncVars of `NetworkIdentity` and other networked objects internally use a field of netId to make them resilient when interest management happens.
This prevents SyncVars of those types from being forever null when the object is hidden to clients.
SyncLists don't do such caching, so if an interest management happens and object gets hidden, SyncLists will point to null forever.

This PR implements same care to SyncLists by making clients store `netId`s and `componentIndex`es instead of direct references to those networked objects. (`NetworkIdentity`, `GameObject`, `NetworkBehaviour`)

### What now works with this PR
```csharp
class Monster : NetworkBehaviour { }

class Human : NetworkBehaviour
{
    public readonly SyncList<Monster> pets = new SyncList<Monster>();
}

// ...

someHuman.pets.Add(rabbitMonster);

// ... Rabbit gets really far away and gets hidden

Debug.Log(someHuman.pets[0]); // is now null on client

// ... Rabbit gets closeby again

Debug.Log(someHuman.[0]); // points to rabbit again!

```

### Caveats
1. Some list operations are now a few lines longer, which will affect SyncList performance even non-networked object ones (although difference will be miniscule)
2. This does nothing if said networked objects are inside structs. e.g. `SyncList<StructWithNetIdentityField>`

### Alternatives we could perhaps consider?

1. Leave SyncList alone, and add several special traited types of SyncList.
e.g.
`SyncListNetworkBehaviour<T> where T : NetworkBehaviour`
`SyncListNetworkIdentity`
`SyncListGameObject`
or maybe a single type `SyncListNetworkedObject<T>` that supports caching of `NetworkIdentity`, `GameObject`, and `NetworkBehaviour`

2. Introduce `Syncable<T>` and make users use them like `SyncList<Syncable<GameObject>>`, `SyncList<Syncable<Monster>>`
(requires Weaver work, as it can't generate readers/writers for generic types)
```csharp
struct Syncable<T>
{
   public Syncable(T original)
   {
      // Store relevant data of networked object (netId, componentIndex)
   }
   
   public T Get()
   {
      // Dereference back to networked object
   }
}
```