### PR TITLE
breaking: NetworkReader/WriterPool API simplified: GetReader/Writer => Get; Recycle => Return;

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -175,7 +175,7 @@ namespace Mirror.Discovery
 
             UdpReceiveResult udpReceiveResult = await udpClient.ReceiveAsync();
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Get(udpReceiveResult.Buffer))
             {
                 long handshake = networkReader.ReadLong();
                 if (handshake != secretHandshake)
@@ -206,7 +206,7 @@ namespace Mirror.Discovery
             if (info == null)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 try
                 {
@@ -369,7 +369,7 @@ namespace Mirror.Discovery
 
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Broadcast, serverBroadcastListenPort);
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 writer.WriteLong(secretHandshake);
 
@@ -406,7 +406,7 @@ namespace Mirror.Discovery
 
             UdpReceiveResult udpReceiveResult = await udpClient.ReceiveAsync();
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Get(udpReceiveResult.Buffer))
             {
                 if (networkReader.ReadLong() != secretHandshake)
                     return;

--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -175,7 +175,7 @@ namespace Mirror.Discovery
 
             UdpReceiveResult udpReceiveResult = await udpClient.ReceiveAsync();
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(udpReceiveResult.Buffer))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
             {
                 long handshake = networkReader.ReadLong();
                 if (handshake != secretHandshake)
@@ -206,7 +206,7 @@ namespace Mirror.Discovery
             if (info == null)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 try
                 {
@@ -369,7 +369,7 @@ namespace Mirror.Discovery
 
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Broadcast, serverBroadcastListenPort);
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 writer.WriteLong(secretHandshake);
 
@@ -406,7 +406,7 @@ namespace Mirror.Discovery
 
             UdpReceiveResult udpReceiveResult = await udpClient.ReceiveAsync();
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(udpReceiveResult.Buffer))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
             {
                 if (networkReader.ReadLong() != secretHandshake)
                     return;

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -106,7 +106,7 @@ namespace Mirror
                     continue;
                 }
 
