### PR TITLE
breaking: NetworkIdentity.spawned split into NetworkServer/Client.Spawned

### DIFF
--- a/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
@@ -17,10 +17,10 @@ namespace Mirror
         {
             Guid currentMatch = identity.GetComponent<NetworkMatch>().matchId;
             lastObjectMatch[identity] = currentMatch;
-            
+
             // Guid.Empty is never a valid matchId...do not add to matchObjects collection
             if (currentMatch == Guid.Empty) return;
-            
+
             // Debug.Log($"MatchInterestManagement.OnSpawned({identity.name}) currentMatch: {currentMatch}");
             if (!matchObjects.TryGetValue(currentMatch, out HashSet<NetworkIdentity> objects))
             {
@@ -48,7 +48,7 @@ namespace Mirror
             //   if match changed:
             //     add previous to dirty
             //     add new to dirty
-            foreach (NetworkIdentity netIdentity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity netIdentity in NetworkServer.spawned.Values)
             {
                 Guid currentMatch = lastObjectMatch[netIdentity];
                 Guid newMatch = netIdentity.GetComponent<NetworkMatch>().matchId;
@@ -70,10 +70,10 @@ namespace Mirror
 
                 // Set this to the new match this object just entered
                 lastObjectMatch[netIdentity] = newMatch;
-                
+
                 // Guid.Empty is never a valid matchId...do not add to matchObjects collection
                 if (newMatch == Guid.Empty) continue;
-                
+
 
                 // Make sure this new match is in the dictionary
                 if (!matchObjects.ContainsKey(newMatch))
@@ -109,10 +109,10 @@ namespace Mirror
             bool initialize)
         {
             Guid matchId = identity.GetComponent<NetworkMatch>().matchId;
-            
+
             // Guid.Empty is never a valid matchId
             if (matchId == Guid.Empty) return;
-            
+
             if (!matchObjects.TryGetValue(matchId, out HashSet<NetworkIdentity> objects))
                 return;
 

--- a/Assets/Mirror/Components/InterestManagement/Scene/SceneInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Scene/SceneInterestManagement.cs
@@ -46,7 +46,7 @@ namespace Mirror
             //   if scene changed:
             //     add previous to dirty
             //     add new to dirty
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity identity in NetworkServer.spawned.Values)
             {
                 Scene currentScene = lastObjectScene[identity];
                 Scene newScene = identity.gameObject.scene;

--- a/Assets/Mirror/Runtime/InterestManagement.cs
+++ b/Assets/Mirror/Runtime/InterestManagement.cs
@@ -58,7 +58,7 @@ namespace Mirror
         // IMPORTANT: check if NetworkServer.active when using Update()!
         protected void RebuildAll()
         {
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity identity in NetworkServer.spawned.Values)
             {
                 NetworkServer.RebuildObservers(identity, false);
             }

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -293,7 +293,7 @@ namespace Mirror
 
             // client always looks up based on netId because objects might get in and out of range
             // over and over again, which shouldn't null them forever
-            if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity) && identity != null)
+            if (NetworkClient.spawned.TryGetValue(netId, out NetworkIdentity identity) && identity != null)
                 return gameObjectField = identity.gameObject;
             return null;
         }
@@ -352,7 +352,7 @@ namespace Mirror
 
             // client always looks up based on netId because objects might get in and out of range
             // over and over again, which shouldn't null them forever
-            NetworkIdentity.spawned.TryGetValue(netId, out identityField);
+            NetworkClient.spawned.TryGetValue(netId, out identityField);
             return identityField;
         }
 
@@ -414,7 +414,7 @@ namespace Mirror
 
             // client always looks up based on netId because objects might get in and out of range
             // over and over again, which shouldn't null them forever
-            if (!NetworkIdentity.spawned.TryGetValue(syncNetBehaviour.netId, out NetworkIdentity identity))
+            if (!NetworkClient.spawned.TryGetValue(syncNetBehaviour.netId, out NetworkIdentity identity))
             {
                 return null;
             }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1413,6 +1413,7 @@ namespace Mirror
             DestroyAllClientObjects();
             connectState = ConnectState.None;
             handlers.Clear();
+            spawned.Clear();
             // disconnect the client connection.
             // we do NOT call Transport.Shutdown, because someone only called
             // NetworkClient.Shutdown. we can't assume that the server is

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -23,6 +23,11 @@ namespace Mirror
         internal static readonly Dictionary<ushort, NetworkMessageDelegate> handlers =
             new Dictionary<ushort, NetworkMessageDelegate>();
 
+        /// <summary>All spawned NetworkIdentities by netId.</summary>
+        // client sees OBSERVED spawned ones.
+        public static readonly Dictionary<uint, NetworkIdentity> spawned =
+            new Dictionary<uint, NetworkIdentity>();
+
         /// <summary>Client's NetworkConnection to server.</summary>
         public static NetworkConnection connection { get; internal set; }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -151,10 +151,11 @@ namespace Mirror
                 // client
                 if (NetworkClient.active) return NetworkClient.spawned;
 
-                // neither: then we are testing. for now, keep compatibility
-                // with old tests where we could use .spawned without starting
-                // server or client. so for now, route them to server.spawned.
-                return NetworkServer.spawned;
+                // neither: then we are testing.
+                // we could default to NetworkServer.spawned.
+                // but from the outside, that's not obvious.
+                // better to throw an exception to make it obvious.
+                throw new Exception("NetworkIdentity.spawned was accessed before NetworkServer/NetworkClient were active.");
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -136,8 +136,27 @@ namespace Mirror
         /// <summary>All spawned NetworkIdentities by netId. Available on server and client.</summary>
         // server sees ALL spawned ones.
         // client sees OBSERVED spawned ones.
