### PR TITLE
fix: onlySendOnMove for new NetworkTransform

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -171,25 +171,11 @@ namespace Mirror
         }
 
 #if EXPERIMENTAL_BANDWIDTH_SAVING
-        protected virtual bool CompareSnapshots(NTSnapshot currentSnapshot)
-        {
-            if (Vector3.SqrMagnitude(lastSnapshot.position - currentSnapshot.position) > positionSensitivity * positionSensitivity)
-            {
-                return false;
-            }
-            else if (Quaternion.Angle(lastSnapshot.rotation, currentSnapshot.rotation) > rotationSensitivity)
-            {
-                return false;
-            }
-            else if (Vector3.SqrMagnitude(lastSnapshot.scale - currentSnapshot.scale) > scaleSensitivity * scaleSensitivity)
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
-        }
+        // Returns true if position, rotation AND scale are unchanged, within given sensitivity range.
+        protected virtual bool CompareSnapshots(NTSnapshot currentSnapshot) =>
+            Vector3.SqrMagnitude(lastSnapshot.position - currentSnapshot.position) <= positionSensitivity * positionSensitivity &&
+            Quaternion.Angle(lastSnapshot.rotation, currentSnapshot.rotation) <= rotationSensitivity &&
+            Vector3.SqrMagnitude(lastSnapshot.scale - currentSnapshot.scale) <= scaleSensitivity * scaleSensitivity;
 #endif
 
         // cmd /////////////////////////////////////////////////////////////////

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -112,6 +112,7 @@ namespace Mirror
 
         // Used to store last sent snapshots
         protected NTSnapshot lastSnapshot;
+        protected bool cachedSnapshotComparison;
         protected bool hasSentUnchangedPosition;
 
         [Header("Debug")]
@@ -347,7 +348,9 @@ namespace Mirror
                 // receiver gets it from batch timestamp to save bandwidth.
                 NTSnapshot snapshot = ConstructSnapshot();
 
-                if (CompareSnapshots(snapshot) && hasSentUnchangedPosition && onlySendOnMove) { return; }
+                cachedSnapshotComparison = CompareSnapshots(snapshot);
+
+                if (cachedSnapshotComparison && hasSentUnchangedPosition && onlySendOnMove) { return; }
 
                 RpcServerToClientSync(
                     // only sync what the user wants to sync
@@ -358,7 +361,7 @@ namespace Mirror
 
                 lastServerSendTime = NetworkTime.localTime;
 
-                if (CompareSnapshots(snapshot))
+                if (cachedSnapshotComparison)
                 {
                     hasSentUnchangedPosition = true;
                 }
@@ -428,7 +431,9 @@ namespace Mirror
                     // receiver gets it from batch timestamp to save bandwidth.
                     NTSnapshot snapshot = ConstructSnapshot();
 
-                    if (CompareSnapshots(snapshot) && hasSentUnchangedPosition && onlySendOnMove) { return; }
+                    cachedSnapshotComparison = CompareSnapshots(snapshot);
+
+                    if (cachedSnapshotComparison && hasSentUnchangedPosition && onlySendOnMove) { return; }
 
                     CmdClientToServerSync(
                         // only sync what the user wants to sync
@@ -439,7 +444,7 @@ namespace Mirror
 
                     lastClientSendTime = NetworkTime.localTime;
 
-                    if (CompareSnapshots(snapshot))
+                    if (cachedSnapshotComparison)
                     {
                         hasSentUnchangedPosition = true;
                     }

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -81,8 +81,9 @@ namespace Mirror
         [Tooltip("When true, data is not sent when object does not move, refer to internal comments.")]
         public bool onlySendOnMove = true;
 
+        // 3 was original, but testing under really bad network conditions, 2%-5% packet loss and 250-1200ms ping, 5 proved to eliminate any twitching.
         [Tooltip("How much time, as a multiple of send interval, has passed before clearing buffers.")]
-        public float timeMultiplierToResetBuffers = 3;
+        public float timeMultiplierToResetBuffers = 5;
 
         [Tooltip("Set sensitivity of change needed before a state is considered to 'have moved'")]
         public float positionSensitivity = 0.01f;
@@ -223,7 +224,7 @@ namespace Mirror
             {
                 double timeIntervalCheck = timeMultiplierToResetBuffers * sendInterval;
 
-                if (serverBuffer.Count == 2 && serverBuffer.Values[1].remoteTimestamp + timeIntervalCheck < timestamp)
+                if (serverBuffer.Count > 0 && serverBuffer.Values[serverBuffer.Count - 1].remoteTimestamp + timeIntervalCheck < timestamp)
                 {
                     Reset();
                 }
@@ -288,7 +289,7 @@ namespace Mirror
             {
                 double timeIntervalCheck = timeMultiplierToResetBuffers * sendInterval;
 
-                if (clientBuffer.Count == 2 && clientBuffer.Values[1].remoteTimestamp + timeIntervalCheck < timestamp)
+                if (clientBuffer.Count > 0 && clientBuffer.Values[clientBuffer.Count - 1].remoteTimestamp + timeIntervalCheck < timestamp)
                 {
                     Reset();
                 }


### PR DESCRIPTION
- added defines by request, to easier revert or disable new addition.
- added cachedSnapshotComparison by request.
- adjusted default variable and buffer check + thoroughly tested.
Majority of credits to Ninja.
Check comments, tooltips, and messages us if further clarification needed.