-                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
                 {
                     WriteParameters(writer);
                     SendAnimationMessage(stateHash, normalizedTime, i, layerWeight[i], writer.ToArray());
@@ -193,7 +193,7 @@ namespace Mirror
             {
                 nextSendTime = now + syncInterval;
 
-                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
                 {
                     if (WriteParameters(writer))
                         SendAnimationParametersMessage(writer.ToArray());
@@ -527,7 +527,7 @@ namespace Mirror
             //Debug.Log($"OnAnimationMessage for netId {netId}");
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
             {
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
                 RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, weight, parameters);
@@ -542,7 +542,7 @@ namespace Mirror
                 return;
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
             {
                 HandleAnimParamsMsg(networkReader);
                 RpcOnAnimationParametersClientMessage(parameters);
@@ -600,14 +600,14 @@ namespace Mirror
         [ClientRpc]
         void RpcOnAnimationClientMessage(int stateHash, float normalizedTime, int layerId, float weight, byte[] parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
         }
 
         [ClientRpc]
         void RpcOnAnimationParametersClientMessage(byte[] parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
                 HandleAnimParamsMsg(networkReader);
         }
 

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -106,7 +106,7 @@ namespace Mirror
                     continue;
                 }
 
-                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Get())
                 {
                     WriteParameters(writer);
                     SendAnimationMessage(stateHash, normalizedTime, i, layerWeight[i], writer.ToArray());
@@ -193,7 +193,7 @@ namespace Mirror
             {
                 nextSendTime = now + syncInterval;
 
-                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Get())
                 {
                     if (WriteParameters(writer))
                         SendAnimationParametersMessage(writer.ToArray());
@@ -527,7 +527,7 @@ namespace Mirror
             //Debug.Log($"OnAnimationMessage for netId {netId}");
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Get(parameters))
             {
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
                 RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, weight, parameters);
@@ -542,7 +542,7 @@ namespace Mirror
                 return;
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Get(parameters))
             {
                 HandleAnimParamsMsg(networkReader);
                 RpcOnAnimationParametersClientMessage(parameters);
@@ -600,14 +600,14 @@ namespace Mirror
         [ClientRpc]
         void RpcOnAnimationClientMessage(int stateHash, float normalizedTime, int layerId, float weight, byte[] parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Get(parameters))
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
         }
 
         [ClientRpc]
         void RpcOnAnimationParametersClientMessage(byte[] parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Get(parameters))
                 HandleAnimParamsMsg(networkReader);
         }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -59,7 +59,7 @@ namespace Mirror.Weaver
             worker.Emit(requiresAuthority ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
             worker.Emit(OpCodes.Call, weaverTypes.sendCommandInternal);
 
-            NetworkBehaviourProcessor.WriteRecycleWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteReturnWriter(worker, weaverTypes);
 
             worker.Emit(OpCodes.Ret);
             return cmd;

--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -38,7 +38,7 @@ namespace Mirror.Weaver
             NetworkBehaviourProcessor.WriteSetupLocals(worker, weaverTypes);
 
             // NetworkWriter writer = new NetworkWriter();
-            NetworkBehaviourProcessor.WriteCreateWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteGetWriter(worker, weaverTypes);
 
             // write all the arguments that the user passed to the Cmd call
             if (!NetworkBehaviourProcessor.WriteArguments(worker, writers, Log, md, RemoteCallType.Command, ref WeavingFailed))

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -140,10 +140,10 @@ namespace Mirror.Weaver
             worker.Body.Variables.Add(new VariableDefinition(weaverTypes.Import<PooledNetworkWriter>()));
         }
 
-        public static void WriteCreateWriter(ILProcessor worker, WeaverTypes weaverTypes)
+        public static void WriteGetWriter(ILProcessor worker, WeaverTypes weaverTypes)
         {
             // create writer
-            worker.Emit(OpCodes.Call, weaverTypes.TakeWriterReference);
+            worker.Emit(OpCodes.Call, weaverTypes.GetWriterReference);
             worker.Emit(OpCodes.Stloc_0);
         }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -143,15 +143,15 @@ namespace Mirror.Weaver
         public static void WriteCreateWriter(ILProcessor worker, WeaverTypes weaverTypes)
         {
             // create writer
-            worker.Emit(OpCodes.Call, weaverTypes.GetPooledWriterReference);
+            worker.Emit(OpCodes.Call, weaverTypes.TakeWriterReference);
             worker.Emit(OpCodes.Stloc_0);
         }
 
-        public static void WriteRecycleWriter(ILProcessor worker, WeaverTypes weaverTypes)
+        public static void WriteReturnWriter(ILProcessor worker, WeaverTypes weaverTypes)
         {
             // NetworkWriterPool.Recycle(writer);
             worker.Emit(OpCodes.Ldloc_0);
-            worker.Emit(OpCodes.Call, weaverTypes.RecycleWriterReference);
+            worker.Emit(OpCodes.Call, weaverTypes.ReturnWriterReference);
         }
 
         public static bool WriteArguments(ILProcessor worker, Writers writers, Logger Log, MethodDefinition method, RemoteCallType callType, ref bool WeavingFailed)

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -89,7 +89,7 @@ namespace Mirror.Weaver
             worker.Emit(includeOwner ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
             worker.Emit(OpCodes.Callvirt, weaverTypes.sendRpcInternal);
 
-            NetworkBehaviourProcessor.WriteRecycleWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteReturnWriter(worker, weaverTypes);
 
             worker.Emit(OpCodes.Ret);
 

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -68,7 +68,7 @@ namespace Mirror.Weaver
             //worker.Emit(OpCodes.Ldstr, $"Call ClientRpc function {md.Name}");
             //worker.Emit(OpCodes.Call, WeaverTypes.logErrorReference);
 
-            NetworkBehaviourProcessor.WriteCreateWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteGetWriter(worker, weaverTypes);
 
             // write all the arguments that the user passed to the Rpc call
             if (!NetworkBehaviourProcessor.WriteArguments(worker, writers, Log, md, RemoteCallType.ClientRpc, ref WeavingFailed))

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -100,7 +100,7 @@ namespace Mirror.Weaver
 
             NetworkBehaviourProcessor.WriteSetupLocals(worker, weaverTypes);
 
-            NetworkBehaviourProcessor.WriteCreateWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteGetWriter(worker, weaverTypes);
 
             // write all the arguments that the user passed to the TargetRpc call
             // (skip first one if first one is NetworkConnection)

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -127,7 +127,7 @@ namespace Mirror.Weaver
             worker.Emit(OpCodes.Ldc_I4, targetRpcAttr.GetField("channel", 0));
             worker.Emit(OpCodes.Callvirt, weaverTypes.sendTargetRpcInternal);
 
-            NetworkBehaviourProcessor.WriteRecycleWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteReturnWriter(worker, weaverTypes);
 
             worker.Emit(OpCodes.Ret);
 

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -11,8 +11,8 @@ namespace Mirror.Weaver
         public MethodReference ScriptableObjectCreateInstanceMethod;
 
         public MethodReference NetworkBehaviourDirtyBitsReference;
-        public MethodReference GetPooledWriterReference;
-        public MethodReference RecycleWriterReference;
+        public MethodReference TakeWriterReference;
+        public MethodReference ReturnWriterReference;
 
         public MethodReference NetworkClientConnectionReference;
 
@@ -95,8 +95,8 @@ namespace Mirror.Weaver
 
             NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, assembly, "syncVarDirtyBits");
             TypeReference NetworkWriterPoolType = Import(typeof(NetworkWriterPool));
-            GetPooledWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "GetWriter", ref WeavingFailed);
-            RecycleWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Recycle", ref WeavingFailed);
+            TakeWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Take", ref WeavingFailed);
+            ReturnWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Return", ref WeavingFailed);
 
             NetworkClientConnectionReference = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_connection", ref WeavingFailed);
 

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -11,7 +11,7 @@ namespace Mirror.Weaver
         public MethodReference ScriptableObjectCreateInstanceMethod;
 
         public MethodReference NetworkBehaviourDirtyBitsReference;
