### PR TITLE
Force Network Manager to scene root if DDOL

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -669,7 +669,13 @@ namespace Mirror
                 }
                 //Debug.Log("NetworkManager created singleton (DontDestroyOnLoad)");
                 singleton = this;
-                if (Application.isPlaying) DontDestroyOnLoad(gameObject);
+                if (Application.isPlaying)
+                {
+                    // Force the object to scene root, in case user made it a child of something
+                    // in the scene since DDOL is only allowed for scene root objects
+                    transform.SetParent(null);
+                    DontDestroyOnLoad(gameObject);
+                }
             }
             else
             {


### PR DESCRIPTION
DDOL is only valid for scene root objects.  Sometimes users try to "organize" their scene by putting things under empty elements with names like folders.  This forces the Network Manager object to scene root before calling `DontDestroyOnLoad`.