### PR TITLE
fix: Android multicast Discovery. Fixes #2878

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -93,6 +93,7 @@ namespace Mirror.Discovery
 
         void Shutdown()
         {
+            EndpMulticastLock();
             if (serverUdpClient != null)
             {
                 try
@@ -149,6 +150,7 @@ namespace Mirror.Discovery
 
         public async Task ServerListenAsync()
         {
+            BeginMulticastLock();
             while (true)
             {
                 try
@@ -236,7 +238,41 @@ namespace Mirror.Discovery
         /// <returns>The message to be sent back to the client or null</returns>
         protected abstract Response ProcessRequest(Request request, IPEndPoint endpoint);
 
-        #endregion
+#if UNITY_ANDROID
+        AndroidJavaObject multicastLock;
+        bool hasMulticastLock;
+#endif
+        void BeginMulticastLock()
+		{
+#if UNITY_ANDROID
+            if (hasMulticastLock)
+                return;
+            if (Application.platform == RuntimePlatform.Android)
+            {
+                using (AndroidJavaObject activity = new AndroidJavaClass("com.unity3d.player.UnityPlayer").GetStatic<AndroidJavaObject>("currentActivity"))
+                {
+                    using (var wifiManager = activity.Call<AndroidJavaObject>("getSystemService", "wifi"))
+                    {
+                        multicastLock = wifiManager.Call<AndroidJavaObject>("createMulticastLock", "lock");
+                        multicastLock.Call("acquire");
+                        hasMulticastLock = true;
+                    }
+                }
+			}
+#endif
+        }
+
+        void EndpMulticastLock()
+        {
+#if UNITY_ANDROID
+            if (!hasMulticastLock)
+                return;
+            multicastLock?.Call("release");
+#endif
+
+        }
+
+#endregion
 
         #region Client
 

--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -238,6 +238,7 @@ namespace Mirror.Discovery
         /// <returns>The message to be sent back to the client or null</returns>
         protected abstract Response ProcessRequest(Request request, IPEndPoint endpoint);
 
+        // Android Multicast fix: https://github.com/vis2k/Mirror/pull/2887
 #if UNITY_ANDROID
         AndroidJavaObject multicastLock;
         bool hasMulticastLock;
@@ -245,8 +246,8 @@ namespace Mirror.Discovery
         void BeginMulticastLock()
 		{
 #if UNITY_ANDROID
-            if (hasMulticastLock)
-                return;
+            if (hasMulticastLock) return;
+                
             if (Application.platform == RuntimePlatform.Android)
             {
                 using (AndroidJavaObject activity = new AndroidJavaClass("com.unity3d.player.UnityPlayer").GetStatic<AndroidJavaObject>("currentActivity"))
@@ -265,12 +266,11 @@ namespace Mirror.Discovery
         void EndpMulticastLock()
         {
 #if UNITY_ANDROID
-            if (!hasMulticastLock)
-                return;
+            if (!hasMulticastLock) return;
+            
             multicastLock?.Call("release");
             hasMulticastLock = false;
 #endif
-
         }
 
 #endregion

--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -268,6 +268,7 @@ namespace Mirror.Discovery
             if (!hasMulticastLock)
                 return;
             multicastLock?.Call("release");
+            hasMulticastLock = false;
 #endif
 
         }

--- a/Assets/Mirror/Editor/AndroidManifestHelper.cs
+++ b/Assets/Mirror/Editor/AndroidManifestHelper.cs
@@ -1,0 +1,120 @@
+
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using System.Xml;
+using System.IO;
+#if UNITY_ANDROID
+using UnityEditor.Android;
+#endif
+
+
+[InitializeOnLoad]
+public class AndroidManifestHelper : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+#if UNITY_ANDROID
+	, IPostGenerateGradleAndroidProject
+#endif
+{
+    public int callbackOrder { get { return 99999; } }
+
+#if UNITY_ANDROID
+    public void OnPostGenerateGradleAndroidProject(string path)
+	{
+        string manifestFolder = Path.Combine(path, "src/main");
+        string sourceFile = manifestFolder + "/AndroidManifest.xml";
+        // Load android manfiest file
+        XmlDocument doc = new XmlDocument();
+        doc.Load(sourceFile);
+
+        string androidNamepsaceURI;
+        XmlElement element = (XmlElement)doc.SelectSingleNode("/manifest");
+        if (element == null)
+        {
+            UnityEngine.Debug.LogError("Could not find manifest tag in android manifest.");
+            return;
+        }
+
+        // Get android namespace URI from the manifest
+        androidNamepsaceURI = element.GetAttribute("xmlns:android");
+        if (string.IsNullOrEmpty(androidNamepsaceURI))
+        {
+            UnityEngine.Debug.LogError("Could not find Android Namespace in manifest.");
+            return;
+        }
+        AddOrRemoveTag(doc,
+               androidNamepsaceURI,
+               "/manifest",
+               "uses-permission",
+               "android.permission.CHANGE_WIFI_MULTICAST_STATE",
+               true,
+               false);
+        AddOrRemoveTag(doc,
+               androidNamepsaceURI,
+               "/manifest",
+               "uses-permission",
+               "android.permission.INTERNET",
+               true,
+               false);
+        doc.Save(sourceFile);
+    }
+#endif
+
+    private static void AddOrRemoveTag(XmlDocument doc, string @namespace, string path, string elementName, string name, bool required, bool modifyIfFound, params string[] attrs) // name, value pairs	
+    {
+        var nodes = doc.SelectNodes(path + "/" + elementName);
+        XmlElement element = null;
+        foreach (XmlElement e in nodes)
+        {
+            if (name == null || name == e.GetAttribute("name", @namespace))
+            {
+                element = e;
+                break;
+            }
+        }
+
+        if (required)
+        {
+            if (element == null)
+            {
+                var parent = doc.SelectSingleNode(path);
+                element = doc.CreateElement(elementName);
+                element.SetAttribute("name", @namespace, name);
+                parent.AppendChild(element);
+            }
+
+            for (int i = 0; i < attrs.Length; i += 2)
+            {
+                if (modifyIfFound || string.IsNullOrEmpty(element.GetAttribute(attrs[i], @namespace)))
+                {
+                    if (attrs[i + 1] != null)
+                    {
+                        element.SetAttribute(attrs[i], @namespace, attrs[i + 1]);
+                    }
+                    else
+                    {
+                        element.RemoveAttribute(attrs[i], @namespace);
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (element != null && modifyIfFound)
+            {
+                element.ParentNode.RemoveChild(element);
+            }
+        }
+    }
+
+    public void OnPostprocessBuild(BuildReport report)
+	{
+        
+	}
+
+	public void OnPreprocessBuild(BuildReport report)
+	{
+
+	}
+
+}

--- a/Assets/Mirror/Editor/AndroidManifestHelper.cs
+++ b/Assets/Mirror/Editor/AndroidManifestHelper.cs
@@ -1,4 +1,5 @@
-
+// Android NetworkDiscovery Multicast fix
+// https://github.com/vis2k/Mirror/pull/2887
 using UnityEditor;
 using UnityEngine;
 using UnityEditor.Build;
@@ -60,7 +61,7 @@ public class AndroidManifestHelper : IPreprocessBuildWithReport, IPostprocessBui
     }
 #endif
 
-    private static void AddOrRemoveTag(XmlDocument doc, string @namespace, string path, string elementName, string name, bool required, bool modifyIfFound, params string[] attrs) // name, value pairs	
+    static void AddOrRemoveTag(XmlDocument doc, string @namespace, string path, string elementName, string name, bool required, bool modifyIfFound, params string[] attrs) // name, value pairs	
     {
         var nodes = doc.SelectNodes(path + "/" + elementName);
         XmlElement element = null;
@@ -107,14 +108,6 @@ public class AndroidManifestHelper : IPreprocessBuildWithReport, IPostprocessBui
         }
     }
 
-    public void OnPostprocessBuild(BuildReport report)
-	{
-        
-	}
-
-	public void OnPreprocessBuild(BuildReport report)
-	{
-
-	}
-
+    public void OnPostprocessBuild(BuildReport report) {}
+	public void OnPreprocessBuild(BuildReport report) {}
 }

--- a/Assets/Mirror/Editor/AndroidManifestHelper.cs.meta
+++ b/Assets/Mirror/Editor/AndroidManifestHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80cc70189403d7444bbffd185ca28462
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This will add support for turning on and off Multicast for Android devices.
It also contains an Android manifest editor that will add the appropriate permissions.