### PR TITLE
fix: Snapshot Interpolation 'localTime' removed. 'old enough' checks are now done based on 'remoteTime'

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -112,8 +112,6 @@ namespace Mirror
             return new NTSnapshot(
                 // our local time is what the other end uses as remote time
                 NetworkTime.localTime,
-                // the other end fills out local time itself
-                0,
                 targetComponent.localPosition,
                 targetComponent.localRotation,
                 targetComponent.localScale
@@ -192,7 +190,6 @@ namespace Mirror
             // construct snapshot with batch timestamp to save bandwidth
             NTSnapshot snapshot = new NTSnapshot(
                 timestamp,
-                NetworkTime.localTime,
                 position.Value, rotation.Value, scale.Value
             );
 
@@ -245,7 +242,6 @@ namespace Mirror
             // construct snapshot with batch timestamp to save bandwidth
             NTSnapshot snapshot = new NTSnapshot(
                 timestamp,
-                NetworkTime.localTime,
                 position.Value, rotation.Value, scale.Value
             );
 
@@ -587,19 +583,13 @@ namespace Mirror
             // only draw if we have at least two entries
             if (buffer.Count < 2) return;
 
-            // calcluate threshold for 'old enough' snapshots
-            double threshold = NetworkTime.localTime - bufferTime;
-            Color oldEnoughColor = new Color(0, 1, 0, 0.5f);
-            Color notOldEnoughColor = new Color(0.5f, 0.5f, 0.5f, 0.3f);
-
             // draw the whole buffer for easier debugging.
             // it's worth seeing how much we have buffered ahead already
             for (int i = 0; i < buffer.Count; ++i)
             {
                 // color depends on if old enough or not
                 NTSnapshot entry = buffer.Values[i];
-                bool oldEnough = entry.localTimestamp <= threshold;
-                Gizmos.color = oldEnough ? oldEnoughColor : notOldEnoughColor;
+                Gizmos.color = Color.green;
                 Gizmos.DrawCube(entry.position, Vector3.one);
             }
 

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformSnapshot.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformSnapshot.cs
@@ -24,18 +24,14 @@ namespace Mirror
         // [REMOTE TIME, NOT LOCAL TIME]
         // => DOUBLE for long term accuracy & batching gives us double anyway
         public double remoteTimestamp { get; set; }
-        // the local timestamp (when we received it)
-        // used to know if the first two snapshots are old enough to start.
-        public double localTimestamp { get; set; }
 
         public Vector3 position;
         public Quaternion rotation;
         public Vector3 scale;
 
-        public NTSnapshot(double remoteTimestamp, double localTimestamp, Vector3 position, Quaternion rotation, Vector3 scale)
+        public NTSnapshot(double remoteTimestamp, Vector3 position, Quaternion rotation, Vector3 scale)
         {
             this.remoteTimestamp = remoteTimestamp;
-            this.localTimestamp = localTimestamp;
             this.position = position;
             this.rotation = rotation;
             this.scale = scale;
@@ -47,8 +43,8 @@ namespace Mirror
             // Vector3 & Quaternion components are float anyway, so we can
             // keep using the functions with 't' as float instead of double.
             return new NTSnapshot(
-                // interpolated snapshot is applied directly. don't need timestamps.
-                0, 0,
+                // interpolated snapshot is applied directly. don't need timestamp.
+                0,
                 // lerp position/rotation/scale unclamped in case we ever need
                 // to extrapolate. atm SnapshotInterpolation never does.
                 Vector3.LerpUnclamped(from.position, to.position, (float)t),

--- a/Assets/Mirror/Runtime/SnapshotInterpolation/Snapshot.cs
+++ b/Assets/Mirror/Runtime/SnapshotInterpolation/Snapshot.cs
@@ -6,15 +6,10 @@ namespace Mirror
 {
     public interface Snapshot
     {
-        // snapshots have two timestamps:
-        // -> the remote timestamp (when it was sent by the remote)
-        //    used to interpolate.
-        // -> the local timestamp (when we received it)
-        //    used to know if the first two snapshots are old enough to start.
-        //
+        // snapshots a REMOTE timestamp (when it was sent by the remote)
+        // used to interpolate.
         // IMPORTANT: the timestamp does _NOT_ need to be sent over the
         //            network. simply get it from batching.
         double remoteTimestamp { get; set; }
-        double localTimestamp { get; set; }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
@@ -59,14 +59,12 @@ namespace Mirror.Tests.NetworkTransform2k
         {
             NTSnapshot from = new NTSnapshot(
                 1,
-                1,
                 new Vector3(1, 1, 1),
                 Quaternion.Euler(new Vector3(0, 0, 0)),
                 new Vector3(3, 3, 3)
             );
 
             NTSnapshot to = new NTSnapshot(
-                2,
                 2,
                 new Vector3(2, 2, 2),
                 Quaternion.Euler(new Vector3(0, 90, 0)),
@@ -129,7 +127,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.interpolatePosition = true;
             component.interpolateRotation = true;
             component.interpolateScale = true;
-            component.ApplySnapshot(default, default, new NTSnapshot(0, 0, position, rotation, scale));
+            component.ApplySnapshot(default, default, new NTSnapshot(0, position, rotation, scale));
 
             // was it applied?
             Assert.That(transform.position, Is.EqualTo(position));
@@ -152,7 +150,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.interpolatePosition = false;
             component.interpolateRotation = false;
             component.interpolateScale = false;
-            component.ApplySnapshot(default, new NTSnapshot(0, 0, position, rotation, scale), default);
+            component.ApplySnapshot(default, new NTSnapshot(0, position, rotation, scale), default);
 
             // was it applied?
             Assert.That(transform.position, Is.EqualTo(position));
@@ -175,7 +173,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.interpolatePosition = false;
             component.interpolateRotation = true;
             component.interpolateScale = true;
-            component.ApplySnapshot(default, default, new NTSnapshot(0, 0, position, rotation, scale));
+            component.ApplySnapshot(default, default, new NTSnapshot(0, position, rotation, scale));
 
             // was it applied?
             Assert.That(transform.position, Is.EqualTo(Vector3.zero));
@@ -198,7 +196,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.interpolatePosition = true;
             component.interpolateRotation = false;
             component.interpolateScale = true;
-            component.ApplySnapshot(default, default, new NTSnapshot(0, 0, position, rotation, scale));
+            component.ApplySnapshot(default, default, new NTSnapshot(0, position, rotation, scale));
 
             // was it applied?
             Assert.That(transform.position, Is.EqualTo(position));
@@ -221,7 +219,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.interpolatePosition = true;
             component.interpolateRotation = true;
             component.interpolateScale = false;
-            component.ApplySnapshot(default, default, new NTSnapshot(0, 0, position, rotation, scale));
+            component.ApplySnapshot(default, default, new NTSnapshot(0, position, rotation, scale));
 
             // was it applied?
             Assert.That(transform.position, Is.EqualTo(position));


### PR DESCRIPTION
original bug discovered by ninja here: https://github.com/vis2k/Mirror/pull/2854

before: https://gyazo.com/4ae3d7794744892bfc1c28844f0a9fc8
after: https://gyazo.com/4e7619911460c946b1e5bc07ebd43cdb
