### PR TITLE
perf: breaking: SyncObjects (SyncList/SyncSet/SyncDict) Dirty Searching (O(N)) replaced with bit mask (O(1))

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -84,6 +84,7 @@ namespace Mirror
         protected ulong syncVarDirtyBits { get; private set; }
         // 64 bit mask, tracking up to 64 sync collections (internal for tests).
         // internal for tests, field for faster access (instead of property)
+        // TODO 64 SyncLists are too much. consider smaller mask later.
         internal ulong syncObjectDirtyBits;
 
         // hook guard to avoid deadlocks when calling hooks in host mode

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -157,11 +157,17 @@ namespace Mirror
                 Debug.LogError("Uninitialized SyncObject. Manually call the constructor on your SyncList, SyncSet or SyncDictionary");
                 return;
             }
+
+            // we will add this syncObject at index...
+            // if Count=0 then index is 0, etc.
+            int index = syncObjects.Count;
+
+            // add it
             syncObjects.Add(syncObject);
 
             // when the syncObject gets dirty, set the nth bit in our dirty mask
             // we know the index right now, so calculate the nth bit mask now.
-            ulong nthBit = 1UL << syncObjects.Count;
+            ulong nthBit = 1UL << index;
             syncObject.OnDirty = () => syncObjectDirtyBits |= nthBit;
         }
 

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -82,8 +82,9 @@ namespace Mirror
         //
         // 64 bit mask, tracking up to 64 SyncVars.
         protected ulong syncVarDirtyBits { get; private set; }
-        // 64 bit mask, tracking up to 64 sync collections (internal for tests)
-        internal ulong syncObjectDirtyBits { get; private set; }
+        // 64 bit mask, tracking up to 64 sync collections (internal for tests).
+        // internal for tests, field for faster access (instead of property)
+        internal ulong syncObjectDirtyBits;
 
         // hook guard to avoid deadlocks when calling hooks in host mode
         ulong syncVarHookGuard;

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -80,9 +80,10 @@ namespace Mirror
         //   -> spares us from running delta algorithms
         //   -> still supports dynamically sized types
         //
-        // syncVarDirtyBits is a 64 bit mask, tracking up to 64 SyncVars.
-        // (NOT for SyncLists/Dicts/Sets. AnySyncObjectDirty checks them.)
+        // 64 bit mask, tracking up to 64 SyncVars.
         protected ulong syncVarDirtyBits { get; private set; }
+        // 64 bit mask, tracking up to 64 sync collections (internal for tests)
+        internal ulong syncObjectDirtyBits { get; private set; }
 
         // hook guard to avoid deadlocks when calling hooks in host mode
         ulong syncVarHookGuard;
@@ -117,32 +118,13 @@ namespace Mirror
             syncVarDirtyBits |= dirtyBit;
         }
 
-        // creates a 64 bit dirty mask for Sync Collections (aka SyncObjects)
-        // TODO 64 SyncLists are too much. consider smaller mask later.
-        internal ulong DirtyObjectBits()
-        {
-            ulong dirtyObjects = 0;
-            for (int i = 0; i < syncObjects.Count; i++)
-            {
-                SyncObject syncObject = syncObjects[i];
-                if (syncObject.IsDirty)
-                {
-                    dirtyObjects |= 1UL << i;
-                }
-            }
-            return dirtyObjects;
-        }
-
-        // internal for tests
-        // reuses DirtyObjectBits for simplicity.
-        internal bool AnySyncObjectDirty() => DirtyObjectBits() != 0UL;
-
         // true if syncInterval elapsed and any SyncVar or SyncObject is dirty
         public bool IsDirty()
         {
             if (NetworkTime.localTime - lastSyncTime >= syncInterval)
             {
-                return syncVarDirtyBits != 0L || AnySyncObjectDirty();
+                // TODO | both masks then compare with 0 might be faster
+                return syncVarDirtyBits != 0L || syncObjectDirtyBits != 0UL;
             }
             return false;
         }
