### PR TITLE
fix: OnDeserializeAllSafely null check

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1008,7 +1008,7 @@ namespace Mirror
             {
                 // read & check index [0..255]
                 byte index = reader.ReadByte();
-                if (index < components.Length)
+                if (components != null && index < components.Length)
                 {
                     // deserialize this component
                     OnDeserializeSafely(components[index], reader, initialState);


### PR DESCRIPTION
As our game need to enable/disable player objects instead of instantiating new objects each time a player joins, we are calling `NetworkServer.AddPlayerForConnection` method and passing our already existing player object. For some reasons, on our standalone build, when trying to connect as a client to the editor that is running as a server only, we get an exception and the connection shuts down : 

```Exception in MessageHandler: NullReferenceException Object reference not set to an instance of an object   at Mirror.NetworkIdentity.OnDeserializeAllSafely```

Strangely, if trying to reconnect, everything works as expected, so it's only on the first connection that this happens. After going down the rabbit hole of stack tracing, I figured out that the issue in `OnDeserializeAllSafely` is on line `1011`  `if (index < components.Length)`. For some reasons `components` is null in our case and throws an error. Adding a simple null checker fixes the issue for us.

However, this might totally be a misunderstanding on how we should handle assigning player objects in the first place.