### PR TITLE
Weaver: move [SyncVar] generated setter to C#

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -481,11 +481,6 @@ namespace Mirror.Weaver
             return (syncVars, syncVarNetIds);
         }
 
-        public void WriteCallHookMethodUsingArgument(ILProcessor worker, MethodDefinition hookMethod, VariableDefinition oldValue)
-        {
-            WriteCallHookMethod(worker, hookMethod, oldValue, null);
-        }
-
         public void WriteCallHookMethodUsingField(ILProcessor worker, MethodDefinition hookMethod, VariableDefinition oldValue, FieldDefinition newValue, ref bool WeavingFailed)
         {
             if (newValue == null)

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -221,12 +221,42 @@ namespace Mirror.Weaver
 
 
             // call GeneratedSyncVarSetter<T>.
-            // it's generic, so make one for type <T>.
-            MethodReference generic = weaverTypes.generatedSyncVarSetter.MakeGeneric(assembly.MainModule, fd.FieldType);
-            worker.Emit(OpCodes.Call, generic);
+            // special cases for GameObject/NetworkIdentity/NetworkBehaviour
+            // passing netId too for persistence.
+            if (fd.FieldType.Is<UnityEngine.GameObject>())
+            {
+                // reference to netId Field to set
+                /*worker.Emit(OpCodes.Ldarg_0);
+                worker.Emit(OpCodes.Ldflda, netFieldId);
 
+                worker.Emit(OpCodes.Call, weaverTypes.setSyncVarGameObjectReference);*/
+                Log.Warning("TODO [SyncVar] GameObject persistence.");
+            }
+            else if (fd.FieldType.Is<NetworkIdentity>())
+            {
+                // reference to netId Field to set
+                /*worker.Emit(OpCodes.Ldarg_0);
+                worker.Emit(OpCodes.Ldflda, netFieldId);
 
+                worker.Emit(OpCodes.Call, weaverTypes.setSyncVarNetworkIdentityReference);*/
+                Log.Warning("TODO [SyncVar] NetworkIdentity persistence.");
+            }
+            else if (fd.FieldType.IsDerivedFrom<NetworkBehaviour>())
+            {
+                // reference to netId Field to set
+                /*worker.Emit(OpCodes.Ldarg_0);
+                worker.Emit(OpCodes.Ldflda, netFieldId);
 
+                MethodReference getFunc = weaverTypes.setSyncVarNetworkBehaviourReference.MakeGeneric(assembly.MainModule, fd.FieldType);
+                worker.Emit(OpCodes.Call, getFunc);*/
+                Log.Warning("TODO [SyncVar] NetworkBehaviour persistence.");
+            }
+            else
+            {
+                // make generic version of GeneratedSyncVarSetter<T>
+                MethodReference generic = weaverTypes.generatedSyncVarSetter.MakeGeneric(assembly.MainModule, fd.FieldType);
+                worker.Emit(OpCodes.Call, generic);
+            }
 
             /*
             // new value to set

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -219,7 +219,6 @@ namespace Mirror.Weaver
             // pass 'null' as hook
             else worker.Emit(OpCodes.Ldnull);
 
-
             // call GeneratedSyncVarSetter<T>.
             // special cases for GameObject/NetworkIdentity/NetworkBehaviour
             // passing netId too for persistence.

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -220,7 +220,7 @@ namespace Mirror.Weaver
             else worker.Emit(OpCodes.Ldnull);
 
 
-            // TODO call this.WeaverSyncVarSetter<T>.
+            // call GeneratedSyncVarSetter<T>.
             // it's generic, so make one for type <T>.
             MethodReference generic = weaverTypes.generatedSyncVarSetter.MakeGeneric(assembly.MainModule, fd.FieldType);
             worker.Emit(OpCodes.Call, generic);

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -205,11 +205,16 @@ namespace Mirror.Weaver
                 worker.Emit(OpCodes.Ldftn, hookMethod);
 
                 // call 'new Action<T, T>()'
+                // need to make an instance of the generic version.
+
+                // first, we need a TypeReference from our TypeDefinition
+                TypeReference reference = td.GetElementType();
+                Log.Warning("hook reference: " + reference);
+
                 // TODO make this a field so we don't allocate every time.
-                TypeReference reference = td;
-                GenericInstanceType genericInstance = (GenericInstanceType)reference;
-                TypeReference elementType = genericInstance.GenericArguments[0];
-                worker.Emit(OpCodes.Newobj, weaverTypes.ActionT_T.MakeHostInstanceGeneric(assembly.MainModule, genericInstance));
+                //GenericInstanceType genericInstance = (GenericInstanceType)reference;
+                //TypeReference elementType = genericInstance.GenericArguments[0];
+                worker.Emit(OpCodes.Newobj, weaverTypes.ActionT_T);
             }
             // pass 'null' as hook
             else worker.Emit(OpCodes.Ldnull);

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -236,15 +236,18 @@ namespace Mirror.Weaver
                 worker.Emit(OpCodes.Ldflda, netFieldId);
                 worker.Emit(OpCodes.Call, weaverTypes.generatedSyncVarSetter_NetworkIdentity);
             }
+            // TODO this only uses the persistent netId for types DERIVED FROM NB.
+            //      not if the type is just 'NetworkBehaviour'.
+            //      this is what original implementation did too. fix it after.
             else if (fd.FieldType.IsDerivedFrom<NetworkBehaviour>())
             {
-                // reference to netId Field to set
-                /*worker.Emit(OpCodes.Ldarg_0);
+                // NetworkIdentity setter needs one more parameter: netId field ref
+                // (actually its a NetworkBehaviourSyncVar type)
+                worker.Emit(OpCodes.Ldarg_0);
                 worker.Emit(OpCodes.Ldflda, netFieldId);
-
-                MethodReference getFunc = weaverTypes.setSyncVarNetworkBehaviourReference.MakeGeneric(assembly.MainModule, fd.FieldType);
-                worker.Emit(OpCodes.Call, getFunc);*/
-                Log.Warning("TODO [SyncVar] NetworkBehaviour persistence.");
+                // make generic version of GeneratedSyncVarSetter_NetworkBehaviour<T>
+                MethodReference getFunc = weaverTypes.generatedSyncVarSetter_NetworkBehaviour_T.MakeGeneric(assembly.MainModule, fd.FieldType);
+                worker.Emit(OpCodes.Call, getFunc);
             }
             else
             {

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -225,21 +225,17 @@ namespace Mirror.Weaver
             // passing netId too for persistence.
             if (fd.FieldType.Is<UnityEngine.GameObject>())
             {
-                // reference to netId Field to set
-                /*worker.Emit(OpCodes.Ldarg_0);
+                // GameObject setter needs one more parameter: netId field ref
+                worker.Emit(OpCodes.Ldarg_0);
                 worker.Emit(OpCodes.Ldflda, netFieldId);
-
-                worker.Emit(OpCodes.Call, weaverTypes.setSyncVarGameObjectReference);*/
-                Log.Warning("TODO [SyncVar] GameObject persistence.");
+                worker.Emit(OpCodes.Call, weaverTypes.generatedSyncVarSetter_GameObject);
             }
             else if (fd.FieldType.Is<NetworkIdentity>())
             {
-                // reference to netId Field to set
-                /*worker.Emit(OpCodes.Ldarg_0);
+                // NetworkIdentity setter needs one more parameter: netId field ref
+                worker.Emit(OpCodes.Ldarg_0);
                 worker.Emit(OpCodes.Ldflda, netFieldId);
-
-                worker.Emit(OpCodes.Call, weaverTypes.setSyncVarNetworkIdentityReference);*/
-                Log.Warning("TODO [SyncVar] NetworkIdentity persistence.");
+                worker.Emit(OpCodes.Call, weaverTypes.generatedSyncVarSetter_NetworkIdentity);
             }
             else if (fd.FieldType.IsDerivedFrom<NetworkBehaviour>())
             {

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -32,6 +32,8 @@ namespace Mirror.Weaver
 
         // syncvar
         public MethodReference generatedSyncVarSetter;
+        public MethodReference generatedSyncVarSetter_GameObject;
+        public MethodReference generatedSyncVarSetter_NetworkIdentity;
         public MethodReference syncVarEqualReference;
         public MethodReference getSyncVarGameObjectReference;
         public MethodReference getSyncVarNetworkIdentityReference;
@@ -95,6 +97,9 @@ namespace Mirror.Weaver
             NetworkClientConnectionReference = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_connection", ref WeavingFailed);
 
             generatedSyncVarSetter = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter", ref WeavingFailed);
+            generatedSyncVarSetter_GameObject = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter_GameObject", ref WeavingFailed);
+            generatedSyncVarSetter_NetworkIdentity = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter_NetworkIdentity", ref WeavingFailed);
+
             syncVarEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarEqual", ref WeavingFailed);
 
             getSyncVarGameObjectReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GetSyncVarGameObject", ref WeavingFailed);

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -104,8 +104,6 @@ namespace Mirror.Weaver
             syncVarNetworkIdentityEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarNetworkIdentityEqual", ref WeavingFailed);
             syncVarGameObjectEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarGameObjectEqual", ref WeavingFailed);
             setSyncVarReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SetSyncVar", ref WeavingFailed);
-            setSyncVarHookGuard = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SetSyncVarHookGuard", ref WeavingFailed);
-            getSyncVarHookGuard = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GetSyncVarHookGuard", ref WeavingFailed);
 
             setSyncVarGameObjectReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SetSyncVarGameObject", ref WeavingFailed);
             getSyncVarGameObjectReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GetSyncVarGameObject", ref WeavingFailed);

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -34,6 +34,7 @@ namespace Mirror.Weaver
         public MethodReference generatedSyncVarSetter;
         public MethodReference generatedSyncVarSetter_GameObject;
         public MethodReference generatedSyncVarSetter_NetworkIdentity;
+        public MethodReference generatedSyncVarSetter_NetworkBehaviour_T;
         public MethodReference syncVarEqualReference;
         public MethodReference getSyncVarGameObjectReference;
         public MethodReference getSyncVarNetworkIdentityReference;
@@ -99,6 +100,7 @@ namespace Mirror.Weaver
             generatedSyncVarSetter = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter", ref WeavingFailed);
             generatedSyncVarSetter_GameObject = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter_GameObject", ref WeavingFailed);
             generatedSyncVarSetter_NetworkIdentity = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter_NetworkIdentity", ref WeavingFailed);
+            generatedSyncVarSetter_NetworkBehaviour_T = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter_NetworkBehaviour", ref WeavingFailed);
 
             syncVarEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarEqual", ref WeavingFailed);
 

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -28,6 +28,9 @@ namespace Mirror.Weaver
         // array segment
         public MethodReference ArraySegmentConstructorReference;
 
+        // Action<T,T> for SyncVar Hooks
+        public MethodReference ActionT_T;
+
         // syncvar
         public MethodReference generatedSyncVarSetter;
         public MethodReference syncVarEqualReference;
@@ -72,6 +75,9 @@ namespace Mirror.Weaver
 
             TypeReference ArraySegmentType = Import(typeof(ArraySegment<>));
             ArraySegmentConstructorReference = Resolvers.ResolveMethod(ArraySegmentType, assembly, Log, ".ctor", ref WeavingFailed);
+
+            TypeReference ActionType = Import(typeof(Action<,>));
+            ActionT_T = Resolvers.ResolveMethod(ActionType, assembly, Log, ".ctor", ref WeavingFailed);
 
             TypeReference NetworkServerType = Import(typeof(NetworkServer));
             NetworkServerGetActive = Resolvers.ResolveMethod(NetworkServerType, assembly, Log, "get_active", ref WeavingFailed);

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -29,7 +29,7 @@ namespace Mirror.Weaver
         public MethodReference ArraySegmentConstructorReference;
 
         // syncvar
-        public MethodReference weaverSyncVarSetter;
+        public MethodReference generatedSyncVarSetter;
         public MethodReference syncVarEqualReference;
         public MethodReference syncVarNetworkIdentityEqualReference;
         public MethodReference syncVarGameObjectEqualReference;
@@ -99,7 +99,7 @@ namespace Mirror.Weaver
 
             NetworkClientConnectionReference = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_connection", ref WeavingFailed);
 
-            weaverSyncVarSetter = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "WeaverSyncVarSetter", ref WeavingFailed);
+            generatedSyncVarSetter = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter", ref WeavingFailed);
             syncVarEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarEqual", ref WeavingFailed);
             syncVarNetworkIdentityEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarNetworkIdentityEqual", ref WeavingFailed);
             syncVarGameObjectEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarGameObjectEqual", ref WeavingFailed);

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -19,7 +19,6 @@ namespace Mirror.Weaver
         public MethodReference RemoteCallDelegateConstructor;
 
         public MethodReference NetworkServerGetActive;
-        public MethodReference NetworkServerGetLocalClientActive;
         public MethodReference NetworkClientGetActive;
 
         // custom attribute types
@@ -34,17 +33,8 @@ namespace Mirror.Weaver
         // syncvar
         public MethodReference generatedSyncVarSetter;
         public MethodReference syncVarEqualReference;
-        public MethodReference syncVarNetworkIdentityEqualReference;
-        public MethodReference syncVarGameObjectEqualReference;
-        public MethodReference setSyncVarReference;
-        public MethodReference setSyncVarHookGuard;
-        public MethodReference getSyncVarHookGuard;
-        public MethodReference setSyncVarGameObjectReference;
         public MethodReference getSyncVarGameObjectReference;
-        public MethodReference setSyncVarNetworkIdentityReference;
         public MethodReference getSyncVarNetworkIdentityReference;
-        public MethodReference syncVarNetworkBehaviourEqualReference;
-        public MethodReference setSyncVarNetworkBehaviourReference;
         public MethodReference getSyncVarNetworkBehaviourReference;
         public MethodReference registerCommandReference;
         public MethodReference registerRpcReference;
@@ -81,7 +71,6 @@ namespace Mirror.Weaver
 
             TypeReference NetworkServerType = Import(typeof(NetworkServer));
             NetworkServerGetActive = Resolvers.ResolveMethod(NetworkServerType, assembly, Log, "get_active", ref WeavingFailed);
-            NetworkServerGetLocalClientActive = Resolvers.ResolveMethod(NetworkServerType, assembly, Log, "get_localClientActive", ref WeavingFailed);
             TypeReference NetworkClientType = Import(typeof(NetworkClient));
             NetworkClientGetActive = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_active", ref WeavingFailed);
 
@@ -107,16 +96,9 @@ namespace Mirror.Weaver
 
             generatedSyncVarSetter = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter", ref WeavingFailed);
             syncVarEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarEqual", ref WeavingFailed);
-            syncVarNetworkIdentityEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarNetworkIdentityEqual", ref WeavingFailed);
-            syncVarGameObjectEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarGameObjectEqual", ref WeavingFailed);
-            setSyncVarReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SetSyncVar", ref WeavingFailed);
 
-            setSyncVarGameObjectReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SetSyncVarGameObject", ref WeavingFailed);
             getSyncVarGameObjectReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GetSyncVarGameObject", ref WeavingFailed);
-            setSyncVarNetworkIdentityReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SetSyncVarNetworkIdentity", ref WeavingFailed);
             getSyncVarNetworkIdentityReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GetSyncVarNetworkIdentity", ref WeavingFailed);
-            syncVarNetworkBehaviourEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarNetworkBehaviourEqual", ref WeavingFailed);
-            setSyncVarNetworkBehaviourReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SetSyncVarNetworkBehaviour", ref WeavingFailed);
             getSyncVarNetworkBehaviourReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GetSyncVarNetworkBehaviour", ref WeavingFailed);
 
             registerCommandReference = Resolvers.ResolveMethod(RemoteProcedureCallsType, assembly, Log, "RegisterCommand", ref WeavingFailed);

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -29,6 +29,7 @@ namespace Mirror.Weaver
         public MethodReference ArraySegmentConstructorReference;
 
         // syncvar
+        public MethodReference weaverSyncVarSetter;
         public MethodReference syncVarEqualReference;
         public MethodReference syncVarNetworkIdentityEqualReference;
         public MethodReference syncVarGameObjectEqualReference;
@@ -98,6 +99,7 @@ namespace Mirror.Weaver
 
             NetworkClientConnectionReference = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_connection", ref WeavingFailed);
 
+            weaverSyncVarSetter = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "WeaverSyncVarSetter", ref WeavingFailed);
             syncVarEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarEqual", ref WeavingFailed);
             syncVarNetworkIdentityEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarNetworkIdentityEqual", ref WeavingFailed);
             syncVarGameObjectEqualReference = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "SyncVarGameObjectEqual", ref WeavingFailed);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -376,6 +376,54 @@ namespace Mirror
             }
         }
 
