### PR TITLE
Update NetworkServer.cs

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -859,6 +859,8 @@ namespace Mirror
             // client is ready to start spawning objects
             if (conn.identity != null)
                 SpawnObserversForConnection(conn);
+            else
+                conn.Send(new ObjectSpawnFinishedMessage());
         }
 
         /// <summary>Marks the client of the connection to be not-ready.</summary>


### PR DESCRIPTION
NetworkIdentity.OnStartClient is not called when spawned when player object is not null. This is why network behaviours do not work properly because isClient is not set.

The proposed code fixes the problem by sending object spawn finished message to client if player object does not exist so isSpawnFinished variable on the client can be set to true.