### PR TITLE
feat: Allow generic NetworkBehaviour subclasses

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -140,6 +140,8 @@ namespace Mirror.Weaver
             return module.ImportReference(reference);
         }
 
+        // needed for NetworkBehaviour<T> support
+        // https://github.com/vis2k/Mirror/pull/3073/
         public static FieldReference MakeHostInstanceGeneric(this FieldReference self)
         {
             var declaringType = new GenericInstanceType(self.DeclaringType);

--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -140,6 +140,16 @@ namespace Mirror.Weaver
             return module.ImportReference(reference);
         }
 
+        public static FieldReference MakeHostInstanceGeneric(this FieldReference self)
+        {
+            var declaringType = new GenericInstanceType(self.DeclaringType);
+            foreach (var parameter in self.DeclaringType.GenericParameters)
+            {
+                declaringType.GenericArguments.Add(parameter);
+            }
+            return new FieldReference(self.Name, self.FieldType, declaringType);
+        }
+
         // Given a field of a generic class such as Writer<T>.write,
         // and a generic instance such as ArraySegment`int
         // Creates a reference to the specialized method  ArraySegment`int`.get_Count

--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -262,15 +262,10 @@ namespace Mirror.Weaver
             return null;
         }
 
-        /// <summary>
-        /// Takes generic arguments from child class and applies them to parent reference, if possible
-        /// <br/>
-        /// eg makes `Base{T}` in <c>Child{int} : Base{int}</c> have `int` instead of `T`
-        /// </summary>
-        /// <param name="parentReference"></param>
-        /// <param name="childReference"></param>
-        /// <returns></returns>
-        // Originally by James-Frowen under MIT https://github.com/MirageNet/Mirage/commit/cf91e1d54796866d2cf87f8e919bb5c681977e45
+        // Takes generic arguments from child class and applies them to parent reference, if possible
+        // eg makes `Base<T>` in Child<int> : Base<int> have `int` instead of `T`
+        // Originally by James-Frowen under MIT 
+        // https://github.com/MirageNet/Mirage/commit/cf91e1d54796866d2cf87f8e919bb5c681977e45
         public static TypeReference ApplyGenericParameters(this TypeReference parentReference,
             TypeReference childReference)
         {
@@ -308,14 +303,9 @@ namespace Mirror.Weaver
             return generic;
         }
 
-        /// <summary>
-        /// Finds the type reference for a generic parameter with the provided name in the child reference
-        /// </summary>
-        /// <param name="childReference"></param>
-        /// <param name="paramName"></param>
-        /// <returns></returns>
-        /// <exception cref="InvalidOperationException">Thrown if child reference is not generic or doesn't contain the param</exception>
-        // Originally by James-Frowen under MIT https://github.com/MirageNet/Mirage/commit/cf91e1d54796866d2cf87f8e919bb5c681977e45
+        // Finds the type reference for a generic parameter with the provided name in the child reference
+        // Originally by James-Frowen under MIT 
+        // https://github.com/MirageNet/Mirage/commit/cf91e1d54796866d2cf87f8e919bb5c681977e45
         static TypeReference FindMatchingGenericArgument(TypeReference childReference, string paramName)
         {
             TypeDefinition def = childReference.Resolve();

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -68,14 +68,6 @@ namespace Mirror.Weaver
                 return false;
             }
 
-            if (netBehaviourSubclass.HasGenericParameters)
-            {
-                Log.Error($"{netBehaviourSubclass.Name} cannot have generic parameters", netBehaviourSubclass);
-                WeavingFailed = true;
-                // originally Process returned true in every case, except if already processed.
-                // maybe return false here in the future.
-                return true;
-            }
             MarkAsProcessed(netBehaviourSubclass);
 
             // deconstruct tuple and set fields
