### PR TITLE
fix: NetworkClient - Check for duplicate sceneId

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1175,7 +1175,9 @@ namespace Mirror
                         Debug.LogWarning(msg, identity.gameObject);
                     }
                     else
+                    {
                         spawnableObjects.Add(identity.sceneId, identity);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This also prevents the stopper error below from being raised by the Add failing:
```cs
Disconnecting connId=0 to prevent exploits from an Exception in MessageHandler: ArgumentException An item with the same key has already been added. Key: 11401015102050507569
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) [0x000dd] in <6073cf49ed704e958b8a66d540dea948>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) [0x00000] in <6073cf49ed704e958b8a66d540dea948>:0 
  at Mirror.NetworkClient.PrepareToSpawnSceneObjects () [0x00020] in F:\Unity3D Projects\ProjectCamino_v2_clone_0\Assets\Mirror\Runtime\NetworkClient.cs:1167 
  at Mirror.NetworkClient.OnObjectSpawnStarted (Mirror.ObjectSpawnStartedMessage _) [0x00000] in F:\Unity3D Projects\ProjectCamino_v2_clone_0\Assets\Mirror\Runtime\NetworkClient.cs:1175 
```