### PR TITLE
feat: NetworkTime.localTime/.time is now frame time

### DIFF
--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -178,6 +178,7 @@ namespace Mirror
         static void NetworkEarlyUpdate()
         {
             //Debug.Log("NetworkEarlyUpdate @ " + Time.time);
+            NetworkTime.NetworkEarlyUpdate();
             NetworkServer.NetworkEarlyUpdate();
             NetworkClient.NetworkEarlyUpdate();
         }


### PR DESCRIPTION
This is for consistency, a frame is should be simulated for a fixed point in time, no matter how long simulation takes
This mirrors how Time.time works

