### PR TITLE
fix: Weaved static constructors need to always run

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Helpers.cs
+++ b/Assets/Mirror/Editor/Weaver/Helpers.cs
@@ -2,6 +2,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Mono.CecilX;
+using Mono.CecilX.Rocks;
+using UnityEngine;
 
 namespace Mirror.Weaver
 {
@@ -21,6 +23,47 @@ namespace Mirror.Weaver
             return currentAssembly.MainModule.AssemblyReferences.Any(assemblyReference =>
                 assemblyReference.Name.StartsWith(nameof(UnityEditor))
             );
+        }
+
+        // helper function to add [RuntimeInitializeOnLoad] attribute to method
+        public static void AddRuntimeInitializeOnLoadAttribute(AssemblyDefinition assembly, WeaverTypes weaverTypes, MethodDefinition method)
+        {
+            // NOTE: previously we used reflection because according paul,
+            // 'weaving Mirror.dll caused unity to rebuild all dlls but in wrong
+            //  order, which breaks rewired'
+            // it's not obvious why importing an attribute via reflection instead
+            // of cecil would break anything. let's use cecil.
+
+            // to add a CustomAttribute, we need the attribute's constructor.
+            // in this case, there are two: empty, and RuntimeInitializeOnLoadType.
+            // we want the last one, with the type parameter.
+            MethodDefinition ctor = weaverTypes.runtimeInitializeOnLoadMethodAttribute.GetConstructors().Last();
+            //MethodDefinition ctor = weaverTypes.runtimeInitializeOnLoadMethodAttribute.GetConstructors().First();
+            // using ctor directly throws: ArgumentException: Member 'System.Void UnityEditor.InitializeOnLoadMethodAttribute::.ctor()' is declared in another module and needs to be imported
+            // we need to import it first.
+            CustomAttribute attribute = new CustomAttribute(assembly.MainModule.ImportReference(ctor));
+            // add the RuntimeInitializeLoadType.BeforeSceneLoad argument to ctor
+            attribute.ConstructorArguments.Add(new CustomAttributeArgument(weaverTypes.Import<RuntimeInitializeLoadType>(), RuntimeInitializeLoadType.BeforeSceneLoad));
+            method.CustomAttributes.Add(attribute);
+        }
+
+        // helper function to add [InitializeOnLoad] attribute to method
+        // (only works in Editor assemblies. check IsEditorAssembly first.)
+        public static void AddInitializeOnLoadAttribute(AssemblyDefinition assembly, WeaverTypes weaverTypes, MethodDefinition method)
+        {
+            // NOTE: previously we used reflection because according paul,
+            // 'weaving Mirror.dll caused unity to rebuild all dlls but in wrong
+            //  order, which breaks rewired'
+            // it's not obvious why importing an attribute via reflection instead
+            // of cecil would break anything. let's use cecil.
+
+            // to add a CustomAttribute, we need the attribute's constructor.
+            // in this case, there's only one - and it's an empty constructor.
+            MethodDefinition ctor = weaverTypes.initializeOnLoadMethodAttribute.GetConstructors().First();
+            // using ctor directly throws: ArgumentException: Member 'System.Void UnityEditor.InitializeOnLoadMethodAttribute::.ctor()' is declared in another module and needs to be imported
+            // we need to import it first.
+            CustomAttribute attribute = new CustomAttribute(assembly.MainModule.ImportReference(ctor));
+            method.CustomAttributes.Add(attribute);
         }
     }
 }

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Mono.CecilX;
 using Mono.CecilX.Cil;
+using UnityEngine;
 
 namespace Mirror.Weaver
 {
@@ -274,6 +275,32 @@ namespace Mirror.Weaver
                         MethodAttributes.RTSpecialName |
                         MethodAttributes.Static,
                         weaverTypes.Import(typeof(void)));
+            }
+
+            // Static constructors are lazily called when the class is first "used"
+            // https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/static-constructors
+            // > It is called automatically before the first instance is created or any static members are referenced.
+            //
+            // This means, in particular circumstances, client and server may diverge on which classes they have "loaded"
+            // and thus the rpc index will be desynced
+            //
+            // One such example would be on-demand-loading of prefabs via custom spawn handlers:
+            //   A game might not want to preload all its monster prefabs since there's quite many of them
+            //   and it is practically impossible to encounter them all (or even a majority of them) in a single play
+            //   session.
+            //   So a custom spawn handler is used to load the monster prefabs on demand.
+            //   All monsters would have the "Monster" NetworkBehaviour class, which would have a few RPCs on it.
+            //   Since the monster prefabs are loaded ONLY when needed via a custom spawn handler and the Monster class
+            //   itself isn't referenced or "loaded" by anything else other than the prefab, the monster classes static
+            //   constructor will not have been called when a client first joins a game, while it may have been called
+            //   on the server/host. This will in turn cause Rpc indexes to not match up between client/server
+            //
+            // By just forcing the static constructors to run via the [RuntimeInitializeOnLoadMethod] attribute
+            // this is not a problem anymore, since all static constructors are always run and all RPCs will
+            // always be registered by the time they are used
+            if (!cctor.HasCustomAttribute<RuntimeInitializeOnLoadMethodAttribute>())
+            {
+                Helpers.AddRuntimeInitializeOnLoadAttribute(assembly, weaverTypes, cctor);
             }
 
             ILProcessor cctorWorker = cctor.Body.GetILProcessor();