-        public MethodReference TakeWriterReference;
+        public MethodReference GetWriterReference;
         public MethodReference ReturnWriterReference;
 
         public MethodReference NetworkClientConnectionReference;
@@ -95,7 +95,7 @@ namespace Mirror.Weaver
 
             NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, assembly, "syncVarDirtyBits");
             TypeReference NetworkWriterPoolType = Import(typeof(NetworkWriterPool));
-            TakeWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Take", ref WeavingFailed);
+            GetWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Get", ref WeavingFailed);
             ReturnWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Return", ref WeavingFailed);
 
             NetworkClientConnectionReference = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_connection", ref WeavingFailed);

--- a/Assets/Mirror/Runtime/Batching/Batcher.cs
+++ b/Assets/Mirror/Runtime/Batching/Batcher.cs
@@ -52,7 +52,7 @@ namespace Mirror
             //    would add a size header. we want to write directly.
             // -> will be returned to pool when making the batch!
             // IMPORTANT: NOT adding a size header / msg saves LOTS of bandwidth
-            PooledNetworkWriter writer = NetworkWriterPool.Take();
+            PooledNetworkWriter writer = NetworkWriterPool.Get();
             writer.WriteBytes(message.Array, message.Offset, message.Count);
             messages.Enqueue(writer);
         }

--- a/Assets/Mirror/Runtime/Batching/Batcher.cs
+++ b/Assets/Mirror/Runtime/Batching/Batcher.cs
@@ -52,7 +52,7 @@ namespace Mirror
             //    would add a size header. we want to write directly.
             // -> will be returned to pool when making the batch!
             // IMPORTANT: NOT adding a size header / msg saves LOTS of bandwidth
-            PooledNetworkWriter writer = NetworkWriterPool.GetWriter();
+            PooledNetworkWriter writer = NetworkWriterPool.Take();
             writer.WriteBytes(message.Array, message.Offset, message.Count);
             messages.Enqueue(writer);
         }
@@ -83,7 +83,7 @@ namespace Mirror
                 writer.WriteBytes(segment.Array, segment.Offset, segment.Count);
 
                 // return the writer to pool
-                NetworkWriterPool.Recycle(message);
+                NetworkWriterPool.Return(message);
             }
             // keep going as long as we have more messages,
             // AND the next one would fit into threshold.

--- a/Assets/Mirror/Runtime/Batching/Unbatcher.cs
+++ b/Assets/Mirror/Runtime/Batching/Unbatcher.cs
@@ -55,7 +55,7 @@ namespace Mirror
             // -> WriteBytes instead of WriteSegment because the latter
             //    would add a size header. we want to write directly.
             // -> will be returned to pool when sending!
-            PooledNetworkWriter writer = NetworkWriterPool.GetWriter();
+            PooledNetworkWriter writer = NetworkWriterPool.Take();
             writer.WriteBytes(batch.Array, batch.Offset, batch.Count);
 
             // first batch? then point reader there
