### PR TITLE
fix: #2060 serializing GameObjects / NetworkIdentities now throws an obvious exception for prefabs / unspawned objects

### DIFF
--- a/Assets/Mirror/Runtime/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterExtensions.cs
@@ -366,29 +366,15 @@ namespace Mirror
                 writer.WriteUInt(0);
                 return;
             }
-            NetworkIdentity identity = value.GetComponent<NetworkIdentity>();
-            if (identity != null)
-            {
-                // users might try to use unspawned / prefab GameObjects in
-                // rpcs/cmds/syncvars/messages. they would be null on the other
-                // end, and it might not be obvious why. let's make it obvious.
-                // https://github.com/vis2k/Mirror/issues/2060
-                //
-                // => exception because this is comparable to a compilation.
-                //    error. user should fix this asap to make sure the game
-                //    works as intended.
-                if (identity.netId == 0)
-                    throw new ArgumentException($"Attempted to serialize unspawned GameObject: {value.name}. Prefabs and unspawned GameObjects would always be null on the other side. Please spawn it before using it in [SyncVar]s/Rpcs/Cmds/NetworkMessages etc.");
 
-                // write netId in any case though. guarantee same amount of
-                // written & read data.
-                writer.WriteUInt(identity.netId);
-            }
-            else
-            {
+            // warn if the GameObject doesn't have a NetworkIdentity,
+            NetworkIdentity identity = value.GetComponent<NetworkIdentity>();
+            if (identity == null)
                 Debug.LogWarning($"NetworkWriter {value} has no NetworkIdentity");
-                writer.WriteUInt(0);
-            }
+
+            // serialize the correct amount of data in any case to make sure
+            // that the other end can read the expected amount of data too.
+            writer.WriteNetworkIdentity(identity);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Assets/Mirror/Runtime/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterExtensions.cs
@@ -317,11 +317,10 @@ namespace Mirror
             // end, and it might not be obvious why. let's make it obvious.
             // https://github.com/vis2k/Mirror/issues/2060
             //
-            // => exception because this is comparable to a compilation.
-            //    error. user should fix this asap to make sure the game
-            //    works as intended.
+            // => warning (instead of exception) because we also use a warning
+            //    if a GameObject doesn't have a NetworkIdentity component etc.
             if (value.netId == 0)
-                throw new ArgumentException($"Attempted to serialize unspawned GameObject: {value.name}. Prefabs and unspawned GameObjects would always be null on the other side. Please spawn it before using it in [SyncVar]s/Rpcs/Cmds/NetworkMessages etc.");
+                Debug.LogWarning($"Attempted to serialize unspawned GameObject: {value.name}. Prefabs and unspawned GameObjects would always be null on the other side. Please spawn it before using it in [SyncVar]s/Rpcs/Cmds/NetworkMessages etc.");
 
             writer.WriteUInt(value.netId);
         }

--- a/Assets/Mirror/Runtime/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterExtensions.cs
@@ -311,6 +311,18 @@ namespace Mirror
                 writer.WriteUInt(0);
                 return;
             }
+
+            // users might try to use unspawned / prefab GameObjects in
+            // rpcs/cmds/syncvars/messages. they would be null on the other
+            // end, and it might not be obvious why. let's make it obvious.
+            // https://github.com/vis2k/Mirror/issues/2060
+            //
+            // => exception because this is comparable to a compilation.
+            //    error. user should fix this asap to make sure the game
+            //    works as intended.
+            if (value.netId == 0)
+                throw new ArgumentException($"Attempted to serialize unspawned GameObject: {value.name}. Prefabs and unspawned GameObjects would always be null on the other side. Please spawn it before using it in [SyncVar]s/Rpcs/Cmds/NetworkMessages etc.");
+
             writer.WriteUInt(value.netId);
         }
 
