### PR TITLE
fix: Revert making SyncVarGameObjectEqual and SyncVarNetworkIdentityEqual internal

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -320,6 +320,7 @@ namespace Mirror
         }
 
         // helper function for [SyncVar] GameObjects.
+        // IMPORTANT: keep as 'protected', not 'internal', otherwise Weaver can't resolve it
         protected static bool SyncVarGameObjectEqual(GameObject newGameObject, uint netIdField)
         {
             uint newNetId = 0;
@@ -385,6 +386,7 @@ namespace Mirror
         }
 
         // helper function for [SyncVar] NetworkIdentities.
+        // IMPORTANT: keep as 'protected', not 'internal', otherwise Weaver can't resolve it
         protected static bool SyncVarNetworkIdentityEqual(NetworkIdentity newIdentity, uint netIdField)
         {
             uint newNetId = 0;

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -320,7 +320,7 @@ namespace Mirror
         }
 
         // helper function for [SyncVar] GameObjects.
-        internal static bool SyncVarGameObjectEqual(GameObject newGameObject, uint netIdField)
+        protected static bool SyncVarGameObjectEqual(GameObject newGameObject, uint netIdField)
         {
             uint newNetId = 0;
             if (newGameObject != null)
@@ -385,7 +385,7 @@ namespace Mirror
         }
 
         // helper function for [SyncVar] NetworkIdentities.
-        internal static bool SyncVarNetworkIdentityEqual(NetworkIdentity newIdentity, uint netIdField)
+        protected static bool SyncVarNetworkIdentityEqual(NetworkIdentity newIdentity, uint netIdField)
         {
             uint newNetId = 0;
             if (newIdentity != null)

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -320,7 +320,7 @@ namespace Mirror
         }
 
         // helper function for [SyncVar] GameObjects.
-        // IMPORTANT: keep as 'protected', not 'internal', otherwise Weaver can't resolve it
+        // IMPORTANT: keep as 'protected', not 'internal', otherwise weaver-generated code can't access it
         protected static bool SyncVarGameObjectEqual(GameObject newGameObject, uint netIdField)
         {
             uint newNetId = 0;
@@ -386,7 +386,7 @@ namespace Mirror
         }
 
         // helper function for [SyncVar] NetworkIdentities.
-        // IMPORTANT: keep as 'protected', not 'internal', otherwise Weaver can't resolve it
+        // IMPORTANT: keep as 'protected', not 'internal', otherwise weaver-generated code can't access it
         protected static bool SyncVarNetworkIdentityEqual(NetworkIdentity newIdentity, uint netIdField)
         {
             uint newNetId = 0;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9826063/134666862-b939e399-a88e-41eb-80df-46293ecf9346.png)
