### PR TITLE
breaking: OnError(Exception) changed to OnError(enum, reason)

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -71,7 +71,7 @@ namespace Mirror
         // => public so that custom NetworkManagers can hook into it
         public static Action OnConnectedEvent;
         public static Action OnDisconnectedEvent;
-        public static Action<Exception> OnErrorEvent;
+        public static Action<TransportError, string> OnErrorEvent;
 
         /// <summary>Registered spawnable prefabs by assetId.</summary>
         public static readonly Dictionary<Guid, GameObject> prefabs =
@@ -433,12 +433,12 @@ namespace Mirror
         }
 
         // transport errors are forwarded to high level
-        static void OnTransportError(Exception exception)
+        static void OnTransportError(TransportError error, string reason)
         {
             // transport errors will happen. logging a warning is enough.
             // make sure the user does not panic.
-            Debug.LogWarning($"Client Transport Error: {exception}. This is fine.");
-            OnErrorEvent?.Invoke(exception);
+            Debug.LogWarning($"Client Transport Error: {error}: {reason}. This is fine.");
+            OnErrorEvent?.Invoke(error, reason);
         }
 
         // send ////////////////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1243,8 +1243,16 @@ namespace Mirror
             NetworkServer.AddPlayerForConnection(conn, player);
         }
 
+        // DEPRECATED 2022-05-12
+        [Obsolete("OnServerError(conn, Exception) was changed to OnServerError(conn, TransportError, string)")]
+        public virtual void OnServerError(NetworkConnectionToClient conn, Exception exception) {}
         /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
-        public virtual void OnServerError(NetworkConnectionToClient conn, TransportError error, string reason) {}
+        public virtual void OnServerError(NetworkConnectionToClient conn, TransportError error, string reason)
+        {
+#pragma warning disable CS0618
+            OnServerError(conn, new Exception(reason));
+#pragma warning restore CS0618
+        }
 
         /// <summary>Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed</summary>
         public virtual void OnServerChangeScene(string newSceneName) {}
@@ -1279,8 +1287,16 @@ namespace Mirror
             StopClient();
         }
 
+        // DEPRECATED 2022-05-12
+        [Obsolete("OnClientError(Exception) was changed to OnClientError(TransportError, string)")]
+        public virtual void OnClientError(Exception exception) {}
         /// <summary>Called on client when transport raises an exception.</summary>
-        public virtual void OnClientError(TransportError error, string reason) {}
+        public virtual void OnClientError(TransportError error, string reason)
+        {
+#pragma warning disable CS0618
+            OnClientError(new Exception(reason));
+#pragma warning restore CS0618
+        }
 
         /// <summary>Called on clients when a servers tells the client it is no longer ready, e.g. when switching scenes.</summary>
         public virtual void OnClientNotReady() {}

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1244,7 +1244,7 @@ namespace Mirror
         }
 
         /// <summary>Called on server when transport raises an exception. NetworkConnection may be null.</summary>
-        public virtual void OnServerError(NetworkConnectionToClient conn, Exception exception) {}
+        public virtual void OnServerError(NetworkConnectionToClient conn, TransportError error, string reason) {}
 
         /// <summary>Called from ServerChangeScene immediately before SceneManager.LoadSceneAsync is executed</summary>
         public virtual void OnServerChangeScene(string newSceneName) {}
@@ -1280,7 +1280,7 @@ namespace Mirror
         }
 
         /// <summary>Called on client when transport raises an exception.</summary>
-        public virtual void OnClientError(Exception exception) {}
+        public virtual void OnClientError(TransportError error, string reason) {}
 
         /// <summary>Called on clients when a servers tells the client it is no longer ready, e.g. when switching scenes.</summary>
         public virtual void OnClientNotReady() {}

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -52,7 +52,7 @@ namespace Mirror
         // => public so that custom NetworkManagers can hook into it
         public static Action<NetworkConnectionToClient> OnConnectedEvent;
         public static Action<NetworkConnectionToClient> OnDisconnectedEvent;
