### PR TITLE
perf: NetworkIdentity.Serialize bandwidth reduced from 1 byte per component index to (roughly) 1 bit per component

### DIFF
--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -927,8 +927,8 @@ namespace Mirror
             // the ulong is also varint compressed for minimum bandwidth.
             (ulong ownerMask, ulong observerMask) = DirtyMasks(initialState);
 
-            // write the mask, but as varint.
-            // most NetworkIdentities have very few components.
+            // varint compresses the mask to 1 byte in most cases.
+            // instead of writing an 8 byte ulong.
             Compression.CompressVarUInt(ownerWriter,     ownerMask);
             Compression.CompressVarUInt(observersWriter, observerMask);
 

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -929,6 +929,9 @@ namespace Mirror
 
             // varint compresses the mask to 1 byte in most cases.
             // instead of writing an 8 byte ulong.
+            //   7 components fit into 1 byte.  (previously  7 bytes)
+            //  11 components fit into 2 bytes. (previously 11 bytes)
+            //  16 components fit into 3 bytes. (previously 16 bytes)
             Compression.CompressVarUInt(ownerWriter,     ownerMask);
             Compression.CompressVarUInt(observersWriter, observerMask);
 

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -889,7 +889,7 @@ namespace Mirror
                 // check if dirty.
                 // for owner, it's always included if dirty.
                 // for observers, it's only included if dirty AND syncmode to observers.
-                bool ownerDirty = initialState || component.IsDirty();
+                bool ownerDirty    = initialState || component.IsDirty();
                 bool observerDirty = ownerDirty && component.syncMode == SyncMode.Observers;
 
                 // set the n-th bit.
@@ -899,32 +899,6 @@ namespace Mirror
             }
 
             return (ownerMask, observerMask);
-        }
-
-
-        // build dirty mask for observers (= all dirty components with observers mode)
-        ulong ObserverDirtyMask(bool initialState)
-        {
-            ulong mask = 0;
-
-            NetworkBehaviour[] components = NetworkBehaviours;
-            for (int i = 0; i < components.Length; ++i)
-            {
-                // check if dirty
-                NetworkBehaviour component = components[i];
-                bool dirty = initialState || component.IsDirty();
-
-                // only include if observers syncmode
-                dirty &= component.syncMode == SyncMode.Observers;
-
-                // set the n-th bit.
-                // shifting from small to large numbers is varint-efficient.
-                byte flag = (byte)(dirty ? 1 : 0);
-                ulong nthBit = (ulong)(flag << i);
-                mask |= nthBit;
-            }
-
-            return mask;
         }
 
         // check if n-th component is dirty.

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -887,8 +887,8 @@ namespace Mirror
                 bool dirty = initialState || component.IsDirty();
 
                 // set the n-th bit.
+                // shifting from small to large numbers is varint-efficient.
                 byte flag = (byte)(dirty ? 1 : 0);
-                // TODO ensure we set it in a varint-friendly way
                 ulong nthBit = (ulong)(flag << i);
                 mask |= nthBit;
             }
@@ -913,8 +913,8 @@ namespace Mirror
                 dirty &= component.syncMode == SyncMode.Observers;
 
                 // set the n-th bit.
+                // shifting from small to large numbers is varint-efficient.
                 byte flag = (byte)(dirty ? 1 : 0);
-                // TODO ensure we set it in a varint-friendly way
                 ulong nthBit = (ulong)(flag << i);
                 mask |= nthBit;
             }

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -884,12 +884,12 @@ namespace Mirror
             {
                 // check if dirty
                 NetworkBehaviour component = components[i];
-                bool dirty = initialState || components[i].IsDirty();
+                bool dirty = initialState || component.IsDirty();
 
                 // set the n-th bit.
                 byte flag = (byte)(dirty ? 1 : 0);
                 // TODO ensure we set it in a varint-friendly way
-                ulong nthBit = (ulong)(flag >> i);
+                ulong nthBit = (ulong)(flag << i);
                 mask |= nthBit;
             }
 
@@ -915,7 +915,7 @@ namespace Mirror
                 // set the n-th bit.
                 byte flag = (byte)(dirty ? 1 : 0);
                 // TODO ensure we set it in a varint-friendly way
