### PR TITLE
fix: Explicit types for default nullables

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -316,7 +316,7 @@ namespace Mirror
         public static Matrix4x4? ReadMatrix4x4Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadMatrix4x4(reader) : default(Matrix4x4?);
 
         public static Guid ReadGuid(this NetworkReader reader) => new Guid(reader.ReadBytes(16));
-        public static Guid? ReadGuidNullable(this NetworkReader reader) => reader.ReadBool() ? ReadGuid(reader) : Guid.Empty;
+        public static Guid? ReadGuidNullable(this NetworkReader reader) => reader.ReadBool() ? ReadGuid(reader) : default(Guid?);
 
         public static NetworkIdentity ReadNetworkIdentity(this NetworkReader reader)
         {

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -127,19 +127,19 @@ namespace Mirror
         static readonly UTF8Encoding encoding = new UTF8Encoding(false, true);
 
         public static byte ReadByte(this NetworkReader reader) => reader.ReadByte();
-        public static byte? ReadByteNullable(this NetworkReader reader) => reader.ReadBool() ? ReadByte(reader) : default;
+        public static byte? ReadByteNullable(this NetworkReader reader) => reader.ReadBool() ? ReadByte(reader) : default(byte?);
 
         public static sbyte ReadSByte(this NetworkReader reader) => (sbyte)reader.ReadByte();
-        public static sbyte? ReadSByteNullable(this NetworkReader reader) => reader.ReadBool() ? ReadSByte(reader) : default;
+        public static sbyte? ReadSByteNullable(this NetworkReader reader) => reader.ReadBool() ? ReadSByte(reader) : default(sbyte?);
 
         public static char ReadChar(this NetworkReader reader) => (char)reader.ReadUShort();
-        public static char? ReadCharNullable(this NetworkReader reader) => reader.ReadBool() ? ReadChar(reader) : default;
+        public static char? ReadCharNullable(this NetworkReader reader) => reader.ReadBool() ? ReadChar(reader) : default(char?);
 
         public static bool ReadBool(this NetworkReader reader) => reader.ReadByte() != 0;
-        public static bool? ReadBoolNullable(this NetworkReader reader) => reader.ReadBool() ? ReadBool(reader) : default;
+        public static bool? ReadBoolNullable(this NetworkReader reader) => reader.ReadBool() ? ReadBool(reader) : default(bool?);
 
         public static short ReadShort(this NetworkReader reader) => (short)reader.ReadUShort();
-        public static short? ReadShortNullable(this NetworkReader reader) => reader.ReadBool() ? ReadShort(reader) : default;
+        public static short? ReadShortNullable(this NetworkReader reader) => reader.ReadBool() ? ReadShort(reader) : default(short?);
 
         public static ushort ReadUShort(this NetworkReader reader)
         {
@@ -148,10 +148,10 @@ namespace Mirror
             value |= (ushort)(reader.ReadByte() << 8);
             return value;
         }
-        public static ushort? ReadUShortNullable(this NetworkReader reader) => reader.ReadBool() ? ReadUShort(reader) : default;
+        public static ushort? ReadUShortNullable(this NetworkReader reader) => reader.ReadBool() ? ReadUShort(reader) : default(ushort?);
 
         public static int ReadInt(this NetworkReader reader) => (int)reader.ReadUInt();
-        public static int? ReadIntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadInt(reader) : default;
+        public static int? ReadIntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadInt(reader) : default(int?);
 
         public static uint ReadUInt(this NetworkReader reader)
         {
@@ -162,10 +162,10 @@ namespace Mirror
             value |= (uint)(reader.ReadByte() << 24);
             return value;
         }
-        public static uint? ReadUIntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadUInt(reader) : default;
+        public static uint? ReadUIntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadUInt(reader) : default(uint?);
 
         public static long ReadLong(this NetworkReader reader) => (long)reader.ReadULong();
-        public static long? ReadLongNullable(this NetworkReader reader) => reader.ReadBool() ? ReadLong(reader) : default;
+        public static long? ReadLongNullable(this NetworkReader reader) => reader.ReadBool() ? ReadLong(reader) : default(long?);
 
         public static ulong ReadULong(this NetworkReader reader)
         {
@@ -180,7 +180,7 @@ namespace Mirror
             value |= ((ulong)reader.ReadByte()) << 56;
             return value;
         }
-        public static ulong? ReadULongNullable(this NetworkReader reader) => reader.ReadBool() ? ReadULong(reader) : default;
+        public static ulong? ReadULongNullable(this NetworkReader reader) => reader.ReadBool() ? ReadULong(reader) : default(ulong?);
 
         public static float ReadFloat(this NetworkReader reader)
         {
@@ -188,7 +188,7 @@ namespace Mirror
             converter.intValue = reader.ReadUInt();
             return converter.floatValue;
         }
-        public static float? ReadFloatNullable(this NetworkReader reader) => reader.ReadBool() ? ReadFloat(reader) : default;
+        public static float? ReadFloatNullable(this NetworkReader reader) => reader.ReadBool() ? ReadFloat(reader) : default(float?);
 
         public static double ReadDouble(this NetworkReader reader)
         {
@@ -196,7 +196,7 @@ namespace Mirror
             converter.longValue = reader.ReadULong();
             return converter.doubleValue;
         }
-        public static double? ReadDoubleNullable(this NetworkReader reader) => reader.ReadBool() ? ReadDouble(reader) : default;
+        public static double? ReadDoubleNullable(this NetworkReader reader) => reader.ReadBool() ? ReadDouble(reader) : default(double?);
 
         public static decimal ReadDecimal(this NetworkReader reader)
         {
@@ -205,7 +205,7 @@ namespace Mirror
             converter.longValue2 = reader.ReadULong();
             return converter.decimalValue;
         }
-        public static decimal? ReadDecimalNullable(this NetworkReader reader) => reader.ReadBool() ? ReadDecimal(reader) : default;
+        public static decimal? ReadDecimalNullable(this NetworkReader reader) => reader.ReadBool() ? ReadDecimal(reader) : default(decimal?);
 
         /// <exception cref="T:System.ArgumentException">if an invalid utf8 string is sent</exception>
         public static string ReadString(this NetworkReader reader)
@@ -259,37 +259,37 @@ namespace Mirror
         }
 
         public static Vector2 ReadVector2(this NetworkReader reader) => new Vector2(reader.ReadFloat(), reader.ReadFloat());
