### PR TITLE
perf: NetworkWriter/Reader Write/ReadBlittable<T> for 4-6x performance improvement! (based on #2441)

### DIFF
--- a/Assets/Mirror/Runtime/Mirror.asmdef
+++ b/Assets/Mirror/Runtime/Mirror.asmdef
@@ -8,7 +8,7 @@
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -173,7 +173,8 @@ namespace Mirror
         public static sbyte ReadSByte(this NetworkReader reader) => reader.ReadBlittable<sbyte>();
         public static sbyte? ReadSByteNullable(this NetworkReader reader) => reader.ReadBool() ? ReadSByte(reader) : default(sbyte?);
 
-        public static char ReadChar(this NetworkReader reader) => reader.ReadBlittable<char>();
+        // bool is not blittable. read as ushort.
+        public static char ReadChar(this NetworkReader reader) => (char)reader.ReadBlittable<ushort>();
         public static char? ReadCharNullable(this NetworkReader reader) => reader.ReadBool() ? ReadChar(reader) : default(char?);
 
         // bool is not blittable. read as byte.

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -100,7 +100,8 @@ namespace Mirror
             fixed (byte* ptr = &buffer.Array[buffer.Offset + Position])
             {
                 // cast buffer to a T* pointer and then read from it.
-                // TODO *(T*) failed on android before. consider PtrToStructure
+                // note: this failed on android before.
+                //       supposedly works with 2020.3 LTS though.
                 value = *(T*)ptr;
             }
             Position += size;

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -173,7 +173,8 @@ namespace Mirror
                 writer.WriteSByte(value.Value);
         }
 
-        public static void WriteChar(this NetworkWriter writer, char value) => writer.WriteBlittable(value);
+        // char is not blittable. convert to ushort.
+        public static void WriteChar(this NetworkWriter writer, char value) => writer.WriteBlittable((ushort)value);
 
         public static void WriteCharNullable(this NetworkWriter writer, char? value)
         {

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1271,7 +1271,7 @@ namespace Mirror.Tests
                 _ = reader.ReadArray<int>();
             });
             // todo improve this message check
-            Assert.That(exception, Has.Message.Contains($"ReadByte out of range"));
+            Assert.That(exception, Has.Message.Contains($"ReadBlittable<System.Int32> out of range"));
 
             void WriteBadArray()
             {


### PR DESCRIPTION
Restored the PR because it supposedly works on Android now.
-------------
Write/ReadBlittable<T> from DOTSNET.

**Benchmark:**
<img width="689" alt="2020-11-17_21-36-54@2x" src="https://user-images.githubusercontent.com/16416509/99396719-0d5e3400-291d-11eb-9953-4f02930cb65d.png">

**Reasons to use Blittable**
+ 4-6x faster within Unity versions
+ (2020.1 + Blittable is 10x faster than 2018.4 without Blittable)
+ The code is a lot cleaner.
+ Removes 160 LOC
+ All Unity 2018+ platforms are little endian
+ This has been heavily tested in DOTSNET
+ Non-Blittable types still work fine
+ Invisible change to the user
+ No more UIntFloat etc. conversion structs
+ The more complex the type, the more significant the performance gain compared to serializing each member manually
+ Will allow us to reduce generated weaver code later. All blittable types can simply use WriteBlittable.

It's 4-6x performance for free. Would be silly not to use it.

**Unity Platform Endianness**
  [Little] Windows
  [Little] Mac(Intel)
  [Little] Mac(Apple Silicon)
  [Little] Linux(Intel)
  [Little] Android
  [Little] iOS
  [Little] UWP
  [Little] PS4
  [Little] XBOX ONE
  [Little] Nintendo Switch
  [Little] WebGL
  [Little] Android TV
  [Little] tvOS @ Apple A10