### PR TITLE
breaking: NetworkServer/Client configs

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -102,7 +102,7 @@ namespace Mirror
             base.OnValidate();
 
             // always <= maxConnections
-            minPlayers = Mathf.Min(minPlayers, maxConnections);
+            minPlayers = Mathf.Min(minPlayers, serverConfig.maxConnections);
 
             // always >= 0
             minPlayers = Mathf.Max(minPlayers, 0);
@@ -240,7 +240,7 @@ namespace Mirror
         /// <param name="conn">Connection from client.</param>
         public override void OnServerConnect(NetworkConnectionToClient conn)
         {
-            if (numPlayers >= maxConnections)
+            if (numPlayers >= serverConfig.maxConnections)
             {
                 conn.Disconnect();
                 return;
@@ -314,7 +314,7 @@ namespace Mirror
 
             if (IsSceneActive(RoomScene))
             {
-                if (roomSlots.Count == maxConnections)
+                if (roomSlots.Count == serverConfig.maxConnections)
                     return;
 
                 allPlayersReady = false;

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -17,9 +17,27 @@ namespace Mirror
         Disconnected
     }
 
+    [Serializable]
+    public struct NetworkClientConfig
+    {
+        // default settings in one place. used by both NetworkClient & Manager.
+        public static readonly NetworkClientConfig Default = new NetworkClientConfig
+        {
+        };
+
+        // call this from Unity's OnValidate
+        public void OnValidate()
+        {
+        }
+    }
+
     /// <summary>NetworkClient with connection to server.</summary>
     public static partial class NetworkClient
     {
+        // configuration as struct to be exposable in NetworkManager easily.
+        // initialized to default settings so all values aren't 0 initially.
+        public static NetworkClientConfig config = NetworkClientConfig.Default;
+
         // message handlers by messageId
         internal static readonly Dictionary<ushort, NetworkMessageDelegate> handlers =
             new Dictionary<ushort, NetworkMessageDelegate>();

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -78,9 +78,8 @@ namespace Mirror
         public string networkAddress = "localhost";
 
         /// <summary>The maximum number of concurrent network connections to support.</summary>
-        [FormerlySerializedAs("m_MaxConnections")]
-        [Tooltip("Maximum number of concurrent connections.")]
-        public int maxConnections = 100;
+        [Obsolete("NetworkManager.maxConnections was moved to NetworkManager.serverConfig.maxConnections")] // 2022-10-03
+        public int maxConnections => serverConfig.maxConnections;
 
         [Header("Authentication")]
         [Tooltip("Authentication component attached to this object")]
@@ -143,9 +142,6 @@ namespace Mirror
         {
             serverConfig.OnValidate();
             clientConfig.OnValidate();
-
-            // always >= 0
-            maxConnections = Mathf.Max(maxConnections, 0);
 
             if (playerPrefab != null && playerPrefab.GetComponent<NetworkIdentity>() == null)
             {
@@ -257,8 +253,8 @@ namespace Mirror
 
             ConfigureHeadlessFrameRate();
 
-            // start listening to network connections
-            NetworkServer.Listen(maxConnections);
+            // start listening to network connections (after configuration)
+            NetworkServer.Listen();
 
             // call OnStartServer AFTER Listen, so that NetworkServer.active is
             // true and we can call NetworkServer.Spawn in OnStartServer

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -27,6 +27,12 @@ namespace Mirror
         [Tooltip("Multiplayer games should always run in the background so the network doesn't time out.")]
         public bool runInBackground = true;
 
+        // server/client configs are copied to static NetworkServer/Client.
+        // instead of duplicating every setting manually.
+        // initialized to default settings so all values aren't 0 initially.
+        public NetworkServerConfig serverConfig = NetworkServerConfig.Default;
+        public NetworkClientConfig clientConfig = NetworkClientConfig.Default;
+
         /// <summary>Should the server auto-start when 'Server Build' is checked in build settings</summary>
         [Tooltip("Should the server auto-start when 'Server Build' is checked in build settings")]
         [FormerlySerializedAs("startOnHeadless")]
@@ -135,6 +141,9 @@ namespace Mirror
         // virtual so that inheriting classes' OnValidate() can call base.OnValidate() too
         public virtual void OnValidate()
         {
+            serverConfig.OnValidate();
+            clientConfig.OnValidate();
+
             // always >= 0
             maxConnections = Mathf.Max(maxConnections, 0);
 
@@ -244,6 +253,8 @@ namespace Mirror
                 authenticator.OnServerAuthenticated.AddListener(OnServerAuthenticated);
             }
 
+            NetworkServer.config = serverConfig;
+
             ConfigureHeadlessFrameRate();
 
             // start listening to network connections
@@ -316,6 +327,8 @@ namespace Mirror
                 authenticator.OnStartClient();
                 authenticator.OnClientAuthenticated.AddListener(OnClientAuthenticated);
             }
+
+            NetworkClient.config = clientConfig;
         }
 
         /// <summary>Starts the client, connects it to the server with networkAddress.</summary>

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -41,18 +41,10 @@ namespace Mirror
         [Tooltip("Automatically connect the client in headless builds. Useful for CCU tests with bot clients.\n\nAddress may be passed as command line argument.\n\nMake sure that only 'autostartServer' or 'autoconnectClient' is enabled, not both!")]
         public bool autoConnectClientBuild;
 
-        /// <summary>Server Update frequency, per second. Use around 60Hz for fast paced games like Counter-Strike to minimize latency. Use around 30Hz for games like WoW to minimize computations. Use around 1-10Hz for slow paced games like EVE.</summary>
-        [Tooltip("Server Update frequency, per second. Use around 60Hz for fast paced games like Counter-Strike to minimize latency. Use around 30Hz for games like WoW to minimize computations. Use around 1-10Hz for slow paced games like EVE.")]
-        public int serverTickRate = 30;
-
-        // tick rate is in Hz.
-        // convert to interval in seconds for convenience where needed.
-        //
-        // send interval is 1 / sendRate.
-        // but for tests we need a way to set it to exactly 0.
-        // 1 / int.max would not be exactly 0, so handel that manually.
-        public float serverTickInterval =>
-            serverTickRate < int.MaxValue ? 1f / serverTickRate : 0; // for 30 Hz, that's 33ms
+        [Obsolete("NetworkManager.serverTickRate was moved to .serverConfig.tickRate")] // 2022-10-03
+        public int serverTickRate => serverConfig.tickRate;
+        [Obsolete("NetworkManager.serverTickInterval was moved to .serverConfig.tickInterval")] // 2022-10-03
+        public float serverTickInterval => serverConfig.tickInterval;
 
         /// <summary>Automatically switch to this scene upon going offline (on start / on disconnect / on shutdown).</summary>
         [Header("Scene Management")]
@@ -640,7 +632,7 @@ namespace Mirror
         public virtual void ConfigureHeadlessFrameRate()
         {
 #if UNITY_SERVER
-            Application.targetFrameRate = serverTickRate;
+            Application.targetFrameRate = serverConfig.tickRate;
             // Debug.Log($"Server Tick Rate set to {Application.targetFrameRate} Hz.");
 #endif
         }

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -17,7 +17,7 @@ namespace Mirror
     {
         /// <summary>Enable to keep NetworkManager alive when changing scenes.</summary>
         // This should be set if your game has a single NetworkManager that exists for the lifetime of the process. If there is a NetworkManager in each scene, then this should not be set.</para>
-        [Header("Configuration")]
+        [Header("General")]
         [FormerlySerializedAs("m_DontDestroyOnLoad")]
         [Tooltip("Should the Network Manager object be persisted through scene changes?")]
         public bool dontDestroyOnLoad = true;
@@ -30,10 +30,12 @@ namespace Mirror
         // server/client configs are copied to static NetworkServer/Client.
         // instead of duplicating every setting manually.
         // initialized to default settings so all values aren't 0 initially.
+        [Header("Configs")]
         public NetworkServerConfig serverConfig = NetworkServerConfig.Default;
         public NetworkClientConfig clientConfig = NetworkClientConfig.Default;
 
         /// <summary>Should the server auto-start when 'Server Build' is checked in build settings</summary>
+        [Header("Headless Builds")]
         [Tooltip("Should the server auto-start when 'Server Build' is checked in build settings")]
         [FormerlySerializedAs("startOnHeadless")]
         public bool autoStartServerBuild = true;

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -6,9 +6,27 @@ using UnityEngine;
 
 namespace Mirror
 {
+    [Serializable]
+    public struct NetworkServerConfig
+    {
+        // default settings in one place. used by both NetworkServer & Manager.
+        public static readonly NetworkServerConfig Default = new NetworkServerConfig
+        {
+        };
+
+        // call this from Unity's OnValidate
+        public void OnValidate()
+        {
+        }
+    }
+
     /// <summary>NetworkServer handles remote connections and has a local connection for a local client.</summary>
     public static partial class NetworkServer
     {
+        // configuration as struct to be exposable in NetworkManager easily.
+        // initialized to default settings so all values aren't 0 initially.
+        public static NetworkServerConfig config = NetworkServerConfig.Default;
+
         static        bool initialized;
         public static int  maxConnections;
 

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -47,7 +47,7 @@ namespace Mirror
         static bool initialized;
 
         [Obsolete("NetworkServer.maxConnection is now in NetworkServer.config.maxConnections so we can expose server settings in NetworkManager more easily.")]
-        public static int  maxConnections => config.maxConnections;
+        public static int maxConnections => config.maxConnections;
 
         /// <summary>Connection to host mode client (if any)</summary>
         public static NetworkConnectionToClient localConnection { get; private set; }

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -11,10 +11,23 @@ namespace Mirror
     {
         public int maxConnections;
 
+        [Tooltip("Server Update frequency, per second. Use around 60Hz for fast paced games like Counter-Strike to minimize latency. Use around 30Hz for games like WoW to minimize computations. Use around 1-10Hz for slow paced games like EVE.")]
+        public int tickRate;
+
+        // tick rate is in Hz.
+        // convert to interval in seconds for convenience where needed.
+        //
+        // send interval is 1 / sendRate.
+        // but for tests we need a way to set it to exactly 0.
+        // 1 / int.max would not be exactly 0, so handel that manually.
+        public float tickInterval =>
+            tickRate < int.MaxValue ? 1f / tickRate : 0; // for 30 Hz, that's 33ms
+
         // default settings in one place. used by both NetworkServer & Manager.
         public static readonly NetworkServerConfig Default = new NetworkServerConfig
         {
-            maxConnections = 1000
+            maxConnections = 1000,
+            tickRate = 30
         };
 
         // call this from Unity's OnValidate

--- a/Assets/Mirror/Tests/Editor/ClientRpcOverrideTest.cs
+++ b/Assets/Mirror/Tests/Editor/ClientRpcOverrideTest.cs
@@ -44,7 +44,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
         }
 

--- a/Assets/Mirror/Tests/Editor/ClientRpcTest.cs
+++ b/Assets/Mirror/Tests/Editor/ClientRpcTest.cs
@@ -55,7 +55,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
         }
 
@@ -166,7 +166,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
         }
 

--- a/Assets/Mirror/Tests/Editor/CommandOverrideTest.cs
+++ b/Assets/Mirror/Tests/Editor/CommandOverrideTest.cs
@@ -57,7 +57,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
         }
 

--- a/Assets/Mirror/Tests/Editor/CommandTest.cs
+++ b/Assets/Mirror/Tests/Editor/CommandTest.cs
@@ -71,7 +71,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
         }
 
@@ -247,7 +247,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
         }
 

--- a/Assets/Mirror/Tests/Editor/InterestManagementTests_Common.cs
+++ b/Assets/Mirror/Tests/Editor/InterestManagementTests_Common.cs
@@ -36,7 +36,7 @@ namespace Mirror.Tests
             NetworkServer.spawned[0xBB] = identityB;
 
             // need to start server so that interest management works
-            NetworkServer.Listen(10);
+            NetworkServer.Listen();
 
             // add both connections
             NetworkServer.connections[connectionA.connectionId] = connectionA;

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourDirtyBitsTests.cs
@@ -31,7 +31,7 @@ namespace Mirror.Tests
 
             // SyncLists are only set dirty while owner has observers.
             // need a connection.
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourSerializeTest.cs
@@ -143,7 +143,7 @@ namespace Mirror.Tests.NetworkBehaviourSerialize
 
             // SyncLists are only set dirty while owner has observers.
             // need a connection.
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -597,7 +597,7 @@ namespace Mirror.Tests
         public void GetSyncVarGameObjectOnClient()
         {
             // start server & connect client because we need spawn functions
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             CreateNetworked(out GameObject _, out NetworkIdentity identity);
@@ -755,7 +755,7 @@ namespace Mirror.Tests
         public void GetSyncVarNetworkIdentityOnClient()
         {
             // start server & connect client because we need spawn functions
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             CreateNetworked(out GameObject _, out NetworkIdentity identity, out NetworkBehaviourGetSyncVarNetworkIdentityComponent comp);
@@ -826,7 +826,7 @@ namespace Mirror.Tests
         {
             // SyncLists are only set dirty while owner has observers.
             // need a connection.
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             CreateNetworkedAndSpawn(out _, out _, out NetworkBehaviourWithSyncVarsAndCollections comp,

--- a/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
@@ -10,7 +10,7 @@ namespace Mirror.Tests
         {
             base.SetUp();
             // we need a server to connect to
-            NetworkServer.Listen(10);
+            NetworkServer.Listen();
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkIdentitySerializationTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentitySerializationTests.cs
@@ -18,7 +18,7 @@ namespace Mirror.Tests
             ownerWriter = new NetworkWriter();
             observersWriter = new NetworkWriter();
 
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -258,7 +258,7 @@ namespace Mirror.Tests
             CreateNetworked(out GameObject gameObject, out NetworkIdentity _, out IsClientServerCheckComponent component);
 
             // start the server
-            NetworkServer.Listen(1000);
+            NetworkServer.Listen();
 
             // spawn it
             NetworkServer.Spawn(gameObject);
@@ -276,7 +276,7 @@ namespace Mirror.Tests
             CreateNetworked(out GameObject gameObject, out NetworkIdentity identity, out IsClientServerCheckComponent component);
 
             // start the server
-            NetworkServer.Listen(1000);
+            NetworkServer.Listen();
 
             // start the client
             NetworkClient.ConnectHost();
@@ -576,7 +576,7 @@ namespace Mirror.Tests
             Assert.That(result, Is.False);
 
             // server is needed
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // call OnStartServer so that isServer is true
             identity.OnStartServer();

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -64,7 +64,7 @@ namespace Mirror.Tests
         public void IsActive()
         {
             Assert.That(NetworkServer.active, Is.False);
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             Assert.That(NetworkServer.active, Is.True);
             NetworkServer.Shutdown();
             Assert.That(NetworkServer.active, Is.False);
@@ -74,7 +74,8 @@ namespace Mirror.Tests
         public void MaxConnections()
         {
             // listen with maxconnections=1
-            NetworkServer.Listen(1);
+            NetworkServer.config.maxConnections = 1;
+            NetworkServer.Listen();
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(0));
 
             // connect first: should work
@@ -94,7 +95,7 @@ namespace Mirror.Tests
             NetworkServer.OnConnectedEvent = conn => connectCalled = true;
 
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             transport.OnServerConnected.Invoke(42);
             Assert.That(connectCalled, Is.True);
         }
@@ -107,7 +108,7 @@ namespace Mirror.Tests
             NetworkServer.OnDisconnectedEvent = conn => disconnectCalled = true;
 
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             transport.OnServerConnected.Invoke(42);
 
             // disconnect
@@ -119,7 +120,7 @@ namespace Mirror.Tests
         public void ConnectionsDict()
         {
             // listen
-            NetworkServer.Listen(2);
+            NetworkServer.Listen();
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(0));
 
             // connect first
@@ -150,7 +151,7 @@ namespace Mirror.Tests
             // <0 is never used
 
             // listen
-            NetworkServer.Listen(2);
+            NetworkServer.Listen();
 
             // connect with connectionId == 0 should fail
             // (it will show an error message, which is expected)
@@ -164,7 +165,7 @@ namespace Mirror.Tests
         public void ConnectDuplicateConnectionIds()
         {
             // listen
-            NetworkServer.Listen(2);
+            NetworkServer.Listen();
 
             // connect first
             transport.OnServerConnected.Invoke(42);
@@ -181,7 +182,7 @@ namespace Mirror.Tests
         public void SetLocalConnection()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // set local connection
             LocalConnectionToClient localConnection = new LocalConnectionToClient();
@@ -193,7 +194,7 @@ namespace Mirror.Tests
         public void SetLocalConnection_PreventsOverwrite()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // set local connection
             LocalConnectionToClient localConnection = new LocalConnectionToClient();
@@ -211,7 +212,7 @@ namespace Mirror.Tests
         public void RemoveLocalConnection()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // set local connection
             CreateLocalConnectionPair(out LocalConnectionToClient connectionToClient, out _);
@@ -226,7 +227,7 @@ namespace Mirror.Tests
         public void LocalClientActive()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             Assert.That(NetworkServer.localClientActive, Is.False);
 
             // set local connection
@@ -238,7 +239,7 @@ namespace Mirror.Tests
         public void AddConnection()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // add first connection
             NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42);
@@ -258,7 +259,7 @@ namespace Mirror.Tests
         public void AddConnection_PreventsDuplicates()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // add a connection
             NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42);
@@ -277,7 +278,7 @@ namespace Mirror.Tests
         public void RemoveConnection()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // add connection
             NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42);
@@ -293,7 +294,7 @@ namespace Mirror.Tests
         public void DisconnectAllTest_RemoteConnection()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // add connection
             NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42);
@@ -309,7 +310,7 @@ namespace Mirror.Tests
         public void DisconnectAllTest_LocalConnection()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // set local connection
             LocalConnectionToClient localConnection = new LocalConnectionToClient();
@@ -325,7 +326,7 @@ namespace Mirror.Tests
         public void Destroy_HostMode_CallsOnStopAuthority()
         {
             // listen & connect a HOST client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
 
             // spawn a player(!) object
@@ -355,7 +356,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<TestMessage1>((conn, msg) => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out _);
 
             // send message & process
@@ -374,7 +375,7 @@ namespace Mirror.Tests
             NetworkClient.RegisterHandler<TestMessage1>(msg => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send message & process
@@ -394,7 +395,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<VariableSizedMessage>((conn, msg) => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out _);
 
             // send message & process
@@ -415,7 +416,7 @@ namespace Mirror.Tests
             NetworkClient.RegisterHandler<VariableSizedMessage>(msg => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send message & process
@@ -436,7 +437,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<VariableSizedMessage>((conn, msg) => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out _);
 
             // calculate max := transport.max - message header
@@ -461,7 +462,7 @@ namespace Mirror.Tests
             NetworkClient.RegisterHandler<VariableSizedMessage>(msg => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send message & process
@@ -491,7 +492,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<VariableSizedMessage>((conn, msg) => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out _);
 
             // send message & process
@@ -519,7 +520,7 @@ namespace Mirror.Tests
             NetworkClient.RegisterHandler<VariableSizedMessage>(msg => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send large message & process
@@ -544,7 +545,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<VariableSizedMessage>((conn, msg) => received.Add("big"), false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out _);
 
             // send small message first
@@ -576,7 +577,7 @@ namespace Mirror.Tests
             NetworkClient.RegisterHandler<VariableSizedMessage>(msg => received.Add("big"), false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send small message first
@@ -605,7 +606,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<TestMessage1>((conn, msg) => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send message
@@ -638,7 +639,7 @@ namespace Mirror.Tests
         public void Send_ClientToServerMessage_UnknownMessageIdDisconnects()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send a message without a registered handler
@@ -657,7 +658,7 @@ namespace Mirror.Tests
             NetworkClient.RegisterHandler<TestMessage1>(msg => ++called, false);
 
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send message
@@ -690,7 +691,7 @@ namespace Mirror.Tests
         public void Send_ServerToClientMessage_UnknownMessageIdDisconnects()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient connectionToClient);
 
             // send a message without a registered handler
@@ -709,7 +710,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<TestMessage1>((conn, msg) => ++called, false);
 
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // serialize a test message into an arraysegment
             byte[] message = NetworkMessagesTest.PackToByteArray(new TestMessage1());
@@ -727,7 +728,7 @@ namespace Mirror.Tests
         [Test]
         public void SetClientReadyAndNotReady()
         {
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticated(out NetworkConnectionToClient connectionToClient);
             Assert.That(connectionToClient.isReady, Is.False);
 
@@ -741,7 +742,7 @@ namespace Mirror.Tests
         [Test]
         public void SetAllClientsNotReady()
         {
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out NetworkConnectionToClient connectionToClient);
             Assert.That(connectionToClient.isReady, Is.True);
 
@@ -754,7 +755,7 @@ namespace Mirror.Tests
         public void ReadyMessageSetsClientReady()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out NetworkConnectionToClient connectionToClient);
             Assert.That(connectionToClient.isReady, Is.True);
         }
@@ -764,7 +765,7 @@ namespace Mirror.Tests
         public void SendCommand()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
 
             // add an identity with two networkbehaviour components
@@ -784,7 +785,7 @@ namespace Mirror.Tests
         public void SendCommand_CalledOnCorrectComponent()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
 
             // add an identity with two networkbehaviour components.
@@ -803,7 +804,7 @@ namespace Mirror.Tests
         public void SendCommand_OnlyAllowedOnOwnedObjects()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
 
             // add an identity with two networkbehaviour components
@@ -824,7 +825,7 @@ namespace Mirror.Tests
         public void SendCommand_RequiresAuthority()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             // add an identity with two networkbehaviour components
@@ -843,7 +844,7 @@ namespace Mirror.Tests
         public void ActivateHostSceneCallsOnStartClient()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             // spawn identity with a networkbehaviour.
@@ -869,7 +870,7 @@ namespace Mirror.Tests
             NetworkClient.RegisterHandler<TestMessage1>(msg => ++called, false);
 
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out _);
 
             // send & process
@@ -888,7 +889,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<TestMessage1>((conn, msg) => ++variant1Called, false);
 
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out _);
 
             // send a message, check if it was handled
@@ -911,7 +912,7 @@ namespace Mirror.Tests
             NetworkServer.RegisterHandler<TestMessage1>((conn, msg) => ++variant1Called, false);
 
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out _);
 
             // send a message, check if it was handled
@@ -955,7 +956,7 @@ namespace Mirror.Tests
         public void ShowForConnection()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out NetworkConnectionToClient connectionToClient);
 
             // overwrite spawn message handler
@@ -980,7 +981,7 @@ namespace Mirror.Tests
         {
             // listen & connect
             // DO NOT set ready this time
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticated(out NetworkConnectionToClient connectionToClient);
 
             // overwrite spawn message handler
@@ -1004,7 +1005,7 @@ namespace Mirror.Tests
         public void HideForConnection()
         {
             // listen & connect
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out NetworkConnectionToClient connectionToClient);
 
             // overwrite spawn message handler
@@ -1060,7 +1061,7 @@ namespace Mirror.Tests
             go2.SetActive(false);
 
             // start server
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // SpawnObjects() should return true and activate the scene object
             Assert.That(NetworkServer.SpawnObjects(), Is.True);
@@ -1132,7 +1133,7 @@ namespace Mirror.Tests
         public void Shutdown_CallsSceneObjectsOnStopServer()
         {
             // listen & connect a client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlocking(out NetworkConnectionToClient _);
 
             // create & spawn an object
@@ -1152,7 +1153,7 @@ namespace Mirror.Tests
         public void ShutdownCleanup()
         {
             // listen
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // add some test event hooks to make sure they are cleaned up.
             // there used to be a bug where they wouldn't be cleaned up.
@@ -1254,7 +1255,7 @@ namespace Mirror.Tests
         public void UpdateDetectsNullEntryInObserving()
         {
             // start
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // add a connection that is observed by a null entity
             NetworkServer.connections[42] = new FakeNetworkConnection{isReady=true};
@@ -1274,7 +1275,7 @@ namespace Mirror.Tests
         public void UpdateDetectsDestroyedEntryInObserving()
         {
             // start
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // add a connection that is observed by a destroyed entity
             CreateNetworked(out GameObject go, out NetworkIdentity ni);
@@ -1294,7 +1295,7 @@ namespace Mirror.Tests
         [Test]
         public void SyncObjectChanges_DontGrowWithoutObservers()
         {
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             // one monster
@@ -1319,7 +1320,7 @@ namespace Mirror.Tests
         [Test]
         public void RemovePlayerForConnection_CallsOnStopLocalPlayer()
         {
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out NetworkConnectionToClient connectionToClient);
 
             // spawn owned object
@@ -1341,7 +1342,7 @@ namespace Mirror.Tests
         [Test]
         public void ReplacePlayerForConnection_CallsOnStartLocalPlayer()
         {
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out NetworkConnectionToClient connectionToClient);
 
             // spawn owned object
@@ -1371,7 +1372,7 @@ namespace Mirror.Tests
         [Test]
         public void ReplacePlayerForConnection_CallsOnStopLocalPlayer()
         {
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out NetworkConnectionToClient connectionToClient);
 
             // spawn owned object

--- a/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
@@ -34,7 +34,7 @@ namespace Mirror.Tests.NetworkTransform2k
             //      we can use CreateNetworkedAndSpawn that creates on sv & cl.
             //      then move on server, update, verify client position etc.
             base.SetUp();
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
             connectionToClient = NetworkServer.localConnection;
 

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -19,7 +19,7 @@ namespace Mirror.Tests
             base.SetUp();
 
             // start server & connect client because we need spawn functions
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
         }
 

--- a/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
+++ b/Assets/Mirror/Tests/Editor/RemoteTestBase.cs
@@ -8,7 +8,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         public void Setup()
         {
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
         }
     }

--- a/Assets/Mirror/Tests/Editor/RpcNetworkIdentityTest.cs
+++ b/Assets/Mirror/Tests/Editor/RpcNetworkIdentityTest.cs
@@ -46,7 +46,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
         }
 

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeHookTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeHookTest.cs
@@ -164,7 +164,7 @@ namespace Mirror.Tests.SyncVarAttributeTests
             base.SetUp();
 
             // start server & connect client because we need spawn functions
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
         }
 

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeHook_HostModeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeHook_HostModeTest.cs
@@ -10,7 +10,7 @@ namespace Mirror.Tests.SyncVarAttributeTests
             base.SetUp();
 
             // start server & connect client because we need spawn functions
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // need host mode!
             ConnectHostClientBlockingAuthenticatedAndReady();

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
@@ -66,7 +66,7 @@ namespace Mirror.Tests.SyncVarAttributeTests
             base.SetUp();
 
             // start server & connect client because we need spawn functions
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // we are testing server->client syncs.
             // so we need truly separted server & client, not host.

--- a/Assets/Mirror/Tests/Editor/SyncVarGameObjectTests.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarGameObjectTests.cs
@@ -16,7 +16,7 @@ namespace Mirror.Tests
             base.SetUp();
 
             // need a connected client & server so we can have spawned identities
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             // need a spawned GameObject with a netId (we store by netId)

--- a/Assets/Mirror/Tests/Editor/SyncVarNetworkBehaviourAbstractTests.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarNetworkBehaviourAbstractTests.cs
@@ -17,7 +17,7 @@ namespace Mirror.Tests
             base.SetUp();
 
             // need a connected client & server so we can have spawned identities
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             // need a spawned NetworkIdentity with a netId (we store by netId)

--- a/Assets/Mirror/Tests/Editor/SyncVarNetworkBehaviourInheritedTests.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarNetworkBehaviourInheritedTests.cs
@@ -17,7 +17,7 @@ namespace Mirror.Tests
             base.SetUp();
 
             // need a connected client & server so we can have spawned identities
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             // need a spawned NetworkIdentity with a netId (we store by netId)

--- a/Assets/Mirror/Tests/Editor/SyncVarNetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarNetworkIdentityTests.cs
@@ -14,7 +14,7 @@ namespace Mirror.Tests
             base.SetUp();
 
             // need a connected client & server so we can have spawned identities
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
             // need a spawned NetworkIdentity with a netId (we store by netId)

--- a/Assets/Mirror/Tests/Editor/SyncVarTests.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarTests.cs
@@ -14,7 +14,7 @@ namespace Mirror.Tests
 
             // SyncVar<T> hooks are only called while client is active for now.
             // so we need an active client.
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out _);
         }
 

--- a/Assets/Mirror/Tests/Editor/TargetRpcOverrideTest.cs
+++ b/Assets/Mirror/Tests/Editor/TargetRpcOverrideTest.cs
@@ -48,7 +48,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
         }
 

--- a/Assets/Mirror/Tests/Editor/TargetRpcTest.cs
+++ b/Assets/Mirror/Tests/Editor/TargetRpcTest.cs
@@ -44,7 +44,7 @@ namespace Mirror.Tests.RemoteAttrributeTest
         {
             base.SetUp();
             // start server/client
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
         }
 

--- a/Assets/Mirror/Tests/Runtime/ClientSceneTests_DestroyAllClientObjects.cs
+++ b/Assets/Mirror/Tests/Runtime/ClientSceneTests_DestroyAllClientObjects.cs
@@ -44,7 +44,8 @@ namespace Mirror.Tests.Runtime.ClientSceneTests
             yield return base.UnitySetUp();
 
             // start server & client and wait 1 frame
-            NetworkServer.Listen(1);
+            NetworkServer.config.maxConnections = 1;
+            NetworkServer.Listen();
             ConnectClientBlockingAuthenticatedAndReady(out connectionToClient);
             yield return null;
         }

--- a/Assets/Mirror/Tests/Runtime/ClientSceneTests_LocalPlayer.cs
+++ b/Assets/Mirror/Tests/Runtime/ClientSceneTests_LocalPlayer.cs
@@ -12,7 +12,7 @@ namespace Mirror.Tests.Runtime.ClientSceneTests
         {
             base.SetUp();
 
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
         }
 

--- a/Assets/Mirror/Tests/Runtime/ClientSceneTests_LocalPlayer_AsHost.cs
+++ b/Assets/Mirror/Tests/Runtime/ClientSceneTests_LocalPlayer_AsHost.cs
@@ -11,7 +11,7 @@ namespace Mirror.Tests.Runtime
         {
             yield return base.UnitySetUp();
 
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
         }
 

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -15,7 +15,8 @@ namespace Mirror.Tests.Runtime
             yield return base.UnitySetUp();
 
             // start server & client and wait 1 frame
-            NetworkServer.Listen(1);
+            NetworkServer.config.maxConnections = 1;
+            NetworkServer.Listen();
             ConnectHostClientBlockingAuthenticatedAndReady();
             yield return null;
         }
@@ -55,7 +56,8 @@ namespace Mirror.Tests.Runtime
         public IEnumerator Shutdown_DestroysAllSpawnedPrefabs()
         {
             // setup
-            NetworkServer.Listen(1);
+            NetworkServer.config.maxConnections = 1;
+            NetworkServer.Listen();
 
             const string ValidPrefabAssetGuid = "33169286da0313d45ab5bfccc6cf3775";
             GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(ValidPrefabAssetGuid));
@@ -88,7 +90,7 @@ namespace Mirror.Tests.Runtime
         public void Shutdown_DisablesAllSpawnedPrefabs()
         {
             // setup
-            NetworkServer.Listen(1);
+            NetworkServer.Listen();
 
             // spawn two scene objects
             CreateNetworkedAndSpawn(out _, out NetworkIdentity identity1);


### PR DESCRIPTION
merge, don't squash!


prepares for NetworkClient timeline globally instead of per-NetworkTransform.
because this way we can expose all the Snapshot Interpolation settings in the config easily.

this PR:
<img width="384" alt="2022-10-03 - 10-09-59@2x" src="https://user-images.githubusercontent.com/16416509/193530204-203d63aa-7fbc-4f7f-a473-3251844a7fe3.png">

afterwards with client snap interp settings:
<img width="450" alt="2022-10-03 - 10-19-58@2x" src="https://user-images.githubusercontent.com/16416509/193531863-9850365d-6898-4c6a-9da2-237df1241788.png">