@@ -821,6 +813,14 @@ namespace Mirror.Weaver
         // validate parameters for a remote function call like Rpc/Cmd
         bool ValidateParameter(MethodReference method, ParameterDefinition param, RemoteCallType callType, bool firstParam, ref bool WeavingFailed)
         {
+            // need to check this before any type lookups since those will fail since generic types don't resolve
+            if (param.ParameterType.IsGenericParameter)
+            {
+                Log.Error($"{method.Name} cannot have generic parameters", method);
+                WeavingFailed = true;
+                return false;
+            }
+
             bool isNetworkConnection = param.ParameterType.Is<NetworkConnection>();
             bool isSenderConnection = IsSenderConnection(param, callType);
 

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
@@ -16,6 +16,12 @@ namespace Mirror.Weaver
 
             foreach (FieldDefinition fd in td.Fields)
             {
+                if (fd.FieldType.IsGenericParameter)
+                {
+                    // can't call .Resolve on generic ones
+                    continue;
+                }
+
                 if (fd.FieldType.Resolve().IsDerivedFrom<SyncObject>())
                 {
                     if (fd.IsStatic)

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -377,6 +377,13 @@ namespace Mirror.Weaver
                         continue;
                     }
 
+                    if (fd.FieldType.IsGenericParameter)
+                    {
+                        Log.Error($"{fd.Name} has generic type. Generic SyncVars are not supported", fd);
+                        WeavingFailed = true;
+                        continue;
+                    }
+
                     if (fd.FieldType.IsArray)
                     {
                         Log.Error($"{fd.Name} has invalid type. Use SyncLists instead of arrays", fd);

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -69,17 +69,28 @@ namespace Mirror.Weaver
                 worker.Emit(OpCodes.Ldarg_0);
             }
 
+            MethodReference hookMethodReference;
+            // if the network behaviour class is generic, we need to make the method reference generic for correct IL
+            if (hookMethod.DeclaringType.HasGenericParameters)
+            {
+                hookMethodReference = hookMethod.MakeHostInstanceGeneric(hookMethod.Module, hookMethod.DeclaringType.MakeGenericInstanceType(hookMethod.DeclaringType.GenericParameters.ToArray()));
+            }
+            else
+            {
+                hookMethodReference = hookMethod;
+            }
+
             // we support regular and virtual hook functions.
             if (hookMethod.IsVirtual)
             {
                 // for virtual / overwritten hooks, we need different IL.
                 // this is from simply testing Action = VirtualHook; in C#.
                 worker.Emit(OpCodes.Dup);
-                worker.Emit(OpCodes.Ldvirtftn, hookMethod);
+                worker.Emit(OpCodes.Ldvirtftn, hookMethodReference);
             }
             else
             {
-                worker.Emit(OpCodes.Ldftn, hookMethod);
+                worker.Emit(OpCodes.Ldftn, hookMethodReference);
             }
 
             // call 'new Action<T,T>()' constructor to convert the function to an action
@@ -143,6 +154,29 @@ namespace Mirror.Weaver
 
             ILProcessor worker = get.Body.GetILProcessor();
 
+            FieldReference fr;
+            if (fd.DeclaringType.HasGenericParameters)
+            {
+                fr = fd.MakeHostInstanceGeneric();
+            }
+            else
+            {
+                fr = fd;
+            }
+
+            FieldReference netIdFieldReference = null;
+            if (netFieldId != null)
+            {
+                if (netFieldId.DeclaringType.HasGenericParameters)
+                {
+                    netIdFieldReference = netFieldId.MakeHostInstanceGeneric();
+                }
+                else
+                {
+                    netIdFieldReference = netFieldId;
+                }
+            }
+
             // [SyncVar] GameObject?
             if (fd.FieldType.Is<UnityEngine.GameObject>())
             {
@@ -150,9 +184,9 @@ namespace Mirror.Weaver
                 // this.
                 worker.Emit(OpCodes.Ldarg_0);
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldfld, netFieldId);
+                worker.Emit(OpCodes.Ldfld, netIdFieldReference);
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldflda, fd);
+                worker.Emit(OpCodes.Ldflda, fr);
                 worker.Emit(OpCodes.Call, weaverTypes.getSyncVarGameObjectReference);
                 worker.Emit(OpCodes.Ret);
             }
@@ -163,9 +197,9 @@ namespace Mirror.Weaver
                 // this.
                 worker.Emit(OpCodes.Ldarg_0);
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldfld, netFieldId);
+                worker.Emit(OpCodes.Ldfld, netIdFieldReference);
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldflda, fd);
+                worker.Emit(OpCodes.Ldflda, fr);
                 worker.Emit(OpCodes.Call, weaverTypes.getSyncVarNetworkIdentityReference);
                 worker.Emit(OpCodes.Ret);
             }
