### PR TITLE
fix: Prevent NetworkManager.ServerChangeScene from being called while already loading the requested scene

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -764,6 +764,12 @@ namespace Mirror
                 return;
             }
 
+            if (NetworkServer.isLoadingScene && newSceneName == networkSceneName)
+            {
+                Debug.LogError("ServerChangeScene is already in progress for " + newSceneName);
+                return;
+            }
+
             // Debug.Log("ServerChangeScene " + newSceneName);
             NetworkServer.SetAllClientsNotReady();
             networkSceneName = newSceneName;


### PR DESCRIPTION
Prevents NetworkManager.ServerChangeScene from being called when networkmanager is already processing a scene change for the requested scene.

Just in case someone (definitely not me) accidentally calls ServerChangeScene in Update multiple times and is confused why they're getting "There is already a player for this connection" error messages from clients trying to load the same scene multiple times.