-        public static Action<NetworkConnectionToClient, Exception> OnErrorEvent;
+        public static Action<NetworkConnectionToClient, TransportError, string> OnErrorEvent;
 
         // initialization / shutdown ///////////////////////////////////////////
         static void Initialize()
@@ -591,14 +591,14 @@ namespace Mirror
         }
 
         // transport errors are forwarded to high level
-        static void OnTransportError(int connectionId, Exception exception)
+        static void OnTransportError(int connectionId, TransportError error, string reason)
         {
             // transport errors will happen. logging a warning is enough.
             // make sure the user does not panic.
-            Debug.LogWarning($"Server Transport Error for connId={connectionId}: {exception}. This is fine.");
+            Debug.LogWarning($"Server Transport Error for connId={connectionId}: {error}: {reason}. This is fine.");
             // try get connection. passes null otherwise.
             connections.TryGetValue(connectionId, out NetworkConnectionToClient conn);
-            OnErrorEvent?.Invoke(conn, exception);
+            OnErrorEvent?.Invoke(conn, error, reason);
         }
 
         // message handlers ////////////////////////////////////////////////////

--- a/Assets/Mirror/Runtime/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport.cs
@@ -52,7 +52,7 @@ namespace Mirror
         public Action<ArraySegment<byte>, int> OnClientDataSent;
 
         /// <summary>Called by Transport when the client encountered an error.</summary>
-        public Action<Exception> OnClientError;
+        public Action<TransportError, string> OnClientError;
 
         /// <summary>Called by Transport when the client disconnected from the server.</summary>
         public Action OnClientDisconnected;
@@ -73,7 +73,7 @@ namespace Mirror
 
         /// <summary>Called by Transport when a server's connection encountered a problem.</summary>
         /// If a Disconnect will also be raised, raise the Error first.
-        public Action<int, Exception> OnServerError;
+        public Action<int, TransportError, string> OnServerError;
 
         /// <summary>Called by Transport when a client disconnected from the server.</summary>
         public Action<int> OnServerDisconnected;

--- a/Assets/Mirror/Runtime/TransportError.cs
+++ b/Assets/Mirror/Runtime/TransportError.cs
@@ -1,0 +1,16 @@
+// Mirror transport error code enum.
+// most transport implementations should use a subset of this,
+// and then translate the transport error codes to mirror error codes.
+namespace Mirror
+{
+    public enum TransportError : byte
+    {
+        DnsResolve,       // failed to resolve a host name
+        Timeout,          // ping timeout or dead link
+        Congestion,       // more messages than transport / network can process
+        InvalidReceive,   // recv invalid packet (possibly intentional attack)
+        InvalidSend,      // user tried to send invalid data
+        ConnectionClosed, // connection closed voluntarily or lost involuntarily
+        Unexpected        // unexpected error / exception, requires fix.
+    }
+}

--- a/Assets/Mirror/Runtime/TransportError.cs
+++ b/Assets/Mirror/Runtime/TransportError.cs
@@ -6,6 +6,7 @@ namespace Mirror
     public enum TransportError : byte
     {
         DnsResolve,       // failed to resolve a host name
+        Refused,          // connection refused by other end. server full etc.
         Timeout,          // ping timeout or dead link
         Congestion,       // more messages than transport / network can process
         InvalidReceive,   // recv invalid packet (possibly intentional attack)

--- a/Assets/Mirror/Runtime/TransportError.cs.meta
+++ b/Assets/Mirror/Runtime/TransportError.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ce162bdedd704db9b8c35d163f0c1d54
+timeCreated: 1652330240

--- a/Assets/Mirror/Runtime/Transports/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transports/MultiplexTransport.cs
@@ -185,9 +185,9 @@ namespace Mirror
                     OnServerDataReceived.Invoke(FromBaseId(locali, baseConnectionId), data, channel);
                 };
 