@@ -112,7 +112,7 @@ namespace Mirror
             {
                 // retire the batch
                 PooledNetworkWriter writer = batches.Dequeue();
-                NetworkWriterPool.Recycle(writer);
+                NetworkWriterPool.Return(writer);
 
                 // do we have another batch?
                 if (batches.Count > 0)

--- a/Assets/Mirror/Runtime/Batching/Unbatcher.cs
+++ b/Assets/Mirror/Runtime/Batching/Unbatcher.cs
@@ -55,7 +55,7 @@ namespace Mirror
             // -> WriteBytes instead of WriteSegment because the latter
             //    would add a size header. we want to write directly.
             // -> will be returned to pool when sending!
-            PooledNetworkWriter writer = NetworkWriterPool.Take();
+            PooledNetworkWriter writer = NetworkWriterPool.Get();
             writer.WriteBytes(batch.Array, batch.Offset, batch.Count);
 
             // first batch? then point reader there

--- a/Assets/Mirror/Runtime/LocalConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/LocalConnectionToClient.cs
@@ -21,7 +21,7 @@ namespace Mirror
             // => WriteBytes instead of WriteArraySegment because the latter
             //    includes a 4 bytes header. we just want to write raw.
             //Debug.Log($"Enqueue {BitConverter.ToString(segment.Array, segment.Offset, segment.Count)}");
-            PooledNetworkWriter writer = NetworkWriterPool.Take();
+            PooledNetworkWriter writer = NetworkWriterPool.Get();
             writer.WriteBytes(segment.Array, segment.Offset, segment.Count);
             connectionToServer.queue.Enqueue(writer);
         }

--- a/Assets/Mirror/Runtime/LocalConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/LocalConnectionToClient.cs
@@ -21,7 +21,7 @@ namespace Mirror
             // => WriteBytes instead of WriteArraySegment because the latter
             //    includes a 4 bytes header. we just want to write raw.
             //Debug.Log($"Enqueue {BitConverter.ToString(segment.Array, segment.Offset, segment.Count)}");
-            PooledNetworkWriter writer = NetworkWriterPool.GetWriter();
+            PooledNetworkWriter writer = NetworkWriterPool.Take();
             writer.WriteBytes(segment.Array, segment.Offset, segment.Count);
             connectionToServer.queue.Enqueue(writer);
         }

--- a/Assets/Mirror/Runtime/LocalConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/LocalConnectionToServer.cs
@@ -37,7 +37,7 @@ namespace Mirror
 
             // flush it to the server's OnTransportData immediately.
             // local connection to server always invokes immediately.
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 // make a batch with our local time (double precision)
                 if (batcher.MakeNextBatch(writer, NetworkTime.localTime))
@@ -71,7 +71,7 @@ namespace Mirror
                 Batcher batcher = GetBatchForChannelId(Channels.Reliable);
                 batcher.AddMessage(message);
 
-                using (PooledNetworkWriter batchWriter = NetworkWriterPool.Take())
+                using (PooledNetworkWriter batchWriter = NetworkWriterPool.Get())
                 {
                     // make a batch with our local time (double precision)
                     if (batcher.MakeNextBatch(batchWriter, NetworkTime.localTime))

--- a/Assets/Mirror/Runtime/LocalConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/LocalConnectionToServer.cs
@@ -37,7 +37,7 @@ namespace Mirror
 
             // flush it to the server's OnTransportData immediately.
             // local connection to server always invokes immediately.
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // make a batch with our local time (double precision)
                 if (batcher.MakeNextBatch(writer, NetworkTime.localTime))
@@ -71,7 +71,7 @@ namespace Mirror
                 Batcher batcher = GetBatchForChannelId(Channels.Reliable);
                 batcher.AddMessage(message);
 
-                using (PooledNetworkWriter batchWriter = NetworkWriterPool.GetWriter())
+                using (PooledNetworkWriter batchWriter = NetworkWriterPool.Take())
                 {
                     // make a batch with our local time (double precision)
                     if (batcher.MakeNextBatch(batchWriter, NetworkTime.localTime))
@@ -80,7 +80,7 @@ namespace Mirror
                     }
                 }
 
-                NetworkWriterPool.Recycle(writer);
+                NetworkWriterPool.Return(writer);
             }
 
             // should we still process a disconnected event?

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1005,7 +1005,7 @@ namespace Mirror
             // (Count is 0 if there were no components)
             if (message.payload.Count > 0)
             {
-                using (PooledNetworkReader payloadReader = NetworkReaderPool.GetReader(message.payload))
+                using (PooledNetworkReader payloadReader = NetworkReaderPool.Take(message.payload))
                 {
                     identity.OnDeserializeAllSafely(payloadReader, true);
                 }
@@ -1238,7 +1238,7 @@ namespace Mirror
             // Debug.Log($"NetworkClient.OnUpdateVarsMessage {msg.netId}");
             if (spawned.TryGetValue(message.netId, out NetworkIdentity localObject) && localObject != null)
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(message.payload))
+                using (PooledNetworkReader networkReader = NetworkReaderPool.Take(message.payload))
                     localObject.OnDeserializeAllSafely(networkReader, false);
             }
             else Debug.LogWarning($"Did not find target for sync message for {message.netId} . Note: this can be completely normal because UDP messages may arrive out of order, so this message might have arrived after a Destroy message.");
