### PR TITLE
breaking: SyncObject as class instead of interface

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectInitializer.cs
@@ -21,7 +21,7 @@ namespace Mirror.Weaver
                     return false;
                 }
 
-                return typeRef.Resolve().ImplementsInterface<SyncObject>();
+                return typeRef.Resolve().IsDerivedFrom<SyncObject>();
             }
             catch
             {

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
@@ -16,7 +16,7 @@ namespace Mirror.Weaver
 
             foreach (FieldDefinition fd in td.Fields)
             {
-                if (fd.FieldType.Resolve().ImplementsInterface<SyncObject>())
+                if (fd.FieldType.Resolve().IsDerivedFrom<SyncObject>())
                 {
                     if (fd.IsStatic)
                     {

--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -17,9 +17,6 @@ namespace Mirror
         // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
         public override Action OnDirty { get; set; }
 
-        // used to stop recording ever growing changes while we have no observers
-        public override Func<bool> IsRecording { get; set; } = () => true;
-
         public enum Operation : byte
         {
             OP_ADD,

--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -13,9 +12,6 @@ namespace Mirror
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
         public event SyncDictionaryChanged Callback;
-
-        // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
-        public override Action OnDirty { get; set; }
 
         public enum Operation : byte
         {

--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -68,10 +68,6 @@ namespace Mirror
         // this should be called after a successful sync
         public override void ClearChanges() => changes.Clear();
 
-        // Deprecated 2021-09-17
-        [Obsolete("Deprecated: Use ClearChanges instead.")]
-        public override void Flush() => changes.Clear();
-
         public SyncIDictionary(IDictionary<TKey, TValue> objects)
         {
             this.objects = objects;

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -18,9 +18,6 @@ namespace Mirror
         // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
         public override Action OnDirty { get; set; }
 
-        // used to stop recording ever growing changes while we have no observers
-        public override Func<bool> IsRecording { get; set; } = () => true;
-
         public enum Operation : byte
         {
             OP_ADD,

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Mirror
 {
-    public class SyncList<T> : IList<T>, IReadOnlyList<T>, SyncObject
+    public class SyncList<T> : SyncObject, IList<T>, IReadOnlyList<T>
     {
         public delegate void SyncListChanged(Operation op, int itemIndex, T oldItem, T newItem);
 
@@ -16,10 +16,10 @@ namespace Mirror
         public event SyncListChanged Callback;
 
         // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
-        public Action OnDirty { get; set; }
+        public override Action OnDirty { get; set; }
 
         // used to stop recording ever growing changes while we have no observers
-        public Func<bool> IsRecording { get; set; } = () => true;
+        public override Func<bool> IsRecording { get; set; } = () => true;
 
         public enum Operation : byte
         {
@@ -65,13 +65,13 @@ namespace Mirror
 
         // throw away all the changes
         // this should be called after a successful sync
-        public void ClearChanges() => changes.Clear();
+        public override void ClearChanges() => changes.Clear();
 
         // Deprecated 2021-09-17
         [Obsolete("Deprecated: Use ClearChanges instead.")]
-        public void Flush() => changes.Clear();
+        public override void Flush() => changes.Clear();
 
-        public void Reset()
+        public override void Reset()
         {
             IsReadOnly = false;
             changes.Clear();
@@ -102,7 +102,7 @@ namespace Mirror
             Callback?.Invoke(op, itemIndex, oldItem, newItem);
         }
 
-        public void OnSerializeAll(NetworkWriter writer)
+        public override void OnSerializeAll(NetworkWriter writer)
         {
             // if init,  write the full list content
             writer.WriteUInt((uint)objects.Count);
@@ -120,7 +120,7 @@ namespace Mirror
             writer.WriteUInt((uint)changes.Count);
         }
 
-        public void OnSerializeDelta(NetworkWriter writer)
+        public override void OnSerializeDelta(NetworkWriter writer)
         {
             // write all the queued up changes
             writer.WriteUInt((uint)changes.Count);
@@ -152,7 +152,7 @@ namespace Mirror
             }
         }
 
-        public void OnDeserializeAll(NetworkReader reader)
+        public override void OnDeserializeAll(NetworkReader reader)
         {
             // This list can now only be modified by synchronization
             IsReadOnly = true;
@@ -175,7 +175,7 @@ namespace Mirror
             changesAhead = (int)reader.ReadUInt();
         }
 
-        public void OnDeserializeDelta(NetworkReader reader)
+        public override void OnDeserializeDelta(NetworkReader reader)
         {
             // This list can now only be modified by synchronization
             IsReadOnly = true;

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -15,9 +15,6 @@ namespace Mirror
         public bool IsReadOnly { get; private set; }
         public event SyncListChanged Callback;
 
-        // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
-        public override Action OnDirty { get; set; }
-
         public enum Operation : byte
         {
             OP_ADD,

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -67,10 +67,6 @@ namespace Mirror
         // this should be called after a successful sync
         public override void ClearChanges() => changes.Clear();
 
-        // Deprecated 2021-09-17
-        [Obsolete("Deprecated: Use ClearChanges instead.")]
-        public override void Flush() => changes.Clear();
-
         public override void Reset()
         {
             IsReadOnly = false;

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -29,7 +29,7 @@ namespace Mirror
 
         // Deprecated 2021-09-17
         [Obsolete("Deprecated: Use ClearChanges instead.")]
-        public abstract void Flush();
+        public void Flush() => ClearChanges();
 
         /// <summary>Write a full copy of the object</summary>
         public abstract void OnSerializeAll(NetworkWriter writer);

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -23,7 +23,7 @@ namespace Mirror
         // => Func so we can set it to () => observers.Count > 0
         //    without depending on NetworkComponent/NetworkIdentity here.
         // => virtual so it sipmly always records by default
-        public virtual Func<bool> IsRecording { get; set; } = () => true;
+        public Func<bool> IsRecording = () => true;
 
         /// <summary>Discard all the queued changes</summary>
         // Consider the object fully synchronized with clients

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -4,7 +4,8 @@ namespace Mirror
 {
     /// <summary>SyncObjects sync state between server and client. E.g. SyncLists.</summary>
     // SyncObject should be a class (instead of an interface) for a few reasons:
-    // * NetworkBehaviour stores SyncObjects in a list. structs would be a copy.
+    // * NetworkBehaviour stores SyncObjects in a list. structs would be a copy
+    //   and OnSerialize would use the copy instead of the original struct.
     // * Obsolete functions like Flush() don't need to be defined by each type
     // * OnDirty/IsRecording etc. default functions can be defined once here
     //   for example, handling 'OnDirty wasn't initialized' with a default

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -3,10 +3,16 @@ using System;
 namespace Mirror
 {
     /// <summary>SyncObjects sync state between server and client. E.g. SyncLists.</summary>
-    public interface SyncObject
+    // SyncObject should be a class (instead of an interface) for a few reasons:
+    // * NetworkBehaviour stores SyncObjects in a list. structs would be a copy.
+    // * Obsolete functions like Flush() don't need to be defined by each type
+    // * OnDirty/IsRecording etc. default functions can be defined once here
+    //   for example, handling 'OnDirty wasn't initialized' with a default
+    //   function that throws an exception will be useful for SyncVar<T>
+    public abstract class SyncObject
     {
         /// <summary>Used internally to set owner NetworkBehaviour's dirty mask bit when changed.</summary>
-        Action OnDirty { get; set; }
+        public abstract Action OnDirty { get; set; }
 
         /// <summary>Used internally to check if we are currently tracking changes.</summary>
         // prevents ever growing .changes lists:
@@ -15,29 +21,29 @@ namespace Mirror
         // because OnSerialize isn't called without observers.
         // => Func so we can set it to () => observers.Count > 0
         //    without depending on NetworkComponent/NetworkIdentity here.
-        Func<bool> IsRecording { get; set; }
+        public abstract Func<bool> IsRecording { get; set; }
 
         /// <summary>Discard all the queued changes</summary>
         // Consider the object fully synchronized with clients
-        void ClearChanges();
+        public abstract void ClearChanges();
 
         // Deprecated 2021-09-17
         [Obsolete("Deprecated: Use ClearChanges instead.")]
-        void Flush();
+        public abstract void Flush();
 
         /// <summary>Write a full copy of the object</summary>
-        void OnSerializeAll(NetworkWriter writer);
+        public abstract void OnSerializeAll(NetworkWriter writer);
 
         /// <summary>Write the changes made to the object since last sync</summary>
-        void OnSerializeDelta(NetworkWriter writer);
+        public abstract void OnSerializeDelta(NetworkWriter writer);
 
         /// <summary>Reads a full copy of the object</summary>
-        void OnDeserializeAll(NetworkReader reader);
+        public abstract void OnDeserializeAll(NetworkReader reader);
 
         /// <summary>Reads the changes made to the object since last sync</summary>
-        void OnDeserializeDelta(NetworkReader reader);
+        public abstract void OnDeserializeDelta(NetworkReader reader);
 
         /// <summary>Resets the SyncObject so that it can be re-used</summary>
-        void Reset();
+        public abstract void Reset();
     }
 }

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -12,7 +12,7 @@ namespace Mirror
     public abstract class SyncObject
     {
         /// <summary>Used internally to set owner NetworkBehaviour's dirty mask bit when changed.</summary>
-        public abstract Action OnDirty { get; set; }
+        public virtual Action OnDirty { get; set; }
 
         /// <summary>Used internally to check if we are currently tracking changes.</summary>
         // prevents ever growing .changes lists:

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -21,7 +21,8 @@ namespace Mirror
         // because OnSerialize isn't called without observers.
         // => Func so we can set it to () => observers.Count > 0
         //    without depending on NetworkComponent/NetworkIdentity here.
-        public abstract Func<bool> IsRecording { get; set; }
+        // => virtual so it sipmly always records by default
+        public virtual Func<bool> IsRecording { get; set; } = () => true;
 
         /// <summary>Discard all the queued changes</summary>
         // Consider the object fully synchronized with clients

--- a/Assets/Mirror/Runtime/SyncObject.cs
+++ b/Assets/Mirror/Runtime/SyncObject.cs
@@ -13,7 +13,7 @@ namespace Mirror
     public abstract class SyncObject
     {
         /// <summary>Used internally to set owner NetworkBehaviour's dirty mask bit when changed.</summary>
-        public virtual Action OnDirty { get; set; }
+        public Action OnDirty;
 
         /// <summary>Used internally to check if we are currently tracking changes.</summary>
         // prevents ever growing .changes lists:

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -63,10 +63,6 @@ namespace Mirror
         // this should be called after a successful sync
         public override void ClearChanges() => changes.Clear();
 
-        // Deprecated 2021-09-17
-        [Obsolete("Deprecated: Use ClearChanges instead.")]
-        public override void Flush() => changes.Clear();
-
         void AddOperation(Operation op, T item)
         {
             if (IsReadOnly)

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -14,9 +14,6 @@ namespace Mirror
         public bool IsReadOnly { get; private set; }
         public event SyncSetChanged Callback;
 
-        // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
-        public override Action OnDirty { get; set; }
-
         public enum Operation : byte
         {
             OP_ADD,

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -17,9 +17,6 @@ namespace Mirror
         // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
         public override Action OnDirty { get; set; }
 
-        // used to stop recording ever growing changes while we have no observers
-        public override Func<bool> IsRecording { get; set; } = () => true;
-
         public enum Operation : byte
         {
             OP_ADD,

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Mirror
 {
-    public class SyncSet<T> : ISet<T>, SyncObject
+    public class SyncSet<T> : SyncObject, ISet<T>
     {
         public delegate void SyncSetChanged(Operation op, T item);
 
@@ -15,10 +15,10 @@ namespace Mirror
         public event SyncSetChanged Callback;
 
         // OnDirty sets owner NetworkBehaviour's dirty mask when changed.
-        public Action OnDirty { get; set; }
+        public override Action OnDirty { get; set; }
 
         // used to stop recording ever growing changes while we have no observers
-        public Func<bool> IsRecording { get; set; } = () => true;
+        public override Func<bool> IsRecording { get; set; } = () => true;
 
         public enum Operation : byte
         {
@@ -51,7 +51,7 @@ namespace Mirror
             this.objects = objects;
         }
 
-        public void Reset()
+        public override void Reset()
         {
             IsReadOnly = false;
             changes.Clear();
@@ -61,11 +61,11 @@ namespace Mirror
 
         // throw away all the changes
         // this should be called after a successful sync
-        public void ClearChanges() => changes.Clear();
+        public override void ClearChanges() => changes.Clear();
 
         // Deprecated 2021-09-17
         [Obsolete("Deprecated: Use ClearChanges instead.")]
-        public void Flush() => changes.Clear();
+        public override void Flush() => changes.Clear();
 
         void AddOperation(Operation op, T item)
         {
@@ -91,7 +91,7 @@ namespace Mirror
 
         void AddOperation(Operation op) => AddOperation(op, default);
 
-        public void OnSerializeAll(NetworkWriter writer)
+        public override void OnSerializeAll(NetworkWriter writer)
         {
             // if init,  write the full list content
             writer.WriteUInt((uint)objects.Count);
@@ -108,7 +108,7 @@ namespace Mirror
             writer.WriteUInt((uint)changes.Count);
         }
 
-        public void OnSerializeDelta(NetworkWriter writer)
+        public override void OnSerializeDelta(NetworkWriter writer)
         {
             // write all the queued up changes
             writer.WriteUInt((uint)changes.Count);
@@ -134,7 +134,7 @@ namespace Mirror
             }
         }
 
-        public void OnDeserializeAll(NetworkReader reader)
+        public override void OnDeserializeAll(NetworkReader reader)
         {
             // This list can now only be modified by synchronization
             IsReadOnly = true;
@@ -157,7 +157,7 @@ namespace Mirror
             changesAhead = (int)reader.ReadUInt();
         }
 
-        public void OnDeserializeDelta(NetworkReader reader)
+        public override void OnDeserializeDelta(NetworkReader reader)
         {
             // This list can now only be modified by synchronization
             IsReadOnly = true;

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests~/SyncVarsSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests~/SyncVarsSyncList.cs
@@ -16,10 +16,6 @@ namespace WeaverSyncVarTests.SyncVarsSyncList
             public override void OnDeserializeAll(NetworkReader reader) { }
             public override void OnDeserializeDelta(NetworkReader reader) { }
             public override void Reset() { }
-
-            // Deprecated 2021-09-17
-            [Obsolete("Use ClearChanges instead")]
-            public override void Flush() { }
         }
 
         [SyncVar]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests~/SyncVarsSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests~/SyncVarsSyncList.cs
@@ -8,7 +8,6 @@ namespace WeaverSyncVarTests.SyncVarsSyncList
     {
         public class SyncObjImplementer : SyncObject
         {
-            public override Action OnDirty { get; set; }
             public override void ClearChanges() { }
             public override void OnSerializeAll(NetworkWriter writer) { }
             public override void OnSerializeDelta(NetworkWriter writer) { }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests~/SyncVarsSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests~/SyncVarsSyncList.cs
@@ -8,18 +8,18 @@ namespace WeaverSyncVarTests.SyncVarsSyncList
     {
         public class SyncObjImplementer : SyncObject
         {
-            public Action OnDirty { get; set; }
-            public Func<bool> IsRecording { get; set; } = () => true;
-            public void ClearChanges() { }
-            public void OnSerializeAll(NetworkWriter writer) { }
-            public void OnSerializeDelta(NetworkWriter writer) { }
-            public void OnDeserializeAll(NetworkReader reader) { }
-            public void OnDeserializeDelta(NetworkReader reader) { }
-            public void Reset() { }
+            public override Action OnDirty { get; set; }
+            public override Func<bool> IsRecording { get; set; } = () => true;
+            public override void ClearChanges() { }
+            public override void OnSerializeAll(NetworkWriter writer) { }
+            public override void OnSerializeDelta(NetworkWriter writer) { }
+            public override void OnDeserializeAll(NetworkReader reader) { }
+            public override void OnDeserializeDelta(NetworkReader reader) { }
+            public override void Reset() { }
 
             // Deprecated 2021-09-17
             [Obsolete("Use ClearChanges instead")]
-            public void Flush() { }
+            public override void Flush() { }
         }
 
         [SyncVar]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests~/SyncVarsSyncList.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests~/SyncVarsSyncList.cs
@@ -9,7 +9,6 @@ namespace WeaverSyncVarTests.SyncVarsSyncList
         public class SyncObjImplementer : SyncObject
         {
             public override Action OnDirty { get; set; }
-            public override Func<bool> IsRecording { get; set; } = () => true;
             public override void ClearChanges() { }
             public override void OnSerializeAll(NetworkWriter writer) { }
             public override void OnSerializeDelta(NetworkWriter writer) { }


### PR DESCRIPTION
- NetworkBehaviour stores all SyncObjects in a list. they should always be a class, otherwise a struct would be copied by value and OnSerialize wouldn't use the original one, but the copy
- [Obsolete] Flush() can be defined in base, instead of doing it in every implementation
- default OnDirty, IsRecording can be defined in base instead of every implementation
- prepares for SyncVar<T> where we need default behaviour for OnDirty which wasn't initialized

it just makes life easier.