-        public static Vector2? ReadVector2Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector2(reader) : default;
+        public static Vector2? ReadVector2Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector2(reader) : default(Vector2?);
 
         public static Vector3 ReadVector3(this NetworkReader reader) => new Vector3(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Vector3? ReadVector3Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector3(reader) : default;
+        public static Vector3? ReadVector3Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector3(reader) : default(Vector3?);
 
         public static Vector4 ReadVector4(this NetworkReader reader) => new Vector4(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Vector4? ReadVector4Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector4(reader) : default;
+        public static Vector4? ReadVector4Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector4(reader) : default(Vector4?);
 
         public static Vector2Int ReadVector2Int(this NetworkReader reader) => new Vector2Int(reader.ReadInt(), reader.ReadInt());
-        public static Vector2Int? ReadVector2IntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector2Int(reader) : default;
+        public static Vector2Int? ReadVector2IntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector2Int(reader) : default(Vector2Int?);
 
         public static Vector3Int ReadVector3Int(this NetworkReader reader) => new Vector3Int(reader.ReadInt(), reader.ReadInt(), reader.ReadInt());
-        public static Vector3Int? ReadVector3IntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector3Int(reader) : default;
+        public static Vector3Int? ReadVector3IntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector3Int(reader) : default(Vector3Int?);
 
         public static Color ReadColor(this NetworkReader reader) => new Color(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Color? ReadColorNullable(this NetworkReader reader) => reader.ReadBool() ? new Color(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat()) : default;
+        public static Color? ReadColorNullable(this NetworkReader reader) => reader.ReadBool() ? new Color(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat()) : default(Color?);
 
         public static Color32 ReadColor32(this NetworkReader reader) => new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
-        public static Color32? ReadColor32Nullable(this NetworkReader reader) => reader.ReadBool() ? new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte()) : default;
+        public static Color32? ReadColor32Nullable(this NetworkReader reader) => reader.ReadBool() ? new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte()) : default(Color32?);
 
         public static Quaternion ReadQuaternion(this NetworkReader reader) => new Quaternion(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Quaternion? ReadQuaternionNullable(this NetworkReader reader) => reader.ReadBool() ? ReadQuaternion(reader) : default;
+        public static Quaternion? ReadQuaternionNullable(this NetworkReader reader) => reader.ReadBool() ? ReadQuaternion(reader) : default(Quaternion?);
 
         public static Rect ReadRect(this NetworkReader reader) => new Rect(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Rect? ReadRectNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRect(reader) : default;
+        public static Rect? ReadRectNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRect(reader) : default(Rect?);
 
         public static Plane ReadPlane(this NetworkReader reader) => new Plane(reader.ReadVector3(), reader.ReadFloat());
-        public static Plane? ReadPlaneNullable(this NetworkReader reader) => reader.ReadBool() ? ReadPlane(reader) : default;
+        public static Plane? ReadPlaneNullable(this NetworkReader reader) => reader.ReadBool() ? ReadPlane(reader) : default(Plane);
 
         public static Ray ReadRay(this NetworkReader reader) => new Ray(reader.ReadVector3(), reader.ReadVector3());
-        public static Ray? ReadRayNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRay(reader) : default;
+        public static Ray? ReadRayNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRay(reader) : default(Ray?);
 
         public static Matrix4x4 ReadMatrix4x4(this NetworkReader reader)
         {
@@ -313,7 +313,7 @@ namespace Mirror
                 m33 = reader.ReadFloat()
             };
         }
-        public static Matrix4x4? ReadMatrix4x4Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadMatrix4x4(reader) : default;
+        public static Matrix4x4? ReadMatrix4x4Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadMatrix4x4(reader) : default(Matrix4x4?);
 
         public static Guid ReadGuid(this NetworkReader reader) => new Guid(reader.ReadBytes(16));
         public static Guid? ReadGuidNullable(this NetworkReader reader) => reader.ReadBool() ? ReadGuid(reader) : Guid.Empty;

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -286,7 +286,7 @@ namespace Mirror
         public static Rect? ReadRectNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRect(reader) : default(Rect?);
 
         public static Plane ReadPlane(this NetworkReader reader) => new Plane(reader.ReadVector3(), reader.ReadFloat());
-        public static Plane? ReadPlaneNullable(this NetworkReader reader) => reader.ReadBool() ? ReadPlane(reader) : default(Plane);
+        public static Plane? ReadPlaneNullable(this NetworkReader reader) => reader.ReadBool() ? ReadPlane(reader) : default(Plane?);
 
         public static Ray ReadRay(this NetworkReader reader) => new Ray(reader.ReadVector3(), reader.ReadVector3());
         public static Ray? ReadRayNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRay(reader) : default(Ray?);

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -228,6 +228,17 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestVector2Nullable()
+        {
+            Vector2? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteVector2Nullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Vector2? output = reader.ReadVector2Nullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
         public void TestVector3()
         {
             Vector3[] inputs = {
@@ -247,6 +258,17 @@ namespace Mirror.Tests
                 Vector3 output = reader.ReadVector3();
                 Assert.That(output, Is.EqualTo(input));
             }
+        }
+
+        [Test]
+        public void TestVector3Nullable()
+        {
+            Vector3? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteVector3Nullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Vector3? output = reader.ReadVector3Nullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]
@@ -271,6 +293,17 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestVector4Nullable()
+        {
+            Vector4? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteVector4Nullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Vector4? output = reader.ReadVector4Nullable();
+            Assert.That(output, Is.EqualTo(output));
+        }
+
+        [Test]
         public void TestVector2Int()
         {
             Vector2Int[] inputs = {
@@ -290,6 +323,17 @@ namespace Mirror.Tests
                 Vector2Int output = reader.ReadVector2Int();
                 Assert.That(output, Is.EqualTo(input));
             }
+        }
+
+        [Test]
+        public void TestVector2IntNullable()
+        {
+            Vector2Int? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteVector2IntNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Vector2Int? output = reader.ReadVector2IntNullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]
@@ -316,6 +360,17 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestVector3IntNullable()
+        {
+            Vector3Int? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteVector3IntNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Vector3Int? output = reader.ReadVector3IntNullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
         public void TestColor()
         {
             Color[] inputs = {
@@ -335,6 +390,17 @@ namespace Mirror.Tests
                 Color output = reader.ReadColor();
                 Assert.That(output, Is.EqualTo(input));
             }
+        }
+
+        [Test]
+        public void TestColorNullable()
+        {
+            Color? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteColorNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Color? output = reader.ReadColorNullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]
@@ -361,6 +427,17 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestColor32Nullable()
+        {
+            Color32? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteColor32Nullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Color32? output = reader.ReadColor32Nullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
         public void TestQuaternion()
         {
             Quaternion[] inputs = {
@@ -377,6 +454,17 @@ namespace Mirror.Tests
                 Quaternion output = reader.ReadQuaternion();
                 Assert.That(output, Is.EqualTo(input));
             }
+        }
+
+        [Test]
+        public void TestQuaternionNullable()
+        {
+            Quaternion? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteQuaternionNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Quaternion? output = reader.ReadQuaternionNullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]
@@ -397,6 +485,17 @@ namespace Mirror.Tests
                 Rect output = reader.ReadRect();
                 Assert.That(output, Is.EqualTo(input));
             }
+        }
+
+        [Test]
+        public void TestRectNullable()
+        {
+            Rect? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteRectNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Rect? output = reader.ReadRectNullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]
@@ -423,6 +522,17 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestPlaneNullable()
+        {
+            Plane? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WritePlaneNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Plane? output = reader.ReadPlaneNullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
         public void TestRay()
         {
             Ray[] inputs = {
@@ -439,6 +549,17 @@ namespace Mirror.Tests
                 Assert.That((output.direction - input.direction).magnitude, Is.LessThan(1e-6f));
                 Assert.That(output.origin, Is.EqualTo(input.origin));
             }
+        }
+
+        [Test]
+        public void TestRayNullable()
+        {
+            Ray? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteRayNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Ray? output = reader.ReadRayNullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]
@@ -459,6 +580,17 @@ namespace Mirror.Tests
                 Matrix4x4 output = reader.ReadMatrix4x4();
                 Assert.That(output, Is.EqualTo(input));
             }
+        }
+
+        [Test]
+        public void TestMatrix4x4Nullable()
+        {
+            Matrix4x4? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteMatrix4x4Nullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Matrix4x4? output = reader.ReadMatrix4x4Nullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]
@@ -610,6 +742,17 @@ namespace Mirror.Tests
             NetworkReader reader = new NetworkReader(writer.ToArray());
             Guid readGuid = reader.ReadGuid();
             Assert.That(readGuid, Is.EqualTo(originalGuid));
+        }
+
+        [Test]
+        public void TestGuidNullable()
+        {
+            Guid? input = Guid.Empty;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteGuidNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            Guid? output = reader.ReadGuidNullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -207,6 +207,81 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestBool()
+        {
+            bool[] inputs = { true, false };
+            foreach (bool input in inputs)
+            {
+                NetworkWriter writer = new NetworkWriter();
+                writer.WriteBool(input);
+                NetworkReader reader = new NetworkReader(writer.ToArray());
+                bool output = reader.ReadBool();
+                Assert.That(output, Is.EqualTo(input));
+            }
+        }
+
+        [Test]
+        public void TestBoolNullable()
+        {
+            bool? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteBoolNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            bool? output = reader.ReadBoolNullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
+        public void TestByte()
+        {
+            byte[] inputs = { 1, 2, 3, 4 };
+            foreach (byte input in inputs)
+            {
+                NetworkWriter writer = new NetworkWriter();
+                writer.WriteByte(input);
+                NetworkReader reader = new NetworkReader(writer.ToArray());
+                byte output = reader.ReadByte();
+                Assert.That(output, Is.EqualTo(input));
+            }
+        }
+
+        [Test]
+        public void TestByteNullable()
+        {
+            byte? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteByteNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            byte? output = reader.ReadByteNullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
+        public void TestSByte()
+        {
+            sbyte[] inputs = { 1, 2, 3, 4 };
+            foreach (sbyte input in inputs)
+            {
+                NetworkWriter writer = new NetworkWriter();
+                writer.WriteSByte(input);
+                NetworkReader reader = new NetworkReader(writer.ToArray());
+                sbyte output = reader.ReadSByte();
+                Assert.That(output, Is.EqualTo(input));
+            }
+        }
+
+        [Test]
+        public void TestSByteNullable()
+        {
+            sbyte? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteSByteNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            sbyte? output = reader.ReadSByteNullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
         public void TestVector2()
         {
             Vector2[] inputs = {
@@ -682,6 +757,17 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestCharNullable()
+        {
+            char? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteCharNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            char? output = reader.ReadCharNullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
         public void TestUnicodeString()
         {
             string[] weirdUnicode = {
@@ -787,6 +873,17 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestFloatNullable()
+        {
+            float? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteFloatNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            float? output = reader.ReadFloatNullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
         public void TestDoubles()
         {
             double[] weirdDoubles = {
@@ -818,6 +915,17 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestDoubleNullable()
+        {
+            double? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteDoubleNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            double? output = reader.ReadDoubleNullable();
+            Assert.That(output, Is.EqualTo(input));
+        }
+
+        [Test]
         public void TestDecimals()
         {
             decimal[] weirdDecimals = {
@@ -836,6 +944,17 @@ namespace Mirror.Tests
                 decimal readDecimal = reader.ReadDecimal();
                 Assert.That(readDecimal, Is.EqualTo(weird));
             }
+        }
+
+        [Test]
+        public void TestDecimalNullable()
+        {
+            decimal? input = null;
+            NetworkWriter writer = new NetworkWriter();
+            writer.WriteDecimalNullable(input);
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            decimal? output = reader.ReadDecimalNullable();
+            Assert.That(output, Is.EqualTo(input));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -747,7 +747,7 @@ namespace Mirror.Tests
         [Test]
         public void TestGuidNullable()
         {
-            Guid? input = Guid.Empty;
+            Guid? input = null;
             NetworkWriter writer = new NetworkWriter();
             writer.WriteGuidNullable(input);
             NetworkReader reader = new NetworkReader(writer.ToArray());


### PR DESCRIPTION
Returning default alone doesn't return give a true null. Explicit types required.