+        // GameObject needs custom handling for persistence via netId
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GeneratedSyncVarSetter_GameObject(GameObject value, ref GameObject field, ulong dirtyBit, Action<GameObject, GameObject> OnChanged, ref uint netIdField)
+        {
+            if (!SyncVarEqual(value, ref field))
+            {
+                GameObject oldValue = field;
+                SetSyncVarGameObject(value, ref field, dirtyBit, ref netIdField);
+
+                // call hook (if any)
+                if (OnChanged != null)
+                {
+                    // we use hook guard to protect against deadlock where hook
+                    // changes syncvar, calling hook again.
+                    if (NetworkServer.localClientActive && !GetSyncVarHookGuard(dirtyBit))
+                    {
+                        SetSyncVarHookGuard(dirtyBit, true);
+                        OnChanged(oldValue, value);
+                        SetSyncVarHookGuard(dirtyBit, false);
+                    }
+                }
+            }
+        }
+
+        // NetworkIdentity needs custom handling for persistence via netId
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GeneratedSyncVarSetter_NetworkIdentity(NetworkIdentity value, ref NetworkIdentity field, ulong dirtyBit, Action<NetworkIdentity, NetworkIdentity> OnChanged, ref uint netIdField)
+        {
+            if (!SyncVarEqual(value, ref field))
+            {
+                NetworkIdentity oldValue = field;
+                SetSyncVarNetworkIdentity(value, ref field, dirtyBit, ref netIdField);
+
+                // call hook (if any)
+                if (OnChanged != null)
+                {
+                    // we use hook guard to protect against deadlock where hook
+                    // changes syncvar, calling hook again.
+                    if (NetworkServer.localClientActive && !GetSyncVarHookGuard(dirtyBit))
+                    {
+                        SetSyncVarHookGuard(dirtyBit, true);
+                        OnChanged(oldValue, value);
+                        SetSyncVarHookGuard(dirtyBit, false);
+                    }
+                }
+            }
+        }
+
         // helper function for [SyncVar] GameObjects.
         // needs to be public so that tests & NetworkBehaviours from other
         // assemblies both find it

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -352,7 +352,7 @@ namespace Mirror
         //           }
         //       }
         //   }
