### PR TITLE
breaking: NetworkServer/NetworkClient/NetworkManager OnTransportError changed from Exception to string to avoid users panicking. otherwise every kcp OnError message would be shown as a scary exception.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -71,7 +71,7 @@ namespace Mirror
         // => public so that custom NetworkManagers can hook into it
         public static Action OnConnectedEvent;
         public static Action OnDisconnectedEvent;
-        public static Action<Exception> OnErrorEvent;
+        public static Action<string> OnErrorEvent;
 
         /// <summary>Registered spawnable prefabs by assetId.</summary>
         public static readonly Dictionary<Guid, GameObject> prefabs =
@@ -433,12 +433,12 @@ namespace Mirror
         }
 
         // transport errors are forwarded to high level
-        static void OnTransportError(Exception exception)
+        static void OnTransportError(string error)
         {
             // transport errors will happen. logging a warning is enough.
             // make sure the user does not panic.
-            Debug.LogWarning($"Client Transport Error: {exception}. This is fine.");
-            OnErrorEvent?.Invoke(exception);
+            Debug.LogWarning($"Client Transport Error: {error}. This is fine.");
+            OnErrorEvent?.Invoke(error);
         }
 
         // send ////////////////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1244,7 +1244,7 @@ namespace Mirror
         }
 
         /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
-        public virtual void OnServerError(NetworkConnectionToClient conn, Exception exception) {}
+        public virtual void OnServerError(NetworkConnectionToClient conn, string error) {}
 
         /// <summary>Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed</summary>
         public virtual void OnServerChangeScene(string newSceneName) {}
@@ -1280,7 +1280,7 @@ namespace Mirror
         }
 
         /// <summary>Called on client when transport raises an exception.</summary>
-        public virtual void OnClientError(Exception exception) {}
+        public virtual void OnClientError(string error) {}
 
         /// <summary>Called on clients when a servers tells the client it is no longer ready, e.g. when switching scenes.</summary>
         public virtual void OnClientNotReady() {}

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -52,7 +52,7 @@ namespace Mirror
         // => public so that custom NetworkManagers can hook into it
         public static Action<NetworkConnectionToClient> OnConnectedEvent;
         public static Action<NetworkConnectionToClient> OnDisconnectedEvent;
-        public static Action<NetworkConnectionToClient, Exception> OnErrorEvent;
+        public static Action<NetworkConnectionToClient, string> OnErrorEvent;
 
         // initialization / shutdown ///////////////////////////////////////////
         static void Initialize()
@@ -591,14 +591,14 @@ namespace Mirror
         }
 
         // transport errors are forwarded to high level
-        static void OnTransportError(int connectionId, Exception exception)
+        static void OnTransportError(int connectionId, string error)
         {
             // transport errors will happen. logging a warning is enough.
             // make sure the user does not panic.
-            Debug.LogWarning($"Server Transport Error for connId={connectionId}: {exception}. This is fine.");
+            Debug.LogWarning($"Server Transport Error for connId={connectionId}: {error}. This is fine.");
             // try get connection. passes null otherwise.
             connections.TryGetValue(connectionId, out NetworkConnectionToClient conn);
-            OnErrorEvent?.Invoke(conn, exception);
+            OnErrorEvent?.Invoke(conn, error);
         }
 
         // message handlers ////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport.cs
@@ -50,7 +50,8 @@ namespace Mirror
         public Action<ArraySegment<byte>, int> OnClientDataSent;
 
         /// <summary>Called by Transport when the client encountered an error.</summary>
-        public Action<Exception> OnClientError;
+        // (string instead of Exception for ease of use and to avoid user panic)
+        public Action<string> OnClientError;
 
         /// <summary>Called by Transport when the client disconnected from the server.</summary>
         public Action OnClientDisconnected;
@@ -95,7 +96,8 @@ namespace Mirror
 
         /// <summary>Called by Transport when a server's connection encountered a problem.</summary>
         /// If a Disconnect will also be raised, raise the Error first.
-        public Action<int, Exception> OnServerError;
+        // (string instead of Exception for ease of use and to avoid user panic)
+        public Action<int, string> OnServerError;
 
         /// <summary>Called by Transport when a client disconnected from the server.</summary>
         public Action<int> OnServerDisconnected;

--- a/Assets/Mirror/Runtime/Transports/KCP/MirrorTransport/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transports/KCP/MirrorTransport/KcpTransport.cs
@@ -91,12 +91,12 @@ namespace kcp2k
                       () => OnClientConnected.Invoke(),
                       (message, channel) => OnClientDataReceived.Invoke(message, FromKcpChannel(channel)),
                       () => OnClientDisconnected.Invoke(),
-                      (error) => OnClientError.Invoke(new Exception(error)))
+                      (error) => OnClientError.Invoke(error))
                 : new KcpClient(
                       () => OnClientConnected.Invoke(),
                       (message, channel) => OnClientDataReceived.Invoke(message, FromKcpChannel(channel)),
                       () => OnClientDisconnected.Invoke(),
-                      (error) => OnClientError.Invoke(new Exception(error)));
+                      (error) => OnClientError.Invoke(error));
 
             // server
             server = NonAlloc
