### PR TITLE
fix: Use TryGetComponent in DistantInterestManagement

### DIFF
--- a/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
@@ -16,12 +16,7 @@ namespace Mirror
         // helper function to get vis range for a given object, or default.
         int GetVisRange(NetworkIdentity identity)
         {
-            if(identity.TryGetComponent(out DistanceInterestManagementCustomRange custom))
-            {
-                return custom.visRange;
-            }
-
-            return visRange;
+            return identity.TryGetComponent(out DistanceInterestManagementCustomRange custom) ? custom.visRange : visRange;
         }
 
         [ServerCallback]

--- a/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
@@ -16,8 +16,12 @@ namespace Mirror
         // helper function to get vis range for a given object, or default.
         int GetVisRange(NetworkIdentity identity)
         {
-            DistanceInterestManagementCustomRange custom = identity.GetComponent<DistanceInterestManagementCustomRange>();
-            return custom != null ? custom.visRange : visRange;
+            if(identity.TryGetComponent(out DistanceInterestManagementCustomRange custom))
+            {
+                return custom.visRange;
+            }
+
+            return visRange;
         }
 
         [ServerCallback]


### PR DESCRIPTION
- changes dist. interest management to use TryGetComponent instead of GetComponent and null checking, TryGet doesn't allocate in the editor if nothing is found (component == null), whereas GetComponent will.

https://docs.unity3d.com/ScriptReference/Component.TryGetComponent.html