### PR TITLE
Weaver: ignore protected/internal fields when generating reader/writer for class/struct

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Extensions.cs
+++ b/Assets/Mirror/Editor/Weaver/Extensions.cs
@@ -229,7 +229,7 @@ namespace Mirror.Weaver
             {
                 foreach (FieldDefinition field in typeDefinition.Fields)
                 {
-                    if (field.IsStatic || field.IsPrivate)
+                    if (field.IsStatic || !field.IsPublic)
                         continue;
 
                     if (field.IsNotSerialized)


### PR DESCRIPTION
FindAllPublicFields should only find public fields, not all non-private ones.