### PR TITLE
fix: NT checks NetworkClient.ready

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -331,6 +331,7 @@ namespace Mirror
             // client authority, and local player (= allowed to move myself)?
             if (IsClientWithAuthority)
             {
+                // https://github.com/vis2k/Mirror/pull/2992/
                 if (!NetworkClient.ready) return;
 
                 // send to server each 'sendInterval'

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -331,6 +331,8 @@ namespace Mirror
             // client authority, and local player (= allowed to move myself)?
             if (IsClientWithAuthority)
             {
+                if (!NetworkClient.ready) return;
+
                 // send to server each 'sendInterval'
                 // NetworkTime.localTime for double precision until Unity has it too
                 //


### PR DESCRIPTION
NT should not be calling Cmd's when client isn't ready.
Client is made not ready during scene changes...NT needs to respect that.
```
Send command attempted while NetworkClient is not ready.
0x00007FF65DC8189C (Unity) StackWalker::GetCurrentCallstack
0x00007FF65DC85841 (Unity) StackWalker::ShowCallstack
0x00007FF65C2DC4E5 (Unity) GetStacktrace
0x00007FF65E93FB2E (Unity) DebugStringToFile
0x00007FF65DCE5441 (Unity) DebugLogHandler_CUSTOM_Internal_Log
0x000001C0E1C2E4FB (Mono JIT Code) (wrapper managed-to-native) UnityEngine.DebugLogHandler:Internal_Log (UnityEngine.LogType,UnityEngine.LogOption,string,UnityEngine.Object)
0x000001C0E1C2E3AB (Mono JIT Code) UnityEngine.DebugLogHandler:LogFormat (UnityEngine.LogType,UnityEngine.Object,string,object[])
0x000001C0E1C2D9DE (Mono JIT Code) UnityEngine.Logger:Log (UnityEngine.LogType,object)
0x000001C0E25C5C5A (Mono JIT Code) UnityEngine.Debug:LogError (object)
0x000001C0E256B79B (Mono JIT Code) [NetworkBehaviour.cs:212] Mirror.NetworkBehaviour:SendCommandInternal (System.Type,string,Mirror.NetworkWriter,int,bool) 
0x000001C0E256A5CB (Mono JIT Code) Mirror.NetworkTransformBase:CmdClientToServerSync (System.Nullable`1<UnityEngine.Vector3>,System.Nullable`1<UnityEngine.Quaternion>,System.Nullable`1<UnityEngine.Vector3>)
0x000001C0E2564B23 (Mono JIT Code) [NetworkTransformBase.cs:359] Mirror.NetworkTransformBase:UpdateClient () 
0x000001C0E2563853 (Mono JIT Code) [NetworkTransformBase.cs:396] Mirror.NetworkTransformBase:Update () 
0x000001C0E2038C38 (Mono JIT Code) (wrapper runtime-invoke) object:runtime_invoke_void__this__ (object,intptr,intptr,intptr)
0x00007FF954DBE270 (mono-2.0-bdwgc) [mini-runtime.c:2813] mono_jit_runtime_invoke 
0x00007FF954D42AC2 (mono-2.0-bdwgc) [object.c:2921] do_runtime_invoke 
0x00007FF954D4BB1F (mono-2.0-bdwgc) [object.c:2968] mono_runtime_invoke 
0x00007FF65DBF324E (Unity) scripting_method_invoke
0x00007FF65DBECC9D (Unity) ScriptingInvocation::Invoke
0x00007FF65DBAF9C4 (Unity) MonoBehaviour::CallMethodIfAvailable
0x00007FF65DBAFAD6 (Unity) MonoBehaviour::CallUpdateMethod
0x00007FF65D236D48 (Unity) BaseBehaviourManager::CommonUpdate<BehaviourManager>
0x00007FF65D23FC94 (Unity) BehaviourManager::Update
0x00007FF65D681603 (Unity) `InitPlayerLoopCallbacks'::`2'::UpdateScriptRunBehaviourUpdateRegistrator::Forward
0x00007FF65D66AA58 (Unity) ExecutePlayerLoop
0x00007FF65D66AB2D (Unity) ExecutePlayerLoop
0x00007FF65D66FE4C (Unity) PlayerLoop
0x00007FF65B960431 (Unity) PlayerLoopController::UpdateScene
0x00007FF65B95E398 (Unity) Application::TickTimer
0x00007FF65C301FB5 (Unity) MainMessageLoop
0x00007FF65C30C1C8 (Unity) WinMain
0x00007FF65F4090F2 (Unity) __scrt_common_main_seh
0x00007FF9CF487034 (KERNEL32) BaseThreadInitThunk
0x00007FF9D0902651 (ntdll) RtlUserThreadStart
```