@@ -154,6 +136,7 @@ namespace Mirror
         {
             lastSyncTime = NetworkTime.localTime;
             syncVarDirtyBits = 0L;
+            syncObjectDirtyBits = 0L;
 
             // clear all unsynchronized changes in syncobjects
             // (Linq allocates, use for instead)
@@ -174,6 +157,7 @@ namespace Mirror
                 return;
             }
             syncObjects.Add(syncObject);
+            // TODO set up dirty mask
         }
 
         protected void SendCommandInternal(Type invokeClass, string cmdName, NetworkWriter writer, int channelId, bool requiresAuthority = true)
@@ -629,12 +613,13 @@ namespace Mirror
         {
             bool dirty = false;
             // write the mask
-            writer.WriteULong(DirtyObjectBits());
+            writer.WriteULong(syncObjectDirtyBits);
             // serializable objects, such as synclists
             for (int i = 0; i < syncObjects.Count; i++)
             {
+                // check dirty mask at nth bit
                 SyncObject syncObject = syncObjects[i];
-                if (syncObject.IsDirty)
+                if ((syncObjectDirtyBits & (1UL << i)) != 0)
                 {
                     syncObject.OnSerializeDelta(writer);
                     dirty = true;
@@ -657,6 +642,7 @@ namespace Mirror
             ulong dirty = reader.ReadULong();
             for (int i = 0; i < syncObjects.Count; i++)
             {
+                // check dirty mask at nth bit
                 SyncObject syncObject = syncObjects[i];
                 if ((dirty & (1UL << i)) != 0)
                 {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -158,7 +158,11 @@ namespace Mirror
                 return;
             }
             syncObjects.Add(syncObject);
-            // TODO set up dirty mask
+
+            // when the syncObject gets dirty, set the nth bit in our dirty mask
+            // we know the index right now, so calculate the nth bit mask now.
+            ulong nthBit = 1UL << syncObjects.Count;
+            syncObject.OnDirty = () => syncObjectDirtyBits |= nthBit;
         }
 
         protected void SendCommandInternal(Type invokeClass, string cmdName, NetworkWriter writer, int channelId, bool requiresAuthority = true)

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -158,15 +158,11 @@ namespace Mirror
                 return;
             }
 
-            // we will add this syncObject at index...
-            // if Count=0 then index is 0, etc.
+            // add it, remember the index in list (if Count=0, index=0 etc.)
             int index = syncObjects.Count;
-
-            // add it
             syncObjects.Add(syncObject);
 
-            // when the syncObject gets dirty, set the nth bit in our dirty mask
-            // we know the index right now, so calculate the nth bit mask now.
+            // OnDirty needs to set nth bit in our dirty mask
             ulong nthBit = 1UL << index;
             syncObject.OnDirty = () => syncObjectDirtyBits |= nthBit;
         }

--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -13,6 +13,8 @@ namespace Mirror
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
         public event SyncDictionaryChanged Callback;
+
+        // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
         public Action OnDirty { get; set; }
 
         public enum Operation : byte
@@ -77,6 +79,7 @@ namespace Mirror
             };
 
             changes.Add(change);
+            OnDirty?.Invoke();
 
             Callback?.Invoke(op, key, item);
         }

--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -12,6 +13,7 @@ namespace Mirror
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
         public event SyncDictionaryChanged Callback;
+        public Action OnDirty { get; set; }
 
         public enum Operation : byte
         {

--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -43,8 +43,6 @@ namespace Mirror
             objects.Clear();
         }
 
-        public bool IsDirty => changes.Count > 0;
-
         public ICollection<TKey> Keys => objects.Keys;
 
         public ICollection<TValue> Values => objects.Values;

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -15,6 +15,10 @@ namespace Mirror
         public bool IsReadOnly { get; private set; }
         public event SyncListChanged Callback;
 