@@ -175,9 +209,9 @@ namespace Mirror.Weaver
                 // this.
                 worker.Emit(OpCodes.Ldarg_0);
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldfld, netFieldId);
+                worker.Emit(OpCodes.Ldfld, netIdFieldReference);
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldflda, fd);
+                worker.Emit(OpCodes.Ldflda, fr);
                 MethodReference getFunc = weaverTypes.getSyncVarNetworkBehaviourReference.MakeGeneric(assembly.MainModule, fd.FieldType);
                 worker.Emit(OpCodes.Call, getFunc);
                 worker.Emit(OpCodes.Ret);
@@ -186,7 +220,7 @@ namespace Mirror.Weaver
             else
             {
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldfld, fd);
+                worker.Emit(OpCodes.Ldfld, fr);
                 worker.Emit(OpCodes.Ret);
             }
 
@@ -215,6 +249,28 @@ namespace Mirror.Weaver
                     weaverTypes.Import(typeof(void)));
 
             ILProcessor worker = set.Body.GetILProcessor();
+            FieldReference fr;
+            if (fd.DeclaringType.HasGenericParameters)
+            {
+               fr = fd.MakeHostInstanceGeneric();
+            }
+            else
+            {
+                fr = fd;
+            }
+
+            FieldReference netIdFieldReference = null;
+            if (netFieldId != null)
+            {
+                if (netFieldId.DeclaringType.HasGenericParameters)
+                {
+                    netIdFieldReference = netFieldId.MakeHostInstanceGeneric();
+                }
+                else
+                {
+                  netIdFieldReference = netFieldId;
+                }
+            }
 
             // if (!SyncVarEqual(value, ref playerData))
             Instruction endOfMethod = worker.Create(OpCodes.Nop);
@@ -241,7 +297,7 @@ namespace Mirror.Weaver
 
             // push 'ref T this.field'
             worker.Emit(OpCodes.Ldarg_0);
-            worker.Emit(OpCodes.Ldflda, fd);
+            worker.Emit(OpCodes.Ldflda, fr);
 
             // push the dirty bit for this SyncVar
             worker.Emit(OpCodes.Ldc_I8, dirtyBit);
@@ -265,14 +321,14 @@ namespace Mirror.Weaver
             {
                 // GameObject setter needs one more parameter: netId field ref
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldflda, netFieldId);
+                worker.Emit(OpCodes.Ldflda, netIdFieldReference);
                 worker.Emit(OpCodes.Call, weaverTypes.generatedSyncVarSetter_GameObject);
             }
             else if (fd.FieldType.Is<NetworkIdentity>())
             {
                 // NetworkIdentity setter needs one more parameter: netId field ref
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldflda, netFieldId);
+                worker.Emit(OpCodes.Ldflda, netIdFieldReference);
                 worker.Emit(OpCodes.Call, weaverTypes.generatedSyncVarSetter_NetworkIdentity);
             }
             // TODO this only uses the persistent netId for types DERIVED FROM NB.
@@ -283,7 +339,7 @@ namespace Mirror.Weaver
                 // NetworkIdentity setter needs one more parameter: netId field ref
                 // (actually its a NetworkBehaviourSyncVar type)
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Ldflda, netFieldId);
+                worker.Emit(OpCodes.Ldflda, netIdFieldReference);
                 // make generic version of GeneratedSyncVarSetter_NetworkBehaviour<T>
                 MethodReference getFunc = weaverTypes.generatedSyncVarSetter_NetworkBehaviour_T.MakeGeneric(assembly.MainModule, fd.FieldType);
                 worker.Emit(OpCodes.Call, getFunc);
@@ -315,16 +371,18 @@ namespace Mirror.Weaver
             if (fd.FieldType.IsDerivedFrom<NetworkBehaviour>())
             {
                 netIdField = new FieldDefinition($"___{fd.Name}NetId",
-                   FieldAttributes.Private,
+                   FieldAttributes.Family, // needs to be protected for generic classes, otherwise access isn't allowed
                    weaverTypes.Import<NetworkBehaviour.NetworkBehaviourSyncVar>());
+                netIdField.DeclaringType = td;
 
                 syncVarNetIds[fd] = netIdField;
             }
             else if (fd.FieldType.IsNetworkIdentityField())
             {
                 netIdField = new FieldDefinition($"___{fd.Name}NetId",
-                    FieldAttributes.Private,
+                    FieldAttributes.Family, // needs to be protected for generic classes, otherwise access isn't allowed
                     weaverTypes.Import<uint>());
+                netIdField.DeclaringType = td;
 
                 syncVarNetIds[fd] = netIdField;
             }

