### PR TITLE
breaking: NetworkConnection cleanup

### DIFF
--- a/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
@@ -32,7 +32,7 @@ namespace Mirror
             return Vector3.Distance(identity.transform.position, newObserver.identity.transform.position) < range;
         }
 
-        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnection> newObservers, bool initialize)
+        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnectionToClient> newObservers, bool initialize)
         {
             // cache range and .transform because both call GetComponent.
             int range = GetVisRange(identity);

--- a/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
@@ -26,7 +26,7 @@ namespace Mirror
             lastRebuildTime = 0D;
         }
 
-        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnection newObserver)
+        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnectionToClient newObserver)
         {
             int range = GetVisRange(identity);
             return Vector3.Distance(identity.transform.position, newObserver.identity.transform.position) < range;

--- a/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
@@ -116,7 +116,7 @@ namespace Mirror
                     NetworkServer.RebuildObservers(netIdentity, false);
         }
 
-        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnection newObserver)
+        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnectionToClient newObserver)
         {
             if (!identity.TryGetComponent<NetworkMatch>(out NetworkMatch identityNetworkMatch))
                 return false;

--- a/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
@@ -127,7 +127,7 @@ namespace Mirror
             return identityNetworkMatch.matchId == newObserverNetworkMatch.matchId;
         }
 
-        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnection> newObservers, bool initialize)
+        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnectionToClient> newObservers, bool initialize)
         {
             if (!identity.TryGetComponent<NetworkMatch>(out NetworkMatch networkMatch))
                 return;
@@ -135,7 +135,7 @@ namespace Mirror
             Guid matchId = networkMatch.matchId;
 
             // Guid.Empty is never a valid matchId
-            if (matchId == Guid.Empty) 
+            if (matchId == Guid.Empty)
                 return;
 
             if (!matchObjects.TryGetValue(matchId, out HashSet<NetworkIdentity> objects))

--- a/Assets/Mirror/Components/InterestManagement/Scene/SceneInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Scene/SceneInterestManagement.cs
@@ -51,7 +51,7 @@ namespace Mirror
             {
                 Scene currentScene = lastObjectScene[identity];
                 Scene newScene = identity.gameObject.scene;
-                if (newScene == currentScene) 
+                if (newScene == currentScene)
                     continue;
 
                 // Mark new/old scenes as dirty so they get rebuilt
@@ -94,7 +94,7 @@ namespace Mirror
             return identity.gameObject.scene == newObserver.identity.gameObject.scene;
         }
 
-        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnection> newObservers, bool initialize)
+        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnectionToClient> newObservers, bool initialize)
         {
             if (!sceneObjects.TryGetValue(identity.gameObject.scene, out HashSet<NetworkIdentity> objects))
                 return;

--- a/Assets/Mirror/Components/InterestManagement/Scene/SceneInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Scene/SceneInterestManagement.cs
@@ -89,7 +89,7 @@ namespace Mirror
                     NetworkServer.RebuildObservers(netIdentity, false);
         }
 
-        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnection newObserver)
+        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnectionToClient newObserver)
         {
             return identity.gameObject.scene == newObserver.identity.gameObject.scene;
         }

--- a/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
@@ -31,7 +31,7 @@ namespace Mirror
         public bool showSlider;
 
         // the grid
-        Grid2D<NetworkConnection> grid = new Grid2D<NetworkConnection>();
+        Grid2D<NetworkConnectionToClient> grid = new Grid2D<NetworkConnectionToClient>();
 
         // project 3d world position to grid position
         Vector2Int ProjectToGrid(Vector3 position) =>
@@ -52,7 +52,7 @@ namespace Mirror
             return (projected - observerProjected).sqrMagnitude <= 2;
         }
 
-        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnection> newObservers, bool initialize)
+        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnectionToClient> newObservers, bool initialize)
         {
             // add everyone in 9 neighbour grid
             // -> pass observers to GetWithNeighbours directly to avoid allocations

--- a/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
@@ -39,7 +39,7 @@ namespace Mirror
             ? Vector2Int.RoundToInt(new Vector2(position.x, position.z) / resolution)
             : Vector2Int.RoundToInt(new Vector2(position.x, position.y) / resolution);
 
-        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnection newObserver)
+        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnectionToClient newObserver)
         {
             // calculate projected positions
             Vector2Int projected = ProjectToGrid(identity.transform.position);

--- a/Assets/Mirror/Components/InterestManagement/Team/TeamInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Team/TeamInterestManagement.cs
@@ -129,7 +129,7 @@ namespace Mirror
             return identityNetworkTeam.forceShown || identityNetworkTeam.teamId == newObserverNetworkTeam.teamId;
         }
 
