### PR TITLE
Defines for OnGUI

### DIFF
--- a/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
@@ -113,6 +113,8 @@ namespace Mirror
             }
         }
 
+        #if UNITY_EDITOR || DEVELOPMENT_BUILD
+        // OnGUI allocates even if it does nothing. avoid in release.
         // slider from dotsnet. it's nice to play around with in the benchmark
         // demo.
         void OnGUI()
@@ -132,5 +134,6 @@ namespace Mirror
             GUILayout.EndHorizontal();
             GUILayout.EndArea();
         }
+        #endif
     }
 }

--- a/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
@@ -113,8 +113,8 @@ namespace Mirror
             }
         }
 
-        #if UNITY_EDITOR || DEVELOPMENT_BUILD
-        // OnGUI allocates even if it does nothing. avoid in release.
+// OnGUI allocates even if it does nothing. avoid in release.
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
         // slider from dotsnet. it's nice to play around with in the benchmark
         // demo.
         void OnGUI()
@@ -134,6 +134,6 @@ namespace Mirror
             GUILayout.EndHorizontal();
             GUILayout.EndArea();
         }
-        #endif
+#endif
     }
 }

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -273,6 +273,8 @@ namespace kcp2k
             return $"{(bytes / (1024f * 1024f * 1024f)):F2} GB";
         }
 
+        #if UNITY_EDITOR || DEVELOPMENT_BUILD
+        // OnGUI allocates even if it does nothing. avoid in release.
         void OnGUI()
         {
             if (!statisticsGUI) return;
@@ -308,6 +310,7 @@ namespace kcp2k
 
             GUILayout.EndArea();
         }
+        #endif
 
         void OnLogStatistics()
         {

--- a/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/KCP/MirrorTransport/KcpTransport.cs
@@ -273,8 +273,8 @@ namespace kcp2k
             return $"{(bytes / (1024f * 1024f * 1024f)):F2} GB";
         }
 
-        #if UNITY_EDITOR || DEVELOPMENT_BUILD
-        // OnGUI allocates even if it does nothing. avoid in release.
+// OnGUI allocates even if it does nothing. avoid in release.
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
         void OnGUI()
         {
             if (!statisticsGUI) return;
@@ -310,7 +310,7 @@ namespace kcp2k
 
             GUILayout.EndArea();
         }
-        #endif
+#endif
 
         void OnLogStatistics()
         {


### PR DESCRIPTION
Related to: https://github.com/vis2k/Mirror/pull/2874
"OnGUI allocates even if it does nothing. avoid in release."

KcpTransport.cs
SpatialHashingInterestManagement.cs

The other OnGUI's i found could be arguably important for client/non dev builds, such as NetworkManagerHUD, the above two are the ones i found that in most cases the GUI shouldn't exist in release.