### PR TITLE
breaking: NetworkWriter inherits from Stream for compatibility with third party libraries.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -131,7 +131,7 @@ namespace Mirror
             {
                 // pack message and send allocation free
                 MessagePacking.Pack(message, writer);
-                NetworkDiagnostics.OnSend(message, channelId, writer.Position, 1);
+                NetworkDiagnostics.OnSend(message, channelId, (int)writer.Position, 1);
                 Send(writer.ToArraySegment(), channelId);
             }
         }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -840,9 +840,9 @@ namespace Mirror
             // write placeholder length bytes
             // (jumping back later is WAY faster than allocating a temporary
             //  writer for the payload, then writing payload.size, payload)
-            int headerPosition = writer.Position;
+            int headerPosition = (int)writer.Position;
             writer.WriteInt(0);
-            int contentPosition = writer.Position;
+            int contentPosition = (int)writer.Position;
 
             // write payload
             bool result = false;
@@ -855,7 +855,7 @@ namespace Mirror
                 // show a detailed error and let the user know what went wrong
                 Debug.LogError("OnSerialize failed for: object=" + name + " component=" + comp.GetType() + " sceneId=" + sceneId.ToString("X") + "\n\n" + e);
             }
-            int endPosition = writer.Position;
+            int endPosition = (int)writer.Position;
 
             // fill in length now
             writer.Position = headerPosition;
@@ -895,7 +895,7 @@ namespace Mirror
 
                     // remember start position in case we need to copy it into
                     // observers writer too
-                    int startPosition = ownerWriter.Position;
+                    int startPosition = (int)ownerWriter.Position;
 
                     // write index as byte [0..255]
                     ownerWriter.WriteByte((byte)i);
@@ -917,7 +917,7 @@ namespace Mirror
                     if (comp.syncMode == SyncMode.Observers)
                     {
                         ArraySegment<byte> segment = ownerWriter.ToArraySegment();
-                        int length = ownerWriter.Position - startPosition;
+                        int length = (int)ownerWriter.Position - startPosition;
                         observersWriter.WriteBytes(segment.Array, startPosition, length);
                         ++observersWritten;
                     }

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -5,7 +5,7 @@ namespace Mirror
     /// <summary>Pooled NetworkWriter, automatically returned to pool when using 'using'</summary>
     public sealed class PooledNetworkWriter : NetworkWriter, IDisposable
     {
-        public void Dispose() => NetworkWriterPool.Recycle(this);
+        public new void Dispose() => NetworkWriterPool.Recycle(this);
     }
 
     /// <summary>Pool of NetworkWriters to avoid allocations.</summary>

--- a/Assets/Mirror/Tests/Editor/MessageInheritanceTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessageInheritanceTest.cs
@@ -59,7 +59,7 @@ namespace Mirror.Tests.MessageTests
             Assert.AreEqual(3, received.parentValue);
             Assert.AreEqual(4, received.childValue);
 
-            int writeLength = writer.Position;
+            int writeLength = (int)writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }
@@ -88,7 +88,7 @@ namespace Mirror.Tests.MessageTests
             Assert.AreEqual(message, received.message);
             Assert.AreEqual(responseId, received.responseId);
 
-            int writeLength = writer.Position;
+            int writeLength = (int)writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }
@@ -117,7 +117,7 @@ namespace Mirror.Tests.MessageTests
             Assert.AreEqual(message, received.message);
             Assert.AreEqual(responseId, received.responseId);
 
-            int writeLength = writer.Position;
+            int writeLength = (int)writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }

--- a/Assets/Mirror/Tests/Editor/StructMessagesTests.cs
+++ b/Assets/Mirror/Tests/Editor/StructMessagesTests.cs
@@ -28,7 +28,7 @@ namespace Mirror.Tests.StructMessages
 
             Assert.AreEqual(someValue, received.someValue);
 
-            int writeLength = writer.Position;
+            int writeLength = (int)writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -17,7 +17,7 @@ namespace Mirror.Tests
             NetworkReader reader = new NetworkReader(writer.ToArray());
             toList.OnDeserializeAll(reader);
 
-            int writeLength = writer.Position;
+            int writeLength = (int)writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeAll and OnDeserializeAll calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
 
@@ -31,7 +31,7 @@ namespace Mirror.Tests
             toList.OnDeserializeDelta(reader);
             fromList.Flush();
 
-            int writeLength = writer.Position;
+            int writeLength = (int)writer.Position;
             int readLength = reader.Position;
             Assert.That(writeLength == readLength, $"OnSerializeDelta and OnDeserializeDelta calls write the same amount of data\n    writeLength={writeLength}\n    readLength={readLength}");
         }

--- a/Assets/Mirror/Tests/Editor/SyncVarTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTestBase.cs
@@ -17,7 +17,7 @@ namespace Mirror.Tests
         {
             NetworkWriter writer = new NetworkWriter();
             bool written = serverObject.OnSerialize(writer, initialState);
-            writeLength = writer.Position;
+            writeLength = (int)writer.Position;
             data = writer.ToArraySegment();
             return written;
         }


### PR DESCRIPTION
third party libraries like delta compression have two ways to return binary results:

- allocate a new byte[] of result size.
- write into a C# 'Stream' that was passed. this avoids allocations.

until now, Mirror's NetworkWriter/Reader didn't need to interact with third party libraries much.
with delta compression, we need to put the result into a Mirror NetworkWriter.

- atm we would need to pass a helper MemoryStream to delta compression. then memcpy its contents to NetworkWriter
- if NetworkWriter inherits from the abstract Stream class, then we can pass it directly to delta compression

NOTE that this will be useful for all third party library binary interactions. today it's for delta compression.

BREAKING: .Position is now long, so users may need to cast to (int) here and there.


**EDIT: may not be necessary for delta compression. leaving open for now. might still be useful in general.**