--- a/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ReaderWriterProcessor.cs
@@ -138,47 +138,6 @@ namespace Mirror.Weaver
             return modified;
         }
 
-        // helper function to add [RuntimeInitializeOnLoad] attribute to method
-        static void AddRuntimeInitializeOnLoadAttribute(AssemblyDefinition assembly, WeaverTypes weaverTypes, MethodDefinition method)
-        {
-            // NOTE: previously we used reflection because according paul,
-            // 'weaving Mirror.dll caused unity to rebuild all dlls but in wrong
-            //  order, which breaks rewired'
-            // it's not obvious why importing an attribute via reflection instead
-            // of cecil would break anything. let's use cecil.
-
-            // to add a CustomAttribute, we need the attribute's constructor.
-            // in this case, there are two: empty, and RuntimeInitializeOnLoadType.
-            // we want the last one, with the type parameter.
-            MethodDefinition ctor = weaverTypes.runtimeInitializeOnLoadMethodAttribute.GetConstructors().Last();
-            //MethodDefinition ctor = weaverTypes.runtimeInitializeOnLoadMethodAttribute.GetConstructors().First();
-            // using ctor directly throws: ArgumentException: Member 'System.Void UnityEditor.InitializeOnLoadMethodAttribute::.ctor()' is declared in another module and needs to be imported
-            // we need to import it first.
-            CustomAttribute attribute = new CustomAttribute(assembly.MainModule.ImportReference(ctor));
-            // add the RuntimeInitializeLoadType.BeforeSceneLoad argument to ctor
-            attribute.ConstructorArguments.Add(new CustomAttributeArgument(weaverTypes.Import<RuntimeInitializeLoadType>(), RuntimeInitializeLoadType.BeforeSceneLoad));
-            method.CustomAttributes.Add(attribute);
-        }
-
-        // helper function to add [InitializeOnLoad] attribute to method
-        // (only works in Editor assemblies. check IsEditorAssembly first.)
-        static void AddInitializeOnLoadAttribute(AssemblyDefinition assembly, WeaverTypes weaverTypes, MethodDefinition method)
-        {
-            // NOTE: previously we used reflection because according paul,
-            // 'weaving Mirror.dll caused unity to rebuild all dlls but in wrong
-            //  order, which breaks rewired'
-            // it's not obvious why importing an attribute via reflection instead
-            // of cecil would break anything. let's use cecil.
-
-            // to add a CustomAttribute, we need the attribute's constructor.
-            // in this case, there's only one - and it's an empty constructor.
-            MethodDefinition ctor = weaverTypes.initializeOnLoadMethodAttribute.GetConstructors().First();
-            // using ctor directly throws: ArgumentException: Member 'System.Void UnityEditor.InitializeOnLoadMethodAttribute::.ctor()' is declared in another module and needs to be imported
-            // we need to import it first.
-            CustomAttribute attribute = new CustomAttribute(assembly.MainModule.ImportReference(ctor));
-            method.CustomAttributes.Add(attribute);
-        }
-
         // adds Mirror.GeneratedNetworkCode.InitReadWriters() method that
         // registers all generated writers into Mirror.Writer<T> static class.
         // -> uses [RuntimeInitializeOnLoad] attribute so it's invoke at runtime
@@ -193,12 +152,12 @@ namespace Mirror.Weaver
                     weaverTypes.Import(typeof(void)));
 
             // add [RuntimeInitializeOnLoad] in any case
-            AddRuntimeInitializeOnLoadAttribute(currentAssembly, weaverTypes, initReadWriters);
+            Helpers.AddRuntimeInitializeOnLoadAttribute(currentAssembly, weaverTypes, initReadWriters);
 
             // add [InitializeOnLoad] if UnityEditor is referenced
             if (Helpers.IsEditorAssembly(currentAssembly))
             {
-                AddInitializeOnLoadAttribute(currentAssembly, weaverTypes, initReadWriters);
+                Helpers.AddInitializeOnLoadAttribute(currentAssembly, weaverTypes, initReadWriters);
             }
 
             // fill function body with reader/writer initializers


### PR DESCRIPTION
Static constructors are lazily called when the class is first "used"
https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/static-constructors
> It is called automatically before the first instance is created or any static members are referenced.

This means, in particular circumstances*, client and server may diverge on which classes they have "loaded"
and thus the rpc index will be desynced
* one such example would be on-demand-loading of prefabs via custom spawn handlers,
where a network behaviour on the prefab is never touched until the prefab is loaded

By just forcing the static constructors to run via the [RuntimeInitializeOnLoadMethod] attribute
this is not a problem anymore, since all static constructors are always run and all rpcs will always be registered