### PR TITLE
breaking: PooledNetworkReader/Writer renamed to NetworkReader/WriterPooled

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -175,7 +175,7 @@ namespace Mirror.Discovery
 
             UdpReceiveResult udpReceiveResult = await udpClient.ReceiveAsync();
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(udpReceiveResult.Buffer))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
             {
                 long handshake = networkReader.ReadLong();
                 if (handshake != secretHandshake)
@@ -206,7 +206,7 @@ namespace Mirror.Discovery
             if (info == null)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 try
                 {
@@ -369,7 +369,7 @@ namespace Mirror.Discovery
 
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Broadcast, serverBroadcastListenPort);
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 writer.WriteLong(secretHandshake);
 
@@ -406,7 +406,7 @@ namespace Mirror.Discovery
 
             UdpReceiveResult udpReceiveResult = await udpClient.ReceiveAsync();
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(udpReceiveResult.Buffer))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
             {
                 if (networkReader.ReadLong() != secretHandshake)
                     return;

--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -175,7 +175,7 @@ namespace Mirror.Discovery
 
             UdpReceiveResult udpReceiveResult = await udpClient.ReceiveAsync();
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
+            using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
             {
                 long handshake = networkReader.ReadLong();
                 if (handshake != secretHandshake)
@@ -206,7 +206,7 @@ namespace Mirror.Discovery
             if (info == null)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 try
                 {
@@ -369,7 +369,7 @@ namespace Mirror.Discovery
 
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Broadcast, serverBroadcastListenPort);
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 writer.WriteLong(secretHandshake);
 
@@ -406,7 +406,7 @@ namespace Mirror.Discovery
 
             UdpReceiveResult udpReceiveResult = await udpClient.ReceiveAsync();
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
+            using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(udpReceiveResult.Buffer))
             {
                 if (networkReader.ReadLong() != secretHandshake)
                     return;

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -106,7 +106,7 @@ namespace Mirror
                     continue;
                 }
 
-                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
                 {
                     WriteParameters(writer);
                     SendAnimationMessage(stateHash, normalizedTime, i, layerWeight[i], writer.ToArray());
@@ -193,7 +193,7 @@ namespace Mirror
             {
                 nextSendTime = now + syncInterval;
 
-                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
                 {
                     if (WriteParameters(writer))
                         SendAnimationParametersMessage(writer.ToArray());
@@ -527,7 +527,7 @@ namespace Mirror
             //Debug.Log($"OnAnimationMessage for netId {netId}");
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
             {
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
                 RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, weight, parameters);
@@ -542,7 +542,7 @@ namespace Mirror
                 return;
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
             {
                 HandleAnimParamsMsg(networkReader);
                 RpcOnAnimationParametersClientMessage(parameters);
@@ -600,14 +600,14 @@ namespace Mirror
         [ClientRpc]
         void RpcOnAnimationClientMessage(int stateHash, float normalizedTime, int layerId, float weight, byte[] parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
         }
 
         [ClientRpc]
         void RpcOnAnimationParametersClientMessage(byte[] parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(parameters))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
                 HandleAnimParamsMsg(networkReader);
         }
 

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -106,7 +106,7 @@ namespace Mirror
                     continue;
                 }
 
-                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+                using (NetworkWriterPooled writer = NetworkWriterPool.Take())
                 {
                     WriteParameters(writer);
                     SendAnimationMessage(stateHash, normalizedTime, i, layerWeight[i], writer.ToArray());
@@ -193,7 +193,7 @@ namespace Mirror
             {
                 nextSendTime = now + syncInterval;
 
-                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+                using (NetworkWriterPooled writer = NetworkWriterPool.Take())
                 {
                     if (WriteParameters(writer))
                         SendAnimationParametersMessage(writer.ToArray());
@@ -527,7 +527,7 @@ namespace Mirror
             //Debug.Log($"OnAnimationMessage for netId {netId}");
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
+            using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(parameters))
             {
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
                 RpcOnAnimationClientMessage(stateHash, normalizedTime, layerId, weight, parameters);
@@ -542,7 +542,7 @@ namespace Mirror
                 return;
 
             // handle and broadcast
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
+            using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(parameters))
             {
                 HandleAnimParamsMsg(networkReader);
                 RpcOnAnimationParametersClientMessage(parameters);
@@ -600,14 +600,14 @@ namespace Mirror
         [ClientRpc]
         void RpcOnAnimationClientMessage(int stateHash, float normalizedTime, int layerId, float weight, byte[] parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
+            using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(parameters))
                 HandleAnimMsg(stateHash, normalizedTime, layerId, weight, networkReader);
         }
 
         [ClientRpc]
         void RpcOnAnimationParametersClientMessage(byte[] parameters)
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(parameters))
+            using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(parameters))
                 HandleAnimParamsMsg(networkReader);
         }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CommandProcessor.cs
@@ -59,7 +59,7 @@ namespace Mirror.Weaver
             worker.Emit(requiresAuthority ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
             worker.Emit(OpCodes.Call, weaverTypes.sendCommandInternal);
 
-            NetworkBehaviourProcessor.WriteRecycleWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteReturnWriter(worker, weaverTypes);
 
             worker.Emit(OpCodes.Ret);
             return cmd;

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -137,7 +137,7 @@ namespace Mirror.Weaver
         public static void WriteSetupLocals(ILProcessor worker, WeaverTypes weaverTypes)
         {
             worker.Body.InitLocals = true;
-            worker.Body.Variables.Add(new VariableDefinition(weaverTypes.Import<PooledNetworkWriter>()));
+            worker.Body.Variables.Add(new VariableDefinition(weaverTypes.Import<NetworkWriterPooled>()));
         }
 
         public static void WriteCreateWriter(ILProcessor worker, WeaverTypes weaverTypes)

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -143,15 +143,15 @@ namespace Mirror.Weaver
         public static void WriteCreateWriter(ILProcessor worker, WeaverTypes weaverTypes)
         {
             // create writer
-            worker.Emit(OpCodes.Call, weaverTypes.GetPooledWriterReference);
+            worker.Emit(OpCodes.Call, weaverTypes.TakeWriterReference);
             worker.Emit(OpCodes.Stloc_0);
         }
 
-        public static void WriteRecycleWriter(ILProcessor worker, WeaverTypes weaverTypes)
+        public static void WriteReturnWriter(ILProcessor worker, WeaverTypes weaverTypes)
         {
             // NetworkWriterPool.Recycle(writer);
             worker.Emit(OpCodes.Ldloc_0);
-            worker.Emit(OpCodes.Call, weaverTypes.RecycleWriterReference);
+            worker.Emit(OpCodes.Call, weaverTypes.ReturnWriterReference);
         }
 
         public static bool WriteArguments(ILProcessor worker, Writers writers, Logger Log, MethodDefinition method, RemoteCallType callType, ref bool WeavingFailed)

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -89,7 +89,7 @@ namespace Mirror.Weaver
             worker.Emit(includeOwner ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
             worker.Emit(OpCodes.Callvirt, weaverTypes.sendRpcInternal);
 
-            NetworkBehaviourProcessor.WriteRecycleWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteReturnWriter(worker, weaverTypes);
 
             worker.Emit(OpCodes.Ret);
 

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -127,7 +127,7 @@ namespace Mirror.Weaver
             worker.Emit(OpCodes.Ldc_I4, targetRpcAttr.GetField("channel", 0));
             worker.Emit(OpCodes.Callvirt, weaverTypes.sendTargetRpcInternal);
 
-            NetworkBehaviourProcessor.WriteRecycleWriter(worker, weaverTypes);
+            NetworkBehaviourProcessor.WriteReturnWriter(worker, weaverTypes);
 
             worker.Emit(OpCodes.Ret);
 

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -11,8 +11,8 @@ namespace Mirror.Weaver
         public MethodReference ScriptableObjectCreateInstanceMethod;
 
         public MethodReference NetworkBehaviourDirtyBitsReference;
-        public MethodReference GetPooledWriterReference;
-        public MethodReference RecycleWriterReference;
+        public MethodReference TakeWriterReference;
+        public MethodReference ReturnWriterReference;
 
         public MethodReference NetworkClientConnectionReference;
 
@@ -95,8 +95,8 @@ namespace Mirror.Weaver
 
             NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, assembly, "syncVarDirtyBits");
             TypeReference NetworkWriterPoolType = Import(typeof(NetworkWriterPool));
-            GetPooledWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "GetWriter", ref WeavingFailed);
-            RecycleWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Recycle", ref WeavingFailed);
+            TakeWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Take", ref WeavingFailed);
+            ReturnWriterReference = Resolvers.ResolveMethod(NetworkWriterPoolType, assembly, Log, "Return", ref WeavingFailed);
 
             NetworkClientConnectionReference = Resolvers.ResolveMethod(NetworkClientType, assembly, Log, "get_connection", ref WeavingFailed);
 

--- a/Assets/Mirror/Runtime/Batching/Batcher.cs
+++ b/Assets/Mirror/Runtime/Batching/Batcher.cs
@@ -35,7 +35,7 @@ namespace Mirror
         // batched messages
         // IMPORTANT: we queue the serialized messages!
         //            queueing NetworkMessage would box and allocate!
-        Queue<PooledNetworkWriter> messages = new Queue<PooledNetworkWriter>();
+        Queue<NetworkWriterPooled> messages = new Queue<NetworkWriterPooled>();
 
         public Batcher(int threshold)
         {
@@ -52,7 +52,7 @@ namespace Mirror
             //    would add a size header. we want to write directly.
             // -> will be returned to pool when making the batch!
             // IMPORTANT: NOT adding a size header / msg saves LOTS of bandwidth
-            PooledNetworkWriter writer = NetworkWriterPool.Take();
+            NetworkWriterPooled writer = NetworkWriterPool.Take();
             writer.WriteBytes(message.Array, message.Offset, message.Count);
             messages.Enqueue(writer);
         }
@@ -78,7 +78,7 @@ namespace Mirror
             {
                 // add next message no matter what. even if > threshold.
                 // (we do allow > threshold sized messages as single batch)
-                PooledNetworkWriter message = messages.Dequeue();
+                NetworkWriterPooled message = messages.Dequeue();
                 ArraySegment<byte> segment = message.ToArraySegment();
                 writer.WriteBytes(segment.Array, segment.Offset, segment.Count);
 

--- a/Assets/Mirror/Runtime/Batching/Batcher.cs
+++ b/Assets/Mirror/Runtime/Batching/Batcher.cs
@@ -52,7 +52,7 @@ namespace Mirror
             //    would add a size header. we want to write directly.
             // -> will be returned to pool when making the batch!
             // IMPORTANT: NOT adding a size header / msg saves LOTS of bandwidth
-            PooledNetworkWriter writer = NetworkWriterPool.GetWriter();
+            PooledNetworkWriter writer = NetworkWriterPool.Take();
             writer.WriteBytes(message.Array, message.Offset, message.Count);
             messages.Enqueue(writer);
         }
@@ -83,7 +83,7 @@ namespace Mirror
                 writer.WriteBytes(segment.Array, segment.Offset, segment.Count);
 
                 // return the writer to pool
-                NetworkWriterPool.Recycle(message);
+                NetworkWriterPool.Return(message);
             }
             // keep going as long as we have more messages,
             // AND the next one would fit into threshold.

--- a/Assets/Mirror/Runtime/Batching/Unbatcher.cs
+++ b/Assets/Mirror/Runtime/Batching/Unbatcher.cs
@@ -55,7 +55,7 @@ namespace Mirror
             // -> WriteBytes instead of WriteSegment because the latter
             //    would add a size header. we want to write directly.
             // -> will be returned to pool when sending!
-            PooledNetworkWriter writer = NetworkWriterPool.GetWriter();
+            PooledNetworkWriter writer = NetworkWriterPool.Take();
             writer.WriteBytes(batch.Array, batch.Offset, batch.Count);
 
             // first batch? then point reader there
@@ -112,7 +112,7 @@ namespace Mirror
             {
                 // retire the batch
                 PooledNetworkWriter writer = batches.Dequeue();
-                NetworkWriterPool.Recycle(writer);
+                NetworkWriterPool.Return(writer);
 
                 // do we have another batch?
                 if (batches.Count > 0)

--- a/Assets/Mirror/Runtime/Batching/Unbatcher.cs
+++ b/Assets/Mirror/Runtime/Batching/Unbatcher.cs
@@ -14,7 +14,7 @@ namespace Mirror
     {
         // supporting adding multiple batches before GetNextMessage is called.
         // just in case.
-        Queue<PooledNetworkWriter> batches = new Queue<PooledNetworkWriter>();
+        Queue<NetworkWriterPooled> batches = new Queue<NetworkWriterPooled>();
 
         public int BatchesCount => batches.Count;
 
@@ -27,7 +27,7 @@ namespace Mirror
         double readerRemoteTimeStamp;
 
         // helper function to start reading a batch.
-        void StartReadingBatch(PooledNetworkWriter batch)
+        void StartReadingBatch(NetworkWriterPooled batch)
         {
             // point reader to it
             reader.SetBuffer(batch.ToArraySegment());
@@ -55,7 +55,7 @@ namespace Mirror
             // -> WriteBytes instead of WriteSegment because the latter
             //    would add a size header. we want to write directly.
             // -> will be returned to pool when sending!
-            PooledNetworkWriter writer = NetworkWriterPool.Take();
+            NetworkWriterPooled writer = NetworkWriterPool.Take();
             writer.WriteBytes(batch.Array, batch.Offset, batch.Count);
 
             // first batch? then point reader there
@@ -111,7 +111,7 @@ namespace Mirror
             if (reader.Remaining == 0)
             {
                 // retire the batch
-                PooledNetworkWriter writer = batches.Dequeue();
+                NetworkWriterPooled writer = batches.Dequeue();
                 NetworkWriterPool.Return(writer);
 
                 // do we have another batch?
@@ -119,7 +119,7 @@ namespace Mirror
                 {
                     // point reader to the next batch.
                     // we'll return the reader below.
-                    PooledNetworkWriter next = batches.Peek();
+                    NetworkWriterPooled next = batches.Peek();
                     StartReadingBatch(next);
                 }
                 // otherwise there's nothing more to read

--- a/Assets/Mirror/Runtime/LocalConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/LocalConnectionToClient.cs
@@ -21,7 +21,7 @@ namespace Mirror
             // => WriteBytes instead of WriteArraySegment because the latter
             //    includes a 4 bytes header. we just want to write raw.
             //Debug.Log($"Enqueue {BitConverter.ToString(segment.Array, segment.Offset, segment.Count)}");
-            PooledNetworkWriter writer = NetworkWriterPool.GetWriter();
+            PooledNetworkWriter writer = NetworkWriterPool.Take();
             writer.WriteBytes(segment.Array, segment.Offset, segment.Count);
             connectionToServer.queue.Enqueue(writer);
         }

--- a/Assets/Mirror/Runtime/LocalConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/LocalConnectionToClient.cs
@@ -21,7 +21,7 @@ namespace Mirror
             // => WriteBytes instead of WriteArraySegment because the latter
             //    includes a 4 bytes header. we just want to write raw.
             //Debug.Log($"Enqueue {BitConverter.ToString(segment.Array, segment.Offset, segment.Count)}");
-            PooledNetworkWriter writer = NetworkWriterPool.Take();
+            NetworkWriterPooled writer = NetworkWriterPool.Take();
             writer.WriteBytes(segment.Array, segment.Offset, segment.Count);
             connectionToServer.queue.Enqueue(writer);
         }

--- a/Assets/Mirror/Runtime/LocalConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/LocalConnectionToServer.cs
@@ -11,7 +11,7 @@ namespace Mirror
         internal LocalConnectionToClient connectionToClient;
 
         // packet queue
-        internal readonly Queue<PooledNetworkWriter> queue = new Queue<PooledNetworkWriter>();
+        internal readonly Queue<NetworkWriterPooled> queue = new Queue<NetworkWriterPooled>();
 
         public override string address => "localhost";
 
@@ -37,7 +37,7 @@ namespace Mirror
 
             // flush it to the server's OnTransportData immediately.
             // local connection to server always invokes immediately.
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 // make a batch with our local time (double precision)
                 if (batcher.MakeNextBatch(writer, NetworkTime.localTime))
@@ -63,7 +63,7 @@ namespace Mirror
             while (queue.Count > 0)
             {
                 // call receive on queued writer's content, return to pool
-                PooledNetworkWriter writer = queue.Dequeue();
+                NetworkWriterPooled writer = queue.Dequeue();
                 ArraySegment<byte> message = writer.ToArraySegment();
 
                 // OnTransportData assumes a proper batch with timestamp etc.
@@ -71,7 +71,7 @@ namespace Mirror
                 Batcher batcher = GetBatchForChannelId(Channels.Reliable);
                 batcher.AddMessage(message);
 
-                using (PooledNetworkWriter batchWriter = NetworkWriterPool.Take())
+                using (NetworkWriterPooled batchWriter = NetworkWriterPool.Take())
                 {
                     // make a batch with our local time (double precision)
                     if (batcher.MakeNextBatch(batchWriter, NetworkTime.localTime))

--- a/Assets/Mirror/Runtime/LocalConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/LocalConnectionToServer.cs
@@ -37,7 +37,7 @@ namespace Mirror
 
             // flush it to the server's OnTransportData immediately.
             // local connection to server always invokes immediately.
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // make a batch with our local time (double precision)
                 if (batcher.MakeNextBatch(writer, NetworkTime.localTime))
@@ -71,7 +71,7 @@ namespace Mirror
                 Batcher batcher = GetBatchForChannelId(Channels.Reliable);
                 batcher.AddMessage(message);
 
-                using (PooledNetworkWriter batchWriter = NetworkWriterPool.GetWriter())
+                using (PooledNetworkWriter batchWriter = NetworkWriterPool.Take())
                 {
                     // make a batch with our local time (double precision)
                     if (batcher.MakeNextBatch(batchWriter, NetworkTime.localTime))
@@ -80,7 +80,7 @@ namespace Mirror
                     }
                 }
 
-                NetworkWriterPool.Recycle(writer);
+                NetworkWriterPool.Return(writer);
             }
 
             // should we still process a disconnected event?

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1005,7 +1005,7 @@ namespace Mirror
             // (Count is 0 if there were no components)
             if (message.payload.Count > 0)
             {
-                using (PooledNetworkReader payloadReader = NetworkReaderPool.Take(message.payload))
+                using (NetworkReaderPooled payloadReader = NetworkReaderPool.Take(message.payload))
                 {
                     identity.OnDeserializeAllSafely(payloadReader, true);
                 }
@@ -1238,7 +1238,7 @@ namespace Mirror
             // Debug.Log($"NetworkClient.OnUpdateVarsMessage {msg.netId}");
             if (spawned.TryGetValue(message.netId, out NetworkIdentity localObject) && localObject != null)
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.Take(message.payload))
+                using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(message.payload))
                     localObject.OnDeserializeAllSafely(networkReader, false);
             }
             else Debug.LogWarning($"Did not find target for sync message for {message.netId} . Note: this can be completely normal because UDP messages may arrive out of order, so this message might have arrived after a Destroy message.");
@@ -1249,7 +1249,7 @@ namespace Mirror
             // Debug.Log($"NetworkClient.OnRPCMessage hash:{msg.functionHash} netId:{msg.netId}");
             if (spawned.TryGetValue(message.netId, out NetworkIdentity identity))
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.Take(message.payload))
+                using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(message.payload))
                     identity.HandleRemoteCall(message.componentIndex, message.functionHash, RemoteCallType.ClientRpc, networkReader);
             }
         }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1005,7 +1005,7 @@ namespace Mirror
             // (Count is 0 if there were no components)
             if (message.payload.Count > 0)
             {
-                using (PooledNetworkReader payloadReader = NetworkReaderPool.GetReader(message.payload))
+                using (PooledNetworkReader payloadReader = NetworkReaderPool.Take(message.payload))
                 {
                     identity.OnDeserializeAllSafely(payloadReader, true);
                 }
@@ -1238,7 +1238,7 @@ namespace Mirror
             // Debug.Log($"NetworkClient.OnUpdateVarsMessage {msg.netId}");
             if (spawned.TryGetValue(message.netId, out NetworkIdentity localObject) && localObject != null)
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(message.payload))
+                using (PooledNetworkReader networkReader = NetworkReaderPool.Take(message.payload))
                     localObject.OnDeserializeAllSafely(networkReader, false);
             }
             else Debug.LogWarning($"Did not find target for sync message for {message.netId} . Note: this can be completely normal because UDP messages may arrive out of order, so this message might have arrived after a Destroy message.");
