### PR TITLE
fix: host mode [SyncVar] setter hooks now support static functions again

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -207,8 +207,20 @@ namespace Mirror.Weaver
                 // IL_000b: ldftn instance void Mirror.Examples.Tanks.Tank::ExampleHook(int32, int32)
                 // IL_0011: newobj instance void class [netstandard]System.Action`2<int32, int32>::.ctor(object, native int)
 
-                // this.
-                worker.Emit(OpCodes.Ldarg_0);
+                // we support static hook sand instance hooks.
+                if (hookMethod.IsStatic)
+                {
+                    // for static hooks, we need to push 'null' first.
+                    // we can't just push nothing.
+                    // stack would get out of balance because we already pushed
+                    // other stuff above.
+                    worker.Emit(OpCodes.Ldnull);
+                }
+                else
+                {
+                    // for instance hooks, we need to push 'this.' first.
+                    worker.Emit(OpCodes.Ldarg_0);
+                }
 
                 // the function
                 worker.Emit(OpCodes.Ldftn, hookMethod);

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeHook_HostModeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeHook_HostModeTest.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+
+namespace Mirror.Tests.SyncVarAttributeTests
+{
+    public class SyncVarAttributeHook_HostModeTest : MirrorTest
+    {
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            // start server & connect client because we need spawn functions
+            NetworkServer.Listen(1);
+
+            // need host mode!
+            ConnectHostClientBlockingAuthenticatedAndReady();
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+        }
+
+        // previously there was 0 coverage for [SyncVar] setters properly
+        // calling static hook functions.
+        // prevents: https://github.com/vis2k/Mirror/pull/3101
+        [Test]
+        public void StaticMethod_HookCalledFromSyncVarSetter()
+        {
+            CreateNetworkedAndSpawn(out _, out _, out StaticHookBehaviour comp);
+
+            const int serverValue = 24;
+
+            // hooks are only called if localClientActive
+            Assert.That(NetworkServer.localClientActive, Is.True);
+
+            int hookcallCount = 0;
+            StaticHookBehaviour.HookCalled += (oldValue, newValue) =>
+            {
+                hookcallCount++;
+                Assert.That(oldValue, Is.EqualTo(0));
+                Assert.That(newValue, Is.EqualTo(serverValue));
+            };
+
+            // change it on server.
+            // the client is active too.
+            // so the setter should call the hook.
+            comp.value = serverValue;
+            Assert.That(hookcallCount, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeHook_HostModeTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeHook_HostModeTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6680af475e674f8c8f5cbe5a3089c115
+timeCreated: 1644906912


### PR DESCRIPTION
previously we moved the [SyncVar] setter to C#.
where we use Weaver to convert the hook to Action and pass that to GeneratedSyncVarSetter.

this always forced instance hooks because we pushed 'this.' onto the stack.
now, this support static hooks too.

IMPORTANT: this slipped through our tests. so we'll need a test for this.

before:
<img width="1313" alt="2022-02-15_14-24-02@2x" src="https://user-images.githubusercontent.com/16416509/154004906-2a7d8de8-97a7-4c74-b82c-6306190c7f2d.png">

after:
<img width="567" alt="2022-02-15_14-27-04@2x" src="https://user-images.githubusercontent.com/16416509/154004967-7ee96482-8a5f-431c-9643-07b64abb7730.png">

also added test coverage so this never happens again:
![image](https://user-images.githubusercontent.com/16416509/154006472-57210e51-e9d8-443c-94de-ec55df3eb097.png)