-        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnection> newObservers, bool initialize)
+        public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnectionToClient> newObservers, bool initialize)
         {
             // If this object doesn't have a NetworkTeam then it's visible to all clients
             if (!identity.TryGetComponent<NetworkTeam>(out NetworkTeam networkTeam))
@@ -159,7 +159,7 @@ namespace Mirror
                     newObservers.Add(networkIdentity.connectionToClient);
         }
 
-        void AddAllConnections(HashSet<NetworkConnection> newObservers)
+        void AddAllConnections(HashSet<NetworkConnectionToClient> newObservers)
         {
             foreach (NetworkConnectionToClient conn in NetworkServer.connections.Values)
             {

--- a/Assets/Mirror/Components/InterestManagement/Team/TeamInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Team/TeamInterestManagement.cs
@@ -115,7 +115,7 @@ namespace Mirror
                     NetworkServer.RebuildObservers(netIdentity, false);
         }
 
-        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnection newObserver)
+        public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnectionToClient newObserver)
         {
             // Always observed if no NetworkTeam component
             if (!identity.TryGetComponent<NetworkTeam>(out NetworkTeam identityNetworkTeam))

--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -269,7 +269,7 @@ namespace Mirror
         /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             if (conn.identity != null)
             {

--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -21,7 +21,7 @@ namespace Mirror
     {
         public struct PendingPlayer
         {
-            public NetworkConnection conn;
+            public NetworkConnectionToClient conn;
             public GameObject roomPlayer;
         }
 
@@ -150,7 +150,7 @@ namespace Mirror
         /// <para>The default implementation of this function calls NetworkServer.SetClientReady() to continue the network setup process.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerReady(NetworkConnection conn)
+        public override void OnServerReady(NetworkConnectionToClient conn)
         {
             Debug.Log("NetworkRoomManager OnServerReady");
             base.OnServerReady(conn);
@@ -165,7 +165,7 @@ namespace Mirror
             }
         }
 
-        void SceneLoadedForPlayer(NetworkConnection conn, GameObject roomPlayer)
+        void SceneLoadedForPlayer(NetworkConnectionToClient conn, GameObject roomPlayer)
         {
             Debug.Log($"NetworkRoom SceneLoadedForPlayer scene: {SceneManager.GetActiveScene().path} {conn}");
 
@@ -314,7 +314,7 @@ namespace Mirror
         /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerAddPlayer(NetworkConnection conn)
+        public override void OnServerAddPlayer(NetworkConnectionToClient conn)
         {
             // increment the index before adding the player, so first player starts at 1
             clientIndex++;
@@ -593,7 +593,7 @@ namespace Mirror
         /// <para>See <see cref="OnRoomServerCreateGamePlayer(NetworkConnection, GameObject)">OnRoomServerCreateGamePlayer(NetworkConnection, GameObject)</see> to customize the player object for the initial GamePlay scene.</para>
         /// </summary>
         /// <param name="conn">The connection the player object is for.</param>
-        public virtual void OnRoomServerAddPlayer(NetworkConnection conn)
+        public virtual void OnRoomServerAddPlayer(NetworkConnectionToClient conn)
         {
             base.OnServerAddPlayer(conn);
         }

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -73,7 +73,7 @@ namespace Mirror
 
         public override bool HasPreviewGUI()
         {
-            // need to check if target is null to stop MissingReferenceException 
+            // need to check if target is null to stop MissingReferenceException
             return target != null && target is GameObject gameObject && gameObject.GetComponent<NetworkIdentity>() != null;
         }
 
@@ -180,7 +180,7 @@ namespace Mirror
                 observerRect.x += 20;
                 observerRect.y += observerRect.height;
 
-                foreach (KeyValuePair<int, NetworkConnection> kvp in identity.observers)
+                foreach (KeyValuePair<int, NetworkConnectionToClient> kvp in identity.observers)
                 {
                     GUI.Label(observerRect, $"{kvp.Value.address}:{kvp.Value}", styles.componentName);
                     observerRect.y += observerRect.height;

--- a/Assets/Mirror/Examples/AdditiveLevels/Scripts/AdditiveLevelsNetworkManager.cs
+++ b/Assets/Mirror/Examples/AdditiveLevels/Scripts/AdditiveLevelsNetworkManager.cs
@@ -144,7 +144,7 @@ namespace Mirror.Examples.AdditiveLevels
         /// <para>The default implementation of this function calls NetworkServer.SetClientReady() to continue the network setup process.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerReady(NetworkConnection conn)
+        public override void OnServerReady(NetworkConnectionToClient conn)
         {
             //Debug.Log($"OnServerReady {conn} {conn.identity}");
 
@@ -157,7 +157,7 @@ namespace Mirror.Examples.AdditiveLevels
 
         // This delay is mostly for the host player that loads too fast for the
         // server to have subscenes async loaded from OnServerSceneChanged ahead of it.
-        IEnumerator AddPlayerDelayed(NetworkConnection conn)
+        IEnumerator AddPlayerDelayed(NetworkConnectionToClient conn)
         {
             // Wait for server to async load all subscenes for game instances
             while (!subscenesLoaded)

--- a/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
@@ -26,7 +26,7 @@ namespace Mirror.Examples.Basic
         /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             base.OnServerDisconnect(conn);
             Player.ResetPlayerNumbers();

--- a/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/BasicNetManager.cs
@@ -15,7 +15,7 @@ namespace Mirror.Examples.Basic
         /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerAddPlayer(NetworkConnection conn)
+        public override void OnServerAddPlayer(NetworkConnectionToClient conn)
         {
             base.OnServerAddPlayer(conn);
             Player.ResetPlayerNumbers();

--- a/Assets/Mirror/Examples/Chat/Scripts/ChatNetworkManager.cs
+++ b/Assets/Mirror/Examples/Chat/Scripts/ChatNetworkManager.cs
@@ -16,7 +16,7 @@ namespace Mirror.Examples.Chat
             networkAddress = hostname;
         }
 
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             // remove player name from the HashSet
             if (conn.authenticationData != null)

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/MultiSceneNetManager.cs
@@ -39,14 +39,14 @@ namespace Mirror.Examples.MultipleAdditiveScenes
         /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerAddPlayer(NetworkConnection conn)
+        public override void OnServerAddPlayer(NetworkConnectionToClient conn)
         {
             StartCoroutine(OnServerAddPlayerDelayed(conn));
         }
 
         // This delay is mostly for the host player that loads too fast for the
         // server to have subscenes async loaded from OnStartServer ahead of it.
-        IEnumerator OnServerAddPlayerDelayed(NetworkConnection conn)
+        IEnumerator OnServerAddPlayerDelayed(NetworkConnectionToClient conn)
         {
             // wait for server to async load all subscenes for game instances
             while (!subscenesLoaded)

--- a/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchNetworkManager.cs
+++ b/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchNetworkManager.cs
@@ -35,7 +35,7 @@ namespace Mirror.Examples.MultipleMatch
         /// <para>The default implementation of this function calls NetworkServer.SetClientReady() to continue the network setup process.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerReady(NetworkConnection conn)
+        public override void OnServerReady(NetworkConnectionToClient conn)
         {
             base.OnServerReady(conn);
             canvasController.OnServerReady(conn);

--- a/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchNetworkManager.cs
+++ b/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchNetworkManager.cs
@@ -46,7 +46,7 @@ namespace Mirror.Examples.MultipleMatch
         /// <para>This is called on the Server when a Client disconnects from the Server. Use an override to decide what should happen when a disconnection is detected.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             canvasController.OnServerDisconnect(conn);
             base.OnServerDisconnect(conn);
@@ -86,7 +86,7 @@ namespace Mirror.Examples.MultipleMatch
         /// </summary>
         public override void OnStartServer()
         {
-            if (mode == NetworkManagerMode.ServerOnly) 
+            if (mode == NetworkManagerMode.ServerOnly)
                 canvas.SetActive(true);
 
             canvasController.OnStartServer();

--- a/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
@@ -32,7 +32,7 @@ namespace Mirror.Examples.Pong
             }
         }
 
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             // destroy ball
             if (ball != null)

--- a/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/NetworkManagerPong.cs
@@ -17,7 +17,7 @@ namespace Mirror.Examples.Pong
         public Transform rightRacketSpawn;
         GameObject ball;
 
-        public override void OnServerAddPlayer(NetworkConnection conn)
+        public override void OnServerAddPlayer(NetworkConnectionToClient conn)
         {
             // add player at correct spawn position
             Transform start = numPlayers == 0 ? leftRacketSpawn : rightRacketSpawn;

--- a/Assets/Mirror/Runtime/InterestManagement.cs
+++ b/Assets/Mirror/Runtime/InterestManagement.cs
@@ -54,7 +54,7 @@ namespace Mirror
         //
         // Mirror maintains .observing automatically in the background. best of
         // both worlds without any worrying now!
-        public abstract void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnection> newObservers, bool initialize);
+        public abstract void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnectionToClient> newObservers, bool initialize);
 
         // helper function to trigger a full rebuild.
         // most implementations should call this in a certain interval.

--- a/Assets/Mirror/Runtime/InterestManagement.cs
+++ b/Assets/Mirror/Runtime/InterestManagement.cs
@@ -35,7 +35,7 @@ namespace Mirror
         // the network connection will be added as an observer.
         //   conn: Network connection of a player.
         //   returns True if the player can see this object.
-        public abstract bool OnCheckObserver(NetworkIdentity identity, NetworkConnection newObserver);
+        public abstract bool OnCheckObserver(NetworkIdentity identity, NetworkConnectionToClient newObserver);
 
         // rebuild observers for the given NetworkIdentity.
         // Server will automatically spawn/despawn added/removed ones.

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Mirror
 {
@@ -6,6 +7,17 @@ namespace Mirror
     {
         public override string address =>
             Transport.activeTransport.ServerGetClientAddress(connectionId);
+
+        /// <summary>NetworkIdentities that this connection can see</summary>
+        // TODO move to server's NetworkConnectionToClient?
+        public new readonly HashSet<NetworkIdentity> observing = new HashSet<NetworkIdentity>();
+
+        /// <summary>All NetworkIdentities owned by this connection. Can be main player, pets, etc.</summary>
+        // IMPORTANT: this needs to be <NetworkIdentity>, not <uint netId>.
+        //            fixes a bug where DestroyOwnedObjects wouldn't find the
+        //            netId anymore: https://github.com/vis2k/Mirror/issues/1380
+        //            Works fine with NetworkIdentity pointers though.
+        public new readonly HashSet<NetworkIdentity> clientOwnedObjects = new HashSet<NetworkIdentity>();
 
         // unbatcher
         public Unbatcher unbatcher = new Unbatcher();
@@ -30,6 +42,60 @@ namespace Mirror
             // -> so all 'on disconnect' cleanup code needs to be in
             //    OnTransportDisconnect, where it's called for both voluntary
             //    and involuntary disconnects!
+        }
+
+        internal void AddToObserving(NetworkIdentity netIdentity)
+        {
+            observing.Add(netIdentity);
+
+            // spawn identity for this conn
+            NetworkServer.ShowForConnection(netIdentity, this);
+        }
+
+        internal void RemoveFromObserving(NetworkIdentity netIdentity, bool isDestroyed)
+        {
+            observing.Remove(netIdentity);
+
+            if (!isDestroyed)
+            {
+                // hide identity for this conn
+                NetworkServer.HideForConnection(netIdentity, this);
+            }
+        }
+
+        internal void RemoveFromObservingsObservers()
+        {
+            foreach (NetworkIdentity netIdentity in observing)
+            {
+                netIdentity.RemoveObserver(this);
+            }
+            observing.Clear();
+        }
+
+        internal void AddOwnedObject(NetworkIdentity obj)
+        {
+            clientOwnedObjects.Add(obj);
+        }
+
+        internal void RemoveOwnedObject(NetworkIdentity obj)
+        {
+            clientOwnedObjects.Remove(obj);
+        }
+
+        internal void DestroyOwnedObjects()
+        {
+            // create a copy because the list might be modified when destroying
+            HashSet<NetworkIdentity> tmp = new HashSet<NetworkIdentity>(clientOwnedObjects);
+            foreach (NetworkIdentity netIdentity in tmp)
+            {
+                if (netIdentity != null)
+                {
+                    NetworkServer.Destroy(netIdentity.gameObject);
+                }
+            }
+
+            // clear the hashset because we destroyed them all
+            clientOwnedObjects.Clear();
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -98,7 +98,7 @@ namespace Mirror
         /// <summary>The set of network connections (players) that can see this object.</summary>
         // note: null until OnStartServer was called. this is necessary for
         //       SendTo* to work properly in server-only mode.
-        public Dictionary<int, NetworkConnection> observers;
+        public Dictionary<int, NetworkConnectionToClient> observers;
 
         /// <summary>The unique network Id of this object (unique at runtime).</summary>
         public uint netId { get; internal set; }
@@ -635,7 +635,7 @@ namespace Mirror
             }
 
             netId = GetNextNetworkId();
-            observers = new Dictionary<int, NetworkConnection>();
+            observers = new Dictionary<int, NetworkConnectionToClient>();
 
             //Debug.Log($"OnStartServer {this} NetId:{netId} SceneId:{sceneId:X}");
 
@@ -1079,7 +1079,7 @@ namespace Mirror
             }
         }
 
-        internal void AddObserver(NetworkConnection conn)
+        internal void AddObserver(NetworkConnectionToClient conn)
         {
             if (observers == null)
             {
@@ -1135,7 +1135,7 @@ namespace Mirror
         {
             if (observers != null)
             {
-                foreach (NetworkConnection conn in observers.Values)
+                foreach (NetworkConnectionToClient conn in observers.Values)
                 {
                     conn.RemoveFromObserving(this, true);
                 }
@@ -1152,7 +1152,7 @@ namespace Mirror
         // Authority can be removed with RemoveClientAuthority. Only one client
         // can own an object at any time. This does not need to be called for
         // player objects, as their authority is setup automatically.
-        public bool AssignClientAuthority(NetworkConnection conn)
+        public bool AssignClientAuthority(NetworkConnectionToClient conn)
         {
             if (!isServer)
             {

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1245,7 +1245,7 @@ namespace Mirror
         }
 
         /// <summary>Called on the server when a client is ready (= loaded the scene)</summary>
-        public virtual void OnServerReady(NetworkConnection conn)
+        public virtual void OnServerReady(NetworkConnectionToClient conn)
         {
             if (conn.identity == null)
             {
@@ -1257,7 +1257,7 @@ namespace Mirror
 
         /// <summary>Called on server when a client requests to add the player. Adds playerPrefab by default. Can be overwritten.</summary>
         // The default implementation for this function creates a new player object from the playerPrefab.
-        public virtual void OnServerAddPlayer(NetworkConnection conn)
+        public virtual void OnServerAddPlayer(NetworkConnectionToClient conn)
         {
             Transform startPos = GetStartPosition();
             GameObject player = startPos != null

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1091,7 +1091,7 @@ namespace Mirror
             }
         }
 
-        void OnServerConnectInternal(NetworkConnection conn)
+        void OnServerConnectInternal(NetworkConnectionToClient conn)
         {
             //Debug.Log("NetworkManager.OnServerConnectInternal");
 
@@ -1235,7 +1235,7 @@ namespace Mirror
 
         /// <summary>Called on the server when a client disconnects.</summary>
         // Called by NetworkServer.OnTransportDisconnect!
-        public virtual void OnServerDisconnect(NetworkConnection conn)
+        public virtual void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             // by default, this function destroys the connection's player.
             // can be overwritten for cases like delayed logouts in MMOs to
@@ -1271,7 +1271,7 @@ namespace Mirror
         }
 
         /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
-        public virtual void OnServerError(NetworkConnection conn, Exception exception) {}
+        public virtual void OnServerError(NetworkConnectionToClient conn, Exception exception) {}
 
         /// <summary>Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed</summary>
         public virtual void OnServerChangeScene(string newSceneName) {}

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -712,7 +712,7 @@ namespace Mirror
         // for that object. This function is used for "adding" a player, not for
         // "replacing" the player on a connection. If there is already a player
         // on this playerControllerId for this connection, this will fail.
-        public static bool AddPlayerForConnection(NetworkConnection conn, GameObject player)
+        public static bool AddPlayerForConnection(NetworkConnectionToClient conn, GameObject player)
         {
             NetworkIdentity identity = player.GetComponent<NetworkIdentity>();
             if (identity == null)
@@ -758,7 +758,7 @@ namespace Mirror
         // for that object. This function is used for "adding" a player, not for
         // "replacing" the player on a connection. If there is already a player
         // on this playerControllerId for this connection, this will fail.
-        public static bool AddPlayerForConnection(NetworkConnection conn, GameObject player, Guid assetId)
+        public static bool AddPlayerForConnection(NetworkConnectionToClient conn, GameObject player, Guid assetId)
         {
             if (GetNetworkIdentity(player, out NetworkIdentity identity))
             {
@@ -770,7 +770,7 @@ namespace Mirror
         /// <summary>Replaces connection's player object. The old object is not destroyed.</summary>
         // This does NOT change the ready state of the connection, so it can
         // safely be used while changing scenes.
-        public static bool ReplacePlayerForConnection(NetworkConnection conn, GameObject player, bool keepAuthority = false)
+        public static bool ReplacePlayerForConnection(NetworkConnectionToClient conn, GameObject player, bool keepAuthority = false)
         {
             NetworkIdentity identity = player.GetComponent<NetworkIdentity>();
             if (identity == null)
@@ -827,7 +827,7 @@ namespace Mirror
         /// <summary>Replaces connection's player object. The old object is not destroyed.</summary>
         // This does NOT change the ready state of the connection, so it can
         // safely be used while changing scenes.
-        public static bool ReplacePlayerForConnection(NetworkConnection conn, GameObject player, Guid assetId, bool keepAuthority = false)
+        public static bool ReplacePlayerForConnection(NetworkConnectionToClient conn, GameObject player, Guid assetId, bool keepAuthority = false)
         {
             if (GetNetworkIdentity(player, out NetworkIdentity identity))
             {
@@ -844,7 +844,7 @@ namespace Mirror
         // SYSTEM_READY message. If there is not specific action a game needs to
         // take for this message, relying on the default ready handler function
         // is probably fine, so this call wont be needed.
-        public static void SetClientReady(NetworkConnection conn)
+        public static void SetClientReady(NetworkConnectionToClient conn)
         {
             // Debug.Log($"SetClientReadyInternal for conn:{conn}");
 
@@ -860,7 +860,7 @@ namespace Mirror
         // Clients that are not ready do not receive spawned objects or state
         // synchronization updates. They client can be made ready again by
         // calling SetClientReady().
-        public static void SetClientNotReady(NetworkConnection conn)
+        public static void SetClientNotReady(NetworkConnectionToClient conn)
         {
             conn.isReady = false;
             conn.RemoveFromObservingsObservers();
@@ -1013,7 +1013,7 @@ namespace Mirror
             }
         }
 
-        internal static void SendChangeOwnerMessage(NetworkIdentity identity, NetworkConnection conn)
+        internal static void SendChangeOwnerMessage(NetworkIdentity identity, NetworkConnectionToClient conn)
         {
             // Don't send if identity isn't spawned or only exists on server
             if (identity.netId == 0 || identity.serverOnly) return;
@@ -1201,7 +1201,7 @@ namespace Mirror
             }
         }
 
-        static void SpawnObserversForConnection(NetworkConnection conn)
+        static void SpawnObserversForConnection(NetworkConnectionToClient conn)
         {
             //Debug.Log($"Spawning {spawned.Count} objects for conn {conn}");
 
@@ -1282,7 +1282,7 @@ namespace Mirror
         // This is used when a client disconnects, to remove the players for
         // that client. This also destroys non-player objects that have client
         // authority set for this connection.
-        public static void DestroyPlayerForConnection(NetworkConnection conn)
+        public static void DestroyPlayerForConnection(NetworkConnectionToClient conn)
         {
             // destroy all objects owned by this connection, including the player object
             conn.DestroyOwnedObjects();
@@ -1416,7 +1416,7 @@ namespace Mirror
 
         // allocate newObservers helper HashSet only once
         // internal for tests
-        internal static readonly HashSet<NetworkConnection> newObservers = new HashSet<NetworkConnection>();
+        internal static readonly HashSet<NetworkConnectionToClient> newObservers = new HashSet<NetworkConnectionToClient>();
 
         // rebuild observers default method (no AOI) - adds all connections
         static void RebuildObserversDefault(NetworkIdentity identity, bool initialize)
@@ -1460,7 +1460,7 @@ namespace Mirror
             bool changed = false;
 
             // add all newObservers that aren't in .observers yet
-            foreach (NetworkConnection conn in newObservers)
+            foreach (NetworkConnectionToClient conn in newObservers)
             {
                 // only add ready connections.
                 // otherwise the player might not be in the world yet or anymore
@@ -1477,7 +1477,7 @@ namespace Mirror
             }
 
             // remove all old .observers that aren't in newObservers anymore
-            foreach (NetworkConnection conn in identity.observers.Values)
+            foreach (NetworkConnectionToClient conn in identity.observers.Values)
             {
                 if (!newObservers.Contains(conn))
                 {
@@ -1492,7 +1492,7 @@ namespace Mirror
             if (changed)
             {
                 identity.observers.Clear();
-                foreach (NetworkConnection conn in newObservers)
+                foreach (NetworkConnectionToClient conn in newObservers)
                 {
                     if (conn != null && conn.isReady)
                         identity.observers.Add(conn.connectionId, conn);

--- a/Assets/Mirror/Tests/Common/MirrorTest.cs
+++ b/Assets/Mirror/Tests/Common/MirrorTest.cs
@@ -378,7 +378,7 @@ namespace Mirror.Tests
         // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN PLAYER.
         // often times, we really need a player object for the client to receive
         // certain messages.
-        protected void CreateNetworkedAndSpawnPlayer(out GameObject go, out NetworkIdentity identity, NetworkConnection ownerConnection)
+        protected void CreateNetworkedAndSpawnPlayer(out GameObject go, out NetworkIdentity identity, NetworkConnectionToClient ownerConnection)
         {
             // server & client need to be active before spawning
             Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
@@ -400,7 +400,7 @@ namespace Mirror.Tests
         protected void CreateNetworkedAndSpawnPlayer(
             out GameObject serverGO, out NetworkIdentity serverIdentity,
             out GameObject clientGO, out NetworkIdentity clientIdentity,
-            NetworkConnection ownerConnection)
+            NetworkConnectionToClient ownerConnection)
         {
             // server & client need to be active before spawning
             Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
@@ -433,7 +433,7 @@ namespace Mirror.Tests
         // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN PLAYER.
         // often times, we really need a player object for the client to receive
         // certain messages.
-        protected void CreateNetworkedAndSpawnPlayer<T>(out GameObject go, out NetworkIdentity identity, out T component, NetworkConnection ownerConnection)
+        protected void CreateNetworkedAndSpawnPlayer<T>(out GameObject go, out NetworkIdentity identity, out T component, NetworkConnectionToClient ownerConnection)
             where T : NetworkBehaviour
         {
             // server & client need to be active before spawning
@@ -456,7 +456,7 @@ namespace Mirror.Tests
         protected void CreateNetworkedAndSpawnPlayer<T>(
             out GameObject serverGO, out NetworkIdentity serverIdentity, out T serverComponent,
             out GameObject clientGO, out NetworkIdentity clientIdentity, out T clientComponent,
-            NetworkConnection ownerConnection)
+            NetworkConnectionToClient ownerConnection)
             where T : NetworkBehaviour
         {
             // server & client need to be active before spawning

--- a/Assets/Mirror/Tests/Editor/NetworkManagerStopHostOnServerDisconnectTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerStopHostOnServerDisconnectTest.cs
@@ -5,10 +5,10 @@ namespace Mirror.Tests
     class NetworkManagerOnServerDisconnect : NetworkManager
     {
         public int called;
-        public override void OnServerDisconnect(NetworkConnection conn)
+        public override void OnServerDisconnect(NetworkConnectionToClient conn)
         {
             base.OnServerDisconnect(conn);
-            ++called; 
+            ++called;
         }
 }
 


### PR DESCRIPTION
NetworkConnection contains a lot of server-only code.
that code should be in NetworkConnectionToClient.
=> otherwise it's available on the client in NetworkConnectionToServer as well.

**this PR cleans this all up.**
safer, better code.
and makes future improvements (like host) mode easier if NetworkConnections are implemented cleanly.

**breaks** some user code where NetworkConnection needs to be changed to NetworkConnectionToClient.
in most cases, what they pass to functions already is a NetworkConnectionToClient though.
some callbacks like InterestManagement need parameter changing though.

---
already found a bug in our test code thanks to strong typing:
<img width="529" alt="2022-02-05_18-12-48@2x" src="https://user-images.githubusercontent.com/16416509/152637911-27d84922-ed00-48cf-be7b-f170dad8bc0d.png">
this used to use FakeNetworkConnection, which is ConnectionToClient, not to Server like NetworkClient.connection is meant to be..
