### PR TITLE
Remove obsolete weaver method calls

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -41,7 +41,7 @@ namespace Mirror.Weaver
                 // TODO
                 // a) .connectionToServer = best solution. no doubt.
                 // b) NetworkClient.connection for now. add TODO to not use static later.
-                worker.Emit(OpCodes.Call, weaverTypes.ReadyConnectionReference);
+                worker.Emit(OpCodes.Call, weaverTypes.NetworkClientConnectionReference);
             }
 
             // process reader parameters and skip first one if first one is NetworkConnection

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -14,7 +14,7 @@ namespace Mirror.Weaver
         public MethodReference GetPooledWriterReference;
         public MethodReference RecycleWriterReference;
 
-        public MethodReference ReadyConnectionReference;
+        public MethodReference NetworkClientConnectionReference;
 
         public MethodReference CmdDelegateConstructor;
 
@@ -96,7 +96,7 @@ namespace Mirror.Weaver
             GetPooledWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "GetWriter", ref WeavingFailed);
             RecycleWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Recycle", ref WeavingFailed);
 
-            ReadyConnectionReference = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_readyConnection", ref WeavingFailed);
+            NetworkClientConnectionReference = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_connection", ref WeavingFailed);
 
             syncVarEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarEqual", ref WeavingFailed);
             syncVarNetworkIdentityEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarNetworkIdentityEqual", ref WeavingFailed);

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests~/TestingScriptableObjectArraySerialization.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneralTests~/TestingScriptableObjectArraySerialization.cs
@@ -7,14 +7,14 @@ namespace WeaverGeneralTests.TestingScriptableObjectArraySerialization
     {
         public static void Writedata(this NetworkWriter writer, Data arg)
         {
-            writer.WriteInt32(arg.Var1);
+            writer.WriteInt(arg.Var1);
         }
 
         public static Data Readdata(this NetworkReader reader)
         {
             return new Data
             {
-                Var1 = reader.ReadInt32()
+                Var1 = reader.ReadInt()
             };
         }
     }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests~/CanUseCustomReadWriteForAbstractClass.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests~/CanUseCustomReadWriteForAbstractClass.cs
