### PR TITLE
fix: NetworkAnimator uses double time

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -196,7 +196,7 @@ namespace Mirror
 
         void CheckSendRate()
         {
-            float now = Time.time;
+            double now = NetworkTime.localTime;
             if (SendMessagesAllowed && syncInterval >= 0 && now > nextSendTime)
             {
                 nextSendTime = now + syncInterval;

--- a/Assets/Mirror/Runtime/NetworkLoop.cs
+++ b/Assets/Mirror/Runtime/NetworkLoop.cs
@@ -178,6 +178,7 @@ namespace Mirror
         static void NetworkEarlyUpdate()
         {
             //Debug.Log("NetworkEarlyUpdate @ " + Time.time);
+            NetworkTime.NetworkEarlyUpdate();
             NetworkServer.NetworkEarlyUpdate();
             NetworkClient.NetworkEarlyUpdate();
         }


### PR DESCRIPTION
Currently the float time will run out of precision and start skipping being dirty after ~a week of runtime.


This should probably be used with #2838 to not encounter weird edge cases