-        internal void GeneratedSyncVarSetter<T>(T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged = null)
+        public void GeneratedSyncVarSetter<T>(T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged = null)
         {
             if (!SyncVarEqual(value, ref field))
             {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -376,7 +376,8 @@ namespace Mirror
             }
         }
 
-        // GameObject needs custom handling for persistence via netId
+        // GameObject needs custom handling for persistence via netId.
+        // has one extra parameter.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void GeneratedSyncVarSetter_GameObject(GameObject value, ref GameObject field, ulong dirtyBit, Action<GameObject, GameObject> OnChanged, ref uint netIdField)
         {
@@ -400,7 +401,8 @@ namespace Mirror
             }
         }
 
-        // NetworkIdentity needs custom handling for persistence via netId
+        // NetworkIdentity needs custom handling for persistence via netId.
+        // has one extra parameter.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void GeneratedSyncVarSetter_NetworkIdentity(NetworkIdentity value, ref NetworkIdentity field, ulong dirtyBit, Action<NetworkIdentity, NetworkIdentity> OnChanged, ref uint netIdField)
         {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Mirror
@@ -352,6 +353,7 @@ namespace Mirror
         //           }
         //       }
         //   }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void GeneratedSyncVarSetter<T>(T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged = null)
         {
             if (!SyncVarEqual(value, ref field))

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -354,7 +354,7 @@ namespace Mirror
         //       }
         //   }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void GeneratedSyncVarSetter<T>(T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged = null)
+        public void GeneratedSyncVarSetter<T>(T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged)
         {
             if (!SyncVarEqual(value, ref field))
             {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -352,7 +352,7 @@ namespace Mirror
         //           }
         //       }
         //   }
-        internal void WeaverSyncVarSetter<T>(ref T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged = null)
+        internal void WeaverSyncVarSetter<T>(T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged = null)
         {
             if (!SyncVarEqual(value, ref field))
             {

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -381,7 +381,7 @@ namespace Mirror
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void GeneratedSyncVarSetter_GameObject(GameObject value, ref GameObject field, ulong dirtyBit, Action<GameObject, GameObject> OnChanged, ref uint netIdField)
         {
-            if (!SyncVarEqual(value, ref field))
+            if (!SyncVarGameObjectEqual(value, netIdField))
             {
                 GameObject oldValue = field;
                 SetSyncVarGameObject(value, ref field, dirtyBit, ref netIdField);
@@ -406,7 +406,7 @@ namespace Mirror
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void GeneratedSyncVarSetter_NetworkIdentity(NetworkIdentity value, ref NetworkIdentity field, ulong dirtyBit, Action<NetworkIdentity, NetworkIdentity> OnChanged, ref uint netIdField)
         {
-            if (!SyncVarEqual(value, ref field))
+            if (!SyncVarNetworkIdentityEqual(value, netIdField))
             {
                 NetworkIdentity oldValue = field;
                 SetSyncVarNetworkIdentity(value, ref field, dirtyBit, ref netIdField);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -352,7 +352,7 @@ namespace Mirror
         //           }
         //       }
         //   }
-        internal void WeaverSyncVarSetter<T>(T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged = null)
+        internal void GeneratedSyncVarSetter<T>(T value, ref T field, ulong dirtyBit, Action<T, T> OnChanged = null)
         {
             if (!SyncVarEqual(value, ref field))
             {


### PR DESCRIPTION
moves generated syncvar .set method to C#.
weaver simply calls it.

this was manually weaver generated before:
<img width="644" alt="2022-01-25_17-38-07@2x" src="https://user-images.githubusercontent.com/16416509/150951226-964a521b-8415-4220-b1f2-3b78c2cbf682.png">

now it's all in NetworkBehaviour. including the GO/NI/NB special persistence cases.
more C# code, but **less weaver code** :)