@@ -27,22 +27,22 @@ namespace GeneratedReaderWriter.CanUseCustomReadWriteForAbstractClass
     {
         public static void WriteData(this NetworkWriter writer, DataBase data)
         {
-            writer.WriteInt32(data.id);
+            writer.WriteInt(data.id);
             // write extra stuff depending on id here
-            writer.WriteInt32(data.someField);
+            writer.WriteInt(data.someField);
 
             if (data.id == 1)
             {
                 SomeData someData = (SomeData)data;
-                writer.WriteSingle(someData.anotherField);
+                writer.WriteFloat(someData.anotherField);
             }
         }
 
         public static DataBase ReadData(this NetworkReader reader)
         {
-            int id = reader.ReadInt32();
+            int id = reader.ReadInt();
 
-            int someField = reader.ReadInt32();
+            int someField = reader.ReadInt();
             DataBase data = null;
             if (data.id == 1)
             {
@@ -52,7 +52,7 @@ namespace GeneratedReaderWriter.CanUseCustomReadWriteForAbstractClass
                 };
                 // read extra stuff depending on id here
 
-                someData.anotherField = reader.ReadSingle();
+                someData.anotherField = reader.ReadFloat();
 
                 data = someData;
             }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests~/CanUseCustomReadWriteForInterfaces.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests~/CanUseCustomReadWriteForInterfaces.cs
@@ -25,13 +25,13 @@ namespace GeneratedReaderWriter.CanUseCustomReadWriteForInterfaces
     {
         public static void WriteData(this NetworkWriter writer, IData data)
         {
-            writer.WriteInt32(data.id);
+            writer.WriteInt(data.id);
             // write extra stuff depending on id here
         }
 
         public static IData ReadData(this NetworkReader reader)
         {
-            int id = reader.ReadInt32();
+            int id = reader.ReadInt();
             // do something with id
 
             SomeData someData = new SomeData();

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests~/GivesWarningWhenRegisteringExistingExtensionMethod.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests~/GivesWarningWhenRegisteringExistingExtensionMethod.cs
@@ -11,22 +11,22 @@ namespace GeneratedReaderWriter.GivesWarningWhenRegisteringExistingExtensionMeth
     {
         public static void WriteMyType(this NetworkWriter writer, MyType data)
         {
-            writer.WriteInt32(data.number);
+            writer.WriteInt(data.number);
         }
 
         public static void WriteMyType2(this NetworkWriter writer, MyType data)
         {
-            writer.WriteInt32(data.number);
+            writer.WriteInt(data.number);
         }
 
         public static MyType ReadMyType(this NetworkReader reader)
         {
-            return new MyType { number = reader.ReadInt32() };
+            return new MyType { number = reader.ReadInt() };
         }
 
         public static MyType ReadMyType2(this NetworkReader reader)
         {
-            return new MyType { number = reader.ReadInt32() };
+            return new MyType { number = reader.ReadInt() };
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests.cs
@@ -21,7 +21,7 @@ namespace Mirror.Weaver.Tests
         public void MonoBehaviourSyncList()
         {
             HasError("potato is a SyncObject and must be inside a NetworkBehaviour.  MonoBehaviourSyncList is not a NetworkBehaviour",
-                "Mirror.SyncListInt WeaverMonoBehaviourTests.MonoBehaviourSyncList.MonoBehaviourSyncList::potato");
+                "Mirror.SyncList`1<System.Int32> WeaverMonoBehaviourTests.MonoBehaviourSyncList.MonoBehaviourSyncList::potato");
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourSyncList.cs
@@ -5,6 +5,6 @@ namespace WeaverMonoBehaviourTests.MonoBehaviourSyncList
 {
     class MonoBehaviourSyncList : MonoBehaviour
     {
-        SyncListInt potato;
+        SyncList<int> potato;
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericStructItemWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericStructItemWithCustomMethods.cs
@@ -17,12 +17,12 @@ namespace WeaverSyncDictionaryTests.SyncDictionaryGenericStructItemWithCustomMet
     {
         public static void WriteItem(this NetworkWriter writer, MyGenericStruct<float> item)
         {
-            writer.WriteSingle(item.genericpotato);
+            writer.WriteFloat(item.genericpotato);
         }
 
         public static MyGenericStruct<float> ReadItem(this NetworkReader reader)
         {
-            return new MyGenericStruct<float>() { genericpotato = reader.ReadSingle() };
+            return new MyGenericStruct<float>() { genericpotato = reader.ReadFloat() };
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericStructKeyWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncDictionaryTests~/SyncDictionaryGenericStructKeyWithCustomMethods.cs
@@ -17,12 +17,12 @@ namespace WeaverSyncDictionaryTests.SyncDictionaryGenericStructKeyWithCustomMeth
     {
         public static void WriteKey(this NetworkWriter writer, MyGenericStruct<float> item)
         {
-            writer.WriteSingle(item.genericpotato);
+            writer.WriteFloat(item.genericpotato);
         }
 
         public static MyGenericStruct<float> ReadKey(this NetworkReader reader)
         {
-            return new MyGenericStruct<float>() { genericpotato = reader.ReadSingle() };
+            return new MyGenericStruct<float>() { genericpotato = reader.ReadFloat() };
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncList.cs
@@ -4,6 +4,6 @@ namespace WeaverSyncListTests.SyncList
 {
     class SyncList : NetworkBehaviour
     {
-        public SyncListInt Foo;
+        public SyncList<int> Foo;
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericStructWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListGenericStructWithCustomMethods.cs
@@ -16,12 +16,12 @@ namespace WeaverSyncListTests.SyncListGenericStructWithCustomMethods
     {
         static void SerializeItem(this NetworkWriter writer, MyGenericStruct<float> item)
         {
-            writer.WriteSingle(item.genericpotato);
+            writer.WriteFloat(item.genericpotato);
         }
 
         static MyGenericStruct<float> DeserializeItem(this NetworkReader reader)
         {
-            return new MyGenericStruct<float>() { genericpotato = reader.ReadSingle() };
+            return new MyGenericStruct<float>() { genericpotato = reader.ReadFloat() };
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInheritance.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInheritance.cs
@@ -4,10 +4,10 @@ namespace WeaverSyncListTests.SyncListInheritance
 {
     class SyncListInheritance : NetworkBehaviour
     {
-        readonly SuperSyncListString superSyncListString = new SuperSyncListString();
+        readonly SuperSyncList<string> superSyncListString = new SuperSyncList<string>();
 
 
-        public class SuperSyncListString : SyncListString
+        public class SuperSyncList<T> : SyncList<T>
         {
 
         }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInterfaceWithCustomMethods.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncListTests~/SyncListInterfaceWithCustomMethods.cs
@@ -21,11 +21,11 @@ namespace WeaverSyncListTests.SyncListInterfaceWithCustomMethods
     {
         static void SerializeItem(this NetworkWriter writer, IMyInterface item)
         {
-            writer.WriteInt32(item.someNumber);
+            writer.WriteInt(item.someNumber);
         }
         static IMyInterface DeserializeItem(this NetworkReader reader)
         {
-            return new MyUser { someNumber = reader.ReadInt32() };
+            return new MyUser { someNumber = reader.ReadInt() };
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSet.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncSetTests~/SyncSet.cs
@@ -4,6 +4,6 @@ namespace WeaverSyncSetTests.SyncSet
 {
     class SyncSet : NetworkBehaviour
     {
-        public SyncListInt Foo;
+        public SyncList<int> Foo;
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests.cs
@@ -70,7 +70,7 @@ namespace Mirror.Weaver.Tests
             HasWarning("syncobj has [SyncVar] attribute. SyncLists should not be marked with SyncVar",
                 "WeaverSyncVarTests.SyncVarsSyncList.SyncVarsSyncList/SyncObjImplementer WeaverSyncVarTests.SyncVarsSyncList.SyncVarsSyncList::syncobj");
             HasWarning("syncints has [SyncVar] attribute. SyncLists should not be marked with SyncVar",
-                "Mirror.SyncListInt WeaverSyncVarTests.SyncVarsSyncList.SyncVarsSyncList::syncints");
+                "Mirror.SyncList`1<System.Int32> WeaverSyncVarTests.SyncVarsSyncList.SyncVarsSyncList::syncints");
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsSyncList.cs
@@ -20,6 +20,6 @@ namespace WeaverSyncVarTests.SyncVarsSyncList
         SyncObjImplementer syncobj;
 
         [SyncVar]
-        SyncListInt syncints;
+        SyncList<int> syncints;
     }
 }


### PR DESCRIPTION
-Weaver uses NetworkConnection.connection instead of NetworkConnection.readyConnection for targetrpcs
-Update weaver tests to use new NetworkReader/Writer API
-Update weaver tests to use SynccList<int> instead of SyncListInt