@@ -357,6 +369,19 @@ namespace Mirror
             NetworkIdentity identity = value.GetComponent<NetworkIdentity>();
             if (identity != null)
             {
+                // users might try to use unspawned / prefab GameObjects in
+                // rpcs/cmds/syncvars/messages. they would be null on the other
+                // end, and it might not be obvious why. let's make it obvious.
+                // https://github.com/vis2k/Mirror/issues/2060
+                //
+                // => exception because this is comparable to a compilation.
+                //    error. user should fix this asap to make sure the game
+                //    works as intended.
+                if (identity.netId == 0)
+                    throw new ArgumentException($"Attempted to serialize unspawned GameObject: {value.name}. Prefabs and unspawned GameObjects would always be null on the other side. Please spawn it before using it in [SyncVar]s/Rpcs/Cmds/NetworkMessages etc.");
+
+                // write netId in any case though. guarantee same amount of
+                // written & read data.
                 writer.WriteUInt(identity.netId);
             }
             else

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1417,5 +1417,37 @@ namespace Mirror.Tests
             RpcNetworkIdentityBehaviour actual = reader.Read<RpcNetworkIdentityBehaviour>();
             Assert.That(actual, Is.EqualTo(behaviour), "Read should find the same behaviour as written");
         }
+
+        // test to make sure unspawned / prefab GameObjects can't be synced.
+        // they would be null on the other end, and it might not be obvious why.
+        // https://github.com/vis2k/Mirror/issues/2060
+        [Test]
+        public void TestWritingUnspawnedGameObject()
+        {
+            // create GO + NI, but unspawned
+            CreateNetworked(out GameObject go, out _);
+
+            // serializing in rpc/cmd/message should throw if unspawned.
+            NetworkWriter writer = new NetworkWriter();
+            Assert.Throws<ArgumentException>(() => {
+                writer.WriteGameObject(go);
+            });
+        }
+
+        // test to make sure unspawned / prefab GameObjects can't be synced.
+        // they would be null on the other end, and it might not be obvious why.
+        // https://github.com/vis2k/Mirror/issues/2060
+        [Test]
+        public void TestWritingUnspawnedNetworkIdentity()
+        {
+            // create GO + NI, but unspawned
+            CreateNetworked(out _, out NetworkIdentity identity);
+
+            // serializing in rpc/cmd/message should throw if unspawned.
+            NetworkWriter writer = new NetworkWriter();
+            Assert.Throws<ArgumentException>(() => {
+                writer.WriteNetworkIdentity(identity);
+            });
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using Mirror.Tests.RemoteAttrributeTest;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Mirror.Tests
 {
@@ -1427,11 +1429,10 @@ namespace Mirror.Tests
             // create GO + NI, but unspawned
             CreateNetworked(out GameObject go, out _);
 
-            // serializing in rpc/cmd/message should throw if unspawned.
+            // serializing in rpc/cmd/message should warn if unspawned.
+            LogAssert.Expect(LogType.Warning, new Regex("Attempted to serialize unspawned.*"));
             NetworkWriter writer = new NetworkWriter();
-            Assert.Throws<ArgumentException>(() => {
-                writer.WriteGameObject(go);
-            });
+            writer.WriteGameObject(go);
         }
 
         // test to make sure unspawned / prefab GameObjects can't be synced.
@@ -1443,11 +1444,10 @@ namespace Mirror.Tests
             // create GO + NI, but unspawned
             CreateNetworked(out _, out NetworkIdentity identity);
 
-            // serializing in rpc/cmd/message should throw if unspawned.
+            // serializing in rpc/cmd/message should warn if unspawned.
+            LogAssert.Expect(LogType.Warning, new Regex("Attempted to serialize unspawned.*"));
             NetworkWriter writer = new NetworkWriter();
-            Assert.Throws<ArgumentException>(() => {
-                writer.WriteNetworkIdentity(identity);
-            });
+            writer.WriteNetworkIdentity(identity);
         }
     }
 }


### PR DESCRIPTION
merge, don't squash.
also removes redundant code

NOTE this could be an exception or a warning. both works.
imho it's comparable to a compilation issue, hence the exception