### PR TITLE
perf: NetworkServer.Broadcast O(N) spawned iteration removed. dirty bits for spawned without observers are now cleared when adding the first observer instead

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -172,8 +172,7 @@ namespace Mirror
             //   if a monster has no observers but we keep modifing a SyncObject,
             //   then the changes would never be flushed and keep growing,
             //   because OnSerialize isn't called without observers.
-            syncObject.IsRecording = () => netIdentity.observers == null ||
-                                           netIdentity.observers.Count > 0;
+            syncObject.IsRecording = () => netIdentity.observers?.Count > 0;
         }
 
         protected void SendCommandInternal(Type invokeClass, string cmdName, NetworkWriter writer, int channelId, bool requiresAuthority = true)

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -166,6 +166,14 @@ namespace Mirror
             // OnDirty needs to set nth bit in our dirty mask
             ulong nthBit = 1UL << index;
             syncObject.OnDirty = () => syncObjectDirtyBits |= nthBit;
+
+            // only record changes while we have observers.
+            // prevents ever growing .changes lists:
+            //   if a monster has no observers but we keep modifing a SyncObject,
+            //   then the changes would never be flushed and keep growing,
+            //   because OnSerialize isn't called without observers.
+            syncObject.IsRecording = () => netIdentity.observers == null ||
+                                           netIdentity.observers.Count > 0;
         }
 
         protected void SendCommandInternal(Type invokeClass, string cmdName, NetworkWriter writer, int channelId, bool requiresAuthority = true)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1626,8 +1626,12 @@ namespace Mirror
             // see test: DirtyBitsAreClearedForSpawnedWithoutObservers()
             // see test: SyncObjectChanges_DontGrowWithoutObservers()
             //
-            // PAUL: we also do this to avoid ever growing SyncList .changes
-            ClearSpawnedDirtyBits();
+            // TODO PAUL: we also do this to avoid ever growing SyncList .changes
+            //ClearSpawnedDirtyBits();
+            //
+            // this was moved to NetworkIdentity.AddObserver!
+            // same result, but no more O(N) loop in here!
+            // TODO remove this comment after moving spawning into Broadcast()!
         }
 
         // update //////////////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1605,7 +1605,7 @@ namespace Mirror
             // see test: DirtyBitsAreClearedForSpawnedWithoutObservers()
             // see test: SyncObjectChanges_DontGrowWithoutObservers()
             //
-            // TODO PAUL: we also do this to avoid ever growing SyncList .changes
+            // PAUL: we also do this to avoid ever growing SyncList .changes
             //ClearSpawnedDirtyBits();
             //
             // this was moved to NetworkIdentity.AddObserver!

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1507,27 +1507,6 @@ namespace Mirror
             return null;
         }
 
-        // helper function to clear dirty bits of all spawned entities
-        static void ClearSpawnedDirtyBits()
-        {
-            // TODO clear dirty bits when removing the last observer instead!
-            //      no need to do it for ALL entities ALL the time.
-            //
-            // for each spawned:
-            //   clear dirty bits if it has no observers.
-            //   we did this before push->pull broadcasting so let's keep
-            //   doing this for now.
-            foreach (NetworkIdentity identity in spawned.Values)
-            {
-                if (identity.observers == null || identity.observers.Count == 0)
-                {
-                    // clear all component's dirty bits.
-                    // it would be spawned on new observers anyway.
-                    identity.ClearAllComponentsDirtyBits();
-                }
-            }
-        }
-
         // helper function to broadcast the world to a connection
         static void BroadcastToConnection(NetworkConnectionToClient connection)
         {

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -110,7 +110,12 @@ namespace Mirror.Tests
         [Test]
         public void ClearAllDirtyBitsClearsSyncObjectsDirtyBits()
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
+            // SyncLists are only set dirty while owner has observers.
+            // need a connection.
+            NetworkServer.Listen(1);
+            ConnectHostClientBlockingAuthenticatedAndReady();
+
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
 
             // set syncinterval so dirtybit works fine
             comp.syncInterval = 0;

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -143,7 +143,10 @@ namespace Mirror.Tests
             ++monsterComp.health;
             Assert.That(monsterComp.IsDirty(), Is.True);
 
-            // at the moment, NetworkServer.Update clears dirty bit if no observers
+            // add observer again. update everything. dirty bits should be cleared.
+            // for this test to pass, either AddObserver or NetworkServer.Update
+            // have to clear the dirty bits if we had no observers before.
+            monster.AddObserver(player.connectionToClient);
             ProcessMessages();
             Assert.That(monsterComp.IsDirty(), Is.False);
         }

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -23,10 +23,21 @@ namespace Mirror.Tests
 
     public class NetworkBehaviourDirtyBitsTests : MirrorEditModeTest
     {
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            // SyncLists are only set dirty while owner has observers.
+            // need a connection.
+            NetworkServer.Listen(1);
+            ConnectHostClientBlockingAuthenticatedAndReady();
+        }
+
         [Test]
         public void SetDirtyBit()
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourSyncVarDirtyBitsExposed comp);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out NetworkBehaviourSyncVarDirtyBitsExposed comp);
 
             // set 3rd dirty bit.
             comp.SetDirtyBit(0b_00000000_00000100);
