### PR TITLE
Added HUD Note for networkAddress

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHUD.cs
@@ -77,6 +77,7 @@ namespace Mirror
                 GUILayout.BeginHorizontal();
                 if (GUILayout.Button("Client"))
                 {
+                    // note: networkAddress should be set before calling StartClient();
                     manager.StartClient();
                 }
                 manager.networkAddress = GUILayout.TextField(manager.networkAddress);


### PR DESCRIPTION
Discord user was creating their own Canvas HUD, used this as template, manager.networkAddress in here is being set after calling StartClient(), which only works as its updating constantly in OnGUI.
Code should be changed round to show proper ordering, or for now a quick note?