### PR TITLE
 perf: NetworkWriter/Reader Write/ReadBlittable<T> for 4-6x performance improvement! (based on #2441, #3036). This time with Android fix.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -103,12 +103,15 @@ namespace Mirror
                 // on some android systems, reading *(T*)ptr throws a NRE if
                 // the ptr isn't aligned (i.e. if Position is 1,2,3,5, etc.).
                 // here we have to use memcpy.
+                //
                 // => we can't get a pointer of a struct in C# without
                 //    marshalling allocations
                 // => instead, we stack allocate an array of type T and use that
                 // => stackalloc avoids GC and is very fast. it only works for
                 //    value types, but all blittable types are anyway.
+                //
                 // this way, we can still support blittable reads on android.
+                // see also: https://github.com/vis2k/Mirror/issues/3044
                 T* valueBuffer = stackalloc T[1];
                 UnsafeUtility.MemCpy(valueBuffer, ptr, size);
                 value = valueBuffer[0];

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace Mirror
@@ -60,17 +61,73 @@ namespace Mirror
             Position = 0;
         }
 
-        // IMPORTANT: ReadBlittable<T> via fixed pinning WON'T WORK on android:
-        //            https://github.com/vis2k/Mirror/issues/3044
-        //            if we ever do it again, use NativeArray + .GetPtr()!
-        public byte ReadByte()
+        // ReadBlittable<T> from DOTSNET
+        // this is extremely fast, but only works for blittable types.
+        // => private to make sure nobody accidentally uses it for non-blittable
+        //
+        // Benchmark: see NetworkWriter.WriteBlittable!
+        //
+        // Note:
+        //   ReadBlittable assumes same endianness for server & client.
+        //   All Unity 2018+ platforms are little endian.
+        internal unsafe T ReadBlittable<T>()
+            where T : unmanaged
         {
-            if (Position + 1 > buffer.Count)
+            // check if blittable for safety
+#if UNITY_EDITOR
+            if (!UnsafeUtility.IsBlittable(typeof(T)))
             {
-                throw new EndOfStreamException($"ReadByte out of range:{ToString()}");
+                throw new ArgumentException($"{typeof(T)} is not blittable!");
             }
-            return buffer.Array[buffer.Offset + Position++];
+#endif
+
+            // calculate size
+            //   sizeof(T) gets the managed size at compile time.
+            //   Marshal.SizeOf<T> gets the unmanaged size at runtime (slow).
+            // => our 1mio writes benchmark is 6x slower with Marshal.SizeOf<T>
+            // => for blittable types, sizeof(T) is even recommended:
+            // https://docs.microsoft.com/en-us/dotnet/standard/native-interop/best-practices
+            int size = sizeof(T);
+
+            // enough data to read?
+            if (Position + size > buffer.Count)
+            {
+                throw new EndOfStreamException($"ReadBlittable<{typeof(T)}> out of range: {ToString()}");
+            }
+
+            // read blittable
+            T value;
+            fixed (byte* ptr = &buffer.Array[buffer.Offset + Position])
+            {
+#if UNITY_ANDROID
+                // on some android systems, reading *(T*)ptr throws a NRE if
+                // the ptr isn't aligned (i.e. if Position is 1,2,3,5, etc.).
+                // here we have to use memcpy.
+                // => we can't get a pointer of a struct in C# without
+                //    marshalling allocations
+                // => instead, we stack allocate an array of type T and use that
+                // => stackalloc avoids GC and is very fast. it only works for
+                //    value types, but all blittable types are anyway.
+                // this way, we can still support blittable reads on android.
+                T* valueBuffer = stackalloc T[1];
+                UnsafeUtility.MemCpy(valueBuffer, ptr, size);
+                value = valueBuffer[0];
+#else
+                // cast buffer to a T* pointer and then read from it.
+                value = *(T*)ptr;
+#endif
+            }
+            Position += size;
+            return value;
         }
+
+        // blittable'?' template for code reuse
+        // note: bool isn't blittable. need to read as byte.
+        internal T? ReadBlittableNullable<T>()
+            where T : unmanaged =>
+                ReadByte() != 0 ? ReadBlittable<T>() : default(T?);
+
+        public byte ReadByte() => ReadBlittable<byte>();
 
         /// <summary>Read 'count' bytes into the bytes array</summary>
         // TODO why does this also return bytes[]???
@@ -129,86 +186,50 @@ namespace Mirror
         // 1000 readers after: 0.8MB GC, 18ms
         static readonly UTF8Encoding encoding = new UTF8Encoding(false, true);
 
-        public static byte ReadByte(this NetworkReader reader) => reader.ReadByte();
-        public static byte? ReadByteNullable(this NetworkReader reader) => reader.ReadBool() ? ReadByte(reader) : default(byte?);
+        public static byte ReadByte(this NetworkReader reader) => reader.ReadBlittable<byte>();
+        public static byte? ReadByteNullable(this NetworkReader reader) => reader.ReadBlittableNullable<byte>();
 
-        public static sbyte ReadSByte(this NetworkReader reader) => (sbyte)reader.ReadByte();
-        public static sbyte? ReadSByteNullable(this NetworkReader reader) => reader.ReadBool() ? ReadSByte(reader) : default(sbyte?);
+        public static sbyte ReadSByte(this NetworkReader reader) => reader.ReadBlittable<sbyte>();
+        public static sbyte? ReadSByteNullable(this NetworkReader reader) => reader.ReadBlittableNullable<sbyte>();
 
