### PR TITLE
fix: Prevent StopClient from running twice

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -593,6 +593,8 @@ namespace Mirror
 
             // set offline mode BEFORE changing scene so that FinishStartScene
             // doesn't think we need initialize anything.
+            // set offline mode BEFORE NetworkClient.Disconnect so StopClient
+            // only runs once.
             mode = NetworkManagerMode.Offline;
 
             // shutdown client
@@ -1278,10 +1280,7 @@ namespace Mirror
 
         /// <summary>Called on clients when disconnected from a server.</summary>
         // TODO client only ever uses NetworkClient.connection. this parameter is redundant.
-        public virtual void OnClientDisconnect(NetworkConnection conn)
-        {
-            StopClient();
-        }
+        public virtual void OnClientDisconnect(NetworkConnection conn) {}
 
         /// <summary>Called on client when transport raises an exception.</summary>
         public virtual void OnClientError(Exception exception) {}

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -569,6 +569,9 @@ namespace Mirror
         /// <summary>Stops and disconnects the client.</summary>
         public void StopClient()
         {
+            if (mode == NetworkManagerMode.Offline)
+                return;
+
             if (authenticator != null)
             {
                 authenticator.OnClientAuthenticated.RemoveListener(OnClientAuthenticated);

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -591,13 +591,13 @@ namespace Mirror
 
             //Debug.Log("NetworkManager StopClient");
 
-            // shutdown client
-            NetworkClient.Disconnect();
-            NetworkClient.Shutdown();
-
             // set offline mode BEFORE changing scene so that FinishStartScene
             // doesn't think we need initialize anything.
             mode = NetworkManagerMode.Offline;
+
+            // shutdown client
+            NetworkClient.Disconnect();
+            NetworkClient.Shutdown();
 
             // If this is the host player, StopServer will already be changing scenes.
             // Check loadingSceneAsync to ensure we don't double-invoke the scene change.
@@ -1182,6 +1182,9 @@ namespace Mirror
         void OnClientDisconnectInternal()
         {
             //Debug.Log("NetworkManager.OnClientDisconnectInternal");
+            if (mode == NetworkManagerMode.Offline)
+                return;
+
             OnClientDisconnect(NetworkClient.connection);
         }
 
@@ -1327,7 +1330,10 @@ namespace Mirror
         public virtual void OnStopServer() {}
 
         /// <summary>This is called when a client is stopped.</summary>
-        public virtual void OnStopClient() {}
+        public virtual void OnStopClient()
+        {
+            Debug.Log("OnStopClient");
+        }
 
         /// <summary>This is called when a host is stopped.</summary>
         public virtual void OnStopHost() {}

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1184,9 +1184,6 @@ namespace Mirror
         void OnClientDisconnectInternal()
         {
             //Debug.Log("NetworkManager.OnClientDisconnectInternal");
-            if (mode == NetworkManagerMode.Offline)
-                return;
-
             OnClientDisconnect(NetworkClient.connection);
         }
 
@@ -1282,6 +1279,9 @@ namespace Mirror
         // TODO client only ever uses NetworkClient.connection. this parameter is redundant.
         public virtual void OnClientDisconnect(NetworkConnection conn)
         {
+            if (mode == NetworkManagerMode.Offline)
+                return;
+
             StopClient();
         }
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1280,7 +1280,10 @@ namespace Mirror
 
         /// <summary>Called on clients when disconnected from a server.</summary>
         // TODO client only ever uses NetworkClient.connection. this parameter is redundant.
-        public virtual void OnClientDisconnect(NetworkConnection conn) {}
+        public virtual void OnClientDisconnect(NetworkConnection conn)
+        {
+            StopClient();
+        }
 
         /// <summary>Called on client when transport raises an exception.</summary>
         public virtual void OnClientError(Exception exception) {}
@@ -1329,10 +1332,7 @@ namespace Mirror
         public virtual void OnStopServer() {}
 
         /// <summary>This is called when a client is stopped.</summary>
-        public virtual void OnStopClient()
-        {
-            Debug.Log("OnStopClient");
-        }
+        public virtual void OnStopClient() {}
 
         /// <summary>This is called when a host is stopped.</summary>
         public virtual void OnStopHost() {}


### PR DESCRIPTION
- Moved the setting of `mode = NetworkManagerMode.Offline` up above `NetworkClient.Disconnect`
- Added check for `mode == NetworkManagerMode.Offline` to `OnClientDisconnect` and `StopClient`

Fixes #2940 
