### PR TITLE
Amend HasAmountOlderThan() - SnapshotInterpolation.cs

### DIFF
--- a/Assets/Mirror/Runtime/SnapshotInterpolation/SnapshotInterpolation.cs
+++ b/Assets/Mirror/Runtime/SnapshotInterpolation/SnapshotInterpolation.cs
@@ -177,7 +177,7 @@ namespace Mirror
             // we always need two OLD ENOUGH snapshots to interpolate.
             // otherwise there's nothing to do.
             double threshold = time - bufferTime;
-            if (!HasAmountOlderThan(buffer, threshold, 2, bufferedTime))
+            if (!HasAmountOlderThan(buffer, threshold, 2, bufferTime))
                 return false;
 
             // multiply deltaTime by catchup.

--- a/Assets/Mirror/Runtime/SnapshotInterpolation/SnapshotInterpolation.cs
+++ b/Assets/Mirror/Runtime/SnapshotInterpolation/SnapshotInterpolation.cs
@@ -228,7 +228,7 @@ namespace Mirror
             //            and then in next compute() wait again because it
             //            wasn't old enough yet.
             while (interpolationTime >= delta &&
-                   HasAmountOlderThan(buffer, threshold, 3, bufferedTime))
+                   HasAmountOlderThan(buffer, threshold, 3, bufferTime))
             {
                 // subtract exactly delta from interpolation time
                 // instead of setting to '0', where we would lose the
@@ -296,7 +296,7 @@ namespace Mirror
             //   instantly instead of actually interpolating through them.
             //
             // in other words, if we DON'T have >= 3 old enough.
-            if (!HasAmountOlderThan(buffer, threshold, 3, bufferedTime))
+            if (!HasAmountOlderThan(buffer, threshold, 3, bufferTime))
             {
                 // interpolationTime is always from 0..delta.
                 // so we cap it at delta.


### PR DESCRIPTION
Instead of checking only if X (threshold) time passes since the required snapshot, it should also check if there exists a subsequent snapshot that when compared with the required snapshot (difference in remoteTimestamp), there is enough time interval between them to cover the buffer time.
This allows a better reaction in the snapshot interpolation, if for some reason, a lot of snapshots are received in a short period of time.