### PR TITLE
fix: Match & Team Int Mgmt OnCheckObserver

### DIFF
--- a/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
@@ -118,10 +118,20 @@ namespace Mirror
 
         public override bool OnCheckObserver(NetworkIdentity identity, NetworkConnection newObserver)
         {
+            // Never observed if no NetworkMatch component
             if (!identity.TryGetComponent<NetworkMatch>(out NetworkMatch identityNetworkMatch))
                 return false;
 
+            // Guid.Empty is never a valid matchId
+            if (identityNetworkMatch.matchId == Guid.Empty)
+                return false;
+
+            // Never observed if no NetworkMatch component
             if (!newObserver.identity.TryGetComponent<NetworkMatch>(out NetworkMatch newObserverNetworkMatch))
+                return false;
+
+            // Guid.Empty is never a valid matchId
+            if (newObserverNetworkMatch.matchId == Guid.Empty)
                 return false;
 
             return identityNetworkMatch.matchId == newObserverNetworkMatch.matchId;

--- a/Assets/Mirror/Components/InterestManagement/Team/TeamInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Team/TeamInterestManagement.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Mirror
@@ -26,6 +27,7 @@ namespace Mirror
             if (currentTeam == string.Empty)
                 return;
 
+            // Debug.Log($"MatchInterestManagement.OnSpawned({identity.name}) currentMatch: {currentTeam}");
             if (!teamObjects.TryGetValue(currentTeam, out HashSet<NetworkIdentity> objects))
             {
                 objects = new HashSet<NetworkIdentity>();
@@ -121,12 +123,26 @@ namespace Mirror
             if (!identity.TryGetComponent<NetworkTeam>(out NetworkTeam identityNetworkTeam))
                 return true;
 
+            if (identityNetworkTeam.forceShown)
+                return true;
+
+            // string.Empty is never a valid teamId
+            if (string.IsNullOrWhiteSpace(identityNetworkTeam.teamId))
+                return false;
+
             // Always observed if no NetworkTeam component
             if (!newObserver.identity.TryGetComponent<NetworkTeam>(out NetworkTeam newObserverNetworkTeam))
                 return true;
 
+            if (newObserverNetworkTeam.forceShown)
+                return true;
+
+            // string.Empty is never a valid teamId
+            if (string.IsNullOrWhiteSpace(newObserverNetworkTeam.teamId))
+                return false;
+
             // Observed only if teamId's match
-            return identityNetworkTeam.forceShown || identityNetworkTeam.teamId == newObserverNetworkTeam.teamId;
+            return identityNetworkTeam.teamId == newObserverNetworkTeam.teamId;
         }
 
         public override void OnRebuildObservers(NetworkIdentity identity, HashSet<NetworkConnection> newObservers, bool initialize)


### PR DESCRIPTION
Fixes OnCheckObserver to have correct visibility of networked objects where Match / Team ID is not yet assigned