### PR TITLE
fix: The type or namespace name 'Exception' could not be found

### DIFF
--- a/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
+++ b/Assets/ScriptTemplates/50-Mirror__Network Manager-NewNetworkManager.cs.txt
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Mirror;
+using System;
 
 /*
 	Documentation: https://mirror-networking.gitbook.io/docs/components/network-manager


### PR DESCRIPTION
missing 'System' namespace