### PR TITLE
fix: ReplacePlayerForConn not clearing isLocalPlayer

### DIFF
--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -69,6 +69,7 @@ namespace Mirror
     {
         public uint netId;
         public bool isOwner;
+        public bool isLocalPlayer;
     }
 
     public struct ObjectSpawnStartedMessage : NetworkMessage {}

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1020,12 +1020,6 @@ namespace Mirror
             }
         }
 
-        internal static void ChangeOwner(NetworkIdentity identity, ChangeOwnerMessage message)
-        {
-            identity.hasAuthority = message.isOwner;
-            identity.NotifyAuthority();
-        }
-
         // Finds Existing Object with NetId or spawns a new one using AssetId or sceneId
         internal static bool FindOrSpawnObject(SpawnMessage message, out NetworkIdentity identity)
         {
@@ -1284,6 +1278,24 @@ namespace Mirror
                 ChangeOwner(identity, message);
             else
                 Debug.LogError($"OnChangeOwner: Could not find object with netId {message.netId}");
+        }
+
+        internal static void ChangeOwner(NetworkIdentity identity, ChangeOwnerMessage message)
+        {
+            identity.hasAuthority = message.isOwner;
+            identity.NotifyAuthority();
+
+            identity.isLocalPlayer = message.isLocalPlayer;
+            if (identity.isLocalPlayer)
+                localPlayer = identity;
+            else if (localPlayer == identity)
+            {
+                // localPlayer may already be assigned to something else
+                // so only make it null if it's this identity.
+                localPlayer = null;
+            }
+
+            CheckForLocalPlayer(identity);
         }
 
         internal static void CheckForLocalPlayer(NetworkIdentity identity)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -762,7 +762,12 @@ namespace Mirror
 
             Respawn(identity);
 
-            if (!keepAuthority)
+            if (keepAuthority)
+                // This needs to be sent to clear isLocalPlayer on
+                // client while keeping hasAuthority true
+                SendChangeOwnerMessage(previousPlayer, conn);
+            else
+                // This clears both isLocalPlayer and hasAuthority on client
                 previousPlayer.RemoveClientAuthority();
 
             return true;
@@ -955,7 +960,12 @@ namespace Mirror
 
             //Debug.Log($"Server SendChangeOwnerMessage: name={identity.name} netid={identity.netId}");
 
-            conn.Send(new ChangeOwnerMessage { netId = identity.netId, isOwner = identity.connectionToClient == conn });
+            conn.Send(new ChangeOwnerMessage
+            {
+                netId = identity.netId,
+                isOwner = identity.connectionToClient == conn,
+                isLocalPlayer = conn.identity == identity
+            });
         }
 
         static void SpawnObject(GameObject obj, NetworkConnection ownerConnection)


### PR DESCRIPTION
- Moved `ChangeOwner` down below `OnChangeOwner`
- Added `isLocalPlayer` bool to `ChangeOwnerMessage`
- Added handling for `isLocalPlayer` to `ChangeOwner`
- Added call to `SendChangeOwnerMessage` to `ReplacePlayerForConnection` for when `keepAuthority` is true
- Fixes #2968