### PR TITLE
feat: Transport Exception Handling

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -74,6 +74,7 @@ namespace Mirror
         // => public so that custom NetworkManagers can hook into it
         public static Action OnConnectedEvent;
         public static Action OnDisconnectedEvent;
+        public static Action<Exception> OnErrorEvent;
 
         /// <summary>Registered spawnable prefabs by assetId.</summary>
         public static readonly Dictionary<Guid, GameObject> prefabs =
@@ -386,7 +387,11 @@ namespace Mirror
             connection = null;
         }
 
-        static void OnError(Exception exception) => Debug.LogException(exception);
+        static void OnError(Exception exception)
+        {
+            Debug.LogException(exception);
+            OnErrorEvent?.Invoke(exception);
+        }
 
         // send ////////////////////////////////////////////////////////////////
         /// <summary>Send a NetworkMessage to the server over the given channel.</summary>

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -685,6 +685,7 @@ namespace Mirror
         {
             NetworkServer.OnConnectedEvent = OnServerConnectInternal;
             NetworkServer.OnDisconnectedEvent = OnServerDisconnect;
+            NetworkServer.OnErrorEvent = OnServerError;
             NetworkServer.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerInternal);
 
             // Network Server initially registers its own handler for this, so we replace it here.
@@ -695,6 +696,7 @@ namespace Mirror
         {
             NetworkClient.OnConnectedEvent = OnClientConnectInternal;
             NetworkClient.OnDisconnectedEvent = OnClientDisconnectInternal;
+            NetworkClient.OnErrorEvent = OnClientError;
             NetworkClient.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal);
             NetworkClient.RegisterHandler<SceneMessage>(OnClientSceneInternal, false);
 
@@ -1230,7 +1232,10 @@ namespace Mirror
 
         // Deprecated 2021-02-13
         [Obsolete("OnServerError was removed because it hasn't been used in a long time.")]
-        public virtual void OnServerError(NetworkConnection conn, int errorCode) {}
+        public virtual void OnServerError(NetworkConnection conn, int errorCode) { }
+
+        /// <summary>Called on server when transport raises an exception.</summary>
+        public virtual void OnServerError(Exception exception) { }
 
         /// <summary>Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed</summary>
         public virtual void OnServerChangeScene(string newSceneName) {}
@@ -1267,7 +1272,10 @@ namespace Mirror
 
         // Deprecated 2021-02-13
         [Obsolete("OnClientError was removed because it hasn't been used in a long time.")]
-        public virtual void OnClientError(NetworkConnection conn, int errorCode) {}
+        public virtual void OnClientError(NetworkConnection conn, int errorCode) { }
+
+        /// <summary>Called on client when transport raises an exception.</summary>
+        public virtual void OnClientError(Exception exception) { }
 
         /// <summary>Called on clients when a servers tells the client it is no longer ready, e.g. when switching scenes.</summary>
         // TODO client only ever uses NetworkClient.connection. this parameter is redundant.

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1234,8 +1234,8 @@ namespace Mirror
         [Obsolete("OnServerError was removed because it hasn't been used in a long time.")]
         public virtual void OnServerError(NetworkConnection conn, int errorCode) { }
 
-        /// <summary>Called on server when transport raises an exception.</summary>
-        public virtual void OnServerError(Exception exception) { }
+        /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
+        public virtual void OnServerError(NetworkConnection conn, Exception exception) { }
 
         /// <summary>Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed</summary>
         public virtual void OnServerChangeScene(string newSceneName) {}

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1232,10 +1232,10 @@ namespace Mirror
 
         // Deprecated 2021-02-13
         [Obsolete("OnServerError was removed because it hasn't been used in a long time.")]
-        public virtual void OnServerError(NetworkConnection conn, int errorCode) { }
+        public virtual void OnServerError(NetworkConnection conn, int errorCode) {}
 
         /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
-        public virtual void OnServerError(NetworkConnection conn, Exception exception) { }
+        public virtual void OnServerError(NetworkConnection conn, Exception exception) {}
 
         /// <summary>Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed</summary>
         public virtual void OnServerChangeScene(string newSceneName) {}
@@ -1272,10 +1272,10 @@ namespace Mirror
 
         // Deprecated 2021-02-13
         [Obsolete("OnClientError was removed because it hasn't been used in a long time.")]
-        public virtual void OnClientError(NetworkConnection conn, int errorCode) { }
+        public virtual void OnClientError(NetworkConnection conn, int errorCode) {}
 
         /// <summary>Called on client when transport raises an exception.</summary>
-        public virtual void OnClientError(Exception exception) { }
+        public virtual void OnClientError(Exception exception) {}
 
         /// <summary>Called on clients when a servers tells the client it is no longer ready, e.g. when switching scenes.</summary>
         // TODO client only ever uses NetworkClient.connection. this parameter is redundant.

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -55,6 +55,7 @@ namespace Mirror
         // => public so that custom NetworkManagers can hook into it
         public static Action<NetworkConnection> OnConnectedEvent;
         public static Action<NetworkConnection> OnDisconnectedEvent;
+        public static Action<Exception> OnErrorEvent;
 
         // initialization / shutdown ///////////////////////////////////////////
         static void Initialize()
@@ -518,8 +519,8 @@ namespace Mirror
 
         static void OnError(int connectionId, Exception exception)
         {
-            // TODO Let's discuss how we will handle errors
             Debug.LogException(exception);
+            OnErrorEvent?.Invoke(exception);
         }
 
         // message handlers ////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -520,10 +520,9 @@ namespace Mirror
         static void OnError(int connectionId, Exception exception)
         {
             Debug.LogException(exception);
-            if (connections.TryGetValue(connectionId, out NetworkConnectionToClient conn))
-                OnErrorEvent?.Invoke(conn, exception);
-            else
-                OnErrorEvent?.Invoke(null, exception);
+            // try get connection. passes null otherwise.
+            connections.TryGetValue(connectionId, out NetworkConnectionToClient conn);
+            OnErrorEvent?.Invoke(conn, exception);
         }
 
         // message handlers ////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -55,7 +55,7 @@ namespace Mirror
         // => public so that custom NetworkManagers can hook into it
         public static Action<NetworkConnection> OnConnectedEvent;
         public static Action<NetworkConnection> OnDisconnectedEvent;