-        public static readonly Dictionary<uint, NetworkIdentity> spawned =
-            new Dictionary<uint, NetworkIdentity>();
+        // => split into NetworkServer.spawned and NetworkClient.spawned to
+        //    reduce shared state between server & client.
+        // => prepares for NetworkServer/Client as component & better host mode.
+        [Obsolete("NetworkIdentity.spawned is now NetworkServer.spawned on server, NetworkClient.spawned on client.\nPrepares for NetworkServer/Client as component, better host mode, better testing.")]
+        public static Dictionary<uint, NetworkIdentity> spawned
+        {
+            get
+            {
+                // server / host mode: use the one from server.
+                // host mode has access to all spawned.
+                if (NetworkServer.active) return NetworkServer.spawned;
+
+                // client
+                if (NetworkClient.active) return NetworkClient.spawned;
+
+                // neither: then we are testing. for now, keep compatibility
+                // with old tests where we could use .spawned without starting
+                // server or client. so for now, route them to server.spawned.
+                return NetworkServer.spawned;
+            }
+        }
 
         // get all NetworkBehaviour components
         public NetworkBehaviour[] NetworkBehaviours { get; private set; }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -646,7 +646,7 @@ namespace Mirror
 
             // add to spawned (note: the original EnableIsServer isn't needed
             // because we already set m_isServer=true above)
-            spawned[netId] = this;
+            NetworkServer.spawned[netId] = this;
 
             // in host mode we set isClient true before calling OnStartServer,
             // otherwise isClient is false in OnStartServer.

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -324,10 +324,15 @@ namespace Mirror
             if (netId == 0)
                 return null;
 
-            if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
-            {
-                return identity;
-            }
+            // look in server spawned
+            if (NetworkServer.active &&
+                NetworkServer.spawned.TryGetValue(netId, out NetworkIdentity serverIdentity))
+                return serverIdentity;
+
+            // look in client spawned
+            if (NetworkClient.active &&
+                NetworkClient.spawned.TryGetValue(netId, out NetworkIdentity clientIdentity))
+                return clientIdentity;
 
             // a netId not being in spawned is common.
             // for example, "[SyncVar] NetworkIdentity target" netId would not

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -26,6 +26,11 @@ namespace Mirror
         internal static Dictionary<ushort, NetworkMessageDelegate> handlers =
             new Dictionary<ushort, NetworkMessageDelegate>();
 
