### PR TITLE
feat: Allow NTC target to be assigned at runtime

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -568,9 +568,9 @@ namespace Mirror
 
         protected virtual void OnDrawGizmos()
         {
-// NetworkTransformChild may not be assigned at design-time but instead
-// later assigned to something that's instantiated at runtime.
-if (targetComponent == null) return;
+            // NetworkTransformChild may not be assigned at design-time but instead
+            // later assigned to something that's instantiated at runtime.
+            if (targetComponent == null) return;
 
             // This fires in edit mode but that spams NRE's so check isPlaying
             if (!Application.isPlaying) return;

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -389,6 +389,10 @@ namespace Mirror
 
         void Update()
         {
+            // NetworkTransformChild may not be assigned at design-time but instead
+            // later assigned to something that's instantiated at runtime.
+            if (targetComponent == null) return;
+
             // if server then always sync to others.
             if (isServer) UpdateServer();
             // 'else if' because host mode shouldn't send anything to server.
@@ -418,6 +422,10 @@ namespace Mirror
         [ClientRpc]
         public void RpcTeleport(Vector3 destination)
         {
+            // NetworkTransformChild may not be assigned at design-time but instead
+            // later assigned to something that's instantiated at runtime.
+            if (targetComponent == null) return;
+
             // NOTE: even in client authority mode, the server is always allowed
             //       to teleport the player. for example:
             //       * CmdEnterPortal() might teleport the player
@@ -434,6 +442,10 @@ namespace Mirror
         [Command]
         public void CmdTeleport(Vector3 destination)
         {
+            // NetworkTransformChild may not be assigned at design-time but instead
+            // later assigned to something that's instantiated at runtime.
+            if (targetComponent == null) return;
+
             // client can only teleport objects that it has authority over.
             if (!clientAuthority) return;
 
@@ -487,7 +499,9 @@ namespace Mirror
         // debug ///////////////////////////////////////////////////////////////
         protected virtual void OnGUI()
         {
-            if (!showOverlay) return;
+            // NetworkTransformChild may not be assigned at design-time but instead
+            // later assigned to something that's instantiated at runtime.
+            if (targetComponent == null || !showOverlay) return;
 
             // show data next to player for easier debugging. this is very useful!
             // IMPORTANT: this is basically an ESP hack for shooter games.
@@ -554,6 +568,10 @@ namespace Mirror
 
         protected virtual void OnDrawGizmos()
         {
+// NetworkTransformChild may not be assigned at design-time but instead
+// later assigned to something that's instantiated at runtime.
+if (targetComponent == null) return;
+
             // This fires in edit mode but that spams NRE's so check isPlaying
             if (!Application.isPlaying) return;
             if (!showGizmos) return;


### PR DESCRIPTION
- checks for null targetComponent

We cannot know what runtime-added child objects may do in terms of their behaviour...each thing could do something different.  The child object could be a whole model with head, hands, feet, antennae, it's own weapons, periscope...whatever.  This would allow users to instantiate anything as child and set NTC targets as needed for whatever it is.

This comes up periodically in Discord
![image](https://user-images.githubusercontent.com/9826063/134807953-382a5207-e1e5-4572-a752-2b6977bcecd8.png)
![image](https://user-images.githubusercontent.com/9826063/134808530-979fe145-7770-4025-833a-e2332b64ad78.png)
![image](https://user-images.githubusercontent.com/9826063/134808631-208f4f68-4c73-4b7f-9bb0-4913b18cbd4c.png)

To test this, I put two NTC's on the player prefab in the Additive Scenes example, one with client auth checked and the other not, neither with anything assigned to Target.  No errors.

Player NetworkBehaviour
```cs
public GameObject swordPrefab;
public NetworkTransformChild clientAuthNTC;

void Update()
{
    if (isLocalPlayer && Input.GetKeyUp(KeyCode.X))
        CmdAddSword();
}

[Command]
void CmdAddSword()
{
    RpcAddSword();
    // instantiate as child of player
    GameObject sword = Instantiate(swordPrefab, transform.position + Vector3.up * 2, Quaternion.identity, transform);
    clientAuthNTC.target = sword.transform;
    if (hasAuthority)
        sword.GetComponent<Rotator>().StartRotating();
}

[ClientRpc]
void RpcAddSword()
{
    // host will get it inside the Cmd
    if (isClientOnly)
    {
        // instantiate as child of player
        GameObject sword = Instantiate(swordPrefab, transform.position + Vector3.up * 2, Quaternion.identity, transform);
        clientAuthNTC.target = sword.transform;
        if (hasAuthority)
            sword.GetComponent<Rotator>().StartRotating();
    }
}
```
Rotator MonoBehaviour
```cs
public class Rotator : MonoBehaviour
{
    public void StartRotating()
    {
        InvokeRepeating(nameof(RotateMe), 1f, 1f);
    }

    void RotateMe()
    {
        transform.rotation = Random.rotation;
    }
}
```