### PR TITLE
Fix unity warnings.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -338,11 +338,19 @@ namespace Mirror
             hasSpawned = false;
 
 #if UNITY_EDITOR
-            SetupIDs();
+            EditorApplication.delayCall += OnValidateLater;
 #endif
         }
 
 #if UNITY_EDITOR
+        void OnValidateLater()
+        {
+            if(this != null)
+            {
+                SetupIDs();
+            }
+        }
+
         void AssignAssetID(string path)
         {
             // only set if not empty. fixes https://github.com/vis2k/Mirror/issues/2765


### PR DESCRIPTION
Repro was to start the game, pause, then change a line in code and save it. When you go back to the unity editor and it compiles scripts you would get like a dozen warnings. Obviously there will be no warnings after merging this, so I recommend testing on a Unity project without this change first. It likely also repros if you change settings on this object in the unity inspector.

```
SendMessage cannot be called during Awake, CheckConsistency, or OnValidate
UnityEngine.StackTraceUtility:ExtractStackTrace ()
Mirror.Utils:IsSceneObjectWithPrefabParent (UnityEngine.GameObject,UnityEngine.GameObject&) (at Assets/Mirror/Runtime/Utils.cs:115)
Mirror.NetworkIdentity:SetupIDs () (at Assets/Mirror/Runtime/NetworkIdentity.cs:535)
Mirror.NetworkIdentity:OnValidate () (at Assets/Mirror/Runtime/NetworkIdentity.cs:347)
```

This thread has some info on these warnings. https://forum.unity.com/threads/sendmessage-cannot-be-called-during-awake-checkconsistency-or-onvalidate-can-we-suppress.537265/#post-5560519