+        /// <summary>All spawned NetworkIdentities by netId.</summary>
+        // server sees ALL spawned ones.
+        public static readonly Dictionary<uint, NetworkIdentity> spawned =
+            new Dictionary<uint, NetworkIdentity>();
+
         /// <summary>Single player mode can use dontListen to not accept incoming connections</summary>
         // see also: https://github.com/vis2k/Mirror/pull/2595
         public static bool dontListen;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -93,7 +93,7 @@ namespace Mirror
         // client doesn't get spawn messages for those, so need to call manually.
         public static void ActivateHostScene()
         {
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity identity in spawned.Values)
             {
                 if (!identity.isClient)
                 {
@@ -130,10 +130,10 @@ namespace Mirror
         // Note: NetworkClient.DestroyAllClientObjects does the same on client.
         static void CleanupSpawned()
         {
-            // iterate a COPY of NetworkIdentity.spawned.
+            // iterate a COPY of spawned.
             // DestroyObject removes them from the original collection.
             // removing while iterating is not allowed.
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values.ToList())
+            foreach (NetworkIdentity identity in spawned.Values.ToList())
             {
                 if (identity != null)
                 {
@@ -155,7 +155,7 @@ namespace Mirror
                 }
             }
 
-            NetworkIdentity.spawned.Clear();
+            spawned.Clear();
         }
 
         /// <summary>Shuts down the server and disconnects all clients</summary>
@@ -863,7 +863,7 @@ namespace Mirror
         // players on a single client
         static void OnCommandMessage(NetworkConnection conn, CommandMessage msg)
         {
-            if (!NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
+            if (!spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
                 Debug.LogWarning("Spawned object not found when handling Command message [netId=" + msg.netId + "]");
                 return;
@@ -1108,7 +1108,7 @@ namespace Mirror
 
         static void SpawnObserversForConnection(NetworkConnection conn)
         {
-            // Debug.Log("Spawning " + NetworkIdentity.spawned.Count + " objects for conn " + conn);
+            // Debug.Log("Spawning " + spawned.Count + " objects for conn " + conn);
 
             if (!conn.isReady)
             {
@@ -1122,7 +1122,7 @@ namespace Mirror
 
             // add connection to each nearby NetworkIdentity's observers, which
             // internally sends a spawn message for each one to the connection.
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity identity in spawned.Values)
             {
                 // try with far away ones in ummorpg!
                 if (identity.gameObject.activeSelf) //TODO this is different
@@ -1230,7 +1230,7 @@ namespace Mirror
                 }
             }
             // Debug.Log("DestroyObject instance:" + identity.netId);
-            NetworkIdentity.spawned.Remove(identity.netId);
+            spawned.Remove(identity.netId);
 
             identity.connectionToClient?.RemoveOwnedObject(identity);
 
@@ -1520,7 +1520,7 @@ namespace Mirror
             //   clear dirty bits if it has no observers.
             //   we did this before push->pull broadcasting so let's keep
             //   doing this for now.
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity identity in spawned.Values)
             {
                 if (identity.observers == null || identity.observers.Count == 0)
                 {

--- a/Assets/Mirror/Tests/Common/MirrorTest.cs
+++ b/Assets/Mirror/Tests/Common/MirrorTest.cs
@@ -41,8 +41,6 @@ namespace Mirror.Tests
                 if (go != null)
                     GameObject.DestroyImmediate(go);
 
-            NetworkIdentity.spawned.Clear();
-
             GameObject.DestroyImmediate(transport.gameObject);
             Transport.activeTransport = null;
         }

--- a/Assets/Mirror/Tests/Common/MirrorTest.cs
+++ b/Assets/Mirror/Tests/Common/MirrorTest.cs
@@ -153,6 +153,36 @@ namespace Mirror.Tests
 
         // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN
         // => ownerConnection can be NetworkServer.localConnection if needed.
+        // => returns objects from client and from server.
+        //    will be same in host mode.
+        protected void CreateNetworkedAndSpawn(
+            out GameObject serverGO, out NetworkIdentity serverIdentity,
+            out GameObject clientGO, out NetworkIdentity clientIdentity,
+            NetworkConnection ownerConnection = null)
+        {
+            // server & client need to be active before spawning
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            // create one on server, one on client
+            // (spawning has to find it on client, it doesn't create it)
+            CreateNetworked(out serverGO, out serverIdentity);
+            CreateNetworked(out clientGO, out clientIdentity);
+
+            // give both a scene id and register it on client for spawnables
+            clientIdentity.sceneId = serverIdentity.sceneId = (ulong)serverGO.GetHashCode();
+            NetworkClient.spawnableObjects[clientIdentity.sceneId] = clientIdentity;
+
+            // spawn
+            NetworkServer.Spawn(serverGO, ownerConnection);
+            ProcessMessages();
+
+            // make sure the client really spawned it.
+            Assert.That(NetworkClient.spawned.ContainsKey(serverIdentity.netId));
+        }
+
+        // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN
+        // => ownerConnection can be NetworkServer.localConnection if needed.
         protected void CreateNetworkedAndSpawn<T>(out GameObject go, out NetworkIdentity identity, out T component, NetworkConnection ownerConnection = null)
             where T : NetworkBehaviour
         {
@@ -169,6 +199,41 @@ namespace Mirror.Tests
             // double check that we have authority if we passed an owner connection
             if (ownerConnection != null)
                 Debug.Assert(component.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+        }
+
+        // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN
+        // => ownerConnection can be NetworkServer.localConnection if needed.
+        // => returns objects from client and from server.
+        //    will be same in host mode.
+        protected void CreateNetworkedAndSpawn<T>(
+            out GameObject serverGO, out NetworkIdentity serverIdentity, out T serverComponent,
+            out GameObject clientGO, out NetworkIdentity clientIdentity, out T clientComponent,
+            NetworkConnection ownerConnection = null)
+            where T : NetworkBehaviour
+        {
+            // server & client need to be active before spawning
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            // create one on server, one on client
+            // (spawning has to find it on client, it doesn't create it)
+            CreateNetworked(out serverGO, out serverIdentity, out serverComponent);
+            CreateNetworked(out clientGO, out clientIdentity, out clientComponent);
+
+            // give both a scene id and register it on client for spawnables
+            clientIdentity.sceneId = serverIdentity.sceneId = (ulong)serverGO.GetHashCode();
+            NetworkClient.spawnableObjects[clientIdentity.sceneId] = clientIdentity;
+
+            // spawn
+            NetworkServer.Spawn(serverGO, ownerConnection);
+            ProcessMessages();
+
+            // double check that we have authority if we passed an owner connection
+            if (ownerConnection != null)
+                Debug.Assert(serverComponent.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+
+            // make sure the client really spawned it.
+            Assert.That(NetworkClient.spawned.ContainsKey(serverIdentity.netId));
         }
 
         // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN
@@ -197,6 +262,45 @@ namespace Mirror.Tests
 
         // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN
         // => ownerConnection can be NetworkServer.localConnection if needed.
+        // => returns objects from client and from server.
+        //    will be same in host mode.
+        protected void CreateNetworkedAndSpawn<T, U>(
+            out GameObject serverGO, out NetworkIdentity serverIdentity, out T serverComponentA, out U serverComponentB,
+            out GameObject clientGO, out NetworkIdentity clientIdentity, out T clientComponentA, out U clientComponentB,
+            NetworkConnection ownerConnection = null)
+            where T : NetworkBehaviour
+            where U : NetworkBehaviour
+        {
+            // server & client need to be active before spawning
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            // create one on server, one on client
+            // (spawning has to find it on client, it doesn't create it)
+            CreateNetworked(out serverGO, out serverIdentity, out serverComponentA, out serverComponentB);
+            CreateNetworked(out clientGO, out clientIdentity, out clientComponentA, out clientComponentB);
+
+            // give both a scene id and register it on client for spawnables
+            clientIdentity.sceneId = serverIdentity.sceneId = (ulong)serverGO.GetHashCode();
+            NetworkClient.spawnableObjects[clientIdentity.sceneId] = clientIdentity;
+
+            // spawn
+            NetworkServer.Spawn(serverGO, ownerConnection);
+            ProcessMessages();
+
+            // double check that we have authority if we passed an owner connection
+            if (ownerConnection != null)
+            {
+                Debug.Assert(serverComponentA.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(serverComponentB.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+            }
+
+            // make sure the client really spawned it.
+            Assert.That(NetworkClient.spawned.ContainsKey(serverIdentity.netId));
+        }
+
+        // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN
+        // => ownerConnection can be NetworkServer.localConnection if needed.
         protected void CreateNetworkedAndSpawn<T, U, V>(out GameObject go, out NetworkIdentity identity, out T componentA, out U componentB, out V componentC, NetworkConnection ownerConnection = null)
             where T : NetworkBehaviour
             where U : NetworkBehaviour
@@ -221,6 +325,47 @@ namespace Mirror.Tests
             }
         }
 
+        // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN
+        // => ownerConnection can be NetworkServer.localConnection if needed.
+        // => returns objects from client and from server.
+        //    will be same in host mode.
+        protected void CreateNetworkedAndSpawn<T, U, V>(
+            out GameObject serverGO, out NetworkIdentity serverIdentity, out T serverComponentA, out U serverComponentB, out V serverComponentC,
+            out GameObject clientGO, out NetworkIdentity clientIdentity, out T clientComponentA, out U clientComponentB, out V clientComponentC,
+            NetworkConnection ownerConnection = null)
+            where T : NetworkBehaviour
+            where U : NetworkBehaviour
+            where V : NetworkBehaviour
+        {
+            // server & client need to be active before spawning
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            // create one on server, one on client
+            // (spawning has to find it on client, it doesn't create it)
+            CreateNetworked(out serverGO, out serverIdentity, out serverComponentA, out serverComponentB, out serverComponentC);
+            CreateNetworked(out clientGO, out clientIdentity, out clientComponentA, out clientComponentB, out clientComponentC);
+
+            // give both a scene id and register it on client for spawnables
+            clientIdentity.sceneId = serverIdentity.sceneId = (ulong)serverGO.GetHashCode();
+            NetworkClient.spawnableObjects[clientIdentity.sceneId] = clientIdentity;
+
+            // spawn
+            NetworkServer.Spawn(serverGO, ownerConnection);
+            ProcessMessages();
+
+            // double check that we have authority if we passed an owner connection
+            if (ownerConnection != null)
+            {
+                Debug.Assert(serverComponentA.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(serverComponentB.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(serverComponentC.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+            }
+
+            // make sure the client really spawned it.
+            Assert.That(NetworkClient.spawned.ContainsKey(serverIdentity.netId));
+        }
+
         // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN PLAYER.
         // often times, we really need a player object for the client to receive
         // certain messages.
@@ -241,6 +386,37 @@ namespace Mirror.Tests
         // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN PLAYER.
         // often times, we really need a player object for the client to receive
         // certain messages.
+        // => returns objects from client and from server.
+        //    will be same in host mode.
+        protected void CreateNetworkedAndSpawnPlayer(
+            out GameObject serverGO, out NetworkIdentity serverIdentity,
+            out GameObject clientGO, out NetworkIdentity clientIdentity,
+            NetworkConnection ownerConnection)
+        {
+            // server & client need to be active before spawning
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            // create one on server, one on client
+            // (spawning has to find it on client, it doesn't create it)
+            CreateNetworked(out serverGO, out serverIdentity);
+            CreateNetworked(out clientGO, out clientIdentity);
+
+            // give both a scene id and register it on client for spawnables
+            clientIdentity.sceneId = serverIdentity.sceneId = (ulong)serverGO.GetHashCode();
+            NetworkClient.spawnableObjects[clientIdentity.sceneId] = clientIdentity;
+
+            // add as player & process spawn message on client.
+            NetworkServer.AddPlayerForConnection(ownerConnection, serverGO);
+            ProcessMessages();
+
+            // make sure the client really spawned it.
+            Assert.That(NetworkClient.spawned.ContainsKey(serverIdentity.netId));
+        }
+
+        // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN PLAYER.
+        // often times, we really need a player object for the client to receive
+        // certain messages.
         protected void CreateNetworkedAndSpawnPlayer<T>(out GameObject go, out NetworkIdentity identity, out T component, NetworkConnection ownerConnection)
             where T : NetworkBehaviour
         {
@@ -254,6 +430,38 @@ namespace Mirror.Tests
             // add as player & process spawn message on client.
             NetworkServer.AddPlayerForConnection(ownerConnection, go);
             ProcessMessages();
+        }
+
+        // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN PLAYER.
+        // often times, we really need a player object for the client to receive
+        // certain messages.
+        // => returns objects from client and from server.
+        //    will be same in host mode.
+        protected void CreateNetworkedAndSpawnPlayer<T>(
+            out GameObject serverGO, out NetworkIdentity serverIdentity, out T serverComponent,
+            out GameObject clientGO, out NetworkIdentity clientIdentity, out T clientComponent,
+            NetworkConnection ownerConnection)
+            where T : NetworkBehaviour
+        {
+            // server & client need to be active before spawning
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            // create one on server, one on client
+            // (spawning has to find it on client, it doesn't create it)
+            CreateNetworked(out serverGO, out serverIdentity, out serverComponent);
+            CreateNetworked(out clientGO, out clientIdentity, out clientComponent);
+
+            // give both a scene id and register it on client for spawnables
+            clientIdentity.sceneId = serverIdentity.sceneId = (ulong)serverGO.GetHashCode();
+            NetworkClient.spawnableObjects[clientIdentity.sceneId] = clientIdentity;
+
+            // add as player & process spawn message on client.
+            NetworkServer.AddPlayerForConnection(ownerConnection, serverGO);
+            ProcessMessages();
+
+            // make sure the client really spawned it.
+            Assert.That(NetworkClient.spawned.ContainsKey(serverIdentity.netId));
         }
 
         // fully connect client to local server

--- a/Assets/Mirror/Tests/Editor/ClientSceneTests_OnSpawn.cs
+++ b/Assets/Mirror/Tests/Editor/ClientSceneTests_OnSpawn.cs
@@ -58,7 +58,7 @@ namespace Mirror.Tests.ClientSceneTests
 
     public class ClientSceneTests_OnSpawn : ClientSceneTestsBase
     {
-        Dictionary<uint, NetworkIdentity> spawned => NetworkIdentity.spawned;
+        Dictionary<uint, NetworkIdentity> spawned => NetworkClient.spawned;
 
         [TearDown]
         public override void TearDown()

--- a/Assets/Mirror/Tests/Editor/InterestManagementTests_Common.cs
+++ b/Assets/Mirror/Tests/Editor/InterestManagementTests_Common.cs
@@ -25,7 +25,7 @@ namespace Mirror.Tests
             connectionA.isAuthenticated = true;
             connectionA.isReady = true;
             connectionA.identity = identityA;
-            NetworkIdentity.spawned[0xAA] = identityA;
+            NetworkServer.spawned[0xAA] = identityA;
 
             // B
             CreateNetworked(out gameObjectB, out identityB);
@@ -33,7 +33,7 @@ namespace Mirror.Tests
             connectionB.isAuthenticated = true;
             connectionB.isReady = true;
             connectionB.identity = identityB;
-            NetworkIdentity.spawned[0xBB] = identityB;
+            NetworkServer.spawned[0xBB] = identityB;
 
             // need to start server so that interest management works
             NetworkServer.Listen(10);

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -687,18 +687,20 @@ namespace Mirror.Tests
 
             // create a spawned, syncable GameObject
             // (client tries to look up via netid, so needs to be spawned)
-            CreateNetworkedAndSpawn(out GameObject go, out NetworkIdentity ni);
+            CreateNetworkedAndSpawn(
+                out GameObject serverGO, out NetworkIdentity serverIdentity,
+                out GameObject clientGO, out NetworkIdentity clientIdentity);
 
             // assign ONLY netId in the component. assume that GameObject was
             // assigned earlier but client walked so far out of range that it
             // was despawned on the client. so it's forced to do the netId look-
             // up.
             Assert.That(comp.test, Is.Null);
-            comp.testNetId = ni.netId;
+            comp.testNetId = clientIdentity.netId;
 
             // get it on the client. should look up netId in spawned
             GameObject result = comp.GetSyncVarGameObjectExposed();
-            Assert.That(result, Is.EqualTo(go));
+            Assert.That(result, Is.EqualTo(clientGO));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -842,18 +842,20 @@ namespace Mirror.Tests
 
             // create a spawned, syncable GameObject
             // (client tries to look up via netid, so needs to be spawned)
-            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity ni);
+            CreateNetworkedAndSpawn(
+                out _, out NetworkIdentity serverIdentity,
+                out _, out NetworkIdentity clientIdentity);
 
             // assign ONLY netId in the component. assume that GameObject was
             // assigned earlier but client walked so far out of range that it
             // was despawned on the client. so it's forced to do the netId look-
             // up.
             Assert.That(comp.test, Is.Null);
-            comp.testNetId = ni.netId;
+            comp.testNetId = clientIdentity.netId;
 
             // get it on the client. should look up netId in spawned
             NetworkIdentity result = comp.GetSyncVarNetworkIdentityExposed();
-            Assert.That(result, Is.EqualTo(ni));
+            Assert.That(result, Is.EqualTo(clientIdentity));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -815,15 +815,17 @@ namespace Mirror.Tests
 
             // spawn identity with a networkbehaviour.
             // (needs to be in .spawned for ActivateHostScene)
-            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity identity, out OnStartClientTestNetworkBehaviour comp);
+            CreateNetworkedAndSpawn(
+                out _, out NetworkIdentity serverIdentity, out OnStartClientTestNetworkBehaviour serverComp,
+                out _, out _, out _);
 
             // ActivateHostScene calls OnStartClient for spawned objects where
             // isClient is still false. set it to false first.
-            identity.isClient = false;
+            serverIdentity.isClient = false;
             NetworkServer.ActivateHostScene();
 
             // was OnStartClient called for all .spawned networkidentities?
-            Assert.That(comp.called, Is.EqualTo(1));
+            Assert.That(serverComp.called, Is.EqualTo(1));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncVarHookTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarHookTest.cs
@@ -127,8 +127,9 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void Hook_CalledWhenSyncingChangedValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out HookBehaviour serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out HookBehaviour clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out HookBehaviour serverObject,
+                out _, out _, out HookBehaviour clientObject);
 
             const int clientValue = 10;
             const int serverValue = 24;
@@ -156,8 +157,9 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void Hook_NotCalledWhenSyncingSameValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out HookBehaviour serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out HookBehaviour clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out HookBehaviour serverObject,
+                out _, out _, out HookBehaviour clientObject);
 
             const int clientValue = 16;
             const int serverValue = 16;
@@ -183,8 +185,9 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void StaticMethod_HookCalledWhenSyncingChangedValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out StaticHookBehaviour serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out StaticHookBehaviour clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out StaticHookBehaviour serverObject,
+                out _, out _, out StaticHookBehaviour clientObject);
 
             const int clientValue = 10;
             const int serverValue = 24;
@@ -244,8 +247,9 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void NetworkIdentityHook_HookCalledWhenSyncingChangedValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkIdentityHookBehaviour serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkIdentityHookBehaviour clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out NetworkIdentityHookBehaviour serverObject,
+                out _, out _, out NetworkIdentityHookBehaviour clientObject);
 
             // create spawned because we will look up netId in .spawned
             CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity serverValue);
@@ -273,8 +277,9 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void NetworkBehaviourHook_HookCalledWhenSyncingChangedValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourHookBehaviour serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourHookBehaviour clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out NetworkBehaviourHookBehaviour serverObject,
+                out _, out _, out NetworkBehaviourHookBehaviour clientObject);
 
             // create spawned because we will look up netId in .spawned
             CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity serverIdentity, out NetworkBehaviourHookBehaviour serverValue);
@@ -302,8 +307,9 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void VirtualHook_HookCalledWhenSyncingChangedValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out VirtualHookBase serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out VirtualHookBase clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out VirtualHookBase serverObject,
+                out _, out _, out VirtualHookBase clientObject);
 
             const int clientValue = 10;
             const int serverValue = 24;
