### PR TITLE
Pass connection when spawning scene objects so that authority is not lost

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1115,6 +1115,8 @@ namespace Mirror
             foreach (NetworkIdentity identity in identities)
             {
                 if (ValidateSceneObject(identity))
+                    // pass connection so that authority is not lost when server loads a scene
+                    // https://github.com/vis2k/Mirror/pull/2987
                     Spawn(identity.gameObject, identity.connectionToClient);
             }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1115,7 +1115,7 @@ namespace Mirror
             foreach (NetworkIdentity identity in identities)
             {
                 if (ValidateSceneObject(identity))
-                    Spawn(identity.gameObject);
+                    Spawn(identity.gameObject, identity.connectionToClient);
             }
 
             return true;


### PR DESCRIPTION
This PR aims to fix a bug where clients (including host) lose authority of scene objects when the server loads a scene.

Since I don't think this behaviour isn't reproducible with the built-in examples, I copied the AdditiveScenes example and did one major change which was was to load the SubScene on demand for the host as well as the clients instead of at Start. This is how my own game works so that the host doesn't need to have the whole map loaded in at the same time, which however comes at the cost of having to make sure the players are mostly in the same areas at the same time. The example [AdditiveScenesPlayerHost.zip](https://github.com/vis2k/Mirror/files/7475667/AdditiveScenesPlayerHost.zip), can be imported to the examples folder and should run with the latest version, i.e. 53.5.0.

Demonstration of the bug and my example can be seen in the following gif. My player gets authority over nearby cubes when I press R and I can then change the color of those cubes by pressing T, done through a Command + SyncVar. When I enter the additive area, you can see in the inspector that I lose authority over the selected cube and I can't change the color of them until I press R again to regain authority over them.
![LoseAuthofSceneObjectsAtServerSceneLoad6](https://user-images.githubusercontent.com/7966092/140338364-2bfd94f3-d30d-40d0-8561-30ccdd79403b.gif)


