### PR TITLE
feat: Prevent Nested Network Identities

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -8,10 +8,10 @@ using UnityEngine.Serialization;
     using UnityEditor;
     using System.Linq;
 
-#if UNITY_2021_2_OR_NEWER
+    #if UNITY_2021_2_OR_NEWER
         using UnityEditor.SceneManagement;
-#elif UNITY_2018_3_OR_NEWER
-using UnityEditor.Experimental.SceneManagement;
+    #elif UNITY_2018_3_OR_NEWER
+        using UnityEditor.Experimental.SceneManagement;
     #endif
 #endif
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1197,16 +1197,6 @@ namespace Mirror
             // This fires in editor when adding a component to an object
             //Debug.Log("NetworkIdentity:Reset");
 
-            // Prevent adding NetworkIdentity to NetworkManager
-            // This adds NO dependency on the presence of a NetworkManager component,
-            // only that NetworkManager class exists in Mirror, which it will forever.
-            if (transform.root.GetComponentInChildren<NetworkManager>() != null)
-            {
-                Debug.LogError("NetworkIdentity cannot be added to the same object hierarchy as NetworkManager.");
-                DestroyImmediate(this, true);
-                return;
-            }
-
             // Prevent adding NetworkIdentity to parent or child of another NetworkIdentity
             foreach (NetworkIdentity networkIdentity in transform.root.GetComponentsInChildren<NetworkIdentity>().ToList())
                 if (networkIdentity != this)

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1195,9 +1195,11 @@ namespace Mirror
         {
 #if UNITY_EDITOR
             // This fires in editor when adding a component to an object
-            Debug.Log("NetworkIdentity:Reset");
+            //Debug.Log("NetworkIdentity:Reset");
 
             // Prevent adding NetworkIdentity to NetworkManager
+            // This adds NO dependency on the presence of a NetworkManager component,
+            // only that NetworkManager class exists in Mirror, which it will forever.
             if (transform.root.GetComponentInChildren<NetworkManager>() != null)
             {
                 Debug.LogError("NetworkIdentity cannot be added to the same object hierarchy as NetworkManager.");


### PR DESCRIPTION
See also https://github.com/vis2k/Mirror/pull/2869

Uses OnValidate and Reset to prevent users from adding components that would conflict that Unity can't catch on its own:

- NetworkIdentity in same object hierarchy as NetworkManager
- NetworkIdentity in same object hierarchy as another NetworkIdentity (prevents nesting)
