### PR TITLE
fix: Duplicate IL2CPP hashes when building to WebGL (#3061)

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -78,7 +78,9 @@ namespace Mirror.Weaver
         */
         public static MethodDefinition ProcessCommandInvoke(WeaverTypes weaverTypes, Readers readers, Logger Log, TypeDefinition td, MethodDefinition method, MethodDefinition cmdCallFunc, ref bool WeavingFailed)
         {
-            MethodDefinition cmd = new MethodDefinition(Weaver.InvokeRpcPrefix + method.Name,
+            string cmdName = Weaver.GenerateMethodName(Weaver.InvokeRpcPrefix, method);
+
+            MethodDefinition cmd = new MethodDefinition(cmdName,
                 MethodAttributes.Family | MethodAttributes.Static | MethodAttributes.HideBySig,
                 weaverTypes.Import(typeof(void)));
 

--- a/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
@@ -80,28 +80,43 @@ namespace Mirror.Weaver
 
             foreach (Instruction instruction in method.Body.Instructions)
             {
-                // if call to base.CmdDoSomething within this.CallCmdDoSomething
-                if (IsCallToMethod(instruction, out MethodDefinition calledMethod) &&
-                    calledMethod.Name == baseRemoteCallName)
+                // is this instruction a Call to a method?
+                // if yes, output the method so we can check it.
+                if (IsCallToMethod(instruction, out MethodDefinition calledMethod))
                 {
-                    TypeDefinition baseType = type.BaseType.Resolve();
-                    MethodDefinition baseMethod = baseType.GetMethodInBaseType(callName);
-
-                    if (baseMethod == null)
+                    // when considering if 'calledMethod' is a call to 'method',
+                    // we originally compared .Name.
+                    //
+                    // to fix IL2CPP build bugs with overloaded Rpcs, we need to
+                    // generated rpc names like
+                    //   RpcTest(string value) => RpcTestString(strig value)
+                    //   RpcTest(int value)    => RpcTestInt(int value)
+                    // to make them unique.
+                    //
+                    // calledMethod.Name is still "RpcTest", so we need to
+                    // convert this to the generated name as well before comparing.
+                    string calledMethodName_Generated = Weaver.GenerateMethodName("", calledMethod);
+                    if (calledMethodName_Generated == baseRemoteCallName)
                     {
-                        Log.Error($"Could not find base method for {callName}", method);
-                        WeavingFailed = true;
-                        return;
-                    }
+                        TypeDefinition baseType = type.BaseType.Resolve();
+                        MethodDefinition baseMethod = baseType.GetMethodInBaseType(callName);
 
-                    if (!baseMethod.IsVirtual)
-                    {
-                        Log.Error($"Could not find base method that was virtual {callName}", method);
-                        WeavingFailed = true;
-                        return;
-                    }
+                        if (baseMethod == null)
+                        {
+                            Log.Error($"Could not find base method for {callName}", method);
+                            WeavingFailed = true;
+                            return;
+                        }
 
-                    instruction.Operand = baseMethod;
+                        if (!baseMethod.IsVirtual)
+                        {
+                            Log.Error($"Could not find base method that was virtual {callName}", method);
+                            WeavingFailed = true;
+                            return;
+                        }
+
+                        instruction.Operand = baseMethod;
+                    }
                 }
             }
         }

--- a/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MethodProcessor.cs
@@ -17,7 +17,8 @@ namespace Mirror.Weaver
         // FixRemoteCallToBaseMethod replaces them afterwards.
         public static MethodDefinition SubstituteMethod(Logger Log, TypeDefinition td, MethodDefinition md, ref bool WeavingFailed)
         {
-            string newName = RpcPrefix + md.Name;
+            string newName = Weaver.GenerateMethodName(RpcPrefix, md);
+
             MethodDefinition cmd = new MethodDefinition(newName, md.Attributes, md.ReturnType);
 
             // force the substitute method to be protected.

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -8,10 +8,10 @@ namespace Mirror.Weaver
     {
         public static MethodDefinition ProcessRpcInvoke(WeaverTypes weaverTypes, Writers writers, Readers readers, Logger Log, TypeDefinition td, MethodDefinition md, MethodDefinition rpcCallFunc, ref bool WeavingFailed)
         {
-            MethodDefinition rpc = new MethodDefinition(
-                Weaver.InvokeRpcPrefix + md.Name,
-                MethodAttributes.Family | MethodAttributes.Static | MethodAttributes.HideBySig,
-                weaverTypes.Import(typeof(void)));
+            string rpcName = Weaver.GenerateMethodName(Weaver.InvokeRpcPrefix, md);
+
+            MethodDefinition rpc = new MethodDefinition(rpcName, MethodAttributes.Family | MethodAttributes.Static | MethodAttributes.HideBySig,
+                                                        weaverTypes.Import(typeof(void)));
 
             ILProcessor worker = rpc.Body.GetILProcessor();
             Instruction label = worker.Create(OpCodes.Nop);

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -15,7 +15,9 @@ namespace Mirror.Weaver
 
         public static MethodDefinition ProcessTargetRpcInvoke(WeaverTypes weaverTypes, Readers readers, Logger Log, TypeDefinition td, MethodDefinition md, MethodDefinition rpcCallFunc, ref bool WeavingFailed)
         {
-            MethodDefinition rpc = new MethodDefinition(Weaver.InvokeRpcPrefix + md.Name, MethodAttributes.Family |
+            string trgName = Weaver.GenerateMethodName(Weaver.InvokeRpcPrefix, md);
+
+            MethodDefinition rpc = new MethodDefinition(trgName, MethodAttributes.Family |
                     MethodAttributes.Static |
                     MethodAttributes.HideBySig,
                 weaverTypes.Import(typeof(void)));

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -31,6 +31,25 @@ namespace Mirror.Weaver
         // multi threaded logging.
         public Logger Log;
 
+        // remote actions now support overloads,
+        // -> but IL2CPP doesnt like it when two generated methods
+        // -> have the same signature,
+        // -> so, append the signature to the generated method name,
+        // -> to create a unique name
+        // Example:
+        // RpcTeleport(Vector3 position) -> InvokeUserCode_RpcTeleportVector3()
+        // RpcTeleport(Vector3 position, Quaternion rotation) -> InvokeUserCode_RpcTeleportVector3Quaternion()
+        // fixes https://github.com/vis2k/Mirror/issues/3060
+        public static string GenerateMethodName(string initialPrefix, MethodDefinition md)
+        {
+            initialPrefix += md.Name;
+
+            for (int i = 0; i < md.Parameters.Count; i++)
+                initialPrefix += md.Parameters[i].ParameterType.Name;
+
+            return initialPrefix;
+        }
+
         public Weaver(Logger Log)
         {
             this.Log = Log;

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -37,15 +37,19 @@ namespace Mirror.Weaver
         // -> so, append the signature to the generated method name,
         // -> to create a unique name
         // Example:
-        // RpcTeleport(Vector3 position) -> InvokeUserCode_RpcTeleportVector3()
-        // RpcTeleport(Vector3 position, Quaternion rotation) -> InvokeUserCode_RpcTeleportVector3Quaternion()
+        // RpcTeleport(Vector3 position) -> InvokeUserCode_RpcTeleport__Vector3()
+        // RpcTeleport(Vector3 position, Quaternion rotation) -> InvokeUserCode_RpcTeleport__Vector3Quaternion()
         // fixes https://github.com/vis2k/Mirror/issues/3060
         public static string GenerateMethodName(string initialPrefix, MethodDefinition md)
         {
             initialPrefix += md.Name;
 
-            for (int i = 0; i < md.Parameters.Count; i++)
-                initialPrefix += md.Parameters[i].ParameterType.Name;
+            for (int i = 0; i < md.Parameters.Count; ++i)
+            {
+                // with __ so it's more obvious that this is the parameter suffix.
+                // otherwise RpcTest(int) => RpcTestInt(int) which is not obvious.
+                initialPrefix += $"__{md.Parameters[i].ParameterType.Name}";
+            }
 
             return initialPrefix;
         }


### PR DESCRIPTION
WIP deadlock test


Deadlock:
  Tests/RemoteATtributeTests/ClientRpcOverrideTest/
    OverrideVirtualWithBaseCallsBothVirtualAndBase