### PR TITLE
Interactable Tank Turret

### DIFF
--- a/Assets/Mirror/Examples/Tanks/Prefabs/Tank.prefab
+++ b/Assets/Mirror/Examples/Tanks/Prefabs/Tank.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 6900008319038825817}
   - component: {fileID: 5194388907919410155}
   - component: {fileID: 114654712548978148}
+  - component: {fileID: 7144377311613369288}
   m_Layer: 0
   m_Name: Tank
   m_TagString: Untagged
@@ -32,11 +33,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7831918942946891954}
-  - {fileID: 6564220120147636086}
-  - {fileID: 5718089106632469514}
   - {fileID: 4116800716706440423}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -60,7 +58,7 @@ MonoBehaviour:
   hasSpawned: 0
 --- !u!95 &2240606817507776182
 Animator:
-  serializedVersion: 4
+  serializedVersion: 3
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -73,7 +71,6 @@ Animator:
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -100,10 +97,15 @@ MonoBehaviour:
   interpolatePosition: 1
   interpolateRotation: 1
   interpolateScale: 0
-  bufferTimeMultiplier: 3
+  bufferTimeMultiplier: 1
   bufferSizeLimit: 64
-  catchupThreshold: 6
+  catchupThreshold: 4
   catchupMultiplier: 0.1
+  onlySendOnMove: 1
+  timeMultiplierToResetBuffers: 5
+  positionSensitivity: 0.01
+  rotationSensitivity: 0.01
+  scaleSensitivity: 0.01
   showGizmos: 0
   showOverlay: 0
   overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
@@ -159,12 +161,48 @@ MonoBehaviour:
   agent: {fileID: 6900008319038825817}
   animator: {fileID: 2240606817507776182}
   healthBar: {fileID: 1985504562751981867}
+  turret: {fileID: 7831918942946891958}
   rotationSpeed: 80
   shootKey: 32
   projectilePrefab: {fileID: 5890560936853567077, guid: b7dd46dbf38c643f09e206f9fa4be008,
     type: 3}
   projectileMount: {fileID: 5718089106632469514}
   health: 4
+--- !u!114 &7144377311613369288
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1916082411674582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 734b48bea0b204338958ee3d885e11f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 1
+  sendInterval: 0.05
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 0
+  bufferTimeMultiplier: 0
+  bufferSizeLimit: 64
+  catchupThreshold: 3
+  catchupMultiplier: 0.1
+  onlySendOnMove: 1
+  timeMultiplierToResetBuffers: 5
+  positionSensitivity: 0.01
+  rotationSensitivity: 0.01
+  scaleSensitivity: 0.01
+  showGizmos: 0
+  showOverlay: 0
+  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  target: {fileID: 7831918942946891958}
 --- !u!1 &4426914200102054949
 GameObject:
   m_ObjectHideFlags: 0
@@ -189,13 +227,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4426914200102054949}
-  m_LocalRotation: {x: 0.02281505, y: -0, z: -0, w: 0.9997397}
-  m_LocalPosition: {x: 0.07, y: 0.46, z: 0.126}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalRotation: {x: 0.022814991, y: 0.000000119178246, z: -0.0000000027197586,
+    w: 0.9997397}
+  m_LocalPosition: {x: 0.00070000027, y: 0.002070647, z: 0.0012600002}
+  m_LocalScale: {x: 0.01, y: 0.010000003, z: 0.010000002}
   m_Children: []
-  m_Father: {fileID: 4492442352427800}
-  m_RootOrder: 1
+  m_Father: {fileID: 7831918942946891958}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 2.615, y: 0, z: 0}
 --- !u!108 &7604806193092689376
 Light:
@@ -256,7 +294,6 @@ Light:
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
-  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!1 &4730779867780281009
@@ -282,13 +319,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4730779867780281009}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.412, z: 0.936}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalRotation: {x: -0, y: 0.000000119209275, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.0015906466, z: 0.009359999}
+  m_LocalScale: {x: 0.01, y: 0.010000003, z: 0.010000002}
   m_Children: []
-  m_Father: {fileID: 4492442352427800}
-  m_RootOrder: 2
+  m_Father: {fileID: 7831918942946891958}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6425560216547760105
 GameObject:
@@ -319,10 +355,9 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4492442352427800}
-  m_RootOrder: 3
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1346539668293290578
 MeshRenderer:
@@ -335,12 +370,10 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -365,7 +398,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!102 &1985504562751981867
 TextMesh:
   serializedVersion: 3
@@ -465,6 +497,12 @@ PrefabInstance:
 --- !u!4 &7831918942946891954 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400010, guid: 38b49695fc0a4418bbc350f2366660c5,
+    type: 3}
+  m_PrefabInstance: {fileID: 7831918942947279416}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &7831918942946891958 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400014, guid: 38b49695fc0a4418bbc350f2366660c5,
     type: 3}
   m_PrefabInstance: {fileID: 7831918942947279416}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Mirror/Examples/Tanks/Scripts/Tank.cs
+++ b/Assets/Mirror/Examples/Tanks/Scripts/Tank.cs
@@ -9,6 +9,7 @@ namespace Mirror.Examples.Tanks
         public NavMeshAgent agent;
         public Animator animator;
         public TextMesh healthBar;
+        public Transform turret;
 
         [Header("Movement")]
         public float rotationSpeed = 100;
@@ -45,6 +46,8 @@ namespace Mirror.Examples.Tanks
                 {
                     CmdFire();
                 }
+
+                RotateTurret();
             }
         }
 
@@ -52,7 +55,7 @@ namespace Mirror.Examples.Tanks
         [Command]
         void CmdFire()
         {
-            GameObject projectile = Instantiate(projectilePrefab, projectileMount.position, transform.rotation);
+            GameObject projectile = Instantiate(projectilePrefab, projectileMount.position, projectileMount.rotation);
             NetworkServer.Spawn(projectile);
             RpcOnFire();
         }
@@ -72,6 +75,18 @@ namespace Mirror.Examples.Tanks
                 --health;
                 if (health == 0)
                     NetworkServer.Destroy(gameObject);
+            }
+        }
+
+        void RotateTurret()
+        {
+            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+            RaycastHit hit;
+            if (Physics.Raycast(ray, out hit, 100))
+            {
+                Debug.DrawLine(ray.origin, hit.point);
+                Vector3 lookRotation = new Vector3(hit.point.x, turret.transform.position.y, hit.point.z);
+                turret.transform.LookAt(lookRotation);
             }
         }
     }


### PR DESCRIPTION
Added NetworkTransformChild, set target as Turret
Adjusted NTC and NT variables
Dragged ProjectileMount and Spot Light into Turret, so they all move together.
Added RotateTurret code
Updated current CmdFire to use projectileMount.rotation

Why was this added?
1: helps us to show people how NTC works, goes on parent, not on child itself (repeat occurrence in #help).
2: its fun to swing turret about

Video preview:
https://user-images.githubusercontent.com/57072365/145177777-4d687710-ccea-4f52-9a5e-aeddad3ebf4a.mp4