@@ -331,8 +337,9 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void VirtualOverrideHook_HookCalledWhenSyncingChangedValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out VirtualOverrideHook serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out VirtualOverrideHook clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out VirtualOverrideHook serverObject,
+                out _, out _, out VirtualOverrideHook clientObject);
 
             const int clientValue = 10;
             const int serverValue = 24;
@@ -366,8 +373,9 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void AbstractHook_HookCalledWhenSyncingChangedValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out AbstractHook serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out AbstractHook clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out AbstractHook serverObject,
+                out _, out _, out AbstractHook clientObject);
 
             const int clientValue = 10;
             const int serverValue = 24;

--- a/Assets/Mirror/Tests/Editor/SyncVarHookTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarHookTest.cs
@@ -252,7 +252,9 @@ namespace Mirror.Tests.SyncVarTests
                 out _, out _, out NetworkIdentityHookBehaviour clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity serverValue);
+            CreateNetworkedAndSpawn(
+                out _, out NetworkIdentity serverValue,
+                out _, out NetworkIdentity clientValue);
 
             // change it on server
             serverObject.value = serverValue;
@@ -264,7 +266,7 @@ namespace Mirror.Tests.SyncVarTests
             {
                 callCount++;
                 Assert.That(oldValue, Is.EqualTo(null));
-                Assert.That(newValue, Is.EqualTo(serverValue));
+                Assert.That(newValue, Is.EqualTo(clientValue));
             };
 
             bool written = SyncToClient(serverObject, clientObject, intialState);