@@ -1249,7 +1249,7 @@ namespace Mirror
             // Debug.Log($"NetworkClient.OnRPCMessage hash:{msg.functionHash} netId:{msg.netId}");
             if (spawned.TryGetValue(message.netId, out NetworkIdentity identity))
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(message.payload))
+                using (PooledNetworkReader networkReader = NetworkReaderPool.Take(message.payload))
                     identity.HandleRemoteCall(message.componentIndex, message.functionHash, RemoteCallType.ClientRpc, networkReader);
             }
         }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1005,7 +1005,7 @@ namespace Mirror
             // (Count is 0 if there were no components)
             if (message.payload.Count > 0)
             {
-                using (PooledNetworkReader payloadReader = NetworkReaderPool.Take(message.payload))
+                using (PooledNetworkReader payloadReader = NetworkReaderPool.Get(message.payload))
                 {
                     identity.OnDeserializeAllSafely(payloadReader, true);
                 }
@@ -1238,7 +1238,7 @@ namespace Mirror
             // Debug.Log($"NetworkClient.OnUpdateVarsMessage {msg.netId}");
             if (spawned.TryGetValue(message.netId, out NetworkIdentity localObject) && localObject != null)
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.Take(message.payload))
+                using (PooledNetworkReader networkReader = NetworkReaderPool.Get(message.payload))
                     localObject.OnDeserializeAllSafely(networkReader, false);
             }
             else Debug.LogWarning($"Did not find target for sync message for {message.netId} . Note: this can be completely normal because UDP messages may arrive out of order, so this message might have arrived after a Destroy message.");
@@ -1249,7 +1249,7 @@ namespace Mirror
             // Debug.Log($"NetworkClient.OnRPCMessage hash:{msg.functionHash} netId:{msg.netId}");
             if (spawned.TryGetValue(message.netId, out NetworkIdentity identity))
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.Take(message.payload))
+                using (PooledNetworkReader networkReader = NetworkReaderPool.Get(message.payload))
                     identity.HandleRemoteCall(message.componentIndex, message.functionHash, RemoteCallType.ClientRpc, networkReader);
             }
         }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -129,7 +129,7 @@ namespace Mirror
         public void Send<T>(T message, int channelId = Channels.Reliable)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // pack message and send allocation free
                 MessagePacking.Pack(message, writer);
@@ -176,7 +176,7 @@ namespace Mirror
                 // make and send as many batches as necessary from the stored
                 // messages.
                 Batcher batcher = kvp.Value;
-                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
                 {
                     // make a batch with our local time (double precision)
                     while (batcher.MakeNextBatch(writer, NetworkTime.localTime))

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -129,7 +129,7 @@ namespace Mirror
         public void Send<T>(T message, int channelId = Channels.Reliable)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 // pack message and send allocation free
                 MessagePacking.Pack(message, writer);
@@ -176,7 +176,7 @@ namespace Mirror
                 // make and send as many batches as necessary from the stored
                 // messages.
                 Batcher batcher = kvp.Value;
-                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Get())
                 {
                     // make a batch with our local time (double precision)
                     while (batcher.MakeNextBatch(writer, NetworkTime.localTime))

--- a/Assets/Mirror/Runtime/NetworkReaderPool.cs
+++ b/Assets/Mirror/Runtime/NetworkReaderPool.cs
@@ -25,12 +25,12 @@ namespace Mirror
         );
 
         // DEPRECATED 2022-03-10
-        [Obsolete("GetReader() was renamed to Take()")]
-        public static PooledNetworkReader GetReader(byte[] bytes) => Take(bytes);
+        [Obsolete("GetReader() was renamed to Get()")]
+        public static PooledNetworkReader GetReader(byte[] bytes) => Get(bytes);
 
         /// <summary>Get the next reader in the pool. If pool is empty, creates a new Reader</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkReader Take(byte[] bytes)
+        public static PooledNetworkReader Get(byte[] bytes)
         {
             // grab from pool & set buffer
             PooledNetworkReader reader = Pool.Take();
@@ -39,12 +39,12 @@ namespace Mirror
         }
 
         // DEPRECATED 2022-03-10
