### PR TITLE
fix: #3138, 3135 revert Cmd/Rpc from 2 byte indices back to 4 byte function hashes for stability

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Helpers.cs
+++ b/Assets/Mirror/Editor/Weaver/Helpers.cs
@@ -2,8 +2,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Mono.CecilX;
-using Mono.CecilX.Rocks;
-using UnityEngine;
 
 namespace Mirror.Weaver
 {
@@ -23,47 +21,6 @@ namespace Mirror.Weaver
             return currentAssembly.MainModule.AssemblyReferences.Any(assemblyReference =>
                 assemblyReference.Name.StartsWith(nameof(UnityEditor))
             );
-        }
-
-        // helper function to add [RuntimeInitializeOnLoad] attribute to method
-        public static void AddRuntimeInitializeOnLoadAttribute(AssemblyDefinition assembly, WeaverTypes weaverTypes, MethodDefinition method)
-        {
-            // NOTE: previously we used reflection because according paul,
-            // 'weaving Mirror.dll caused unity to rebuild all dlls but in wrong
-            //  order, which breaks rewired'
-            // it's not obvious why importing an attribute via reflection instead
-            // of cecil would break anything. let's use cecil.
-
-            // to add a CustomAttribute, we need the attribute's constructor.
-            // in this case, there are two: empty, and RuntimeInitializeOnLoadType.
-            // we want the last one, with the type parameter.
-            MethodDefinition ctor = weaverTypes.runtimeInitializeOnLoadMethodAttribute.GetConstructors().Last();
-            //MethodDefinition ctor = weaverTypes.runtimeInitializeOnLoadMethodAttribute.GetConstructors().First();
-            // using ctor directly throws: ArgumentException: Member 'System.Void UnityEditor.InitializeOnLoadMethodAttribute::.ctor()' is declared in another module and needs to be imported
-            // we need to import it first.
-            CustomAttribute attribute = new CustomAttribute(assembly.MainModule.ImportReference(ctor));
-            // add the RuntimeInitializeLoadType.BeforeSceneLoad argument to ctor
-            attribute.ConstructorArguments.Add(new CustomAttributeArgument(weaverTypes.Import<RuntimeInitializeLoadType>(), RuntimeInitializeLoadType.BeforeSceneLoad));
-            method.CustomAttributes.Add(attribute);
-        }
-
-        // helper function to add [InitializeOnLoad] attribute to method
-        // (only works in Editor assemblies. check IsEditorAssembly first.)
-        public static void AddInitializeOnLoadAttribute(AssemblyDefinition assembly, WeaverTypes weaverTypes, MethodDefinition method)
-        {
-            // NOTE: previously we used reflection because according paul,
-            // 'weaving Mirror.dll caused unity to rebuild all dlls but in wrong
-            //  order, which breaks rewired'
-            // it's not obvious why importing an attribute via reflection instead
-            // of cecil would break anything. let's use cecil.
-
-            // to add a CustomAttribute, we need the attribute's constructor.
-            // in this case, there's only one - and it's an empty constructor.
-            MethodDefinition ctor = weaverTypes.initializeOnLoadMethodAttribute.GetConstructors().First();
-            // using ctor directly throws: ArgumentException: Member 'System.Void UnityEditor.InitializeOnLoadMethodAttribute::.ctor()' is declared in another module and needs to be imported
-            // we need to import it first.
-            CustomAttribute attribute = new CustomAttribute(assembly.MainModule.ImportReference(ctor));
-            method.CustomAttributes.Add(attribute);
         }
     }
 }

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -28,9 +28,7 @@ namespace Mirror
     {
         public uint netId;
         public byte componentIndex;
-        // NOTE: this could be 1 byte most of the time via VarInt!
-        //       but requires custom serialization for Command/RpcMessages.
-        public ushort functionIndex;
+        public int functionHash;
         // the parameters for the Cmd function
         // -> ArraySegment to avoid unnecessary allocations
         public ArraySegment<byte> payload;
@@ -40,9 +38,7 @@ namespace Mirror
     {
         public uint netId;
         public byte componentIndex;
-        // NOTE: this could be 1 byte most of the time via VarInt!
-        //       but requires custom serialization for Command/RpcMessages.
-        public ushort functionIndex;
+        public int functionHash;
         // the parameters for the Cmd function
         // -> ArraySegment to avoid unnecessary allocations
         public ArraySegment<byte> payload;

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using UnityEngine;
-using Mirror.RemoteCalls;
 
 namespace Mirror
 {
@@ -235,7 +234,8 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = (byte)ComponentIndex,
-                functionIndex = RemoteProcedureCalls.GetIndexFromFunctionHash(functionFullName),
+                // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = functionFullName.GetStableHashCode(),
                 // segment to avoid reader allocations
                 payload = writer.ToArraySegment()
             };
@@ -270,7 +270,8 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = (byte)ComponentIndex,
-                functionIndex = RemoteProcedureCalls.GetIndexFromFunctionHash(functionFullName),
+                // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = functionFullName.GetStableHashCode(),
                 // segment to avoid reader allocations
                 payload = writer.ToArraySegment()
             };
@@ -317,7 +318,8 @@ namespace Mirror
             {
                 netId = netId,
                 componentIndex = (byte)ComponentIndex,
-                functionIndex = RemoteProcedureCalls.GetIndexFromFunctionHash(functionFullName),
+                // type+func so Inventory.RpcUse != Equipment.RpcUse
+                functionHash = functionFullName.GetStableHashCode(),
                 // segment to avoid reader allocations
                 payload = writer.ToArraySegment()
             };

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1276,7 +1276,7 @@ namespace Mirror
             if (spawned.TryGetValue(message.netId, out NetworkIdentity identity))
             {
                 using (NetworkReaderPooled networkReader = NetworkReaderPool.Get(message.payload))
-                    identity.HandleRemoteCall(message.componentIndex, message.functionIndex, RemoteCallType.ClientRpc, networkReader);
+                    identity.HandleRemoteCall(message.componentIndex, message.functionHash, RemoteCallType.ClientRpc, networkReader);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1071,12 +1071,12 @@ namespace Mirror
         }
 
         // Helper function to handle Command/Rpc
-        internal void HandleRemoteCall(byte componentIndex, ushort functionIndex, RemoteCallType remoteCallType, NetworkReader reader, NetworkConnectionToClient senderConnection = null)
+        internal void HandleRemoteCall(byte componentIndex, int functionHash, RemoteCallType remoteCallType, NetworkReader reader, NetworkConnectionToClient senderConnection = null)
         {
             // check if unity object has been destroyed
             if (this == null)
             {
-                Debug.LogWarning($"{remoteCallType} [{functionIndex}] received for deleted object [netId={netId}]");
+                Debug.LogWarning($"{remoteCallType} [{functionHash}] received for deleted object [netId={netId}]");
                 return;
             }
 
@@ -1088,9 +1088,9 @@ namespace Mirror
             }
 
             NetworkBehaviour invokeComponent = NetworkBehaviours[componentIndex];
-            if (!RemoteProcedureCalls.Invoke(functionIndex, remoteCallType, reader, invokeComponent, senderConnection))
+            if (!RemoteProcedureCalls.Invoke(functionHash, remoteCallType, reader, invokeComponent, senderConnection))
             {
-                Debug.LogError($"Found no receiver for incoming {remoteCallType} [{functionIndex}] on {gameObject.name}, the server and client should have the same NetworkBehaviour instances [netId={netId}].");
+                Debug.LogError($"Found no receiver for incoming {remoteCallType} [{functionHash}] on {gameObject.name}, the server and client should have the same NetworkBehaviour instances [netId={netId}].");
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -966,7 +966,7 @@ namespace Mirror
             // Commands can be for player objects, OR other objects with client-authority
             // -> so if this connection's controller has a different netId then
             //    only allow the command if clientAuthorityOwner
-            bool requiresAuthority = RemoteProcedureCalls.CommandRequiresAuthority(msg.functionIndex);
+            bool requiresAuthority = RemoteProcedureCalls.CommandRequiresAuthority(msg.functionHash);
             if (requiresAuthority && identity.connectionToClient != conn)
             {
                 Debug.LogWarning($"Command for object without authority [netId={msg.netId}]");
@@ -976,7 +976,7 @@ namespace Mirror
             // Debug.Log($"OnCommandMessage for netId:{msg.netId} conn:{conn}");
 
             using (NetworkReaderPooled networkReader = NetworkReaderPool.Get(msg.payload))
-                identity.HandleRemoteCall(msg.componentIndex, msg.functionIndex, RemoteCallType.Command, networkReader, conn as NetworkConnectionToClient);
+                identity.HandleRemoteCall(msg.componentIndex, msg.functionHash, RemoteCallType.Command, networkReader, conn as NetworkConnectionToClient);
         }
 
         // spawning ////////////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/RemoteCalls.cs
+++ b/Assets/Mirror/Runtime/RemoteCalls.cs
@@ -34,6 +34,14 @@ namespace Mirror.RemoteCalls
         // one lookup for all remote calls.
         // allows us to easily add more remote call types without duplicating code.
         // note: do not clear those with [RuntimeInitializeOnLoad]
+        //
+        // IMPORTANT: cmd/rpc functions are identified via **HASHES**.
+        //   an index would requires half the bandwidth, but introduces issues
+        //   where static constructors are lazily called, so index order isn't
+        //   guaranteed:
+        //     https://github.com/vis2k/Mirror/pull/3135
+        //     https://github.com/vis2k/Mirror/issues/3138
+        //   keep the 4 byte hash for stability!
         static readonly Dictionary<int, Invoker> remoteCallDelegates = new Dictionary<int, Invoker>();
 
         static bool CheckIfDelegateExists(Type componentType, RemoteCallType remoteCallType, RemoteCallDelegate func, int functionHash)

--- a/Assets/Mirror/Runtime/RemoteCalls.cs
+++ b/Assets/Mirror/Runtime/RemoteCalls.cs
@@ -31,45 +31,10 @@ namespace Mirror.RemoteCalls
     /// <summary>Used to help manage remote calls for NetworkBehaviours</summary>
     public static class RemoteProcedureCalls
     {
-        // sending rpc/cmd function hash would require 4 bytes each time.
-        // instead, let's only send the index to save bandwidth.
-        // => 1 byte index with 255 rpcs in total would not be enough.
-        // => 1 byte index with 255 rpcs per type is doable but lookup is hard,
-        //    because an rpc might be in the actual type or in the base type etc
-        // => 2 byte index allows for 64k Rpcs and is very easy to implement
-        //    with a SortedList + .IndexOfKey.
-        //
-        // NOTE: this could be 1 byte most of the time via VarInt!
-        //       but requires custom serialization for Command/RpcMessages.
-        //
-        // SortedList still doesn't allow duplicate keys, which is good.
-        // But it allows accessing keys by index.
-        static readonly SortedList<int, Invoker> remoteCallDelegates = new SortedList<int, Invoker>();
-
-        // hash -> index reverse lookup to cache .IndexOfKey() binary search.
-        static readonly Dictionary<int, ushort> remoteCallIndexLookup = new Dictionary<int, ushort>();
-
-        // helper function to get rpc/cmd index from function name / hash.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ushort GetIndexFromFunctionHash(string functionFullName)
-        {
-            int hash = functionFullName.GetStableHashCode();
-
-            // IndexOfKey runs a binary search.
-            // cache results in lookup.
-            // IMPORTANT: can't cache results when registering rpcs/cmds as the
-            //            indices would only be valid after ALL were registered.
-            // return (ushort)remoteCallDelegates.IndexOfKey(hash);
-
-            // reuse cached index if possible
-            if (remoteCallIndexLookup.TryGetValue(hash, out ushort index))
-                return index;
-
-            // otherwise search and cache
-            ushort searchedIndex = (ushort)remoteCallDelegates.IndexOfKey(hash);
-            remoteCallIndexLookup[hash] = searchedIndex;
-            return searchedIndex;
-        }
+        // one lookup for all remote calls.
+        // allows us to easily add more remote call types without duplicating code.
+        // note: do not clear those with [RuntimeInitializeOnLoad]
+        static readonly Dictionary<int, Invoker> remoteCallDelegates = new Dictionary<int, Invoker>();
 
         static bool CheckIfDelegateExists(Type componentType, RemoteCallType remoteCallType, RemoteCallDelegate func, int functionHash)
         {
@@ -100,7 +65,6 @@ namespace Mirror.RemoteCalls
             if (CheckIfDelegateExists(componentType, remoteCallType, func, hash))
                 return hash;
 
-            // register invoker by hash
             remoteCallDelegates[hash] = new Invoker
             {
                 callType = remoteCallType,
@@ -130,30 +94,18 @@ namespace Mirror.RemoteCalls
         // note: no need to throw an error if not found.
         // an attacker might just try to call a cmd with an rpc's hash etc.
         // returning false is enough.
-        static bool GetInvoker(ushort functionIndex, RemoteCallType remoteCallType, out Invoker invoker)
-        {
-            // valid index?
-            if (functionIndex <= remoteCallDelegates.Count)
-            {
-                // get key by index
-                int functionHash = remoteCallDelegates.Keys[functionIndex];
-                invoker = remoteCallDelegates[functionHash];
-                // check rpc type. don't allow calling cmds from rpcs, etc.
-                return invoker != null &&
-                       invoker.callType == remoteCallType;
-            }
-            invoker = null;
-            return false;
-        }
+        static bool GetInvokerForHash(int functionHash, RemoteCallType remoteCallType, out Invoker invoker) =>
+            remoteCallDelegates.TryGetValue(functionHash, out invoker) &&
+            invoker != null &&
+            invoker.callType == remoteCallType;
 
         // InvokeCmd/Rpc Delegate can all use the same function here
-        // => invoke by index to save bandwidth (2 bytes instead of 4 bytes)
-        internal static bool Invoke(ushort functionIndex, RemoteCallType remoteCallType, NetworkReader reader, NetworkBehaviour component, NetworkConnectionToClient senderConnection = null)
+        internal static bool Invoke(int functionHash, RemoteCallType remoteCallType, NetworkReader reader, NetworkBehaviour component, NetworkConnectionToClient senderConnection = null)
         {
             // IMPORTANT: we check if the message's componentIndex component is
             //            actually of the right type. prevents attackers trying
             //            to invoke remote calls on wrong components.
-            if (GetInvoker(functionIndex, remoteCallType, out Invoker invoker) &&
+            if (GetInvokerForHash(functionHash, remoteCallType, out Invoker invoker) &&
                 invoker.componentType.IsInstanceOfType(component))
             {
                 // invoke function on this component
@@ -164,8 +116,8 @@ namespace Mirror.RemoteCalls
         }
 
         // check if the command 'requiresAuthority' which is set in the attribute
-        internal static bool CommandRequiresAuthority(ushort cmdIndex) =>
-            GetInvoker(cmdIndex, RemoteCallType.Command, out Invoker invoker) &&
+        internal static bool CommandRequiresAuthority(int cmdHash) =>
+            GetInvokerForHash(cmdHash, RemoteCallType.Command, out Invoker invoker) &&
             invoker.cmdRequiresAuthority;
 
         /// <summary>Gets the handler function by hash. Useful for profilers and debuggers.</summary>
@@ -173,14 +125,6 @@ namespace Mirror.RemoteCalls
             remoteCallDelegates.TryGetValue(functionHash, out Invoker invoker)
             ? invoker.function
             : null;
-
-        // RuntimeInitializeOnLoadMethod -> fast playmode without domain reload
-        [RuntimeInitializeOnLoadMethod]
-        internal static void ResetStatics()
-        {
-            // clear rpc lookup every time.
-            // otherwise tests may have issues.
-            remoteCallIndexLookup.Clear();
-        }
     }
 }
+

--- a/Assets/Mirror/Tests/Common/MirrorTest.cs
+++ b/Assets/Mirror/Tests/Common/MirrorTest.cs
@@ -1,7 +1,6 @@
 // base class for networking tests to make things easier.
 using System.Collections.Generic;
 using System.Linq;
-using Mirror.RemoteCalls;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -49,10 +48,6 @@ namespace Mirror.Tests
             GameObject.DestroyImmediate(transport.gameObject);
             Transport.activeTransport = null;
             NetworkManager.singleton = null;
-
-            // clear rpc lookup caches.
-            // this can cause problems in tests otherwise.
-            RemoteProcedureCalls.ResetStatics();
         }
 
         // create a tracked GameObject for tests without Networkidentity


### PR DESCRIPTION
Fixes #3138 