### PR TITLE
NTB.cs defines for OnGUI

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -459,6 +459,7 @@ namespace Mirror
             bufferSizeLimit = Mathf.Max(bufferTimeMultiplier, bufferSizeLimit);
         }
 
+        #if UNITY_EDITOR || DEVELOPMENT_BUILD
         // debug ///////////////////////////////////////////////////////////////
         protected virtual void OnGUI()
         {
@@ -498,6 +499,7 @@ namespace Mirror
                 GUI.color = Color.white;
             }
         }
+        #endif
 
         protected virtual void DrawGizmos(SortedList<double, NTSnapshot> buffer)
         {

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -459,7 +459,8 @@ namespace Mirror
             bufferSizeLimit = Mathf.Max(bufferTimeMultiplier, bufferSizeLimit);
         }
 
-        #if UNITY_EDITOR || DEVELOPMENT_BUILD
+// OnGUI allocates even if it does nothing. avoid in release.
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
         // debug ///////////////////////////////////////////////////////////////
         protected virtual void OnGUI()
         {
@@ -535,6 +536,6 @@ namespace Mirror
             if (isServer) DrawGizmos(serverBuffer);
             if (isClient) DrawGizmos(clientBuffer);
         }
-        #endif
+#endif
     }
 }

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -499,7 +499,6 @@ namespace Mirror
                 GUI.color = Color.white;
             }
         }
-        #endif
 
         protected virtual void DrawGizmos(SortedList<double, NTSnapshot> buffer)
         {
@@ -536,5 +535,6 @@ namespace Mirror
             if (isServer) DrawGizmos(serverBuffer);
             if (isClient) DrawGizmos(clientBuffer);
         }
+        #endif
     }
 }


### PR DESCRIPTION
#if UNITY_EDITOR || DEVELOPMENT_BUILD for OnGUI() added.
Related to this post, and discord discussion: https://github.com/vis2k/Mirror/issues/2871

"OnGUI calls allocate gc even when not doing anything"
This should give developers a mini optimisation, and means no manual editing needed of NTB.cs for their final releases.

Will apply to the other components, if accepted/good idea.  <thumbs up emoji>