### PR TITLE
Add NetworkBehaviour.hasClientOrServerAuthority

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -47,7 +47,7 @@ namespace Mirror
         // keeping this ridiculous summary as a reminder of a time long gone...
         public bool hasAuthority => netIdentity.hasAuthority;
         
-        /// <summary>This returns true if the current client or server has authority over the obect.</summary>
+        /// <summary>This returns true if the current client or server has authority over the object.</summary>
         public bool hasClientOrServerAuthority =>  hasAuthority || (isServer && connectionToClient == null);
 
         /// <summary>The unique network Id of this object (unique at runtime).</summary>

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -46,6 +46,9 @@ namespace Mirror
         /// <summary>This returns true if this object is the authoritative version of the object in the distributed network application.</summary>
         // keeping this ridiculous summary as a reminder of a time long gone...
         public bool hasAuthority => netIdentity.hasAuthority;
+        
+        /// <summary>This returns true if the current client or server has authority over the obect.</summary>
+        public bool hasClientOrServerAuthority =>  hasAuthority || (isServer && connectionToClient == null);
 
         /// <summary>The unique network Id of this object (unique at runtime).</summary>
         public uint netId => netIdentity.netId;


### PR DESCRIPTION
When the same NetworkBehaviour is sometime owned by a client or the server you can't rely on `hasAuthority` to do the owner-only logic you need inside it.

I'm not sure about the naming and the description, but i think it would be info to have, what do you think ?