```
Disconnecting connId=-456458217 to prevent exploits from an Exception in MessageHandler: MethodAccessException Method `Mirror.NetworkBehaviour.SyncVarNetworkIdentityEqual(Mirror.NetworkIdentity,uint)' is inaccessible from method `Mirror.Examples.MultipleMatch.MatchController.set_NetworkcurrentPlayer(Mirror.NetworkIdentity)'
  at (wrapper managed-to-native) System.Object.__icall_wrapper_mono_throw_method_access(intptr,intptr)
  at Mirror.Examples.MultipleMatch.MatchController.set_NetworkcurrentPlayer (Mirror.NetworkIdentity value) <0x1b3ef3f3450 + 0x00082> in <eb2313b4dbe94c1991c7ef5954b46712>:0 
  at Mirror.Examples.MultipleMatch.CanvasController.OnServerStartMatch (Mirror.NetworkConnection conn) [0x0014a] in D:\Unity\Projects\Mirror2019-4\Assets\Mirror\Examples\MultipleMatches\Scripts\CanvasController.cs:517 
  at Mirror.Examples.MultipleMatch.CanvasController.OnServerMatchMessage (Mirror.NetworkConnection conn, Mirror.Examples.MultipleMatch.ServerMatchMessage msg) [0x00062] in D:\Unity\Projects\Mirror2019-4\Assets\Mirror\Examples\MultipleMatches\Scripts\CanvasController.cs:364 
  at Mirror.MessagePacking+<>c__DisplayClass6_0`2[T,C].<WrapHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) [0x00096] in D:\Unity\Projects\Mirror2019-4\Assets\Mirror\Runtime\MessagePacking.cs:118 
0x00007FF686A5C6BC (Unity) StackWalker::GetCurrentCallstack
0x00007FF686A60661 (Unity) StackWalker::ShowCallstack
0x00007FF6850CAAE5 (Unity) GetStacktrace
0x00007FF68771A29E (Unity) DebugStringToFile
0x00007FF686AC01C1 (Unity) DebugLogHandler_CUSTOM_Internal_Log
0x000001B3EEE15C2B (Mono JIT Code) (wrapper managed-to-native) UnityEngine.DebugLogHandler:Internal_Log (UnityEngine.LogType,UnityEngine.LogOption,string,UnityEngine.Object)
0x000001B3EEE15AAB (Mono JIT Code) UnityEngine.DebugLogHandler:LogFormat (UnityEngine.LogType,UnityEngine.Object,string,object[])
0x000001B3EEE14F2E (Mono JIT Code) UnityEngine.Logger:Log (UnityEngine.LogType,object)
0x000001B3EF3FB41A (Mono JIT Code) UnityEngine.Debug:LogError (object)
0x000001B3EF347BD3 (Mono JIT Code) [MessagePacking.cs:122] Mirror.MessagePacking/<>c__DisplayClass6_0`2<Mirror.Examples.MultipleMatch.ServerMatchMessage, Mirror.NetworkConnection>:<WrapHandler>b__0 (Mirror.NetworkConnection,Mirror.NetworkReader,int) 
0x000001B3EF26B699 (Mono JIT Code) [NetworkServer.cs:419] Mirror.NetworkServer:UnpackAndInvoke (Mirror.NetworkConnectionToClient,Mirror.NetworkReader,int) 
0x000001B3EF269393 (Mono JIT Code) [NetworkServer.cs:482] Mirror.NetworkServer:OnTransportData (int,System.ArraySegment`1<byte>,int) 
0x000001B3EF341563 (Mono JIT Code) (wrapper delegate-invoke) System.Action`3<int, System.ArraySegment`1<byte>, int>:invoke_void_T1_T2_T3 (int,System.ArraySegment`1<byte>,int)
0x000001B3EF34122B (Mono JIT Code) [KcpTransport.cs:80] kcp2k.KcpTransport:<Awake>b__16_8 (int,System.ArraySegment`1<byte>) 
0x000001B3EF34110E (Mono JIT Code) [KcpServer.cs:233] kcp2k.KcpServer/<>c__DisplayClass24_0:<TickIncoming>b__1 (System.ArraySegment`1<byte>) 
0x000001B3EF2DB561 (Mono JIT Code) [KcpConnection.cs:331] kcp2k.KcpConnection:TickIncoming_Authenticated (uint) 
0x000001B3EF2D4003 (Mono JIT Code) [KcpConnection.cs:372] kcp2k.KcpConnection:TickIncoming () 
0x000001B3EEE4890B (Mono JIT Code) [KcpServer.cs:285] kcp2k.KcpServer:TickIncoming () 
0x000001B3EEE47AD3 (Mono JIT Code) [KcpTransport.cs:203] kcp2k.KcpTransport:ServerEarlyUpdate () 
0x000001B3EEE47989 (Mono JIT Code) [NetworkServer.cs:1645] Mirror.NetworkServer:NetworkEarlyUpdate () 
0x000001B3EEE47743 (Mono JIT Code) [NetworkLoop.cs:185] Mirror.NetworkLoop:NetworkEarlyUpdate () 
0x000001B3EF0FB678 (Mono JIT Code) (wrapper runtime-invoke) object:runtime_invoke_void__this__ (object,intptr,intptr,intptr)
0x00007FFA7A11E270 (mono-2.0-bdwgc) [mini-runtime.c:2809] mono_jit_runtime_invoke 
0x00007FFA7A0A2AE2 (mono-2.0-bdwgc) [object.c:2921] do_runtime_invoke 
0x00007FFA7A0ABB3F (mono-2.0-bdwgc) [object.c:2968] mono_runtime_invoke 
0x00007FF6869CE06E (Unity) scripting_method_invoke
0x00007FF6869C7DDD (Unity) ScriptingInvocation::Invoke
0x00007FF68644A80F (Unity) ExecutePlayerLoop
0x00007FF68644A82D (Unity) ExecutePlayerLoop
0x00007FF68644FB4C (Unity) PlayerLoop
0x00007FF684754B1C (Unity) PlayerLoopController::UpdateScene
0x00007FF684752AB8 (Unity) Application::TickTimer
0x00007FF6850F05B5 (Unity) MainMessageLoop
0x00007FF6850FA7C8 (Unity) WinMain
0x00007FF6881E34C2 (Unity) __scrt_common_main_seh
0x00007FFAD4B27034 (KERNEL32) BaseThreadInitThunk
0x00007FFAD5C42651 (ntdll) RtlUserThreadStart
```