-                ulong nthBit = (ulong)(flag >> i);
+                ulong nthBit = (ulong)(flag << i);
                 mask |= nthBit;
             }
 
@@ -927,7 +927,7 @@ namespace Mirror
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsDirty(ulong mask, int index)
         {
-            ulong nthBit = (ulong)(1 >> index);
+            ulong nthBit = (ulong)(1 << index);
             return (mask & nthBit) != 0;
         }
 

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -318,7 +318,7 @@ namespace Mirror
             // instead of 1 byte index per dirty component.
             // which means we can't allow > 64 components (it's enough).
             if (NetworkBehaviours.Length > 64)
-                Debug.LogError($"Only {64} NetworkBehaviour components are allowed for NetworkIdentity: {name} because we send the dirty mask as 64 bit ulong in order to save bandwidth.", this);
+                Debug.LogError($"NetworkIdentity {name} has too many components: only {64} NetworkBehaviour components are allowed because we send the dirty mask as 64 bit ulong in order to save bandwidth.", this);
 
             // initialize each one
             for (int i = 0; i < NetworkBehaviours.Length; ++i)

--- a/Assets/Mirror/Tests/Editor/NetworkIdentitySerializationTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentitySerializationTests.cs
@@ -1,4 +1,5 @@
 // OnDe/SerializeSafely tests.
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -131,28 +132,17 @@ namespace Mirror.Tests
             for (int i = 0; i < 65; ++i)
             {
                 serverGO.AddComponent<SerializeTest1NetworkBehaviour>();
-                clientGO.AddComponent<SerializeTest1NetworkBehaviour>();
+                // clientGO.AddComponent<SerializeTest1NetworkBehaviour>();
             }
 
             // CreateNetworked already initializes the components.
             // let's reset and initialize again with the added ones.
+            // this should show the 'too many components' error
+            LogAssert.Expect(LogType.Error, new Regex(".*too many components.*"));
             serverIdentity.Reset();
-            clientIdentity.Reset();
+            // clientIdentity.Reset();
             serverIdentity.Awake();
-            clientIdentity.Awake();
-
-            // ignore error from creating cache (has its own test)
-            LogAssert.ignoreFailingMessages = true;
-            _ = serverIdentity.NetworkBehaviours;
-            _ = clientIdentity.NetworkBehaviours;
-            LogAssert.ignoreFailingMessages = false;
-
-            // try to serialize
-            serverIdentity.Serialize(true, ownerWriter, observersWriter);
-
-            // Should still write with too many Components because NetworkBehavioursCache should handle the error
-            Assert.That(ownerWriter.Position, Is.GreaterThan(0));
-            Assert.That(observersWriter.Position, Is.GreaterThan(0));
+            // clientIdentity.Awake();
         }
 
         // OnDeserializeSafely should be able to detect and handle serialization

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -717,27 +717,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void CreatingNetworkBehavioursCacheShouldLogErrorForTooComponents()
-        {
-            CreateNetworked(out GameObject gameObject, out NetworkIdentity identity);
-
-            // add byte.MaxValue+1 components
-            for (int i = 0; i < byte.MaxValue + 1; ++i)
-            {
-                gameObject.AddComponent<SerializeTest1NetworkBehaviour>();
-            }
-
-            // CreateNetworked already initializes the components.
-            // let's reset and initialize again with the added ones.
-            identity.Reset();
-            identity.Awake();
-
-            // call NetworkBehaviours property to create the cache
-            LogAssert.Expect(LogType.Error, new Regex($"Only {byte.MaxValue} NetworkBehaviour components are allowed for NetworkIdentity.+"));
-            _ = identity.NetworkBehaviours;
-        }
-
-        [Test]
         public void OnStartLocalPlayer()
         {
             CreateNetworked(out GameObject _, out NetworkIdentity identity,

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;


### PR DESCRIPTION
previously, byte.max (=255) components were supported.
for each component we would write: **<<index:byte, payload>>**

now, we build only one **64 bit dirty mask**.
which is then **varint** encoded.

=> which means that for the majority of cases, we only need 1 byte in total instead of 1 byte per component :)
<img width="523" alt="2022-10-09 - 18-29-18@2x" src="https://user-images.githubusercontent.com/16416509/194768378-3d5a5341-5b7b-4a80-9f32-c198222921c8.png">