-                transport.OnServerError = (baseConnectionId, error) =>
+                transport.OnServerError = (baseConnectionId, error, reason) =>
                 {
-                    OnServerError.Invoke(FromBaseId(locali, baseConnectionId), error);
+                    OnServerError.Invoke(FromBaseId(locali, baseConnectionId), error, reason);
                 };
                 transport.OnServerDisconnected = baseConnectionId =>
                 {

--- a/Assets/Mirror/Runtime/Transports/SimpleWebTransport/SimpleWebTransport.cs
+++ b/Assets/Mirror/Runtime/Transports/SimpleWebTransport/SimpleWebTransport.cs
@@ -147,7 +147,7 @@ namespace Mirror.SimpleWeb
             client.onData += (ArraySegment<byte> data) => OnClientDataReceived.Invoke(data, Channels.Reliable);
             client.onError += (Exception e) =>
             {
-                OnClientError.Invoke(e);
+                OnClientError.Invoke(TransportError.Unexpected, e.ToString());
                 ClientDisconnect();
             };
 
@@ -212,7 +212,7 @@ namespace Mirror.SimpleWeb
             server.onConnect += OnServerConnected.Invoke;
             server.onDisconnect += OnServerDisconnected.Invoke;
             server.onData += (int connId, ArraySegment<byte> data) => OnServerDataReceived.Invoke(connId, data, Channels.Reliable);
-            server.onError += OnServerError.Invoke;
+            server.onError += (connId, exception) => OnServerError(connId, TransportError.Unexpected, exception.ToString());
 
             SendLoopConfig.batchSend = batchSend || waitBeforeSend;
             SendLoopConfig.sleepBeforeSend = waitBeforeSend;

--- a/Assets/Mirror/Tests/Editor/MiddlewareTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/MiddlewareTransportTest.cs
@@ -256,23 +256,19 @@ namespace Mirror.Tests
         [Test]
         public void TestClientErrorCallback()
         {
-            Exception exception = new InvalidDataException();
-
             int called = 0;
-            middleware.OnClientError = (e) =>
+            middleware.OnClientError = (error, reason) =>
             {
                 called++;
-                Assert.That(e, Is.EqualTo(exception));
+                Assert.That(error, Is.EqualTo(TransportError.Unexpected));
             };
             // connect to give callback to inner
             middleware.ClientConnect("localhost");
 
-            inner.OnClientError.Invoke(exception);
+            inner.OnClientError.Invoke(TransportError.Unexpected, "");
             Assert.That(called, Is.EqualTo(1));
 
-            exception = new NullReferenceException();
-
-            inner.OnClientError.Invoke(exception);
+            inner.OnClientError.Invoke(TransportError.Unexpected, "");
             Assert.That(called, Is.EqualTo(2));
         }
 
@@ -362,24 +358,20 @@ namespace Mirror.Tests
         [TestCase(19)]
         public void TestServerErrorCallback(int id)
         {
-            Exception exception = new InvalidDataException();
-
             int called = 0;
-            middleware.OnServerError = (i, e) =>
+            middleware.OnServerError = (i, error, reason) =>
             {
                 called++;
                 Assert.That(i, Is.EqualTo(id));
-                Assert.That(e, Is.EqualTo(exception));
+                Assert.That(error, Is.EqualTo(TransportError.Unexpected));
             };
             // start to give callback to inner
             middleware.ServerStart();
 
-            inner.OnServerError.Invoke(id, exception);
+            inner.OnServerError.Invoke(id, TransportError.Unexpected, "");
             Assert.That(called, Is.EqualTo(1));
 
-            exception = new NullReferenceException();
-
-            inner.OnServerError.Invoke(id, exception);
+            inner.OnServerError.Invoke(id, TransportError.Unexpected, "");
             Assert.That(called, Is.EqualTo(2));
         }
     }


### PR DESCRIPTION
=> allows switching on enums
=> simple
=> could send enum over the network (it's a byte)
=> exceptions are for exceptional behaviour. there is nothing exceptional about a network timeout
=> exceptions should be avoided to begin with. 