-        public static Action<Exception> OnErrorEvent;
+        public static Action<NetworkConnection, Exception> OnErrorEvent;
 
         // initialization / shutdown ///////////////////////////////////////////
         static void Initialize()
@@ -520,7 +520,10 @@ namespace Mirror
         static void OnError(int connectionId, Exception exception)
         {
             Debug.LogException(exception);
-            OnErrorEvent?.Invoke(exception);
+            if (connections.TryGetValue(connectionId, out NetworkConnectionToClient conn))
+                OnErrorEvent?.Invoke(conn, exception);
+            else
+                OnErrorEvent?.Invoke(null, exception);
         }
 
         // message handlers ////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -89,7 +89,10 @@ namespace Mirror
         /// <summary>Called by Transport when the server received a message from a client.</summary>
         public Action<int, ArraySegment<byte>, int> OnServerDataReceived = (connId, data, channel) => Debug.LogWarning("OnServerDataReceived called with no handler");
 
-        /// <summary>Called by Transport when a server's connection encountered a problem.</summary>
+        /// <summary>
+        /// Called by Transport when a server's connection encountered a problem.
+        /// <para>If a Disconnect will also be raised, raise the Error first.</para>
+        /// </summary>
         public Action<int, Exception> OnServerError = (connId, error) => Debug.LogWarning("OnServerError called with no handler");
 
         /// <summary>Called by Transport when a client disconnected from the server.</summary>

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -89,10 +89,8 @@ namespace Mirror
         /// <summary>Called by Transport when the server received a message from a client.</summary>
         public Action<int, ArraySegment<byte>, int> OnServerDataReceived = (connId, data, channel) => Debug.LogWarning("OnServerDataReceived called with no handler");
 
-        /// <summary>
-        /// Called by Transport when a server's connection encountered a problem.
-        /// <para>If a Disconnect will also be raised, raise the Error first.</para>
-        /// </summary>
+        /// <summary>Called by Transport when a server's connection encountered a problem.</summary>
+        /// If a Disconnect will also be raised, raise the Error first.
         public Action<int, Exception> OnServerError = (connId, error) => Debug.LogWarning("OnServerError called with no handler");
 
         /// <summary>Called by Transport when a client disconnected from the server.</summary>

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -158,8 +158,8 @@ public class #SCRIPTNAME# : NetworkManager
         base.OnServerDisconnect(conn);
     }
 
-    /// <summary>Called on server when transport raises an exception.</summary>
-    public override void OnServerError(Exception exception) { }
+    /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
+    public override void OnServerError(NetworkConnection conn, Exception exception) { }
 
     #endregion
 

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -158,7 +158,12 @@ public class #SCRIPTNAME# : NetworkManager
         base.OnServerDisconnect(conn);
     }
 
-    /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
+    /// <summary>
+    /// Called on server when transport raises an exception.
+    /// <para>NetworkConnection may be null.</para>
+    /// </summary>
+    /// <param name="conn">Connection of the client...may be null</param>
+    /// <param name="exception">Exception thrown from the Transport.</param>
     public override void OnServerError(NetworkConnection conn, Exception exception) { }
 
     #endregion
@@ -192,7 +197,10 @@ public class #SCRIPTNAME# : NetworkManager
     /// <param name="conn">Connection to the server.</param>
     public override void OnClientNotReady(NetworkConnection conn) { }
 
-    /// <summary>Called on client when transport raises an exception.</summary>
+    /// <summary>
+    /// Called on client when transport raises an exception.</summary>
+    /// </summary>
+    /// <param name="exception">Exception thrown from the Transport.</param>
     public override void OnClientError(Exception exception) { }
 
     #endregion

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -158,6 +158,9 @@ public class #SCRIPTNAME# : NetworkManager
         base.OnServerDisconnect(conn);
     }
 
+    /// <summary>Called on server when transport raises an exception.</summary>
+    public virtual void OnServerError(Exception exception) { }
+
     #endregion
 
     #region Client System Callbacks
@@ -188,6 +191,9 @@ public class #SCRIPTNAME# : NetworkManager
     /// </summary>
     /// <param name="conn">Connection to the server.</param>
     public override void OnClientNotReady(NetworkConnection conn) { }
+
+    /// <summary>Called on client when transport raises an exception.</summary>
+    public virtual void OnClientError(Exception exception) { }
 
     #endregion
 

--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -159,7 +159,7 @@ public class #SCRIPTNAME# : NetworkManager
     }
 
     /// <summary>Called on server when transport raises an exception.</summary>
-    public virtual void OnServerError(Exception exception) { }
+    public override void OnServerError(Exception exception) { }
 
     #endregion
 
@@ -193,7 +193,7 @@ public class #SCRIPTNAME# : NetworkManager
     public override void OnClientNotReady(NetworkConnection conn) { }
 
     /// <summary>Called on client when transport raises an exception.</summary>
-    public virtual void OnClientError(Exception exception) { }
+    public override void OnClientError(Exception exception) { }
 
     #endregion
 


### PR DESCRIPTION
Transports can raise OnServerError and OnClientError
Both are propagated up through NetworkServer & NetworkClient & NetworkManager
Virtual methods added to Network Manager and Template

Fixes: #2782