-        public static char ReadChar(this NetworkReader reader) => (char)reader.ReadUShort();
-        public static char? ReadCharNullable(this NetworkReader reader) => reader.ReadBool() ? ReadChar(reader) : default(char?);
+        // bool is not blittable. read as ushort.
+        public static char ReadChar(this NetworkReader reader) => (char)reader.ReadBlittable<ushort>();
+        public static char? ReadCharNullable(this NetworkReader reader) => (char?)reader.ReadBlittableNullable<ushort>();
 
-        public static bool ReadBool(this NetworkReader reader) => reader.ReadByte() != 0;
-        public static bool? ReadBoolNullable(this NetworkReader reader) => reader.ReadBool() ? ReadBool(reader) : default(bool?);
+        // bool is not blittable. read as byte.
+        public static bool ReadBool(this NetworkReader reader) => reader.ReadBlittable<byte>() != 0;
+        public static bool? ReadBoolNullable(this NetworkReader reader)
+        {
+            byte? value = reader.ReadBlittableNullable<byte>();
+            return value.HasValue ? (value.Value != 0) : default(bool?);
+        }
 
         public static short ReadShort(this NetworkReader reader) => (short)reader.ReadUShort();
-        public static short? ReadShortNullable(this NetworkReader reader) => reader.ReadBool() ? ReadShort(reader) : default(short?);
+        public static short? ReadShortNullable(this NetworkReader reader) => reader.ReadBlittableNullable<short>();
 
-        public static ushort ReadUShort(this NetworkReader reader)
-        {
-            ushort value = 0;
-            value |= reader.ReadByte();
-            value |= (ushort)(reader.ReadByte() << 8);
-            return value;
-        }
-        public static ushort? ReadUShortNullable(this NetworkReader reader) => reader.ReadBool() ? ReadUShort(reader) : default(ushort?);
+        public static ushort ReadUShort(this NetworkReader reader) => reader.ReadBlittable<ushort>();
+        public static ushort? ReadUShortNullable(this NetworkReader reader) => reader.ReadBlittableNullable<ushort>();
 
-        public static int ReadInt(this NetworkReader reader) => (int)reader.ReadUInt();
-        public static int? ReadIntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadInt(reader) : default(int?);
+        public static int ReadInt(this NetworkReader reader) => reader.ReadBlittable<int>();
+        public static int? ReadIntNullable(this NetworkReader reader) => reader.ReadBlittableNullable<int>();
 
-        public static uint ReadUInt(this NetworkReader reader)
-        {
-            uint value = 0;
-            value |= reader.ReadByte();
-            value |= (uint)(reader.ReadByte() << 8);
-            value |= (uint)(reader.ReadByte() << 16);
-            value |= (uint)(reader.ReadByte() << 24);
-            return value;
-        }
-        public static uint? ReadUIntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadUInt(reader) : default(uint?);
+        public static uint ReadUInt(this NetworkReader reader) => reader.ReadBlittable<uint>();
+        public static uint? ReadUIntNullable(this NetworkReader reader) => reader.ReadBlittableNullable<uint>();
 
-        public static long ReadLong(this NetworkReader reader) => (long)reader.ReadULong();
-        public static long? ReadLongNullable(this NetworkReader reader) => reader.ReadBool() ? ReadLong(reader) : default(long?);
+        public static long ReadLong(this NetworkReader reader) => reader.ReadBlittable<long>();
+        public static long? ReadLongNullable(this NetworkReader reader) => reader.ReadBlittableNullable<long>();
 
-        public static ulong ReadULong(this NetworkReader reader)
-        {
-            ulong value = 0;
-            value |= reader.ReadByte();
-            value |= ((ulong)reader.ReadByte()) << 8;
-            value |= ((ulong)reader.ReadByte()) << 16;
-            value |= ((ulong)reader.ReadByte()) << 24;
-            value |= ((ulong)reader.ReadByte()) << 32;
-            value |= ((ulong)reader.ReadByte()) << 40;
-            value |= ((ulong)reader.ReadByte()) << 48;
-            value |= ((ulong)reader.ReadByte()) << 56;
-            return value;
-        }
-        public static ulong? ReadULongNullable(this NetworkReader reader) => reader.ReadBool() ? ReadULong(reader) : default(ulong?);
+        public static ulong ReadULong(this NetworkReader reader) => reader.ReadBlittable<ulong>();
+        public static ulong? ReadULongNullable(this NetworkReader reader) => reader.ReadBlittableNullable<ulong>();
 
-        public static float ReadFloat(this NetworkReader reader)
-        {
-            UIntFloat converter = new UIntFloat();
-            converter.intValue = reader.ReadUInt();
-            return converter.floatValue;
-        }
-        public static float? ReadFloatNullable(this NetworkReader reader) => reader.ReadBool() ? ReadFloat(reader) : default(float?);
+        public static float ReadFloat(this NetworkReader reader) => reader.ReadBlittable<float>();
+        public static float? ReadFloatNullable(this NetworkReader reader) => reader.ReadBlittableNullable<float>();
 