-        [Obsolete("GetReader() was renamed to Take()")]
-        public static PooledNetworkReader GetReader(ArraySegment<byte> segment) => Take(segment);
+        [Obsolete("GetReader() was renamed to Get()")]
+        public static PooledNetworkReader GetReader(ArraySegment<byte> segment) => Get(segment);
 
         /// <summary>Get the next reader in the pool. If pool is empty, creates a new Reader</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkReader Take(ArraySegment<byte> segment)
+        public static PooledNetworkReader Get(ArraySegment<byte> segment)
         {
             // grab from pool & set buffer
             PooledNetworkReader reader = Pool.Take();

--- a/Assets/Mirror/Runtime/NetworkReaderPool.cs
+++ b/Assets/Mirror/Runtime/NetworkReaderPool.cs
@@ -33,7 +33,7 @@ namespace Mirror
         public static PooledNetworkReader Get(byte[] bytes)
         {
             // grab from pool & set buffer
-            PooledNetworkReader reader = Pool.Take();
+            PooledNetworkReader reader = Pool.Get();
             reader.SetBuffer(bytes);
             return reader;
         }
@@ -47,7 +47,7 @@ namespace Mirror
         public static PooledNetworkReader Get(ArraySegment<byte> segment)
         {
             // grab from pool & set buffer
-            PooledNetworkReader reader = Pool.Take();
+            PooledNetworkReader reader = Pool.Get();
             reader.SetBuffer(segment);
             return reader;
         }

--- a/Assets/Mirror/Runtime/NetworkReaderPool.cs
+++ b/Assets/Mirror/Runtime/NetworkReaderPool.cs
@@ -8,7 +8,7 @@ namespace Mirror
     {
         internal PooledNetworkReader(byte[] bytes) : base(bytes) {}
         internal PooledNetworkReader(ArraySegment<byte> segment) : base(segment) {}
-        public void Dispose() => NetworkReaderPool.Recycle(this);
+        public void Dispose() => NetworkReaderPool.Return(this);
     }
 
     /// <summary>Pool of NetworkReaders to avoid allocations.</summary>
@@ -24,9 +24,13 @@ namespace Mirror
             1000
         );
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("GetReader() was renamed to Take()")]
+        public static PooledNetworkReader GetReader(byte[] bytes) => Take(bytes);
+
         /// <summary>Get the next reader in the pool. If pool is empty, creates a new Reader</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkReader GetReader(byte[] bytes)
+        public static PooledNetworkReader Take(byte[] bytes)
         {
             // grab from pool & set buffer
             PooledNetworkReader reader = Pool.Take();
@@ -34,9 +38,13 @@ namespace Mirror
             return reader;
         }
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("GetReader() was renamed to Take()")]
+        public static PooledNetworkReader GetReader(ArraySegment<byte> segment) => Take(segment);
+
         /// <summary>Get the next reader in the pool. If pool is empty, creates a new Reader</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkReader GetReader(ArraySegment<byte> segment)
+        public static PooledNetworkReader Take(ArraySegment<byte> segment)
         {
             // grab from pool & set buffer
             PooledNetworkReader reader = Pool.Take();
@@ -44,9 +52,13 @@ namespace Mirror
             return reader;
         }
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("Recycle() was renamed to Return()")]
+        public static void Recycle(PooledNetworkReader reader) => Return(reader);
+
         /// <summary>Returns a reader to the pool.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Recycle(PooledNetworkReader reader)
+        public static void Return(PooledNetworkReader reader)
         {
             Pool.Return(reader);
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -282,7 +282,7 @@ namespace Mirror
             }
 
             // Debug.Log($"Server.SendToAll {typeof(T)}");
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // pack message only once
                 MessagePacking.Pack(message, writer);
@@ -328,7 +328,7 @@ namespace Mirror
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // pack message into byte[] once
                 MessagePacking.Pack(message, writer);
@@ -352,7 +352,7 @@ namespace Mirror
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // pack message only once
                 MessagePacking.Pack(message, writer);
@@ -960,7 +960,7 @@ namespace Mirror
 
             // Debug.Log($"OnCommandMessage for netId:{msg.netId} conn:{conn}");
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(msg.payload))
                 identity.HandleRemoteCall(msg.componentIndex, msg.functionHash, RemoteCallType.Command, networkReader, conn as NetworkConnectionToClient);
         }
 
