### PR TITLE
fix(SWT): fixing jslib for Unity2021

### DIFF
--- a/Assets/Mirror/Runtime/Transport/SimpleWebTransport/Client/Webgl/plugin/SimpleWeb.jslib
+++ b/Assets/Mirror/Runtime/Transport/SimpleWebTransport/Client/Webgl/plugin/SimpleWeb.jslib
@@ -27,7 +27,16 @@ function IsConnected(index) {
 }
 
 function Connect(addressPtr, openCallbackPtr, closeCallBackPtr, messageCallbackPtr, errorCallbackPtr) {
-    const address = Pointer_stringify(addressPtr);
+    // fix for unity 2021 because unity bug in .jslib
+    if (typeof Runtime === "undefined") {
+        // if unity doesn't create Runtime, then make it here
+        // dont ask why this works, just be happy that it does
+        Runtime = {
+            dynCall: dynCall
+        }
+    }
+
+    const address = UTF8ToString(addressPtr);
     console.log("Connecting to " + address);
     // Create webSocket connection.
     webSocket = new WebSocket(address);


### PR DESCRIPTION
replacing `Pointer_stringify` with `UTF8ToString`, This still works in  2019.4 as well.

fixes "Runtime is not defined" unity bug. Unity does not auto link Runtime in 2021, this is a bug, checking if it is undefined then creating it fixes the issue, and  will continue you work after unity fixes the bug. Note: `Module['dynCall_vi']` fix does not work here because it throws an exception after each call.

original commits:
https://github.com/James-Frowen/SimpleWebTransport/commit/2f5a74ba10865e934be8d3b54ebfdeb14ca491f6
https://github.com/James-Frowen/SimpleWebTransport/commit/945b50dbad5b71c43e2bdaa4033f87d3f62c5572

fixes: https://github.com/vis2k/Mirror/issues/3012