### PR TITLE
perf: Application.isPlaying in hot path is slow

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -968,7 +968,11 @@ namespace Mirror
             // (otherwise [SyncVar] changes would never be serialized in tests)
             //
             // NOTE: != instead of < because int.max+1 overflows at some point.
-            if (lastSerialization.tick != tick || !Application.isPlaying)
+            if (lastSerialization.tick != tick
+#if UNITY_EDITOR
+                || !Application.isPlaying
+#endif
+               )
             {
                 // reset
                 lastSerialization.ownerWriter.Position = 0;


### PR DESCRIPTION
This showed up during a recent il2cpp profile and is accounting for 1% of total cpu usage while being completely unnecessary outside of the editor
![screenshot](https://share.dl.je/2022/08/2022-08-28_14-44-14_CfEcmlR1L6.png)