@@ -996,7 +996,7 @@ namespace Mirror
             //Debug.Log($"Server SendSpawnMessage: name:{identity.name} sceneId:{identity.sceneId:X} netid:{identity.netId}");
 
             // one writer for owner, one for observers
-            using (PooledNetworkWriter ownerWriter = NetworkWriterPool.GetWriter(), observersWriter = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter ownerWriter = NetworkWriterPool.Take(), observersWriter = NetworkWriterPool.Take())
             {
                 bool isOwner = identity.connectionToClient == conn;
                 ArraySegment<byte> payload = CreateSpawnMessagePayload(isOwner, identity, ownerWriter, observersWriter);

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -282,7 +282,7 @@ namespace Mirror
             }
 
             // Debug.Log($"Server.SendToAll {typeof(T)}");
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 // pack message only once
                 MessagePacking.Pack(message, writer);
@@ -328,7 +328,7 @@ namespace Mirror
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 // pack message into byte[] once
                 MessagePacking.Pack(message, writer);
@@ -352,7 +352,7 @@ namespace Mirror
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 // pack message only once
                 MessagePacking.Pack(message, writer);
@@ -960,7 +960,7 @@ namespace Mirror
 
             // Debug.Log($"OnCommandMessage for netId:{msg.netId} conn:{conn}");
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(msg.payload))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Get(msg.payload))
                 identity.HandleRemoteCall(msg.componentIndex, msg.functionHash, RemoteCallType.Command, networkReader, conn as NetworkConnectionToClient);
         }
 
@@ -996,7 +996,7 @@ namespace Mirror
             //Debug.Log($"Server SendSpawnMessage: name:{identity.name} sceneId:{identity.sceneId:X} netid:{identity.netId}");
 
             // one writer for owner, one for observers
-            using (PooledNetworkWriter ownerWriter = NetworkWriterPool.Take(), observersWriter = NetworkWriterPool.Take())
+            using (PooledNetworkWriter ownerWriter = NetworkWriterPool.Get(), observersWriter = NetworkWriterPool.Get())
             {
                 bool isOwner = identity.connectionToClient == conn;
                 ArraySegment<byte> payload = CreateSpawnMessagePayload(isOwner, identity, ownerWriter, observersWriter);

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -33,7 +33,7 @@ namespace Mirror
         public static PooledNetworkWriter Get()
         {
             // grab from pool & reset position
-            PooledNetworkWriter writer = Pool.Take();
+            PooledNetworkWriter writer = Pool.Get();
             writer.Reset();
             return writer;
         }

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -25,12 +25,12 @@ namespace Mirror
         );
 
         // DEPRECATED 2022-03-10
-        [Obsolete("GetWriter() was renamed to Take()")]
-        public static PooledNetworkWriter GetWriter() => Take();
+        [Obsolete("GetWriter() was renamed to Get()")]
+        public static PooledNetworkWriter GetWriter() => Get();
 
         /// <summary>Get a writer from the pool. Creates new one if pool is empty.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkWriter Take()
+        public static PooledNetworkWriter Get()
         {
             // grab from pool & reset position
             PooledNetworkWriter writer = Pool.Take();

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -6,7 +6,7 @@ namespace Mirror
     /// <summary>Pooled NetworkWriter, automatically returned to pool when using 'using'</summary>
     public sealed class PooledNetworkWriter : NetworkWriter, IDisposable
     {
-        public void Dispose() => NetworkWriterPool.Recycle(this);
+        public void Dispose() => NetworkWriterPool.Return(this);
     }
 
     /// <summary>Pool of NetworkWriters to avoid allocations.</summary>
@@ -24,9 +24,13 @@ namespace Mirror
             1000
         );
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("GetWriter() was renamed to Take()")]
+        public static PooledNetworkWriter GetWriter() => Take();
+
         /// <summary>Get a writer from the pool. Creates new one if pool is empty.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkWriter GetWriter()
+        public static PooledNetworkWriter Take()
         {
             // grab from pool & reset position
             PooledNetworkWriter writer = Pool.Take();
@@ -34,9 +38,13 @@ namespace Mirror
             return writer;
         }
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("Recycle() was renamed to Return()")]
+        public static void Recycle(PooledNetworkWriter writer) => Return(writer);
+
         /// <summary>Return a writer to the pool.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Recycle(PooledNetworkWriter writer)
+        public static void Return(PooledNetworkWriter writer)
         {
             Pool.Return(writer);
         }