--- a/Assets/Mirror/Editor/Weaver/Resolvers.cs
+++ b/Assets/Mirror/Editor/Weaver/Resolvers.cs
@@ -48,16 +48,21 @@ namespace Mirror.Weaver
             {
                 return null;
             }
-            foreach (MethodDefinition methodRef in tr.Resolve().Methods)
+            foreach (MethodDefinition methodDef in tr.Resolve().Methods)
             {
-                if (methodRef.Name == name)
+                if (methodDef.Name == name)
                 {
+                    MethodReference methodRef = methodDef;
+                    if (tr.IsGenericInstance)
+                    {
+                        methodRef = methodRef.MakeHostInstanceGeneric(tr.Module, (GenericInstanceType)tr);
+                    }
                     return assembly.MainModule.ImportReference(methodRef);
                 }
             }
 
             // Could not find the method in this class,  try the parent
-            return TryResolveMethodInParents(tr.Resolve().BaseType, assembly, name);
+            return TryResolveMethodInParents(tr.Resolve().BaseType.ApplyGenericParameters(tr), assembly, name);
         }
 
         public static MethodDefinition ResolveDefaultPublicCtor(TypeReference variable)

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
@@ -5,10 +5,17 @@ namespace Mirror.Weaver.Tests
     public class WeaverNetworkBehaviourTests : WeaverTestsBuildFromTestName
     {
         [Test]
-        public void NetworkBehaviourGeneric()
+        public void NetworkBehaviourGenericSyncVar()
         {
-            HasError("NetworkBehaviourGeneric`1 cannot have generic parameters",
-                "WeaverNetworkBehaviourTests.NetworkBehaviourGeneric.NetworkBehaviourGeneric`1");
+            HasError("genericSyncVarNotAllowed has generic type. Generic SyncVars are not supported",
+                "T WeaverNetworkBehaviourTests.NetworkBehaviourGeneric.NetworkBehaviourGeneric`1::genericSyncVarNotAllowed");
+        }
+
+        [Test]
+        public void NetworkBehaviourGenericRpc()
+        {
+            HasError("RpcGeneric cannot have generic parameters",
+                "System.Void WeaverNetworkBehaviourTests.NetworkBehaviourGeneric.NetworkBehaviourGeneric`1::RpcGeneric(T)");
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests_IsValid/NetworkBehaviourGeneric.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests_IsValid/NetworkBehaviourGeneric.cs
@@ -1,0 +1,16 @@
+using Mirror;
+
+namespace WeaverNetworkBehaviourTests.NetworkBehaviourGeneric
+{
+    class NetworkBehaviourGeneric<T> : NetworkBehaviour
+    {
+        public T param;
+        public readonly SyncVar<T> syncVar = new SyncVar<T>(default);
+        public readonly SyncList<T> syncList = new SyncList<T>();
+    }
+
+    class GenericImplInt : NetworkBehaviourGeneric<int>
+    {
+
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests_IsValid/NetworkBehaviourGeneric.cs.meta
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests_IsValid/NetworkBehaviourGeneric.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b279c2f37eaa4de09c1f15a5b80029b4
+timeCreated: 1643560588

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourGenericRpc.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourGenericRpc.cs
@@ -1,0 +1,10 @@
+using Mirror;
+
+namespace WeaverNetworkBehaviourTests.NetworkBehaviourGeneric
+{
+    class NetworkBehaviourGeneric<T> : NetworkBehaviour
+    {
+        [ClientRpc]
+        void RpcGeneric(T param) {}
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourGenericSyncVar.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourGenericSyncVar.cs
@@ -4,6 +4,9 @@ namespace WeaverNetworkBehaviourTests.NetworkBehaviourGeneric
 {
     class NetworkBehaviourGeneric<T> : NetworkBehaviour
     {
-        T genericsNotAllowed;
+        [SyncVar]
+        T genericSyncVarNotAllowed;
+
+        T genericTypeIsFine;
     }
 }


### PR DESCRIPTION
It's only generic SyncVars (via attribute) and rpcs/cmds we don't want to deal with and that aren't supported.
Even generic `SyncVar<T>` works

I'm currently prototyping some client prediction stuff and this would allow for reducing boilerplate by taking state/input structs via template parameter. For example `class Player : NetworkBehaviourCSP<PlayerState, PlayerInput> { /* ... */}`