### PR TITLE
fix: #2822 - OnClientDisconnect wasn't called for host disconnect because LocalConnectionToServer wouldn't call OnTransportDisconnected

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -150,11 +150,17 @@ namespace Mirror
             connectionToClient.DisconnectInternal();
             DisconnectInternal();
 
-            // this was in NetworkClient.Disconnect 'if isLocalConnection' before
-            // but it's clearly local connection related, so put it in here.
+            // simulate what a true remote connection would do:
+            // first, the server should remove it:
             // TODO should probably be in connectionToClient.DisconnectInternal
             //      because that's the NetworkServer's connection!
             NetworkServer.RemoveLocalConnection();
+
+            // then call OnTransportDisconnected for proper disconnect handling,
+            // callbacks & cleanups.
+            // => otherwise OnClientDisconnected() is never called!
+            // => see NetworkClientTests.DisconnectCallsOnClientDisconnect_HostMode()
+            NetworkClient.OnTransportDisconnected();
         }
 
         // true because local connections never timeout

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -368,7 +368,7 @@ namespace Mirror
         //            the disconnect immediately.
         //            => which is fine as long as we guarantee it only runs once
         //            => which we do by setting the state to Disconnected!
-        static void OnTransportDisconnected()
+        internal static void OnTransportDisconnected()
         {
             // StopClient called from user code triggers Disconnected event
             // from transport which calls StopClient again, so check here

--- a/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
@@ -60,7 +60,7 @@ namespace Mirror.Tests
         // - OnTransportDisconnected() early returns because
         //   state == Disconnected already, so it wouldn't call the event.
         [Test]
-        public void DisconnectCallsOnClientDisconnected()
+        public void DisconnectCallsOnClientDisconnected_Remote()
         {
             // setup hook
             bool called = false;
@@ -68,6 +68,26 @@ namespace Mirror.Tests
 
             // connect
             ConnectClientBlocking(out _);
+
+            // disconnect & process everything
+            NetworkClient.Disconnect();
+            UpdateTransport();
+
+            // was it called?
+            Assert.That(called, Is.True);
+        }
+
+        // same as above, but for host mode
+        // prevents https://github.com/vis2k/Mirror/issues/2818 forever.
+        [Test]
+        public void DisconnectCallsOnClientDisconnected_HostMode()
+        {
+            // setup hook
+            bool called = false;
+            NetworkClient.OnDisconnectedEvent = () => called = true;
+
+            // connect host
+            NetworkClient.ConnectHost();
 
             // disconnect & process everything
             NetworkClient.Disconnect();


### PR DESCRIPTION
test added to prevent it in the future too.