@@ -1249,7 +1249,7 @@ namespace Mirror
             // Debug.Log($"NetworkClient.OnRPCMessage hash:{msg.functionHash} netId:{msg.netId}");
             if (spawned.TryGetValue(message.netId, out NetworkIdentity identity))
             {
-                using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(message.payload))
+                using (PooledNetworkReader networkReader = NetworkReaderPool.Take(message.payload))
                     identity.HandleRemoteCall(message.componentIndex, message.functionHash, RemoteCallType.ClientRpc, networkReader);
             }
         }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -129,7 +129,7 @@ namespace Mirror
         public void Send<T>(T message, int channelId = Channels.Reliable)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // pack message and send allocation free
                 MessagePacking.Pack(message, writer);
@@ -176,7 +176,7 @@ namespace Mirror
                 // make and send as many batches as necessary from the stored
                 // messages.
                 Batcher batcher = kvp.Value;
-                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
                 {
                     // make a batch with our local time (double precision)
                     while (batcher.MakeNextBatch(writer, NetworkTime.localTime))

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -129,7 +129,7 @@ namespace Mirror
         public void Send<T>(T message, int channelId = Channels.Reliable)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 // pack message and send allocation free
                 MessagePacking.Pack(message, writer);
@@ -176,7 +176,7 @@ namespace Mirror
                 // make and send as many batches as necessary from the stored
                 // messages.
                 Batcher batcher = kvp.Value;
-                using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+                using (NetworkWriterPooled writer = NetworkWriterPool.Take())
                 {
                     // make a batch with our local time (double precision)
                     while (batcher.MakeNextBatch(writer, NetworkTime.localTime))

--- a/Assets/Mirror/Runtime/NetworkReaderPool.cs
+++ b/Assets/Mirror/Runtime/NetworkReaderPool.cs
@@ -3,11 +3,19 @@ using System.Runtime.CompilerServices;
 
 namespace Mirror
 {
-    /// <summary>Pooled NetworkReader, automatically returned to pool when using 'using'</summary>
-    public sealed class PooledNetworkReader : NetworkReader, IDisposable
+    [Obsolete("NetworkReaderPooled was renamed to NetworkReaderPooled. It's cleaner & slightly easier to use.")]
+    public sealed class PooledNetworkReader : NetworkReaderPooled
     {
         internal PooledNetworkReader(byte[] bytes) : base(bytes) {}
         internal PooledNetworkReader(ArraySegment<byte> segment) : base(segment) {}
+    }
+
+    /// <summary>Pooled NetworkReader, automatically returned to pool when using 'using'</summary>
+    // TODO make sealed again after removing obsolete NetworkWriterPooled!
+    public class NetworkReaderPooled : NetworkReader, IDisposable
+    {
+        internal NetworkReaderPooled(byte[] bytes) : base(bytes) {}
+        internal NetworkReaderPooled(ArraySegment<byte> segment) : base(segment) {}
         public void Dispose() => NetworkReaderPool.Return(this);
     }
 
@@ -17,48 +25,48 @@ namespace Mirror
         // reuse Pool<T>
         // we still wrap it in NetworkReaderPool.Get/Recyle so we can reset the
         // position and array before reusing.
-        static readonly Pool<PooledNetworkReader> Pool = new Pool<PooledNetworkReader>(
+        static readonly Pool<NetworkReaderPooled> Pool = new Pool<NetworkReaderPooled>(
             // byte[] will be assigned in GetReader
-            () => new PooledNetworkReader(new byte[]{}),
+            () => new NetworkReaderPooled(new byte[]{}),
             // initial capacity to avoid allocations in the first few frames
             1000
         );
 
         // DEPRECATED 2022-03-10
         [Obsolete("GetReader() was renamed to Take()")]
-        public static PooledNetworkReader GetReader(byte[] bytes) => Take(bytes);
+        public static NetworkReaderPooled GetReader(byte[] bytes) => Take(bytes);
 
         /// <summary>Get the next reader in the pool. If pool is empty, creates a new Reader</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkReader Take(byte[] bytes)
+        public static NetworkReaderPooled Take(byte[] bytes)
         {
             // grab from pool & set buffer
-            PooledNetworkReader reader = Pool.Take();
+            NetworkReaderPooled reader = Pool.Take();
             reader.SetBuffer(bytes);
             return reader;
         }
 
         // DEPRECATED 2022-03-10
         [Obsolete("GetReader() was renamed to Take()")]
-        public static PooledNetworkReader GetReader(ArraySegment<byte> segment) => Take(segment);
+        public static NetworkReaderPooled GetReader(ArraySegment<byte> segment) => Take(segment);
 
         /// <summary>Get the next reader in the pool. If pool is empty, creates a new Reader</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkReader Take(ArraySegment<byte> segment)
+        public static NetworkReaderPooled Take(ArraySegment<byte> segment)
         {
             // grab from pool & set buffer
-            PooledNetworkReader reader = Pool.Take();
+            NetworkReaderPooled reader = Pool.Take();
             reader.SetBuffer(segment);
             return reader;
         }
 
         // DEPRECATED 2022-03-10
         [Obsolete("Recycle() was renamed to Return()")]
-        public static void Recycle(PooledNetworkReader reader) => Return(reader);
+        public static void Recycle(NetworkReaderPooled reader) => Return(reader);
 
         /// <summary>Returns a reader to the pool.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Return(PooledNetworkReader reader)
+        public static void Return(NetworkReaderPooled reader)
         {
             Pool.Return(reader);
         }

--- a/Assets/Mirror/Runtime/NetworkReaderPool.cs
+++ b/Assets/Mirror/Runtime/NetworkReaderPool.cs
@@ -8,7 +8,7 @@ namespace Mirror
     {
         internal PooledNetworkReader(byte[] bytes) : base(bytes) {}
         internal PooledNetworkReader(ArraySegment<byte> segment) : base(segment) {}
-        public void Dispose() => NetworkReaderPool.Recycle(this);
+        public void Dispose() => NetworkReaderPool.Return(this);
     }
 
     /// <summary>Pool of NetworkReaders to avoid allocations.</summary>
@@ -24,9 +24,13 @@ namespace Mirror
             1000
         );
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("GetReader() was renamed to Take()")]
+        public static PooledNetworkReader GetReader(byte[] bytes) => Take(bytes);
+
         /// <summary>Get the next reader in the pool. If pool is empty, creates a new Reader</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkReader GetReader(byte[] bytes)
+        public static PooledNetworkReader Take(byte[] bytes)
         {
             // grab from pool & set buffer
             PooledNetworkReader reader = Pool.Take();
@@ -34,9 +38,13 @@ namespace Mirror
             return reader;
         }
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("GetReader() was renamed to Take()")]
+        public static PooledNetworkReader GetReader(ArraySegment<byte> segment) => Take(segment);
+
         /// <summary>Get the next reader in the pool. If pool is empty, creates a new Reader</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkReader GetReader(ArraySegment<byte> segment)
+        public static PooledNetworkReader Take(ArraySegment<byte> segment)
         {
             // grab from pool & set buffer
             PooledNetworkReader reader = Pool.Take();
@@ -44,9 +52,13 @@ namespace Mirror
             return reader;
         }
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("Recycle() was renamed to Return()")]
+        public static void Recycle(PooledNetworkReader reader) => Return(reader);
+
         /// <summary>Returns a reader to the pool.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Recycle(PooledNetworkReader reader)
