### PR TITLE
fix: NetworkBehaviour dirty check uses double time

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -24,7 +24,7 @@ namespace Mirror
         [Tooltip("Time in seconds until next change is synchronized to the client. '0' means send immediately if changed. '0.5' means only send changes every 500ms.\n(This is for state synchronization like SyncVars, SyncLists, OnSerialize. Not for Cmds, Rpcs, etc.)")]
         [Range(0, 2)]
         [HideInInspector] public float syncInterval = 0.1f;
-        internal float lastSyncTime;
+        internal double lastSyncTime;
 
         /// <summary>True if this object is on the server and has been spawned.</summary>
         // This is different from NetworkServer.active, which is true if the
@@ -477,7 +477,7 @@ namespace Mirror
         // be called manually as well.
         public void ClearAllDirtyBits()
         {
-            lastSyncTime = Time.time;
+            lastSyncTime = NetworkTime.localTime;
             syncVarDirtyBits = 0L;
 
             // flush all unsynchronized changes in syncobjects
@@ -508,7 +508,7 @@ namespace Mirror
         // true if syncInterval elapsed and any SyncVar or SyncObject is dirty
         public bool IsDirty()
         {
-            if (Time.time - lastSyncTime >= syncInterval)
+            if (NetworkTime.localTime - lastSyncTime >= syncInterval)
             {
                 return syncVarDirtyBits != 0L || AnySyncObjectDirty();
             }

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -68,7 +68,7 @@ namespace Mirror.Tests.SyncVarTests
         public void TestSyncIntervalAndClearDirtyComponents()
         {
             CreateNetworked(out GameObject gameObject, out NetworkIdentity identity, out MockPlayer player);
-            player.lastSyncTime = Time.time;
+            player.lastSyncTime = NetworkTime.localTime;
             // synchronize immediately
             player.syncInterval = 1f;
 
@@ -84,7 +84,7 @@ namespace Mirror.Tests.SyncVarTests
             player.netIdentity.ClearDirtyComponentsDirtyBits();
 
             // set lastSyncTime far enough back to be ready for syncing
-            player.lastSyncTime = Time.time - player.syncInterval;
+            player.lastSyncTime = NetworkTime.localTime - player.syncInterval;
 
             // should be dirty now
             Assert.That(player.IsDirty(), Is.True, "Sync interval met, should be dirty");
@@ -94,7 +94,7 @@ namespace Mirror.Tests.SyncVarTests
         public void TestSyncIntervalAndClearAllComponents()
         {
             CreateNetworked(out GameObject gameObject, out NetworkIdentity identity, out MockPlayer player);
-            player.lastSyncTime = Time.time;
+            player.lastSyncTime = NetworkTime.localTime;
             // synchronize immediately
             player.syncInterval = 1f;
 
@@ -110,7 +110,7 @@ namespace Mirror.Tests.SyncVarTests
             player.netIdentity.ClearAllComponentsDirtyBits();
 
             // set lastSyncTime far enough back to be ready for syncing
-            player.lastSyncTime = Time.time - player.syncInterval;
+            player.lastSyncTime = NetworkTime.localTime - player.syncInterval;
 
             // should be dirty now
             Assert.That(player.IsDirty(), Is.False, "Sync interval met, should still not be dirty");


### PR DESCRIPTION
Currently the float time will run out of precision and start skipping being dirty after ~a week of runtime.
Here's the tank example after 30 days of runtime with float time: https://share.dl.je/2021/07/2021-07-07_17-16-23_EKInti5s4v.mp4 (not fps lag)
Using double time fixes this

This should probably be used with #2838 to not encounter weird edge cases