### PR TITLE
feat: Implemented ChangeOwnerMessage

### DIFF
--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -65,6 +65,12 @@ namespace Mirror
         public ArraySegment<byte> payload;
     }
 
+    public struct ChangeOwnerMessage : NetworkMessage
+    {
+        public uint netId;
+        public bool isOwner;
+    }
+
     public struct ObjectSpawnStartedMessage : NetworkMessage {}
 
     public struct ObjectSpawnFinishedMessage : NetworkMessage {}

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -117,6 +117,7 @@ namespace Mirror
                 RegisterHandler<ObjectDestroyMessage>(OnHostClientObjectDestroy);
                 RegisterHandler<ObjectHideMessage>(OnHostClientObjectHide);
                 RegisterHandler<NetworkPongMessage>(msg => {}, false);
+                RegisterHandler<ChangeOwnerMessage>(OnChangeOwner);
                 RegisterHandler<SpawnMessage>(OnHostClientSpawn);
                 // host mode doesn't need spawning
                 RegisterHandler<ObjectSpawnStartedMessage>(msg => {});
@@ -131,6 +132,7 @@ namespace Mirror
                 RegisterHandler<ObjectHideMessage>(OnObjectHide);
                 RegisterHandler<NetworkPongMessage>(NetworkTime.OnClientPong, false);
                 RegisterHandler<SpawnMessage>(OnSpawn);
+                RegisterHandler<ChangeOwnerMessage>(OnChangeOwner);
                 RegisterHandler<ObjectSpawnStartedMessage>(OnObjectSpawnStarted);
                 RegisterHandler<ObjectSpawnFinishedMessage>(OnObjectSpawnFinished);
                 RegisterHandler<EntityStateMessage>(OnEntityStateMessage);
@@ -1017,6 +1019,12 @@ namespace Mirror
             }
         }
 
+        internal static void ChangeOwner(NetworkIdentity identity, ChangeOwnerMessage message)
+        {
+            identity.hasAuthority = message.isOwner;
+            identity.NotifyAuthority();
+        }
+
         // Finds Existing Object with NetId or spawns a new one using AssetId or sceneId
         internal static bool FindOrSpawnObject(SpawnMessage message, out NetworkIdentity identity)
         {
@@ -1265,6 +1273,16 @@ namespace Mirror
             {
                 ApplySpawnPayload(identity, message);
             }
+        }
+
+        internal static void OnChangeOwner(ChangeOwnerMessage message)
+        {
+            NetworkIdentity identity = GetExistingObject(message.netId);
+
+            if (identity != null)
+                ChangeOwner(identity, message);
+            else
+                Debug.LogError($"OnChangeOwner: Could not find object with netId {message.netId}");
         }
 
         internal static void CheckForLocalPlayer(NetworkIdentity identity)

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1140,8 +1140,7 @@ namespace Mirror
             SetClientOwner(conn);
 
             // The client will match to the existing object
-            // update all variables and assign authority
-            NetworkServer.SendSpawnMessage(this, conn);
+            NetworkServer.SendChangeOwnerMessage(this, conn);
 
             clientAuthorityCallback?.Invoke(conn, this, true);
 
@@ -1169,20 +1168,9 @@ namespace Mirror
             if (connectionToClient != null)
             {
                 clientAuthorityCallback?.Invoke(connectionToClient, this, false);
-
                 NetworkConnectionToClient previousOwner = connectionToClient;
-
-                // TODO why do we clear this twice?
                 connectionToClient = null;
-
-                // we need to resynchronize the entire object
-                // so just spawn it again,
-                // the client will not create a new instance,  it will simply
-                // reset all variables and remove authority
-                NetworkServer.SendSpawnMessage(this, previousOwner);
-
-                // TODO why do we clear this twice?
-                connectionToClient = null;
+                NetworkServer.SendChangeOwnerMessage(this, previousOwner);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -941,7 +941,7 @@ namespace Mirror
         {
             if (identity.serverOnly) return;
 
-            Debug.Log($"Server SendChangeOwnerMessage: name={identity.name} netid={identity.netId}");
+            //Debug.Log($"Server SendChangeOwnerMessage: name={identity.name} netid={identity.netId}");
 
             conn.Send(new ChangeOwnerMessage { netId = identity.netId, isOwner = identity.connectionToClient == conn });
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -937,6 +937,15 @@ namespace Mirror
             }
         }
 
+        internal static void SendChangeOwnerMessage(NetworkIdentity identity, NetworkConnection conn)
+        {
+            if (identity.serverOnly) return;
+
+            Debug.Log($"Server SendChangeOwnerMessage: name={identity.name} netid={identity.netId}");
+
+            conn.Send(new ChangeOwnerMessage { netId = identity.netId, isOwner = identity.connectionToClient == conn });
+        }
+
         static void SpawnObject(GameObject obj, NetworkConnection ownerConnection)
         {
             // verify if we an spawn this

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -606,12 +606,6 @@ namespace Mirror.Tests
             Assert.That(callbackIdentity, Is.EqualTo(identity));
             Assert.That(callbackState, Is.EqualTo(true));
 
-            // assigning authority should respawn the object with proper authority
-            // on the client. that's the best way to sync the new state right now.
-            // process pending messages
-            owner.connectionToServer.Update();
-            Assert.That(spawnCalled, Is.EqualTo(1));
-
             // shouldn't be able to assign authority while already owned by
             // another connection
             // error log is expected


### PR DESCRIPTION
Fixes #2393 
Fixes #2256 

- Separates ownership change from Spawn message
- NetworkIdentityTests updated

![image](https://user-images.githubusercontent.com/9826063/133896227-0987eb77-060c-4a8d-8189-ac66d2d287c9.png)