--- a/Assets/Mirror/Tests/Editor/SyncVarHookTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarHookTest.cs
@@ -212,15 +212,18 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void GameObjectHook_HookCalledWhenSyncingChangedValue(bool intialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out GameObjectHookBehaviour serverObject);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out GameObjectHookBehaviour clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out GameObjectHookBehaviour serverObject,
+                out _, out _, out GameObjectHookBehaviour clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out GameObject serverValue, out NetworkIdentity serverIdentity);
+            CreateNetworkedAndSpawn(
+                out GameObject serverValue, out _,
+                out GameObject clientValue, out _);
 
             // change it on server
-            serverObject.value = serverValue;
             clientObject.value = null;
+            serverObject.value = serverValue;
 
             // hook should change it on client
             int callCount = 0;
@@ -228,7 +231,7 @@ namespace Mirror.Tests.SyncVarTests
             {
                 callCount++;
                 Assert.That(oldValue, Is.EqualTo(null));
-                Assert.That(newValue, Is.EqualTo(serverValue));
+                Assert.That(newValue, Is.EqualTo(clientValue));
             };
 
             bool written = SyncToClient(serverObject, clientObject, intialState);

--- a/Assets/Mirror/Tests/Editor/SyncVarHookTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarHookTest.cs
@@ -282,7 +282,9 @@ namespace Mirror.Tests.SyncVarTests
                 out _, out _, out NetworkBehaviourHookBehaviour clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity serverIdentity, out NetworkBehaviourHookBehaviour serverValue);
