### PR TITLE
breaking: NetworkConnection clean up & strong typing

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -269,7 +269,7 @@ namespace Mirror
         /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             if (conn.identity != null)
             {

--- a/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
@@ -26,7 +26,7 @@ namespace Mirror.Examples.Basic
         /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             base.OnServerDisconnect(conn);
             Player.ResetPlayerNumbers();

--- a/Assets/Mirror/Examples/Chat/Scripts/ChatNetworkManager.cs
+++ b/Assets/Mirror/Examples/Chat/Scripts/ChatNetworkManager.cs
@@ -16,7 +16,7 @@ namespace Mirror.Examples.Chat
             networkAddress = hostname;
         }
 
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             // remove player name from the HashSet
             if (conn.authenticationData != null)

--- a/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchNetworkManager.cs
+++ b/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchNetworkManager.cs
@@ -46,7 +46,7 @@ namespace Mirror.Examples.MultipleMatch
         /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             canvasController.OnServerDisconnect(conn);
             base.OnServerDisconnect(conn);
@@ -86,7 +86,7 @@ namespace Mirror.Examples.MultipleMatch
         /// </summary>
         public override void OnStartServer()
         {
-            if (mode == NetworkManagerMode.ServerOnly) 
+            if (mode == NetworkManagerMode.ServerOnly)
                 canvas.SetActive(true);
 
             canvasController.OnStartServer();

--- a/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
@@ -32,7 +32,7 @@ namespace Mirror.Examples.Pong
             }
         }
 
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             // destroy ball
             if (ball != null)

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1091,7 +1091,7 @@ namespace Mirror
             }
         }
 
-        void OnServerConnectInternal(NetworkConnection conn)
+        void OnServerConnectInternal(NetworkConnectionToClient conn)
         {
             //Debug.Log("NetworkManager.OnServerConnectInternal");
 
@@ -1235,7 +1235,7 @@ namespace Mirror
 
         /// <summary>Called on the server when a client disconnects.</summary>
         // Called by NetworkServer.OnTransportDisconnect!
-        public virtual void OnServerDisconnect(NetworkConnection conn)
+        public virtual void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             // by default, this function destroys the connection's player.
             // can be overwritten for cases like delayed logouts in MMOs to
@@ -1271,7 +1271,7 @@ namespace Mirror
         }
 
         /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
-        public virtual void OnServerError(NetworkConnection conn, Exception exception) {}
+        public virtual void OnServerError(NetworkConnectionToClient conn, Exception exception) {}
 
         /// <summary>Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed</summary>
         public virtual void OnServerChangeScene(string newSceneName) {}

--- a/Assets/Mirror/Tests/Editor/NetworkManagerStopHostOnServerDisconnectTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerStopHostOnServerDisconnectTest.cs
@@ -5,10 +5,10 @@ namespace Mirror.Tests
     class NetworkManagerOnServerDisconnect : NetworkManager
     {
         public int called;
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             base.OnServerDisconnect(conn);
-            ++called; 
+            ++called;
         }
 }
 


### PR DESCRIPTION
NetworkConnection contains a lot of server-only code.
that code should be in NetworkConnectionToClient.
=> otherwise it's available on the client in NetworkConnectionToServer as well.

this PR cleans this all up.
safer, better code.
and makes future improvements (like host) mode easier if NetworkConnections are implemented cleanly.