### PR TITLE
fix: Set previousLocalPlayer null in NI.Reset

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1242,6 +1242,8 @@ namespace Mirror
                 if (NetworkClient.localPlayer == this)
                     NetworkClient.localPlayer = null;
             }
+
+            previousLocalPlayer = null;
             isLocalPlayer = false;
         }
 


### PR DESCRIPTION
Calling RemovePlayerForConnection followed by AddPlayerForConnection with the same player object fails to call OnStartLocalPlayer again because previousLocalPlayer was't properly reset to null.