### PR TITLE
fix: Websocket Transport: ignore headers case when checking handshake key

### DIFF
--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/Client/StandAlone/ClientHandshake.cs
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/Client/StandAlone/ClientHandshake.cs
@@ -55,7 +55,7 @@ namespace Mirror.SimpleWeb
                 string responseString = Encoding.ASCII.GetString(responseBuffer, 0, lengthOrNull.Value);
 
                 string acceptHeader = "Sec-WebSocket-Accept: ";
-                int startIndex = responseString.IndexOf(acceptHeader) + acceptHeader.Length;
+                int startIndex = responseString.IndexOf(acceptHeader, StringComparison.InvariantCultureIgnoreCase) + acceptHeader.Length;
                 int endIndex = responseString.IndexOf("\r\n", startIndex);
                 string responseKey = responseString.Substring(startIndex, endIndex - startIndex);
 


### PR DESCRIPTION
As per [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616/#section-4.2) HTTP headers are case-insensitive, this PRs fixes an issue where the WebSockets handshake fails to find the `Sec-WebSocket-Accept` header if the case doesn't match.

Not doing a case-insensitive check can be a problem when the WebSocket server is served through a reverse proxy, I've had this issue with Traefik returning the header as `Sec-Websocket-Accept`.

This issue does not happen on WebGL builds.