--- a/Assets/Mirror/Runtime/Pool.cs
+++ b/Assets/Mirror/Runtime/Pool.cs
@@ -24,9 +24,13 @@ namespace Mirror
                 objects.Push(objectGenerator());
         }
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("Take() was renamed to Get()")]
+        public T Take() => Get();
+
         // take an element from the pool, or create a new one if empty
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T Take() => objects.Count > 0 ? objects.Pop() : objectGenerator();
+        public T Get() => objects.Count > 0 ? objects.Pop() : objectGenerator();
 
         // return an element to the pool
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
@@ -14,7 +14,7 @@ namespace Mirror.Tests
         public static byte[] PackToByteArray<T>(T message)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 MessagePacking.Pack(message, writer);
                 return writer.ToArray();
@@ -25,7 +25,7 @@ namespace Mirror.Tests
         public static T UnpackFromByteArray<T>(byte[] data)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(data))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Get(data))
             {
                 int msgType = MessagePacking.GetId<T>();
 

--- a/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
@@ -14,7 +14,7 @@ namespace Mirror.Tests
         public static byte[] PackToByteArray<T>(T message)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 MessagePacking.Pack(message, writer);
                 return writer.ToArray();
@@ -25,7 +25,7 @@ namespace Mirror.Tests
         public static T UnpackFromByteArray<T>(byte[] data)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(data))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(data))
             {
                 int msgType = MessagePacking.GetId<T>();
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
@@ -125,11 +125,11 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
     {
         static void SyncNetworkBehaviour(NetworkBehaviour source, NetworkBehaviour target, bool initialState)
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 source.OnSerialize(writer, initialState);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.Take(writer.ToArraySegment()))
                 {
                     target.OnDeserialize(reader, initialState);
                 }

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
@@ -125,11 +125,11 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
     {
         static void SyncNetworkBehaviour(NetworkBehaviour source, NetworkBehaviour target, bool initialState)
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 source.OnSerialize(writer, initialState);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.Take(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.Get(writer.ToArraySegment()))
                 {
                     target.OnDeserialize(reader, initialState);
                 }

--- a/Assets/Mirror/Tests/Editor/NetworkReaderTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderTest.cs
@@ -66,7 +66,7 @@ namespace Mirror.Tests
             // should throw an exception
             byte[] bytes = { 0x00, 0x01 };
 
-            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(bytes))
+            using (PooledNetworkReader reader = NetworkReaderPool.Take(bytes))
             {
                 try
                 {

--- a/Assets/Mirror/Tests/Editor/NetworkReaderTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderTest.cs
@@ -66,7 +66,7 @@ namespace Mirror.Tests
             // should throw an exception
             byte[] bytes = { 0x00, 0x01 };
 
-            using (PooledNetworkReader reader = NetworkReaderPool.Take(bytes))
+            using (PooledNetworkReader reader = NetworkReaderPool.Get(bytes))
             {
                 try
                 {

--- a/Assets/Mirror/Tests/Editor/PoolTests.cs
+++ b/Assets/Mirror/Tests/Editor/PoolTests.cs
@@ -22,7 +22,7 @@ namespace Mirror.Tests
         public void TakeFromEmpty()
         {
             // taking from an empty pool should give us a completely new string
-            Assert.That(pool.Take(), Is.EqualTo("new string"));
+            Assert.That(pool.Get(), Is.EqualTo("new string"));
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace Mirror.Tests
             // returning and then taking should get the returned one, not a
             // newly generated one.
             pool.Return("returned");
-            Assert.That(pool.Take(), Is.EqualTo("returned"));
+            Assert.That(pool.Get(), Is.EqualTo("returned"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -420,11 +420,11 @@ namespace Mirror.Tests
     {
         public static uint GetChangeCount(this SyncObject syncObject)
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 syncObject.OnSerializeDelta(writer);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.Take(writer.ToArraySegment()))
                 {
                     return reader.ReadUInt();
                 }

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -420,11 +420,11 @@ namespace Mirror.Tests
     {
         public static uint GetChangeCount(this SyncObject syncObject)
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Get())
             {
                 syncObject.OnSerializeDelta(writer);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.Take(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.Get(writer.ToArraySegment()))
                 {
                     return reader.ReadUInt();
                 }


### PR DESCRIPTION
GetWriter() + Recycle() sounds a bit complicated.
**Take**() and **Return**().

small change, makes API a little bit easier to use.
+ old API still works, shows [Obsolete] messages.
+ consistency with Pool<T> which has Take() and Return()
+ Recycle function's comment explains that it returns a writer. indication for renaming.