+            CreateNetworkedAndSpawn(
+                out _, out _, out NetworkBehaviourHookBehaviour serverValue,
+                out _, out _, out NetworkBehaviourHookBehaviour clientValue);
 
             // change it on server
             serverObject.value = serverValue;
@@ -294,7 +296,7 @@ namespace Mirror.Tests.SyncVarTests
             {
                 callCount++;
                 Assert.That(oldValue, Is.EqualTo(null));
-                Assert.That(newValue, Is.EqualTo(serverValue));
+                Assert.That(newValue, Is.EqualTo(clientValue));
             };
 
             bool written = SyncToClient(serverObject, clientObject, intialState);

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -185,18 +185,21 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void SyncsGameobject(bool initialState)
         {
-            CreateNetworked(out _, out _, out SyncVarGameObject serverObject);
-            CreateNetworked(out _, out _, out SyncVarGameObject clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out SyncVarGameObject serverObject,
+                out _, out _, out SyncVarGameObject clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out GameObject serverValue, out _);
+            CreateNetworkedAndSpawn(
+                out GameObject serverValue, out _,
+                out GameObject clientValue, out _);
 
             serverObject.value = serverValue;
             clientObject.value = null;
 
             bool written = SyncToClient(serverObject, clientObject, initialState);
             Assert.IsTrue(written);
-            Assert.That(clientObject.value, Is.EqualTo(serverValue));
+            Assert.That(clientObject.value, Is.EqualTo(clientValue));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -207,18 +207,21 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void SyncIdentity(bool initialState)
         {
-            CreateNetworked(out _, out _, out SyncVarNetworkIdentity serverObject);
-            CreateNetworked(out _, out _, out SyncVarNetworkIdentity clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out SyncVarNetworkIdentity serverObject,
+                out _, out _, out SyncVarNetworkIdentity clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity serverValue);
+            CreateNetworkedAndSpawn(
+                out _, out NetworkIdentity serverValue,
+                out _, out NetworkIdentity clientValue);
 
             serverObject.value = serverValue;
             clientObject.value = null;
 
             bool written = SyncToClient(serverObject, clientObject, initialState);
             Assert.IsTrue(written);
-            Assert.That(clientObject.value, Is.EqualTo(serverValue));
+            Assert.That(clientObject.value, Is.EqualTo(clientValue));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -254,18 +254,21 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void SyncsBehaviour(bool initialState)
         {
-            CreateNetworked(out _, out _, out SyncVarNetworkBehaviour serverObject);
-            CreateNetworked(out _, out _, out SyncVarNetworkBehaviour clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out SyncVarNetworkBehaviour serverObject,
+                out _, out _, out SyncVarNetworkBehaviour clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out _, out NetworkIdentity _, out SyncVarNetworkBehaviour serverValue);
+            CreateNetworkedAndSpawn(
+                out _, out _, out SyncVarNetworkBehaviour serverValue,
+                out _, out _, out SyncVarNetworkBehaviour clientValue);
 
             serverObject.value = serverValue;
             clientObject.value = null;
 
             bool written = SyncToClient(serverObject, clientObject, initialState);
             Assert.IsTrue(written);
-            Assert.That(clientObject.value, Is.EqualTo(serverValue));
+            Assert.That(clientObject.value, Is.EqualTo(clientValue));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -223,19 +223,24 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void SyncTransform(bool initialState)
         {
-            CreateNetworked(out _, out _, out SyncVarTransform serverObject);
-            CreateNetworked(out _, out _, out SyncVarTransform clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out SyncVarTransform serverObject,
+                out _, out _, out SyncVarTransform clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out _, out NetworkIdentity serverIdentity);
+            CreateNetworkedAndSpawn(
+                out _, out NetworkIdentity serverIdentity,
+                out _, out NetworkIdentity clientIdentity);
+
             Transform serverValue = serverIdentity.transform;
+            Transform clientValue = clientIdentity.transform;
 
             serverObject.value = serverValue;
             clientObject.value = null;
 
             bool written = SyncToClient(serverObject, clientObject, initialState);
             Assert.IsTrue(written);
-            Assert.That(clientObject.value, Is.EqualTo(serverValue));
+            Assert.That(clientObject.value, Is.EqualTo(clientValue));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -267,36 +267,39 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void SyncsMultipleBehaviour(bool initialState)
         {
-            CreateNetworked(out _, out _, out SyncVarNetworkBehaviour serverObject);
-            CreateNetworked(out _, out _, out SyncVarNetworkBehaviour clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out SyncVarNetworkBehaviour serverObject,
+                out _, out _, out SyncVarNetworkBehaviour clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out _, out NetworkIdentity identity, out SyncVarNetworkBehaviour behaviour1, out SyncVarNetworkBehaviour behaviour2);
+            CreateNetworkedAndSpawn(
+                out _, out NetworkIdentity serverIdentity, out SyncVarNetworkBehaviour serverBehaviour1, out SyncVarNetworkBehaviour serverBehaviour2,
+                out _, out NetworkIdentity clientIdentity, out SyncVarNetworkBehaviour clientBehaviour1, out SyncVarNetworkBehaviour clientBehaviour2);
 
             // create array/set indices
-            _ = identity.NetworkBehaviours;
+            _ = serverIdentity.NetworkBehaviours;
 
-            int index1 = behaviour1.ComponentIndex;
-            int index2 = behaviour2.ComponentIndex;
+            int index1 = serverBehaviour1.ComponentIndex;
+            int index2 = serverBehaviour2.ComponentIndex;
 
             // check components of same type have different indexes
             Assert.That(index1, Is.Not.EqualTo(index2));
 
             // check behaviour 1 can be synced
-            serverObject.value = behaviour1;
+            serverObject.value = serverBehaviour1;
             clientObject.value = null;
 
             bool written1 = SyncToClient(serverObject, clientObject, initialState);
             Assert.IsTrue(written1);
-            Assert.That(clientObject.value, Is.EqualTo(behaviour1));
+            Assert.That(clientObject.value, Is.EqualTo(clientBehaviour1));
 
             // check that behaviour 2 can be synced
-            serverObject.value = behaviour2;
+            serverObject.value = serverBehaviour2;
             clientObject.value = null;
 
             bool written2 = SyncToClient(serverObject, clientObject, initialState);
             Assert.IsTrue(written2);
-            Assert.That(clientObject.value, Is.EqualTo(behaviour2));
+            Assert.That(clientObject.value, Is.EqualTo(clientBehaviour2));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTest.cs
@@ -335,11 +335,14 @@ namespace Mirror.Tests.SyncVarTests
         [TestCase(false)]
         public void SyncVarCacheNetidForIdentity(bool initialState)
         {
-            CreateNetworked(out _, out _, out SyncVarNetworkIdentity serverObject);
-            CreateNetworked(out _, out _, out SyncVarNetworkIdentity clientObject);
+            CreateNetworkedAndSpawn(
+                out _, out _, out SyncVarNetworkIdentity serverObject,
+                out _, out _, out SyncVarNetworkIdentity clientObject);
 
             // create spawned because we will look up netId in .spawned
-            CreateNetworkedAndSpawn(out _, out NetworkIdentity serverValue);
+            CreateNetworkedAndSpawn(
+                out _, out NetworkIdentity serverValue,
+                out _, out NetworkIdentity clientValue);
 
             Assert.That(serverValue, Is.Not.Null, "getCreatedValue should not return null");
 
@@ -350,8 +353,8 @@ namespace Mirror.Tests.SyncVarTests
             bool written = ServerWrite(serverObject, initialState, out ArraySegment<byte> data, out int writeLength);
             Assert.IsTrue(written, "did not write");
 
-            // remove identity from collection
-            NetworkIdentity.spawned.Remove(serverValue.netId);
+            // remove identity from client, as if it walked out of range
+            NetworkClient.spawned.Remove(clientValue.netId);
 
             // read client data, this should be cached in field
             ClientRead(clientObject, initialState, data, writeLength);
@@ -359,11 +362,11 @@ namespace Mirror.Tests.SyncVarTests
             // check field shows as null
             Assert.That(clientObject.value, Is.EqualTo(null), "field should return null");
 
-            // add identity back to collection
-            NetworkIdentity.spawned.Add(serverValue.netId, serverValue);
+            // add identity back to collection, as if it walked back into range
+            NetworkClient.spawned.Add(clientValue.netId, clientValue);
 
             // check field finds value
-            Assert.That(clientObject.value, Is.EqualTo(serverValue), "fields should return serverValue");
+            Assert.That(clientObject.value, Is.EqualTo(clientValue), "fields should return clientValue");
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Runtime/ClientSceneTests_DestroyAllClientObjects.cs
+++ b/Assets/Mirror/Tests/Runtime/ClientSceneTests_DestroyAllClientObjects.cs
@@ -157,7 +157,7 @@ namespace Mirror.Tests.Runtime.ClientSceneTests
 
             NetworkClient.DestroyAllClientObjects();
 
-            Assert.That(NetworkIdentity.spawned, Is.Empty);
+            Assert.That(NetworkClient.spawned, Is.Empty);
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Runtime/ClientSceneTests_DestroyAllClientObjects.cs
+++ b/Assets/Mirror/Tests/Runtime/ClientSceneTests_DestroyAllClientObjects.cs
@@ -28,7 +28,7 @@ namespace Mirror.Tests.Runtime.ClientSceneTests
             const int id = 32032;
             netId.netId = id;
 
-            NetworkIdentity.spawned.Add(id, netId);
+            NetworkClient.spawned.Add(id, netId);
         }
     }
 

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -106,7 +106,7 @@ namespace Mirror.Tests.Runtime
             Assert.IsFalse(identity1.gameObject.activeSelf);
             Assert.IsFalse(identity1.gameObject.activeSelf);
 
-            Assert.That(NetworkIdentity.spawned, Is.Empty);
+            Assert.That(NetworkServer.spawned, Is.Empty);
         }
     }
 }

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -72,7 +72,7 @@ namespace Mirror.Tests.Runtime
             Assert.IsTrue(identity1 == null);
             Assert.IsTrue(identity2 == null);
 
-            Assert.That(NetworkIdentity.spawned, Is.Empty);
+            Assert.That(NetworkServer.spawned, Is.Empty);
         }
 
         NetworkIdentity SpawnPrefab(GameObject prefab)