+        public static void Return(PooledNetworkReader reader)
         {
             Pool.Return(reader);
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -282,7 +282,7 @@ namespace Mirror
             }
 
             // Debug.Log($"Server.SendToAll {typeof(T)}");
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // pack message only once
                 MessagePacking.Pack(message, writer);
@@ -328,7 +328,7 @@ namespace Mirror
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // pack message into byte[] once
                 MessagePacking.Pack(message, writer);
@@ -352,7 +352,7 @@ namespace Mirror
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 // pack message only once
                 MessagePacking.Pack(message, writer);
@@ -960,7 +960,7 @@ namespace Mirror
 
             // Debug.Log($"OnCommandMessage for netId:{msg.netId} conn:{conn}");
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(msg.payload))
                 identity.HandleRemoteCall(msg.componentIndex, msg.functionHash, RemoteCallType.Command, networkReader, conn as NetworkConnectionToClient);
         }
 
@@ -996,7 +996,7 @@ namespace Mirror
             //Debug.Log($"Server SendSpawnMessage: name:{identity.name} sceneId:{identity.sceneId:X} netid:{identity.netId}");
 
             // one writer for owner, one for observers
-            using (PooledNetworkWriter ownerWriter = NetworkWriterPool.GetWriter(), observersWriter = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter ownerWriter = NetworkWriterPool.Take(), observersWriter = NetworkWriterPool.Take())
             {
                 bool isOwner = identity.connectionToClient == conn;
                 ArraySegment<byte> payload = CreateSpawnMessagePayload(isOwner, identity, ownerWriter, observersWriter);

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -282,7 +282,7 @@ namespace Mirror
             }
 
             // Debug.Log($"Server.SendToAll {typeof(T)}");
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 // pack message only once
                 MessagePacking.Pack(message, writer);