-        public static double ReadDouble(this NetworkReader reader)
-        {
-            UIntDouble converter = new UIntDouble();
-            converter.longValue = reader.ReadULong();
-            return converter.doubleValue;
-        }
-        public static double? ReadDoubleNullable(this NetworkReader reader) => reader.ReadBool() ? ReadDouble(reader) : default(double?);
+        public static double ReadDouble(this NetworkReader reader) => reader.ReadBlittable<double>();
+        public static double? ReadDoubleNullable(this NetworkReader reader) => reader.ReadBlittableNullable<double>();
 
-        public static decimal ReadDecimal(this NetworkReader reader)
-        {
-            UIntDecimal converter = new UIntDecimal();
-            converter.longValue1 = reader.ReadULong();
-            converter.longValue2 = reader.ReadULong();
-            return converter.decimalValue;
-        }
-        public static decimal? ReadDecimalNullable(this NetworkReader reader) => reader.ReadBool() ? ReadDecimal(reader) : default(decimal?);
+        public static decimal ReadDecimal(this NetworkReader reader) => reader.ReadBlittable<decimal>();
+        public static decimal? ReadDecimalNullable(this NetworkReader reader) => reader.ReadBlittableNullable<decimal>();
 
         /// <exception cref="T:System.ArgumentException">if an invalid utf8 string is sent</exception>
         public static string ReadString(this NetworkReader reader)
@@ -261,62 +282,41 @@ namespace Mirror
             return count == 0 ? default : reader.ReadBytesSegment(checked((int)(count - 1u)));
         }
 
-        public static Vector2 ReadVector2(this NetworkReader reader) => new Vector2(reader.ReadFloat(), reader.ReadFloat());
-        public static Vector2? ReadVector2Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector2(reader) : default(Vector2?);
+        public static Vector2 ReadVector2(this NetworkReader reader) => reader.ReadBlittable<Vector2>();
+        public static Vector2? ReadVector2Nullable(this NetworkReader reader) => reader.ReadBlittableNullable<Vector2>();
 
