### PR TITLE
 fix: Byte format test uses current culture

### DIFF
--- a/Assets/Mirror/Tests/Editor/UtilsTests.cs
+++ b/Assets/Mirror/Tests/Editor/UtilsTests.cs
@@ -37,19 +37,19 @@ namespace Mirror.Tests
             Assert.That(Utils.PrettyBytes(1023), Is.EqualTo("1023 B"));
 
             // kilobytes
-            Assert.That(Utils.PrettyBytes(1024), Is.EqualTo("1.00 KB"));
-            Assert.That(Utils.PrettyBytes(1024 + 512), Is.EqualTo("1.50 KB"));
-            Assert.That(Utils.PrettyBytes(2048), Is.EqualTo("2.00 KB"));
+            Assert.That(Utils.PrettyBytes(1024), Is.EqualTo($"{1.0:F2} KB"));
+            Assert.That(Utils.PrettyBytes(1024 + 512), Is.EqualTo($"{1.5:F2} KB"));
+            Assert.That(Utils.PrettyBytes(2048), Is.EqualTo($"{2.0:F2} KB"));
 
             // megabytes
-            Assert.That(Utils.PrettyBytes(1024 * 1024), Is.EqualTo("1.00 MB"));
-            Assert.That(Utils.PrettyBytes(1024 * (1024 + 512)), Is.EqualTo("1.50 MB"));
-            Assert.That(Utils.PrettyBytes(1024 * 1024 * 2), Is.EqualTo("2.00 MB"));
+            Assert.That(Utils.PrettyBytes(1024 * 1024), Is.EqualTo($"{1.0:F2} MB"));
+            Assert.That(Utils.PrettyBytes(1024 * (1024 + 512)), Is.EqualTo($"{1.5:F2} MB"));
+            Assert.That(Utils.PrettyBytes(1024 * 1024 * 2), Is.EqualTo($"{2.0:F2} MB"));
 
             // gigabytes
-            Assert.That(Utils.PrettyBytes(1024L * 1024L * 1024L), Is.EqualTo("1.00 GB"));
-            Assert.That(Utils.PrettyBytes(1024L * 1024L * (1024L + 512L)), Is.EqualTo("1.50 GB"));
-            Assert.That(Utils.PrettyBytes(1024L * 1024L * 1024L * 2L), Is.EqualTo("2.00 GB"));
+            Assert.That(Utils.PrettyBytes(1024L * 1024L * 1024L), Is.EqualTo($"{1.0:F2} GB"));
+            Assert.That(Utils.PrettyBytes(1024L * 1024L * (1024L + 512L)), Is.EqualTo($"{1.5:F2} GB"));
+            Assert.That(Utils.PrettyBytes(1024L * 1024L * 1024L * 2L), Is.EqualTo($"{2.0:F2} GB"));
         }
     }
 }


### PR DESCRIPTION
Since some may use , instead of . as their decimal place seperator

```
PrettyBytes (0,002s)
---
String lengths are both 7. Strings differ at index 1.
  Expected: "1.00 KB"
  But was:  "1,00 KB"
  ------------^
---
at Mirror.Tests.UtilsTests.PrettyBytes () [0x0004e] in Mirror\Assets\Mirror\Tests\Editor\UtilsTests.cs:40
```