@@ -104,7 +104,7 @@ namespace kcp2k
                       (connectionId) => OnServerConnected.Invoke(connectionId),
                       (connectionId, message, channel) => OnServerDataReceived.Invoke(connectionId, message, FromKcpChannel(channel)),
                       (connectionId) => OnServerDisconnected.Invoke(connectionId),
-                      (connectionId, error) => OnServerError.Invoke(connectionId, new Exception(error)),
+                      (connectionId, error) => OnServerError.Invoke(connectionId, error),
                       DualMode,
                       NoDelay,
                       Interval,
@@ -119,7 +119,7 @@ namespace kcp2k
                       (connectionId) => OnServerConnected.Invoke(connectionId),
                       (connectionId, message, channel) => OnServerDataReceived.Invoke(connectionId, message, FromKcpChannel(channel)),
                       (connectionId) => OnServerDisconnected.Invoke(connectionId),
-                      (connectionId, error) => OnServerError.Invoke(connectionId, new Exception(error)),
+                      (connectionId, error) => OnServerError.Invoke(connectionId, error),
                       DualMode,
                       NoDelay,
                       Interval,

--- a/Assets/Mirror/Runtime/Transports/SimpleWebTransport/SimpleWebTransport.cs
+++ b/Assets/Mirror/Runtime/Transports/SimpleWebTransport/SimpleWebTransport.cs
@@ -147,7 +147,7 @@ namespace Mirror.SimpleWeb
             client.onData += (ArraySegment<byte> data) => OnClientDataReceived.Invoke(data, Channels.Reliable);
             client.onError += (Exception e) =>
             {
-                OnClientError.Invoke(e);
+                OnClientError.Invoke(e.ToString());
                 ClientDisconnect();
             };
 
@@ -212,7 +212,7 @@ namespace Mirror.SimpleWeb
             server.onConnect += OnServerConnected.Invoke;
             server.onDisconnect += OnServerDisconnected.Invoke;
             server.onData += (int connId, ArraySegment<byte> data) => OnServerDataReceived.Invoke(connId, data, Channels.Reliable);
-            server.onError += OnServerError.Invoke;
+            server.onError += (connId, ex) => OnServerError.Invoke(connId, ex.ToString());
 
             SendLoopConfig.batchSend = batchSend || waitBeforeSend;
             SendLoopConfig.sleepBeforeSend = waitBeforeSend;

--- a/Assets/Mirror/Tests/Editor/MiddlewareTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/MiddlewareTransportTest.cs
@@ -256,23 +256,21 @@ namespace Mirror.Tests
         [Test]
         public void TestClientErrorCallback()
         {
-            Exception exception = new InvalidDataException();
+            string error = "Test Error";
 
             int called = 0;
             middleware.OnClientError = (e) =>
             {
                 called++;
-                Assert.That(e, Is.EqualTo(exception));
+                Assert.That(e, Is.EqualTo(error));
             };
             // connect to give callback to inner
             middleware.ClientConnect("localhost");
 
-            inner.OnClientError.Invoke(exception);
+            inner.OnClientError.Invoke(error);
             Assert.That(called, Is.EqualTo(1));
 
-            exception = new NullReferenceException();
-
-            inner.OnClientError.Invoke(exception);
+            inner.OnClientError.Invoke(error);
             Assert.That(called, Is.EqualTo(2));
         }
 
@@ -362,24 +360,22 @@ namespace Mirror.Tests
         [TestCase(19)]
         public void TestServerErrorCallback(int id)
         {
-            Exception exception = new InvalidDataException();
+            string error = "Test Error";
 
             int called = 0;
             middleware.OnServerError = (i, e) =>
             {
                 called++;
                 Assert.That(i, Is.EqualTo(id));
-                Assert.That(e, Is.EqualTo(exception));
+                Assert.That(e, Is.EqualTo(error));
             };
             // start to give callback to inner
             middleware.ServerStart();
 
-            inner.OnServerError.Invoke(id, exception);
+            inner.OnServerError.Invoke(id, error);
             Assert.That(called, Is.EqualTo(1));
 
-            exception = new NullReferenceException();
-
-            inner.OnServerError.Invoke(id, exception);
+            inner.OnServerError.Invoke(id, error);
             Assert.That(called, Is.EqualTo(2));
         }
     }


### PR DESCRIPTION
before:
<img width="719" alt="2022-05-08 - 11-00-29@2x" src="https://user-images.githubusercontent.com/16416509/167281190-62cabbe3-c05d-47cd-bede-c3d685fbe4d4.png">

after:
<img width="737" alt="2022-05-08 - 11-02-55@2x" src="https://user-images.githubusercontent.com/16416509/167281220-1733f151-bbe0-42b1-a749-ba69ab912f27.png">