-        public static Vector3 ReadVector3(this NetworkReader reader) => new Vector3(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Vector3? ReadVector3Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector3(reader) : default(Vector3?);
+        public static Vector3 ReadVector3(this NetworkReader reader) => reader.ReadBlittable<Vector3>();
+        public static Vector3? ReadVector3Nullable(this NetworkReader reader) => reader.ReadBlittableNullable<Vector3>();
 
-        public static Vector4 ReadVector4(this NetworkReader reader) => new Vector4(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Vector4? ReadVector4Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector4(reader) : default(Vector4?);
+        public static Vector4 ReadVector4(this NetworkReader reader) => reader.ReadBlittable<Vector4>();
+        public static Vector4? ReadVector4Nullable(this NetworkReader reader) => reader.ReadBlittableNullable<Vector4>();
 
-        public static Vector2Int ReadVector2Int(this NetworkReader reader) => new Vector2Int(reader.ReadInt(), reader.ReadInt());
-        public static Vector2Int? ReadVector2IntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector2Int(reader) : default(Vector2Int?);
+        public static Vector2Int ReadVector2Int(this NetworkReader reader) => reader.ReadBlittable<Vector2Int>();
+        public static Vector2Int? ReadVector2IntNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Vector2Int>();
 
-        public static Vector3Int ReadVector3Int(this NetworkReader reader) => new Vector3Int(reader.ReadInt(), reader.ReadInt(), reader.ReadInt());
-        public static Vector3Int? ReadVector3IntNullable(this NetworkReader reader) => reader.ReadBool() ? ReadVector3Int(reader) : default(Vector3Int?);
+        public static Vector3Int ReadVector3Int(this NetworkReader reader) => reader.ReadBlittable<Vector3Int>();
+        public static Vector3Int? ReadVector3IntNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Vector3Int>();
 
-        public static Color ReadColor(this NetworkReader reader) => new Color(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Color? ReadColorNullable(this NetworkReader reader) => reader.ReadBool() ? new Color(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat()) : default(Color?);
+        public static Color ReadColor(this NetworkReader reader) => reader.ReadBlittable<Color>();
+        public static Color? ReadColorNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Color>();
 
-        public static Color32 ReadColor32(this NetworkReader reader) => new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
-        public static Color32? ReadColor32Nullable(this NetworkReader reader) => reader.ReadBool() ? new Color32(reader.ReadByte(), reader.ReadByte(), reader.ReadByte(), reader.ReadByte()) : default(Color32?);
+        public static Color32 ReadColor32(this NetworkReader reader) => reader.ReadBlittable<Color32>();
+        public static Color32? ReadColor32Nullable(this NetworkReader reader) => reader.ReadBlittableNullable<Color32>();
 
-        public static Quaternion ReadQuaternion(this NetworkReader reader) => new Quaternion(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Quaternion? ReadQuaternionNullable(this NetworkReader reader) => reader.ReadBool() ? ReadQuaternion(reader) : default(Quaternion?);
+        public static Quaternion ReadQuaternion(this NetworkReader reader) => reader.ReadBlittable<Quaternion>();
+        public static Quaternion? ReadQuaternionNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Quaternion>();
 
-        public static Rect ReadRect(this NetworkReader reader) => new Rect(reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat(), reader.ReadFloat());
-        public static Rect? ReadRectNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRect(reader) : default(Rect?);
+        public static Rect ReadRect(this NetworkReader reader) => reader.ReadBlittable<Rect>();
+        public static Rect? ReadRectNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Rect>();
 
-        public static Plane ReadPlane(this NetworkReader reader) => new Plane(reader.ReadVector3(), reader.ReadFloat());
-        public static Plane? ReadPlaneNullable(this NetworkReader reader) => reader.ReadBool() ? ReadPlane(reader) : default(Plane?);
+        public static Plane ReadPlane(this NetworkReader reader) => reader.ReadBlittable<Plane>();
+        public static Plane? ReadPlaneNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Plane>();
 
-        public static Ray ReadRay(this NetworkReader reader) => new Ray(reader.ReadVector3(), reader.ReadVector3());
-        public static Ray? ReadRayNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRay(reader) : default(Ray?);
+        public static Ray ReadRay(this NetworkReader reader) => reader.ReadBlittable<Ray>();
+        public static Ray? ReadRayNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Ray>();
 
-        public static Matrix4x4 ReadMatrix4x4(this NetworkReader reader)
-        {
-            return new Matrix4x4
-            {
-                m00 = reader.ReadFloat(),
-                m01 = reader.ReadFloat(),
-                m02 = reader.ReadFloat(),
-                m03 = reader.ReadFloat(),
-                m10 = reader.ReadFloat(),
-                m11 = reader.ReadFloat(),
-                m12 = reader.ReadFloat(),
-                m13 = reader.ReadFloat(),
-                m20 = reader.ReadFloat(),
-                m21 = reader.ReadFloat(),
-                m22 = reader.ReadFloat(),
-                m23 = reader.ReadFloat(),
-                m30 = reader.ReadFloat(),
-                m31 = reader.ReadFloat(),
-                m32 = reader.ReadFloat(),
-                m33 = reader.ReadFloat()
-            };
-        }
-        public static Matrix4x4? ReadMatrix4x4Nullable(this NetworkReader reader) => reader.ReadBool() ? ReadMatrix4x4(reader) : default(Matrix4x4?);
+        public static Matrix4x4 ReadMatrix4x4(this NetworkReader reader)=> reader.ReadBlittable<Matrix4x4>();
+        public static Matrix4x4? ReadMatrix4x4Nullable(this NetworkReader reader) => reader.ReadBlittableNullable<Matrix4x4>();
 
         public static Guid ReadGuid(this NetworkReader reader) => new Guid(reader.ReadBytes(16));
         public static Guid? ReadGuidNullable(this NetworkReader reader) => reader.ReadBool() ? ReadGuid(reader) : default(Guid?);

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -112,6 +112,7 @@ namespace Mirror
                 //
                 // this way, we can still support blittable reads on android.
                 // see also: https://github.com/vis2k/Mirror/issues/3044
+                // (solution discovered by AIIO, FakeByte, mischa)
                 T* valueBuffer = stackalloc T[1];
                 UnsafeUtility.MemCpy(valueBuffer, ptr, size);
                 value = valueBuffer[0];

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace Mirror
@@ -59,14 +61,92 @@ namespace Mirror
             return new ArraySegment<byte>(buffer, 0, Position);
         }
 
-        // IMPORTANT: WriteBlittable<T> via fixed pinning WON'T WORK on android:
-        //            https://github.com/vis2k/Mirror/issues/3044
-        //            if we ever do it again, use NativeArray + .GetPtr()!
-        public void WriteByte(byte value)
+        // WriteBlittable<T> from DOTSNET.
+        // this is extremely fast, but only works for blittable types.
+        //
+        // Benchmark:
+        //   WriteQuaternion x 100k, Macbook Pro 2015 @ 2.2Ghz, Unity 2018 LTS (debug mode)
+        //
+        //                | Median |  Min  |  Max  |  Avg  |  Std  | (ms)
+        //     before     |  30.35 | 29.86 | 48.99 | 32.54 |  4.93 |
+        //     blittable* |   5.69 |  5.52 | 27.51 |  7.78 |  5.65 |
+        //
+        //     * without IsBlittable check
+        //     => 4-6x faster!
+        //
+        //   WriteQuaternion x 100k, Macbook Pro 2015 @ 2.2Ghz, Unity 2020.1 (release mode)
+        //
+        //                | Median |  Min  |  Max  |  Avg  |  Std  | (ms)
+        //     before     |   9.41 |  8.90 | 23.02 | 10.72 |  3.07 |
+        //     blittable* |   1.48 |  1.40 | 16.03 |  2.60 |  2.71 |
+        //
+        //     * without IsBlittable check
+        //     => 6x faster!
+        //
+        // Note:
+        //   WriteBlittable assumes same endianness for server & client.
+        //   All Unity 2018+ platforms are little endian.
+        //   => run NetworkWriterTests.BlittableOnThisPlatform() to verify!
+        internal unsafe void WriteBlittable<T>(T value)
+            where T : unmanaged
         {
-            EnsureCapacity(Position + 1);
-            buffer[Position++] = value;
+            // check if blittable for safety
+#if UNITY_EDITOR
+            if (!UnsafeUtility.IsBlittable(typeof(T)))
+            {
+                Debug.LogError($"{typeof(T)} is not blittable!");
+                return;
+            }
+#endif
+            // calculate size
+            //   sizeof(T) gets the managed size at compile time.
+            //   Marshal.SizeOf<T> gets the unmanaged size at runtime (slow).
+            // => our 1mio writes benchmark is 6x slower with Marshal.SizeOf<T>
+            // => for blittable types, sizeof(T) is even recommended:
+            // https://docs.microsoft.com/en-us/dotnet/standard/native-interop/best-practices
+            int size = sizeof(T);
+
+            // ensure capacity
+            EnsureCapacity(Position + size);
+
+            // TODO TRY
+
+            // write blittable
+            fixed (byte* ptr = &buffer[Position])
+            {
+#if UNITY_ANDROID
+                // on some android systems, assigning *(T*)ptr throws a NRE if
+                // the ptr isn't aligned (i.e. if Position is 1,2,3,5, etc.).
+                // here we have to use memcpy.
+                // => we can't get a pointer of a struct in C# without
+                //    marshalling allocations
+                // => instead, we stack allocate an array of type T and use that
+                // => stackalloc avoids GC and is very fast. it only works for
+                //    value types, but all blittable types are anyway.
+                // this way, we can still support blittable writes on android.
+                T* valueBuffer = stackalloc T[1]{value};
+                UnsafeUtility.MemCpy(ptr, valueBuffer, size);
+#else
+                // cast buffer to T* pointer, then assign value to the area
+                *(T*)ptr = value;
+#endif
+            }
+            Position += size;
         }
+
+        // blittable'?' template for code reuse
+        internal void WriteBlittableNullable<T>(T? value)
+            where T : unmanaged
+        {
+            // bool isn't blittable. write as byte.
+            WriteByte((byte)(value.HasValue ? 0x01 : 0x00));
+
+            // only write value if exists. saves bandwidth.
+            if (value.HasValue)
+                WriteBlittable(value.Value);
+        }
+
+        public void WriteByte(byte value) => WriteBlittable(value);
 
         // for byte arrays with consistent size, where the reader knows how many to read
         // (like a packet opcode that's always the same)
@@ -102,167 +182,63 @@ namespace Mirror
         static readonly UTF8Encoding encoding = new UTF8Encoding(false, true);
         static readonly byte[] stringBuffer = new byte[NetworkWriter.MaxStringLength];
 
-        public static void WriteByte(this NetworkWriter writer, byte value) => writer.WriteByte(value);
+        public static void WriteByte(this NetworkWriter writer, byte value) => writer.WriteBlittable(value);
+        public static void WriteByteNullable(this NetworkWriter writer, byte? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteByteNullable(this NetworkWriter writer, byte? value)
+        public static void WriteSByte(this NetworkWriter writer, sbyte value) => writer.WriteBlittable(value);
+        public static void WriteSByteNullable(this NetworkWriter writer, sbyte? value) => writer.WriteBlittableNullable(value);
+
+        // char is not blittable. convert to ushort.
+        public static void WriteChar(this NetworkWriter writer, char value) => writer.WriteBlittable((ushort)value);
+        public static void WriteCharNullable(this NetworkWriter writer, char? value) => writer.WriteBlittableNullable((ushort?)value);
+
+        // bool is not blittable. convert to byte.
+        public static void WriteBool(this NetworkWriter writer, bool value) => writer.WriteBlittable((byte)(value ? 1 : 0));
+        public static void WriteBoolNullable(this NetworkWriter writer, bool? value) => writer.WriteBlittableNullable(value.HasValue ? ((byte)(value.Value ? 1 : 0)) : new byte?());
+
+        public static void WriteShort(this NetworkWriter writer, short value) => writer.WriteBlittable(value);
+        public static void WriteShortNullable(this NetworkWriter writer, short? value) => writer.WriteBlittableNullable(value);
+
+        public static void WriteUShort(this NetworkWriter writer, ushort value) => writer.WriteBlittable(value);
+        public static void WriteUShortNullable(this NetworkWriter writer, ushort? value) => writer.WriteBlittableNullable(value);
+
+        public static void WriteInt(this NetworkWriter writer, int value) => writer.WriteBlittable(value);
+        public static void WriteIntNullable(this NetworkWriter writer, int? value) => writer.WriteBlittableNullable(value);
+
+        public static void WriteUInt(this NetworkWriter writer, uint value) => writer.WriteBlittable(value);
+        public static void WriteUIntNullable(this NetworkWriter writer, uint? value) => writer.WriteBlittableNullable(value);
+
+        public static void WriteLong(this NetworkWriter writer, long value)  => writer.WriteBlittable(value);
+        public static void WriteLongNullable(this NetworkWriter writer, long? value) => writer.WriteBlittableNullable(value);
+
+        public static void WriteULong(this NetworkWriter writer, ulong value) => writer.WriteBlittable(value);
+        public static void WriteULongNullable(this NetworkWriter writer, ulong? value) => writer.WriteBlittableNullable(value);
+
+        public static void WriteFloat(this NetworkWriter writer, float value) => writer.WriteBlittable(value);
+        public static void WriteFloatNullable(this NetworkWriter writer, float? value) => writer.WriteBlittableNullable(value);
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct UIntDouble
         {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteByte(value.Value);
+            [FieldOffset(0)]
+            public double doubleValue;
+
+            [FieldOffset(0)]
+            public ulong longValue;
         }
-
-        public static void WriteSByte(this NetworkWriter writer, sbyte value) => writer.WriteByte((byte)value);
-
-        public static void WriteSByteNullable(this NetworkWriter writer, sbyte? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteSByte(value.Value);
-        }
-
-        public static void WriteChar(this NetworkWriter writer, char value) => writer.WriteUShort(value);
-
-        public static void WriteCharNullable(this NetworkWriter writer, char? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteChar(value.Value);
-        }
-
-        public static void WriteBool(this NetworkWriter writer, bool value) => writer.WriteByte((byte)(value ? 1 : 0));
-
-        public static void WriteBoolNullable(this NetworkWriter writer, bool? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteBool(value.Value);
-        }
-
-        public static void WriteShort(this NetworkWriter writer, short value) => writer.WriteUShort((ushort)value);
-
-        public static void WriteShortNullable(this NetworkWriter writer, short? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteShort(value.Value);
-        }
-
-        public static void WriteUShort(this NetworkWriter writer, ushort value)
-        {
-            writer.WriteByte((byte)value);
-            writer.WriteByte((byte)(value >> 8));
-        }
-
-        public static void WriteUShortNullable(this NetworkWriter writer, ushort? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteUShort(value.Value);
-        }
-
-        public static void WriteInt(this NetworkWriter writer, int value) => writer.WriteUInt((uint)value);
-
-        public static void WriteIntNullable(this NetworkWriter writer, int? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteInt(value.Value);
-        }
-
-        public static void WriteUInt(this NetworkWriter writer, uint value)
-        {
-            writer.WriteByte((byte)value);
-            writer.WriteByte((byte)(value >> 8));
-            writer.WriteByte((byte)(value >> 16));
-            writer.WriteByte((byte)(value >> 24));
-        }
-
-        public static void WriteUIntNullable(this NetworkWriter writer, uint? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteUInt(value.Value);
-        }
-
-        public static void WriteLong(this NetworkWriter writer, long value) => writer.WriteULong((ulong)value);
-
-        public static void WriteLongNullable(this NetworkWriter writer, long? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteLong(value.Value);
-        }
-
-        public static void WriteULong(this NetworkWriter writer, ulong value)
-        {
-            writer.WriteByte((byte)value);
-            writer.WriteByte((byte)(value >> 8));
-            writer.WriteByte((byte)(value >> 16));
-            writer.WriteByte((byte)(value >> 24));
-            writer.WriteByte((byte)(value >> 32));
-            writer.WriteByte((byte)(value >> 40));
-            writer.WriteByte((byte)(value >> 48));
-            writer.WriteByte((byte)(value >> 56));
-        }
-
-        public static void WriteULongNullable(this NetworkWriter writer, ulong? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteULong(value.Value);
-        }
-
-        public static void WriteFloat(this NetworkWriter writer, float value)
-        {
-            UIntFloat converter = new UIntFloat
-            {
-                floatValue = value
-            };
-            writer.WriteUInt(converter.intValue);
-        }
-
-        public static void WriteFloatNullable(this NetworkWriter writer, float? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteFloat(value.Value);
-        }
-
         public static void WriteDouble(this NetworkWriter writer, double value)
         {
-            UIntDouble converter = new UIntDouble
-            {
-                doubleValue = value
-            };
-            writer.WriteULong(converter.longValue);
-        }
+            // DEBUG: try to find the exact value that fails.
+            //UIntDouble convert = new UIntDouble{doubleValue = value};
+            //Debug.Log($"=> NetworkWriter.WriteDouble: {value} => 0x{convert.longValue:X8}");
 
-        public static void WriteDoubleNullable(this NetworkWriter writer, double? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteDouble(value.Value);
-        }
 
-        public static void WriteDecimal(this NetworkWriter writer, decimal value)
-        {
-            // the only way to read it without allocations is to both read and
-            // write it with the FloatConverter (which is not binary compatible
-            // to writer.Write(decimal), hence why we use it here too)
-            UIntDecimal converter = new UIntDecimal
-            {
-                decimalValue = value
-            };
-            writer.WriteULong(converter.longValue1);
-            writer.WriteULong(converter.longValue2);
+            writer.WriteBlittable(value);
         }
+        public static void WriteDoubleNullable(this NetworkWriter writer, double? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteDecimalNullable(this NetworkWriter writer, decimal? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteDecimal(value.Value);
-        }
+        public static void WriteDecimal(this NetworkWriter writer, decimal value) => writer.WriteBlittable(value);
+        public static void WriteDecimalNullable(this NetworkWriter writer, decimal? value) => writer.WriteBlittableNullable(value);
 
         public static void WriteString(this NetworkWriter writer, string value)
         {
@@ -330,187 +306,41 @@ namespace Mirror
             }
         }
 
-        public static void WriteVector2(this NetworkWriter writer, Vector2 value)
-        {
-            writer.WriteFloat(value.x);
-            writer.WriteFloat(value.y);
-        }
+        public static void WriteVector2(this NetworkWriter writer, Vector2 value) => writer.WriteBlittable(value);
+        public static void WriteVector2Nullable(this NetworkWriter writer, Vector2? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector2Nullable(this NetworkWriter writer, Vector2? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteVector2(value.Value);
-        }
+        public static void WriteVector3(this NetworkWriter writer, Vector3 value) => writer.WriteBlittable(value);
+        public static void WriteVector3Nullable(this NetworkWriter writer, Vector3? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector3(this NetworkWriter writer, Vector3 value)
-        {
-            writer.WriteFloat(value.x);
-            writer.WriteFloat(value.y);
-            writer.WriteFloat(value.z);
-        }
+        public static void WriteVector4(this NetworkWriter writer, Vector4 value) => writer.WriteBlittable(value);
+        public static void WriteVector4Nullable(this NetworkWriter writer, Vector4? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector3Nullable(this NetworkWriter writer, Vector3? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteVector3(value.Value);
-        }
+        public static void WriteVector2Int(this NetworkWriter writer, Vector2Int value) => writer.WriteBlittable(value);
+        public static void WriteVector2IntNullable(this NetworkWriter writer, Vector2Int? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector4(this NetworkWriter writer, Vector4 value)
-        {
-            writer.WriteFloat(value.x);
-            writer.WriteFloat(value.y);
-            writer.WriteFloat(value.z);
-            writer.WriteFloat(value.w);
-        }
+        public static void WriteVector3Int(this NetworkWriter writer, Vector3Int value) => writer.WriteBlittable(value);
+        public static void WriteVector3IntNullable(this NetworkWriter writer, Vector3Int? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector4Nullable(this NetworkWriter writer, Vector4? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteVector4(value.Value);
-        }
+        public static void WriteColor(this NetworkWriter writer, Color value) => writer.WriteBlittable(value);
+        public static void WriteColorNullable(this NetworkWriter writer, Color? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector2Int(this NetworkWriter writer, Vector2Int value)
-        {
-            writer.WriteInt(value.x);
-            writer.WriteInt(value.y);
-        }
+        public static void WriteColor32(this NetworkWriter writer, Color32 value) => writer.WriteBlittable(value);
+        public static void WriteColor32Nullable(this NetworkWriter writer, Color32? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector2IntNullable(this NetworkWriter writer, Vector2Int? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteVector2Int(value.Value);
-        }
+        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value) => writer.WriteBlittable(value);
+        public static void WriteQuaternionNullable(this NetworkWriter writer, Quaternion? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector3Int(this NetworkWriter writer, Vector3Int value)
-        {
-            writer.WriteInt(value.x);
-            writer.WriteInt(value.y);
-            writer.WriteInt(value.z);
-        }
+        public static void WriteRect(this NetworkWriter writer, Rect value) => writer.WriteBlittable(value);
+        public static void WriteRectNullable(this NetworkWriter writer, Rect? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteVector3IntNullable(this NetworkWriter writer, Vector3Int? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteVector3Int(value.Value);
-        }
+        public static void WritePlane(this NetworkWriter writer, Plane value) => writer.WriteBlittable(value);
+        public static void WritePlaneNullable(this NetworkWriter writer, Plane? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteColor(this NetworkWriter writer, Color value)
-        {
-            writer.WriteFloat(value.r);
-            writer.WriteFloat(value.g);
-            writer.WriteFloat(value.b);
-            writer.WriteFloat(value.a);
-        }
+        public static void WriteRay(this NetworkWriter writer, Ray value) => writer.WriteBlittable(value);
+        public static void WriteRayNullable(this NetworkWriter writer, Ray? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteColorNullable(this NetworkWriter writer, Color? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteColor(value.Value);
-        }
-
-        public static void WriteColor32(this NetworkWriter writer, Color32 value)
-        {
-            writer.WriteByte(value.r);
-            writer.WriteByte(value.g);
-            writer.WriteByte(value.b);
-            writer.WriteByte(value.a);
-        }
-
-        public static void WriteColor32Nullable(this NetworkWriter writer, Color32? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteColor32(value.Value);
-        }
-
-        public static void WriteQuaternion(this NetworkWriter writer, Quaternion value)
-        {
-            writer.WriteFloat(value.x);
-            writer.WriteFloat(value.y);
-            writer.WriteFloat(value.z);
-            writer.WriteFloat(value.w);
-        }
-
-        public static void WriteQuaternionNullable(this NetworkWriter writer, Quaternion? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteQuaternion(value.Value);
-        }
-
-        public static void WriteRect(this NetworkWriter writer, Rect value)
-        {
-            writer.WriteFloat(value.xMin);
-            writer.WriteFloat(value.yMin);
-            writer.WriteFloat(value.width);
-            writer.WriteFloat(value.height);
-        }
-
-        public static void WriteRectNullable(this NetworkWriter writer, Rect? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteRect(value.Value);
-        }
-
-        public static void WritePlane(this NetworkWriter writer, Plane value)
-        {
-            writer.WriteVector3(value.normal);
-            writer.WriteFloat(value.distance);
-        }
-
-        public static void WritePlaneNullable(this NetworkWriter writer, Plane? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WritePlane(value.Value);
-        }
-
-        public static void WriteRay(this NetworkWriter writer, Ray value)
-        {
-            writer.WriteVector3(value.origin);
-            writer.WriteVector3(value.direction);
-        }
-
-        public static void WriteRayNullable(this NetworkWriter writer, Ray? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteRay(value.Value);
-        }
-
-        public static void WriteMatrix4x4(this NetworkWriter writer, Matrix4x4 value)
-        {
-            writer.WriteFloat(value.m00);
-            writer.WriteFloat(value.m01);
-            writer.WriteFloat(value.m02);
-            writer.WriteFloat(value.m03);
-            writer.WriteFloat(value.m10);
-            writer.WriteFloat(value.m11);
-            writer.WriteFloat(value.m12);
-            writer.WriteFloat(value.m13);
-            writer.WriteFloat(value.m20);
-            writer.WriteFloat(value.m21);
-            writer.WriteFloat(value.m22);
-            writer.WriteFloat(value.m23);
-            writer.WriteFloat(value.m30);
-            writer.WriteFloat(value.m31);
-            writer.WriteFloat(value.m32);
-            writer.WriteFloat(value.m33);
-        }
-
-        public static void WriteMatrix4x4Nullable(this NetworkWriter writer, Matrix4x4? value)
-        {
-            writer.WriteBool(value.HasValue);
-            if (value.HasValue)
-                writer.WriteMatrix4x4(value.Value);
-        }
+        public static void WriteMatrix4x4(this NetworkWriter writer, Matrix4x4 value) => writer.WriteBlittable(value);
+        public static void WriteMatrix4x4Nullable(this NetworkWriter writer, Matrix4x4? value) => writer.WriteBlittableNullable(value);
 
         public static void WriteGuid(this NetworkWriter writer, Guid value)
         {

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -118,12 +118,15 @@ namespace Mirror
                 // on some android systems, assigning *(T*)ptr throws a NRE if
                 // the ptr isn't aligned (i.e. if Position is 1,2,3,5, etc.).
                 // here we have to use memcpy.
+                //
                 // => we can't get a pointer of a struct in C# without
                 //    marshalling allocations
                 // => instead, we stack allocate an array of type T and use that
                 // => stackalloc avoids GC and is very fast. it only works for
                 //    value types, but all blittable types are anyway.
-                // this way, we can still support blittable writes on android.
+                //
+                // this way, we can still support blittable reads on android.
+                // see also: https://github.com/vis2k/Mirror/issues/3044
                 T* valueBuffer = stackalloc T[1]{value};
                 UnsafeUtility.MemCpy(ptr, valueBuffer, size);
 #else

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -127,6 +127,7 @@ namespace Mirror
                 //
                 // this way, we can still support blittable reads on android.
                 // see also: https://github.com/vis2k/Mirror/issues/3044
+                // (solution discovered by AIIO, FakeByte, mischa)
                 T* valueBuffer = stackalloc T[1]{value};
                 UnsafeUtility.MemCpy(ptr, valueBuffer, size);
 #else

--- a/Assets/Mirror/Runtime/Utils.cs
+++ b/Assets/Mirror/Runtime/Utils.cs
@@ -32,40 +32,6 @@ namespace Mirror
         public const int Unreliable = 1; // unordered
     }
 
-    // -- helpers for float conversion without allocations --
-    [StructLayout(LayoutKind.Explicit)]
-    internal struct UIntFloat
-    {
-        [FieldOffset(0)]
-        public float floatValue;
-
-        [FieldOffset(0)]
-        public uint intValue;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    internal struct UIntDouble
-    {
-        [FieldOffset(0)]
-        public double doubleValue;
-
-        [FieldOffset(0)]
-        public ulong longValue;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    internal struct UIntDecimal
-    {
-        [FieldOffset(0)]
-        public ulong longValue1;
-
-        [FieldOffset(8)]
-        public ulong longValue2;
-
-        [FieldOffset(0)]
-        public decimal decimalValue;
-    }
-
     public static class Utils
     {
         public static uint GetTrueRandomUInt()


### PR DESCRIPTION
Restored the PR because it supposedly works on Android now.
-------------
Write/ReadBlittable<T> from DOTSNET.

**Benchmark:**
<img width="689" alt="2020-11-17_21-36-54@2x" src="https://user-images.githubusercontent.com/16416509/99396719-0d5e3400-291d-11eb-9953-4f02930cb65d.png">

**Reasons to use Blittable**
+ 4-6x faster within Unity versions
+ (2020.1 + Blittable is 10x faster than 2018.4 without Blittable)
+ The code is a lot cleaner.
+ Removes 160 LOC
+ All Unity 2018+ platforms are little endian
+ This has been heavily tested in DOTSNET
+ Non-Blittable types still work fine
+ Invisible change to the user
+ No more UIntFloat etc. conversion structs
+ The more complex the type, the more significant the performance gain compared to serializing each member manually
+ Will allow us to reduce generated weaver code later. All blittable types can simply use WriteBlittable.

It's 4-6x performance for free. Would be silly not to use it.

**Unity Platform Endianness**
  [Little] Windows
  [Little] Mac(Intel)
  [Little] Mac(Apple Silicon)
  [Little] Linux(Intel)
  [Little] Android
  [Little] iOS
  [Little] UWP
  [Little] PS4
  [Little] XBOX ONE
  [Little] Nintendo Switch
  [Little] WebGL
  [Little] Android TV
  [Little] tvOS @ Apple A10