### PR TITLE
fix: Remove identity check SetClientReady

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -857,8 +857,11 @@ namespace Mirror
             conn.isReady = true;
 
             // client is ready to start spawning objects
-            if (conn.identity != null)
-                SpawnObserversForConnection(conn);
+
+            // Disregard identity check in-case a client isn't used as a player but as spectator
+            // if (conn.identity != null)
+            
+            SpawnObserversForConnection(conn);
         }
 
         /// <summary>Marks the client of the connection to be not-ready.</summary>


### PR DESCRIPTION
When having clients with no player prefab, Networked Objects will NOT be spawned in as SpawnObserversForConnection() won't be called due to an identity check. 

In my case, I have a spectator feature in my game. When I host the game locally, the spectator has a identity assigned to its connection and will load all objects correctly. But if I join a remote server, no Networked Objects are loaded in.

Servers also allows its identity to be null, see OnServerReady. All checks should be in place for clients then aswell?