@@ -328,7 +328,7 @@ namespace Mirror
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 // pack message into byte[] once
                 MessagePacking.Pack(message, writer);
@@ -352,7 +352,7 @@ namespace Mirror
             if (identity == null || identity.observers == null || identity.observers.Count == 0)
                 return;
 
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 // pack message only once
                 MessagePacking.Pack(message, writer);
@@ -960,12 +960,12 @@ namespace Mirror
 
             // Debug.Log($"OnCommandMessage for netId:{msg.netId} conn:{conn}");
 
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(msg.payload))
+            using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(msg.payload))
                 identity.HandleRemoteCall(msg.componentIndex, msg.functionHash, RemoteCallType.Command, networkReader, conn as NetworkConnectionToClient);
         }
 
         // spawning ////////////////////////////////////////////////////////////
-        static ArraySegment<byte> CreateSpawnMessagePayload(bool isOwner, NetworkIdentity identity, PooledNetworkWriter ownerWriter, PooledNetworkWriter observersWriter)
+        static ArraySegment<byte> CreateSpawnMessagePayload(bool isOwner, NetworkIdentity identity, NetworkWriterPooled ownerWriter, NetworkWriterPooled observersWriter)
         {
             // Only call OnSerializeAllSafely if there are NetworkBehaviours
             if (identity.NetworkBehaviours.Length == 0)
@@ -996,7 +996,7 @@ namespace Mirror
             //Debug.Log($"Server SendSpawnMessage: name:{identity.name} sceneId:{identity.sceneId:X} netid:{identity.netId}");
 
             // one writer for owner, one for observers
-            using (PooledNetworkWriter ownerWriter = NetworkWriterPool.Take(), observersWriter = NetworkWriterPool.Take())
+            using (NetworkWriterPooled ownerWriter = NetworkWriterPool.Take(), observersWriter = NetworkWriterPool.Take())
             {
                 bool isOwner = identity.connectionToClient == conn;
                 ArraySegment<byte> payload = CreateSpawnMessagePayload(isOwner, identity, ownerWriter, observersWriter);

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -3,8 +3,12 @@ using System.Runtime.CompilerServices;
 
 namespace Mirror
 {
+    [Obsolete("NetworkWriterPooled was renamed to NetworkWriterPooled. It's cleaner & slightly easier to use.")]
+    public sealed class PooledNetworkWriter : NetworkWriterPooled {}
+
     /// <summary>Pooled NetworkWriter, automatically returned to pool when using 'using'</summary>
-    public sealed class PooledNetworkWriter : NetworkWriter, IDisposable
+    // TODO make sealed again after removing obsolete NetworkWriterPooled!
+    public class NetworkWriterPooled : NetworkWriter, IDisposable
     {
         public void Dispose() => NetworkWriterPool.Return(this);
     }
@@ -17,8 +21,8 @@ namespace Mirror
         // position before reusing.
         // this is also more consistent with NetworkReaderPool where we need to
         // assign the internal buffer before reusing.
-        static readonly Pool<PooledNetworkWriter> Pool = new Pool<PooledNetworkWriter>(
-            () => new PooledNetworkWriter(),
+        static readonly Pool<NetworkWriterPooled> Pool = new Pool<NetworkWriterPooled>(
+            () => new NetworkWriterPooled(),
             // initial capacity to avoid allocations in the first few frames
             // 1000 * 1200 bytes = around 1 MB.
             1000
@@ -26,25 +30,25 @@ namespace Mirror
 
         // DEPRECATED 2022-03-10
         [Obsolete("GetWriter() was renamed to Take()")]
-        public static PooledNetworkWriter GetWriter() => Take();
+        public static NetworkWriterPooled GetWriter() => Take();
 
         /// <summary>Get a writer from the pool. Creates new one if pool is empty.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkWriter Take()
+        public static NetworkWriterPooled Take()
         {
             // grab from pool & reset position
-            PooledNetworkWriter writer = Pool.Take();
+            NetworkWriterPooled writer = Pool.Take();
             writer.Reset();
             return writer;
         }
 
         // DEPRECATED 2022-03-10
         [Obsolete("Recycle() was renamed to Return()")]
-        public static void Recycle(PooledNetworkWriter writer) => Return(writer);
+        public static void Recycle(NetworkWriterPooled writer) => Return(writer);
 
         /// <summary>Return a writer to the pool.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Return(PooledNetworkWriter writer)
+        public static void Return(NetworkWriterPooled writer)
         {
             Pool.Return(writer);
         }

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -6,7 +6,7 @@ namespace Mirror
     /// <summary>Pooled NetworkWriter, automatically returned to pool when using 'using'</summary>
     public sealed class PooledNetworkWriter : NetworkWriter, IDisposable
     {
-        public void Dispose() => NetworkWriterPool.Recycle(this);
+        public void Dispose() => NetworkWriterPool.Return(this);
     }
 
     /// <summary>Pool of NetworkWriters to avoid allocations.</summary>
@@ -24,9 +24,13 @@ namespace Mirror
             1000
         );
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("GetWriter() was renamed to Take()")]
+        public static PooledNetworkWriter GetWriter() => Take();
+
         /// <summary>Get a writer from the pool. Creates new one if pool is empty.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledNetworkWriter GetWriter()
+        public static PooledNetworkWriter Take()
         {
             // grab from pool & reset position
             PooledNetworkWriter writer = Pool.Take();
@@ -34,9 +38,13 @@ namespace Mirror
             return writer;
         }
 
+        // DEPRECATED 2022-03-10
+        [Obsolete("Recycle() was renamed to Return()")]
+        public static void Recycle(PooledNetworkWriter writer) => Return(writer);
+
         /// <summary>Return a writer to the pool.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Recycle(PooledNetworkWriter writer)
+        public static void Return(PooledNetworkWriter writer)
         {
             Pool.Return(writer);
         }

--- a/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
@@ -14,7 +14,7 @@ namespace Mirror.Tests
         public static byte[] PackToByteArray<T>(T message)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 MessagePacking.Pack(message, writer);
                 return writer.ToArray();
@@ -25,7 +25,7 @@ namespace Mirror.Tests
         public static T UnpackFromByteArray<T>(byte[] data)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(data))
+            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(data))
             {
                 int msgType = MessagePacking.GetId<T>();
 

--- a/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackingTest.cs
@@ -14,7 +14,7 @@ namespace Mirror.Tests
         public static byte[] PackToByteArray<T>(T message)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 MessagePacking.Pack(message, writer);
                 return writer.ToArray();
@@ -25,7 +25,7 @@ namespace Mirror.Tests
         public static T UnpackFromByteArray<T>(byte[] data)
             where T : struct, NetworkMessage
         {
-            using (PooledNetworkReader networkReader = NetworkReaderPool.Take(data))
+            using (NetworkReaderPooled networkReader = NetworkReaderPool.Take(data))
             {
                 int msgType = MessagePacking.GetId<T>();
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
@@ -125,11 +125,11 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
     {
         static void SyncNetworkBehaviour(NetworkBehaviour source, NetworkBehaviour target, bool initialState)
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 source.OnSerialize(writer, initialState);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.Take(writer.ToArraySegment()))
                 {
                     target.OnDeserialize(reader, initialState);
                 }

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
@@ -125,11 +125,11 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
     {
         static void SyncNetworkBehaviour(NetworkBehaviour source, NetworkBehaviour target, bool initialState)
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 source.OnSerialize(writer, initialState);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.Take(writer.ToArraySegment()))
+                using (NetworkReaderPooled reader = NetworkReaderPool.Take(writer.ToArraySegment()))
                 {
                     target.OnDeserialize(reader, initialState);
                 }

--- a/Assets/Mirror/Tests/Editor/NetworkReaderTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderTest.cs
@@ -66,7 +66,7 @@ namespace Mirror.Tests
             // should throw an exception
             byte[] bytes = { 0x00, 0x01 };
 
-            using (PooledNetworkReader reader = NetworkReaderPool.GetReader(bytes))
+            using (PooledNetworkReader reader = NetworkReaderPool.Take(bytes))
             {
                 try
                 {

--- a/Assets/Mirror/Tests/Editor/NetworkReaderTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderTest.cs
@@ -66,7 +66,7 @@ namespace Mirror.Tests
             // should throw an exception
             byte[] bytes = { 0x00, 0x01 };
 
-            using (PooledNetworkReader reader = NetworkReaderPool.Take(bytes))
+            using (NetworkReaderPooled reader = NetworkReaderPool.Take(bytes))
             {
                 try
                 {

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -420,11 +420,11 @@ namespace Mirror.Tests
     {
         public static uint GetChangeCount(this SyncObject syncObject)
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
             {
                 syncObject.OnSerializeDelta(writer);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.GetReader(writer.ToArraySegment()))
+                using (PooledNetworkReader reader = NetworkReaderPool.Take(writer.ToArraySegment()))
                 {
                     return reader.ReadUInt();
                 }

--- a/Assets/Mirror/Tests/Editor/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListTest.cs
@@ -420,11 +420,11 @@ namespace Mirror.Tests
     {
         public static uint GetChangeCount(this SyncObject syncObject)
         {
-            using (PooledNetworkWriter writer = NetworkWriterPool.Take())
+            using (NetworkWriterPooled writer = NetworkWriterPool.Take())
             {
                 syncObject.OnSerializeDelta(writer);
 
-                using (PooledNetworkReader reader = NetworkReaderPool.Take(writer.ToArraySegment()))
+                using (NetworkReaderPooled reader = NetworkReaderPool.Take(writer.ToArraySegment()))
                 {
                     return reader.ReadUInt();
                 }


### PR DESCRIPTION
ease of use improvement.
not very important, but still was a bit annoying to use every time previously.

merge #3112 first!