@@ -42,11 +53,6 @@ namespace Mirror.Tests
         [Test]
         public void SyncObjectsSetDirtyBits()
         {
-            // SyncLists are only set dirty while owner has observers.
-            // need a connection.
-            NetworkServer.Listen(1);
-            ConnectHostClientBlockingAuthenticatedAndReady();
-
             CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
 
             // not dirty by default
@@ -64,11 +70,6 @@ namespace Mirror.Tests
         [Test]
         public void IsDirty()
         {
-            // SyncLists are only set dirty while owner has observers.
-            // need a connection.
-            NetworkServer.Listen(1);
-            ConnectHostClientBlockingAuthenticatedAndReady();
-
             CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity identity, out NetworkBehaviourWithSyncVarsAndCollections comp);
 
             // not dirty by default
@@ -92,7 +93,7 @@ namespace Mirror.Tests
         [Test]
         public void ClearAllDirtyBitsClearsSyncVarDirtyBits()
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out EmptyBehaviour emptyBehaviour);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out EmptyBehaviour emptyBehaviour);
 
             // set syncinterval so dirtybit works fine
             emptyBehaviour.syncInterval = 0;
@@ -110,11 +111,6 @@ namespace Mirror.Tests
         [Test]
         public void ClearAllDirtyBitsClearsSyncObjectsDirtyBits()
         {
-            // SyncLists are only set dirty while owner has observers.
-            // need a connection.
-            NetworkServer.Listen(1);
-            ConnectHostClientBlockingAuthenticatedAndReady();
-
             CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
 
             // set syncinterval so dirtybit works fine
@@ -140,9 +136,6 @@ namespace Mirror.Tests
         [Test]
         public void DirtyBitsAreClearedForSpawnedWithoutObservers()
         {
-            NetworkServer.Listen(1);
-            ConnectHostClientBlockingAuthenticatedAndReady();
-
             // need one player, one monster
             CreateNetworkedAndSpawnPlayer(out _, out NetworkIdentity player, NetworkServer.localConnection);
             CreateNetworkedAndSpawn(out _, out NetworkIdentity monster, out NetworkBehaviourWithSyncVarsAndCollections monsterComp);

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -143,11 +143,8 @@ namespace Mirror.Tests
             ++monsterComp.health;
             Assert.That(monsterComp.IsDirty(), Is.True);
 
-            // add observer again. update everything. dirty bits should be cleared.
-            // for this test to pass, either AddObserver or NetworkServer.Update
-            // have to clear the dirty bits if we had no observers before.
+            // add first observer. dirty bits should be cleared.
             monster.AddObserver(player.connectionToClient);
-            ProcessMessages();
             Assert.That(monsterComp.IsDirty(), Is.False);
         }
     }

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -42,7 +42,12 @@ namespace Mirror.Tests
         [Test]
         public void SyncObjectsSetDirtyBits()
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
+            // SyncLists are only set dirty while owner has observers.
+            // need a connection.
+            NetworkServer.Listen(1);
+            ConnectHostClientBlockingAuthenticatedAndReady();
+
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
 
             // not dirty by default
             Assert.That(comp.syncObjectDirtyBits, Is.EqualTo(0UL));

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -59,7 +59,12 @@ namespace Mirror.Tests
         [Test]
         public void IsDirty()
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
+            // SyncLists are only set dirty while owner has observers.
+            // need a connection.
+            NetworkServer.Listen(1);
+            ConnectHostClientBlockingAuthenticatedAndReady();
+
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity identity, out NetworkBehaviourWithSyncVarsAndCollections comp);
 
             // not dirty by default
             Assert.That(comp.IsDirty(), Is.False);

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
@@ -136,13 +136,24 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
             }
         }
 
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            // SyncLists are only set dirty while owner has observers.
+            // need a connection.
+            NetworkServer.Listen(1);
+            ConnectHostClientBlockingAuthenticatedAndReady();
+        }
+
         [Test]
         [TestCase(true)]
         [TestCase(false)]
         public void BehaviourWithSyncVarTest(bool initialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out BehaviourWithSyncVar source);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out BehaviourWithSyncVar target);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out BehaviourWithSyncVar source);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out BehaviourWithSyncVar target);
 
             source.SyncField = 10;
             source.syncList.Add(true);
