### PR TITLE
Add Check for NetworkServer.Spawn

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1066,14 +1066,11 @@ namespace Mirror
                 return;
             }
 
+            // Spawn should only be called once per netId
             if (spawned.ContainsKey(identity.netId))
             {
-                String warning = $"GameObject {obj} has already been spawned. Make sure this is what you want to do.";
-                if (ownerConnection != null)
-                {
-                    warning += $" OwnerConnection {ownerConnection} will be assigned but authority will not be given.";
-                }
-                Debug.LogWarning(warning);
+                Debug.LogWarning($"{identity} with netId={identity.netId} was already spawned.");
+                return;
             }
 
             identity.connectionToClient = (NetworkConnectionToClient)ownerConnection;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1066,6 +1066,16 @@ namespace Mirror
                 return;
             }
 
+            if (spawned.ContainsKey(identity.netId))
+            {
+                String warning = $"GameObject {obj} has already been spawned. Make sure this is what you want to do.";
+                if (ownerConnection != null)
+                {
+                    warning += $" OwnerConnection {ownerConnection} will be assigned but authority will not be given.";
+                }
+                Debug.LogWarning(warning);
+            }
+
             identity.connectionToClient = (NetworkConnectionToClient)ownerConnection;
 
             // special case to make sure hasAuthority is set


### PR DESCRIPTION
Added a check for repeatedly calling `NetworkServer.Spawn` on the same gameObject.

Allowing user to call `NetworkServer.Spawn` on the same gameObject more than once and does not prints any warning leads to bugs that are hard to detect.

They might call it  `NetworkServer.Spawn` twice but the second time with a owner client connection. The `connectionToClient` field of the `NetworkIdentity` to be spawned will be set by the second call, but `hasAuthority` field will not be updated by the second call, leading to inconsistent behaviours.

Or, when they have a complicated spawner system in their game, wrapped by several layers of class and abstraction, they might have something like this:

```cs
MyNetworkBehaviour item = MySpawner.InstantiateHere(itemPrefab, pos);
item.mySyncVarInt = -1;
NetworkServer.Spawn(item.gameOject);
```

And they will wonder why in the `OnStartClient` on client side, `mySyncVarInt` is not updated correctly. That is because they forgot that their own method `MySpawner.InstantiateHere` calls not only good old `Instantiate` but also `NetworkServer.Spawn` already.

 (Anyway the above happened to me and it took me quite long to dig through source code to realize what happened.)