### PR TITLE
fix: Simplify NetworkWriter.WriteGuid

### DIFF
--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -511,8 +511,8 @@ namespace Mirror
 
         public static void WriteGuid(this NetworkWriter writer, Guid value)
         {
-            byte[] data = value.ToByteArray();
-            writer.WriteBytes(data, 0, data.Length);
+            // Guid.ToByteArray always returns a 16-byte array
+            writer.WriteBytes(value.ToByteArray(), 0, 16);
         }
 
         public static void WriteGuidNullable(this NetworkWriter writer, Guid? value)


### PR DESCRIPTION
[Guid.ToByteArray()](https://docs.microsoft.com/en-us/dotnet/api/system.guid.tobytearray?view=netframework-4.6#System_Guid_ToByteArray) always returns a 16-byte array.

There is already a test for this in NetworkWriterTest.cs

```cs
[Test]
public void TestGuid()
{
    Guid originalGuid = new Guid("0123456789abcdef9876543210fedcba");
    NetworkWriter writer = new NetworkWriter();
    writer.WriteGuid(originalGuid);

    NetworkReader reader = new NetworkReader(writer.ToArray());
    Guid readGuid = reader.ReadGuid();
    Assert.That(readGuid, Is.EqualTo(originalGuid));
}
```