### PR TITLE
feat: Expose NetworkEarlyUpdate/NetworkLateUpdate

### DIFF
--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -45,6 +45,9 @@ namespace Mirror
         // helper enum to add loop to begin/end of subSystemList
         internal enum AddMode { Beginning, End }
 
+        public static Action OnEarlyUpdate;
+        public static Action OnLateUpdate;
+
         // helper function to find an update function's index in a player loop
         // type. this is used for testing to guarantee our functions are added
         // at the beginning/end properly.
@@ -180,6 +183,7 @@ namespace Mirror
             //Debug.Log("NetworkEarlyUpdate @ " + Time.time);
             NetworkServer.NetworkEarlyUpdate();
             NetworkClient.NetworkEarlyUpdate();
+            OnEarlyUpdate?.Invoke();
         }
 
         static void NetworkLateUpdate()
@@ -187,6 +191,7 @@ namespace Mirror
             //Debug.Log("NetworkLateUpdate @ " + Time.time);
             NetworkServer.NetworkLateUpdate();
             NetworkClient.NetworkLateUpdate();
+            OnLateUpdate?.Invoke();
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -190,6 +190,9 @@ namespace Mirror
 
             // setup OnSceneLoaded callback
             SceneManager.sceneLoaded += OnSceneLoaded;
+
+            NetworkLoop.OnEarlyUpdate += NetworkEarlyUpdate;
+            NetworkLoop.OnLateUpdate += NetworkLateUpdate;
         }
 
         // virtual so that inheriting classes' Start() can call base.Start() too
@@ -723,6 +726,9 @@ namespace Mirror
         public virtual void OnDestroy()
         {
             //Debug.Log("NetworkManager destroyed");
+
+            NetworkLoop.OnEarlyUpdate -= NetworkEarlyUpdate;
+            NetworkLoop.OnLateUpdate -= NetworkLateUpdate;
         }
 
         /// <summary>The name of the current network scene.</summary>
@@ -1317,5 +1323,11 @@ namespace Mirror
 
         /// <summary>This is called when a host is stopped.</summary>
         public virtual void OnStopHost() {}
+
+        /// <summary> This is called during the early update phase of the network loop. Before unity's Update() </summary>
+        public virtual void NetworkEarlyUpdate() {}
+
+        /// <summary> This is called during the late update phase of the network loop. After unity's LateUpdate() </summary>
+        public virtual void NetworkLateUpdate() {}
     }
 }


### PR DESCRIPTION
A little feature so people who could make use of the existing early/late update can use it easily.

Both are called after mirror does it's processing, which is probably the most useful