+        // dirty callback to set dirty mask bits in owner NetworkBehaviour if
+        // anything in there changed.
+        Action OnDirty;
+
         public enum Operation : byte
         {
             OP_ADD,
@@ -51,8 +55,6 @@ namespace Mirror
             this.comparer = comparer ?? EqualityComparer<T>.Default;
             this.objects = objects;
         }
-
-        public bool IsDirty => changes.Count > 0;
 
         // throw away all the changes
         // this should be called after a successful sync

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -14,10 +14,7 @@ namespace Mirror
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
         public event SyncListChanged Callback;
-
-        // dirty callback to set dirty mask bits in owner NetworkBehaviour if
-        // anything in there changed.
-        Action OnDirty;
+        public Action OnDirty { get; set; }
 
         public enum Operation : byte
         {

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -14,6 +14,8 @@ namespace Mirror
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
         public event SyncListChanged Callback;
+
+        // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
         public Action OnDirty { get; set; }
 
         public enum Operation : byte
@@ -80,6 +82,7 @@ namespace Mirror
             };
 
             changes.Add(change);
+            OnDirty?.Invoke();
 
             Callback?.Invoke(op, itemIndex, oldItem, newItem);
         }

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -3,9 +3,6 @@ namespace Mirror
     /// <summary>SyncObjects sync state between server and client. E.g. SyncLists.</summary>
     public interface SyncObject
     {
-        /// <summary>True if there are changes since the last flush</summary>
-        bool IsDirty { get; }
-
         /// <summary>Discard all the queued changes</summary>
         // Consider the object fully synchronized with clients
         void ClearChanges();

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -5,8 +5,7 @@ namespace Mirror
     /// <summary>SyncObjects sync state between server and client. E.g. SyncLists.</summary>
     public interface SyncObject
     {
-        // OnDirty callback can be set by owner NetworkBehaviour to set a bit
-        // in the dirty mask.
+        /// <summary>Used internally to set owner NetworkBehaviour's dirty mask bit when changed.</summary>
         Action OnDirty { get; set; }
 
         /// <summary>Discard all the queued changes</summary>

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -1,8 +1,14 @@
+using System;
+
 namespace Mirror
 {
     /// <summary>SyncObjects sync state between server and client. E.g. SyncLists.</summary>
     public interface SyncObject
     {
+        // OnDirty callback can be set by owner NetworkBehaviour to set a bit
+        // in the dirty mask.
+        Action OnDirty { get; set; }
+
         /// <summary>Discard all the queued changes</summary>
         // Consider the object fully synchronized with clients
         void ClearChanges();

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -13,6 +13,8 @@ namespace Mirror
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
         public event SyncSetChanged Callback;
+
+        // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
         public Action OnDirty { get; set; }
 
         public enum Operation : byte
@@ -66,6 +68,7 @@ namespace Mirror
             };
 
             changes.Add(change);
+            OnDirty?.Invoke();
 
             Callback?.Invoke(op, item);
         }

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -47,8 +47,6 @@ namespace Mirror
             objects.Clear();
         }
 
-        public bool IsDirty => changes.Count > 0;
-
         // throw away all the changes
         // this should be called after a successful sync
         public void ClearChanges() => changes.Clear();

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -13,6 +13,7 @@ namespace Mirror
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
         public event SyncSetChanged Callback;
+        public Action OnDirty { get; set; }
 
         public enum Operation : byte
         {

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -54,10 +54,6 @@ namespace Mirror.Tests
             // change the dict. should both be dirty.
             comp.dict[42] = null;
             Assert.That(comp.syncObjectDirtyBits, Is.EqualTo(0b11));
-
-            // set list not dirty. dict should still make it dirty.
-            comp.list.ClearChanges();
-            Assert.That(comp.syncObjectDirtyBits, Is.EqualTo(0b10));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -38,42 +38,26 @@ namespace Mirror.Tests
             Assert.That(comp.syncVarDirtyBitsExposed, Is.EqualTo(0b_00000000_00010100));
         }
 
+        // changing a SyncObject (collection) should modify the dirty mask.
         [Test]
-        public void DirtyObjectBits()
+        public void SyncObjectsSetDirtyBits()
         {
             CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
 
             // not dirty by default
-            Assert.That(comp.DirtyObjectBits(), Is.EqualTo(0b0));
-
-            // dirty the list
-            comp.list.Add(42);
-            Assert.That(comp.DirtyObjectBits(), Is.EqualTo(0b01));
-
-            // dirty the dict too. now we should have two dirty bits
-            comp.dict[43] = null;
-            Assert.That(comp.DirtyObjectBits(), Is.EqualTo(0b11));
-        }
-
-        [Test]
-        public void AnySyncObjectDirty()
-        {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
-
-            // not dirty by default
-            Assert.That(comp.AnySyncObjectDirty(), Is.False);
+            Assert.That(comp.syncObjectDirtyBits, Is.EqualTo(0UL));
 
             // change the list. should be dirty now.
             comp.list.Add(42);
-            Assert.That(comp.AnySyncObjectDirty(), Is.True);
+            Assert.That(comp.syncObjectDirtyBits, Is.EqualTo(0b01));
 
-            // change the dict. should still be dirty.
+            // change the dict. should both be dirty.
             comp.dict[42] = null;
-            Assert.That(comp.AnySyncObjectDirty(), Is.True);
+            Assert.That(comp.syncObjectDirtyBits, Is.EqualTo(0b11));
 
             // set list not dirty. dict should still make it dirty.
             comp.list.ClearChanges();
-            Assert.That(comp.AnySyncObjectDirty(), Is.True);
+            Assert.That(comp.syncObjectDirtyBits, Is.EqualTo(0b10));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncListStructTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListStructTest.cs
@@ -16,16 +16,22 @@ namespace Mirror.Tests
         {
             SyncList<TestPlayer> serverList = new SyncList<TestPlayer>();
             SyncList<TestPlayer> clientList = new SyncList<TestPlayer>();
+
+            // set up dirty callback
+            int serverListDirtyCalled = 0;
+            serverList.OnDirty = () => ++serverListDirtyCalled;
+
             SyncListTest.SerializeAllTo(serverList, clientList);
             serverList.Add(new TestPlayer { item = new TestItem { price = 10 } });
+            Assert.That(serverListDirtyCalled, Is.EqualTo(1));
             SyncListTest.SerializeDeltaTo(serverList, clientList);
-            Assert.That(serverList.IsDirty, Is.False);
+            serverListDirtyCalled = 0;
 
             TestPlayer player = serverList[0];
             player.item.price = 15;
             serverList[0] = player;
 
-            Assert.That(serverList.IsDirty, Is.True);
+            Assert.That(serverListDirtyCalled, Is.EqualTo(1));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -8,9 +8,8 @@ namespace Mirror.Tests
     public class SyncListTest
     {
         SyncList<string> serverSyncList;
-        int serverSyncListDirtyCalled;
-
         SyncList<string> clientSyncList;
+        int serverSyncListDirtyCalled;
         int clientSyncListDirtyCalled;
 
         public static void SerializeAllTo<T>(T fromList, T toList) where T : SyncObject
@@ -44,18 +43,19 @@ namespace Mirror.Tests
         {
             serverSyncList = new SyncList<string>();
             clientSyncList = new SyncList<string>();
-            serverSyncListDirtyCalled = 0;
-            clientSyncListDirtyCalled = 0;
-            serverSyncList.OnDirty = () => ++serverSyncListDirtyCalled;
-            clientSyncList.OnDirty = () => ++clientSyncListDirtyCalled;
-
-            // set up dirty callbacks for testing
 
             // add some data to the list
             serverSyncList.Add("Hello");
             serverSyncList.Add("World");
             serverSyncList.Add("!");
             SerializeAllTo(serverSyncList, clientSyncList);
+
+            // set up dirty callbacks for testing
+            // AFTER adding the example data. we already know we added that data.
+            serverSyncList.OnDirty = () => ++serverSyncListDirtyCalled;
+            clientSyncList.OnDirty = () => ++clientSyncListDirtyCalled;
+            serverSyncListDirtyCalled = 0;
+            clientSyncListDirtyCalled = 0;
         }
 
         [Test]
@@ -342,18 +342,16 @@ namespace Mirror.Tests
         public void DirtyTest()
         {
             // Sync Delta to clear dirty
+            Assert.That(serverSyncListDirtyCalled, Is.EqualTo(0));
             SerializeDeltaTo(serverSyncList, clientSyncList);
 
             // nothing to send
-            Assert.That(serverSyncList.IsDirty, Is.False);
+            Assert.That(serverSyncListDirtyCalled, Is.EqualTo(0));
 
             // something has changed
             serverSyncList.Add("1");
-            Assert.That(serverSyncList.IsDirty, Is.True);
+            Assert.That(serverSyncListDirtyCalled, Is.EqualTo(1));
             SerializeDeltaTo(serverSyncList, clientSyncList);
-
-            // data has been flushed,  should go back to clear
-            Assert.That(serverSyncList.IsDirty, Is.False);
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -8,7 +8,10 @@ namespace Mirror.Tests
     public class SyncListTest
     {
         SyncList<string> serverSyncList;
+        int serverSyncListDirtyCalled;
+
         SyncList<string> clientSyncList;
+        int clientSyncListDirtyCalled;
 
         public static void SerializeAllTo<T>(T fromList, T toList) where T : SyncObject
         {
@@ -41,6 +44,12 @@ namespace Mirror.Tests
         {
             serverSyncList = new SyncList<string>();
             clientSyncList = new SyncList<string>();
+            serverSyncListDirtyCalled = 0;
+            clientSyncListDirtyCalled = 0;
+            serverSyncList.OnDirty = () => ++serverSyncListDirtyCalled;
+            clientSyncList.OnDirty = () => ++clientSyncListDirtyCalled;
+
+            // set up dirty callbacks for testing
 
             // add some data to the list
             serverSyncList.Add("Hello");

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarTests~/SyncVarsSyncList.cs
@@ -1,4 +1,5 @@
 using Mirror;
+using System;
 
 namespace WeaverSyncVarTests.SyncVarsSyncList
 {
@@ -7,7 +8,7 @@ namespace WeaverSyncVarTests.SyncVarsSyncList
     {
         public class SyncObjImplementer : SyncObject
         {
-            public bool IsDirty { get; }
+            public Action OnDirty { get; set; }
             public void ClearChanges() { }
             public void OnSerializeAll(NetworkWriter writer) { }
             public void OnSerializeDelta(NetworkWriter writer) { }


### PR DESCRIPTION
previously SyncObjects stored their own IsDirty flag.
NetworkBehaviour had to scan through all of them to figure out which are dirty.

this was costly. especially in large worlds where for each entity's NetworkBe
haviour components, it would search through each SyncObject.

(big thanks to imer for non-weaver idea)

**in other words, this code is gone:**
<img width="577" alt="2021-09-17_15-40-05@2x" src="https://user-images.githubusercontent.com/16416509/133744059-d9be5857-b9e0-4d31-a071-66bdab2af140.png">

**replaced with this**:
![image](https://user-images.githubusercontent.com/16416509/133747174-cb0ec0dd-ea20-4eba-bc59-72ebbe397e45.png)

all tests pass.
tested in ummorpg, still only syncs the slots when changed:
<img width="1129" alt="2021-09-17_15-54-49@2x" src="https://user-images.githubusercontent.com/16416509/133746218-542e34ec-1e52-48d8-acc5-31d88b77c748.png">
