### PR TITLE
fix: NetworkLerpRigidbody target position assignment

### DIFF
--- a/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
@@ -85,7 +85,7 @@ namespace Mirror.Experimental
             target.velocity = Vector3.Lerp(target.velocity, targetVelocity, lerpVelocityAmount);
             target.position = Vector3.Lerp(target.position, targetPosition, lerpPositionAmount);
             // add velocity to position as position would have moved on server at that velocity
-            targetPosition += target.velocity * Time.fixedDeltaTime;
+            target.position += target.velocity * Time.fixedDeltaTime;
 
             // TODO does this also need to sync acceleration so and update velocity?
         }


### PR DESCRIPTION
Changed targetPosition to target.position, it was discussed to provide better results, not personally tested.
Screenshot:
![Screenshot 2021-11-25 at 08 18 03](https://user-images.githubusercontent.com/57072365/143404834-ae8f6596-21d8-4570-aee5-fcf3c8065b8f.jpg)
Discord link:
https://discord.com/channels/343440455738064897/467961162558865408/913319303795855360