@@ -80,7 +80,7 @@ namespace Mirror.Tests.Runtime
             GameObject clone1 = GameObject.Instantiate(prefab);
             NetworkServer.Spawn(clone1);
             NetworkIdentity identity1 = clone1.GetComponent<NetworkIdentity>();
-            Assert.IsTrue(NetworkIdentity.spawned.ContainsValue(identity1));
+            Assert.IsTrue(NetworkServer.spawned.ContainsValue(identity1));
             return identity1;
         }
 


### PR DESCRIPTION
to prepare for:
- true server & client tests where we spawn an object on server AND on client
- SyncDirection (tests for SyncDirection require above change)
- Host Mode improvements (easier if state is actually separated between server & client)
- NetworkServer/NetworkClient as component (maybe)

for tests, we can now call CreateNetworkedAndSpawn which returns both server & client object:
<img width="420" alt="2021-08-11_17-13-47@2x" src="https://user-images.githubusercontent.com/16416509/129003077-7b59f3cc-39cb-40c8-823e-b6aa1df5e3cc.png">

note that tests are generally more obvious now. for example:
<img width="1254" alt="2021-08-12_15-50-58@2x" src="https://user-images.githubusercontent.com/16416509/129159034-72c07648-e9ef-41aa-bb5e-ab9c06ba3961.png">

-> all tests pass.
-> uMMORPG still works.
<img width="1135" alt="2021-08-12_18-47-53@2x" src="https://user-images.githubusercontent.com/16416509/129184555-7c465ed7-2509-41d8-b531-3105e274be67.png">