@@ -159,8 +170,8 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
         [TestCase(false)]
         public void OverrideBehaviourFromSyncVarTest(bool initialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out OverrideBehaviourFromSyncVar source);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out OverrideBehaviourFromSyncVar target);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out OverrideBehaviourFromSyncVar source);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out OverrideBehaviourFromSyncVar target);
 
             source.SyncFieldInAbstract = 12;
             source.syncListInAbstract.Add(true);
@@ -179,8 +190,8 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
         [TestCase(false)]
         public void OverrideBehaviourWithSyncVarFromSyncVarTest(bool initialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out OverrideBehaviourWithSyncVarFromSyncVar source);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out OverrideBehaviourWithSyncVarFromSyncVar target);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out OverrideBehaviourWithSyncVarFromSyncVar source);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out OverrideBehaviourWithSyncVarFromSyncVar target);
 
             source.SyncFieldInAbstract = 10;
             source.syncListInAbstract.Add(true);
@@ -208,8 +219,8 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
         [TestCase(false)]
         public void SubClassTest(bool initialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out SubClass source);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out SubClass target);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out SubClass source);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out SubClass target);
 
             source.SyncFieldInAbstract = 10;
             source.syncListInAbstract.Add(true);
@@ -230,8 +241,8 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
         [TestCase(false)]
         public void SubClassFromSyncVarTest(bool initialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out SubClassFromSyncVar source);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out SubClassFromSyncVar target);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out SubClassFromSyncVar source);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out SubClassFromSyncVar target);
 
             source.SyncFieldInAbstract = 10;
             source.syncListInAbstract.Add(true);
@@ -254,8 +265,8 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
         [TestCase(false)]
         public void BehaviourWithSyncVarWithOnSerializeTest(bool initialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out BehaviourWithSyncVarWithOnSerialize source);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out BehaviourWithSyncVarWithOnSerialize target);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out BehaviourWithSyncVarWithOnSerialize source);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out BehaviourWithSyncVarWithOnSerialize target);
 
             source.SyncField = 10;
             source.syncList.Add(true);
@@ -276,8 +287,8 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
         [TestCase(false)]
         public void OverrideBehaviourFromSyncVarWithOnSerializeTest(bool initialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out OverrideBehaviourFromSyncVarWithOnSerialize source);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out OverrideBehaviourFromSyncVarWithOnSerialize target);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out OverrideBehaviourFromSyncVarWithOnSerialize source);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out OverrideBehaviourFromSyncVarWithOnSerialize target);
 
             source.SyncFieldInAbstract = 12;
             source.syncListInAbstract.Add(true);
@@ -300,8 +311,8 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
         [TestCase(false)]
         public void OverrideBehaviourWithSyncVarFromSyncVarWithOnSerializeTest(bool initialState)
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize source);
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize target);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize source);
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out OverrideBehaviourWithSyncVarFromSyncVarWithOnSerialize target);
 
             source.SyncFieldInAbstract = 10;
             source.syncListInAbstract.Add(true);

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -833,7 +833,12 @@ namespace Mirror.Tests
         [Test]
         public void SerializeAndDeserializeObjectsDelta()
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
+            // SyncLists are only set dirty while owner has observers.
+            // need a connection.
+            NetworkServer.Listen(1);
+            ConnectHostClientBlockingAuthenticatedAndReady();
+
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity _, out NetworkBehaviourWithSyncVarsAndCollections comp);
 
             // add to synclist
             comp.list.Add(42);


### PR DESCRIPTION
REQUIRES https://github.com/vis2k/Mirror/pull/2926

with this change, Broadcast() only iterates .connections.
previously, it iterated .connections and .spawned, which was slow.

WIP: some tests still failing