### PR TITLE
breaking: Weaver: add ReaderWriterProcessor [Runtime/InitializeOnLoad] Attributes without Reflection

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -1,5 +1,5 @@
 // finds all readers and writers and register them
-using System;
+using System.Linq;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
 using Mono.CecilX.Rocks;

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -146,10 +146,16 @@ namespace Mirror.Weaver
             }),
             ref WeavingFailed);
 
-            // attributes
-            TypeReference initializeOnLoadMethodAttributeRef = Import(typeof(InitializeOnLoadMethodAttribute));
-            initializeOnLoadMethodAttribute = initializeOnLoadMethodAttributeRef.Resolve();
+            // [InitializeOnLoadMethod]
+            // 'UnityEditor' is not available in builds.
+            // we can only import this attribute if we are in an Editor assembly.
+            if (Helpers.IsEditorAssembly(assembly))
+            {
+                TypeReference initializeOnLoadMethodAttributeRef = Import(typeof(InitializeOnLoadMethodAttribute));
+                initializeOnLoadMethodAttribute = initializeOnLoadMethodAttributeRef.Resolve();
+            }
 
+            // [RuntimeInitializeOnLoadMethod]
             TypeReference runtimeInitializeOnLoadMethodAttributeRef = Import(typeof(RuntimeInitializeOnLoadMethodAttribute));
             runtimeInitializeOnLoadMethodAttribute = runtimeInitializeOnLoadMethodAttributeRef.Resolve();
         }


### PR DESCRIPTION
reduce complexity.
cecil is crazy enough.
don't use reflection on top of it.