### PR TITLE
fix: Prevent recursion overflow when stopping

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -579,7 +579,7 @@ namespace Mirror
         /// <summary>Stops and disconnects the client.</summary>
         public void StopClient()
         {
-            // Recursion prevention
+            // return if already stopped to avoid recursion deadlock
             if (!isNetworkActive)
                 return;
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -532,8 +532,11 @@ namespace Mirror
         /// <summary>Stops the server from listening and simulating the game.</summary>
         public void StopServer()
         {
-            if (!NetworkServer.active)
+            // Recursion prevention
+            if (!isNetworkActive)
                 return;
+
+            //Debug.Log("NetworkManager StopServer");
 
             if (authenticator != null)
             {
@@ -553,10 +556,10 @@ namespace Mirror
                 SceneManager.MoveGameObjectToScene(gameObject, SceneManager.GetActiveScene());
 #pragma warning restore 618
 
+            isNetworkActive = false;
+
             OnStopServer();
 
-            //Debug.Log("NetworkManager StopServer");
-            isNetworkActive = false;
             NetworkServer.Shutdown();
 
             // set offline mode BEFORE changing scene so that FinishStartScene
@@ -576,6 +579,12 @@ namespace Mirror
         /// <summary>Stops and disconnects the client.</summary>
         public void StopClient()
         {
+            // Recursion prevention
+            if (!isNetworkActive)
+                return;
+
+            //Debug.Log("NetworkManager StopClient");
+
             if (authenticator != null)
             {
                 authenticator.OnClientAuthenticated.RemoveListener(OnClientAuthenticated);
@@ -594,10 +603,9 @@ namespace Mirror
                 SceneManager.MoveGameObjectToScene(gameObject, SceneManager.GetActiveScene());
 #pragma warning restore 618
 
-            OnStopClient();
-
-            //Debug.Log("NetworkManager StopClient");
             isNetworkActive = false;
+
+            OnStopClient();
 
             // shutdown client
             NetworkClient.Disconnect();

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -532,7 +532,7 @@ namespace Mirror
         /// <summary>Stops the server from listening and simulating the game.</summary>
         public void StopServer()
         {
-            // Recursion prevention
+            // return if already stopped to avoid recursion deadlock
             if (!isNetworkActive)
                 return;
 


### PR DESCRIPTION
Calling StopServer from OnStartServer or StopClient from OnStopClient (or from user code invoked from those virtual methods) would create a recursion overflow.

This PR moves the setting of `isNetworkActive = false;` up above the virtual method calls in both cases, and adds a check to early out if false to prevent recursion and overflow.

Debug logs were also moved up nearer the top of the method.

Fixes: #2080