### PR TITLE
breaking: .hasAuthority renamed to .isOwned

### DIFF
--- a/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
@@ -31,7 +31,7 @@ namespace Mirror.Experimental
         /// <returns></returns>
         bool IgnoreSync => isServer || ClientWithAuthority;
 
-        bool ClientWithAuthority => clientAuthority && hasAuthority;
+        bool ClientWithAuthority => clientAuthority && isOwned;
 
         void OnValidate()
         {

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
@@ -74,7 +74,7 @@ namespace Mirror.Experimental
         /// <returns></returns>
         bool IgnoreSync => isServer || ClientWithAuthority;
 
-        bool ClientWithAuthority => clientAuthority && hasAuthority;
+        bool ClientWithAuthority => clientAuthority && isOwned;
 
         void OnVelocityChanged(Vector3 _, Vector3 newValue)
         {
@@ -191,7 +191,7 @@ namespace Mirror.Experimental
         [Client]
         void SendToServer()
         {
-            if (!hasAuthority)
+            if (!isOwned)
             {
                 Debug.LogWarning("SendToServer called without authority");
                 return;

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody2D.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody2D.cs
@@ -73,7 +73,7 @@ namespace Mirror.Experimental
         /// <returns></returns>
         bool IgnoreSync => isServer || ClientWithAuthority;
 
-        bool ClientWithAuthority => clientAuthority && hasAuthority;
+        bool ClientWithAuthority => clientAuthority && isOwned;
 
         void OnVelocityChanged(Vector2 _, Vector2 newValue)
         {
@@ -190,7 +190,7 @@ namespace Mirror.Experimental
         [Client]
         void SendToServer()
         {
-            if (!hasAuthority)
+            if (!isOwned)
             {
                 Debug.LogWarning("SendToServer called without authority");
                 return;

--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -67,7 +67,7 @@ namespace Mirror
                         return true;
                 }
 
-                return (hasAuthority && clientAuthority);
+                return (isOwned && clientAuthority);
             }
         }
 
@@ -137,7 +137,7 @@ namespace Mirror
         {
             // skip if host or client with authority
             // they will have already set the speed so don't set again
-            if (isServer || (hasAuthority && clientAuthority))
+            if (isServer || (isOwned && clientAuthority))
                 return;
 
             animator.speed = value;
@@ -227,7 +227,7 @@ namespace Mirror
 
         void HandleAnimMsg(int stateHash, float normalizedTime, int layerId, float weight, NetworkReader reader)
         {
-            if (hasAuthority && clientAuthority)
+            if (isOwned && clientAuthority)
                 return;
 
             // usually transitions will be triggered by parameters, if not, play anims directly.
@@ -245,7 +245,7 @@ namespace Mirror
 
         void HandleAnimParamsMsg(NetworkReader reader)
         {
-            if (hasAuthority && clientAuthority)
+            if (isOwned && clientAuthority)
                 return;
 
             ReadParameters(reader);
@@ -428,7 +428,7 @@ namespace Mirror
                     return;
                 }
 
-                if (!hasAuthority)
+                if (!isOwned)
                 {
                     Debug.LogWarning("Only the client with authority can set animations");
                     return;
@@ -475,7 +475,7 @@ namespace Mirror
                     return;
                 }
 
-                if (!hasAuthority)
+                if (!isOwned)
                 {
                     Debug.LogWarning("Only the client with authority can reset animations");
                     return;
@@ -543,7 +543,7 @@ namespace Mirror
 
             // handle and broadcast
             // host should have already the trigger
-            bool isHostOwner = isClient && hasAuthority;
+            bool isHostOwner = isClient && isOwned;
             if (!isHostOwner)
             {
                 HandleAnimTriggerMsg(hash);
@@ -561,7 +561,7 @@ namespace Mirror
 
             // handle and broadcast
             // host should have already the trigger
-            bool isHostOwner = isClient && hasAuthority;
+            bool isHostOwner = isClient && isOwned;
             if (!isHostOwner)
             {
                 HandleAnimResetTriggerMsg(hash);
@@ -600,7 +600,7 @@ namespace Mirror
         void RpcOnAnimationTriggerClientMessage(int hash)
         {
             // host/owner handles this before it is sent
-            if (isServer || (clientAuthority && hasAuthority)) return;
+            if (isServer || (clientAuthority && isOwned)) return;
 
             HandleAnimTriggerMsg(hash);
         }
@@ -609,7 +609,7 @@ namespace Mirror
         void RpcOnAnimationResetTriggerClientMessage(int hash)
         {
             // host/owner handles this before it is sent
-            if (isServer || (clientAuthority && hasAuthority)) return;
+            if (isServer || (clientAuthority && isOwned)) return;
 
             HandleAnimResetTriggerMsg(hash);
         }

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -33,7 +33,7 @@ namespace Mirror
 
         // Is this a client with authority over this transform?
         // This component could be on the player object or any object that has been assigned authority to this client.
-        protected bool IsClientWithAuthority => hasAuthority && clientAuthority;
+        protected bool IsClientWithAuthority => isOwned && clientAuthority;
 
         // target transform to sync. can be on a child.
         protected abstract Transform targetComponent { get; }
@@ -399,7 +399,7 @@ namespace Mirror
             // -> don't apply for host mode player objects either, even if in
             //    client authority mode. if it doesn't go over the network,
             //    then we don't need to do anything.
-            if (clientAuthority && !hasAuthority)
+            if (clientAuthority && !isOwned)
             {
                 if (serverSnapshots.Count > 0)
                 {

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -45,8 +45,13 @@ namespace Mirror
         /// <summary>True if this object is on the client-only, not host.</summary>
         public bool isClientOnly => netIdentity.isClientOnly;
 
+        /// <summary>isOwned is true on the client if this NetworkIdentity is one of the .owned entities of our connection on the server.</summary>
+        // for example: main player & pets are owned. monsters & npcs aren't.
+        public bool isOwned => netIdentity.isOwned;
+
         /// <summary>True on client if that component has been assigned to the client. E.g. player, pets, henchmen.</summary>
-        public bool hasAuthority => netIdentity.hasAuthority;
+        [Obsolete(".hasAuthority was renamed to .isOwned. This is easier to understand and prepares for SyncDirection, where there is a difference betwen isOwned and authority.")]
+        public bool hasAuthority => isOwned;
 
         /// <summary>The unique network Id of this object (unique at runtime).</summary>
         public uint netId => netIdentity.netId;
@@ -197,7 +202,7 @@ namespace Mirror
             }
 
             // local players can always send commands, regardless of authority, other objects must have authority.
-            if (!(!requiresAuthority || isLocalPlayer || hasAuthority))
+            if (!(!requiresAuthority || isLocalPlayer || isOwned))
             {
                 Debug.LogWarning($"Command Function {functionFullName} called on {name} without authority.", gameObject);
                 return;

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1019,7 +1019,7 @@ namespace Mirror
             identity.transform.localPosition = message.position;
             identity.transform.localRotation = message.rotation;
             identity.transform.localScale = message.scale;
-            identity.hasAuthority = message.isOwner;
+            identity.isOwned = message.isOwner;
             identity.netId = message.netId;
 
             if (message.isLocalPlayer)
@@ -1259,7 +1259,7 @@ namespace Mirror
                 if (message.isLocalPlayer)
                     InternalAddPlayer(localObject);
 
-                localObject.hasAuthority = message.isOwner;
+                localObject.isOwned = message.isOwner;
                 localObject.NotifyAuthority();
                 localObject.OnStartClient();
 
@@ -1327,7 +1327,7 @@ namespace Mirror
             }
 
             // set ownership flag (aka authority)
-            identity.hasAuthority = message.isOwner;
+            identity.isOwned = message.isOwner;
             identity.NotifyAuthority();
 
             // set localPlayer flag

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -89,8 +89,13 @@ namespace Mirror
         /// <summary>True if this object exists on a client that is not also acting as a server.</summary>
         public bool isClientOnly => isClient && !isServer;
 
+        /// <summary>isOwned is true on the client if this NetworkIdentity is one of the .owned entities of our connection on the server.</summary>
+        // for example: main player & pets are owned. monsters & npcs aren't.
+        public bool isOwned { get; internal set; }
+
         /// <summary>True on client if that component has been assigned to the client. E.g. player, pets, henchmen.</summary>
-        public bool hasAuthority { get; internal set; }
+        [Obsolete(".hasAuthority was renamed to .isOwned. This is easier to understand and prepares for SyncDirection, where there is a difference betwen isOwned and authority.")]
+        public bool hasAuthority => isOwned;
 
         /// <summary>The set of network connections (players) that can see this object.</summary>
         // note: null until OnStartServer was called. this is necessary for
@@ -843,11 +848,11 @@ namespace Mirror
         bool hadAuthority;
         internal void NotifyAuthority()
         {
-            if (!hadAuthority && hasAuthority)
+            if (!hadAuthority && isOwned)
                 OnStartAuthority();
-            if (hadAuthority && !hasAuthority)
+            if (hadAuthority && !isOwned)
                 OnStopAuthority();
-            hadAuthority = hasAuthority;
+            hadAuthority = isOwned;
         }
 
         internal void OnStartAuthority()
@@ -1251,7 +1256,7 @@ namespace Mirror
             //isLocalPlayer = false; <- cleared AFTER ClearLocalPlayer below!
 
             // remove authority flag. This object may be unspawned, not destroyed, on client.
-            hasAuthority = false;
+            isOwned = false;
             NotifyAuthority();
 
             netId = 0;

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -759,7 +759,7 @@ namespace Mirror
             // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
             if (conn is LocalConnectionToClient)
             {
-                identity.hasAuthority = true;
+                identity.isOwned = true;
                 NetworkClient.InternalAddPlayer(identity);
             }
 
@@ -819,7 +819,7 @@ namespace Mirror
             // special case,  we are in host mode,  set hasAuthority to true so that all overrides see it
             if (conn is LocalConnectionToClient)
             {
-                identity.hasAuthority = true;
+                identity.isOwned = true;
                 NetworkClient.InternalAddPlayer(identity);
             }
 
@@ -1098,7 +1098,7 @@ namespace Mirror
             // special case to make sure hasAuthority is set
             // on start server in host mode
             if (ownerConnection is LocalConnectionToClient)
-                identity.hasAuthority = true;
+                identity.isOwned = true;
 
             identity.OnStartServer();
 
@@ -1360,7 +1360,7 @@ namespace Mirror
                 // The object may have been spawned with host client ownership,
                 // e.g. a pet so we need to clear hasAuthority and call
                 // NotifyAuthority which invokes OnStopAuthority if hasAuthority.
-                identity.hasAuthority = false;
+                identity.isOwned = false;
                 identity.NotifyAuthority();
 
                 // remove from NetworkClient dictionary

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -252,7 +252,7 @@ namespace Mirror
                 infos.Add(GetString("Network ID", identity.netId.ToString()));
                 infos.Add(GetBoolean("Is Client", identity.isClient));
                 infos.Add(GetBoolean("Is Server", identity.isServer));
-                infos.Add(GetBoolean("Has Authority", identity.hasAuthority));
+                infos.Add(GetBoolean("Is Owned", identity.isOwned));
                 infos.Add(GetBoolean("Is Local Player", identity.isLocalPlayer));
             }
             return infos;

--- a/Assets/Mirror/Tests/Common/MirrorTest.cs
+++ b/Assets/Mirror/Tests/Common/MirrorTest.cs
@@ -188,7 +188,7 @@ namespace Mirror.Tests
 
             // double check that we have authority if we passed an owner connection
             if (ownerConnection != null)
-                Debug.Assert(clientIdentity.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(clientIdentity.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
 
             // make sure the client really spawned it.
             Assert.That(NetworkClient.spawned.ContainsKey(serverIdentity.netId));
@@ -211,7 +211,7 @@ namespace Mirror.Tests
 
             // double check that we have authority if we passed an owner connection
             if (ownerConnection != null)
-                Debug.Assert(component.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(component.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
         }
 
         // create GameObject + NetworkIdentity + NetworkBehaviour & SPAWN
@@ -247,7 +247,7 @@ namespace Mirror.Tests
 
             // double check that we have authority if we passed an owner connection
             if (ownerConnection != null)
-                Debug.Assert(clientComponent.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(clientComponent.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
 
             // make sure the client really spawned it.
             Assert.That(NetworkClient.spawned.ContainsKey(serverIdentity.netId));
@@ -272,8 +272,8 @@ namespace Mirror.Tests
             // double check that we have authority if we passed an owner connection
             if (ownerConnection != null)
             {
-                Debug.Assert(componentA.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
-                Debug.Assert(componentB.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(componentA.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(componentB.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
             }
         }
 
@@ -312,8 +312,8 @@ namespace Mirror.Tests
             // double check that we have authority if we passed an owner connection
             if (ownerConnection != null)
             {
-                Debug.Assert(clientComponentA.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
-                Debug.Assert(clientComponentB.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(clientComponentA.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(clientComponentB.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
             }
 
             // make sure the client really spawned it.
@@ -340,9 +340,9 @@ namespace Mirror.Tests
             // double check that we have authority if we passed an owner connection
             if (ownerConnection != null)
             {
-                Debug.Assert(componentA.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
-                Debug.Assert(componentB.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
-                Debug.Assert(componentC.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(componentA.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(componentB.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(componentC.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
             }
         }
 
@@ -382,9 +382,9 @@ namespace Mirror.Tests
             // double check that we have authority if we passed an owner connection
             if (ownerConnection != null)
             {
-                Debug.Assert(clientComponentA.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
-                Debug.Assert(clientComponentB.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
-                Debug.Assert(clientComponentC.hasAuthority == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(clientComponentA.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(clientComponentB.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
+                Debug.Assert(clientComponentC.isOwned == true, $"Behaviour Had Wrong Authority when spawned, This means that the test is broken and will give the wrong results");
             }
 
             // make sure the client really spawned it.

--- a/Assets/Mirror/Tests/Editor/ClientSceneTests_OnSpawn.cs
+++ b/Assets/Mirror/Tests/Editor/ClientSceneTests_OnSpawn.cs
@@ -415,11 +415,11 @@ namespace Mirror.Tests.ClientSceneTests
             };
 
             // set to opposite to make sure it is changed
-            identity.hasAuthority = !isOwner;
+            identity.isOwned = !isOwner;
 
             NetworkClient.ApplySpawnPayload(identity, msg);
 
-            Assert.That(identity.hasAuthority, Is.EqualTo(isOwner));
+            Assert.That(identity.isOwned, Is.EqualTo(isOwner));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -135,7 +135,7 @@ namespace Mirror.Tests
         {
             // no authority by default
             CreateNetworked(out _, out _, out EmptyBehaviour emptyBehaviour);
-            Assert.That(emptyBehaviour.hasAuthority, Is.False);
+            Assert.That(emptyBehaviour.isOwned, Is.False);
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -649,40 +649,40 @@ namespace Mirror.Tests
             CreateNetworked(out GameObject _, out NetworkIdentity identity, out StartAuthorityCalledNetworkBehaviour compStart, out StopAuthorityCalledNetworkBehaviour compStop);
 
             // set authority from false to true, which should call OnStartAuthority
-            identity.hasAuthority = true;
+            identity.isOwned = true;
             identity.NotifyAuthority();
             // shouldn't be touched
-            Assert.That(identity.hasAuthority, Is.True);
+            Assert.That(identity.isOwned, Is.True);
             // start should be called
             Assert.That(compStart.called, Is.EqualTo(1));
             // stop shouldn't
             Assert.That(compStop.called, Is.EqualTo(0));
 
             // set it to true again, should do nothing because already true
-            identity.hasAuthority = true;
+            identity.isOwned = true;
             identity.NotifyAuthority();
             // shouldn't be touched
-            Assert.That(identity.hasAuthority, Is.True);
+            Assert.That(identity.isOwned, Is.True);
             // same as before
             Assert.That(compStart.called, Is.EqualTo(1));
             // same as before
             Assert.That(compStop.called, Is.EqualTo(0));
 
             // set it to false, should call OnStopAuthority
-            identity.hasAuthority = false;
+            identity.isOwned = false;
             identity.NotifyAuthority();
             // should be changed
-            Assert.That(identity.hasAuthority, Is.False);
+            Assert.That(identity.isOwned, Is.False);
             // same as before
             Assert.That(compStart.called, Is.EqualTo(1));
             // stop should be called
             Assert.That(compStop.called, Is.EqualTo(1));
 
             // set it to false again, should do nothing because already false
-            identity.hasAuthority = false;
+            identity.isOwned = false;
             identity.NotifyAuthority();
             // shouldn't be touched
-            Assert.That(identity.hasAuthority, Is.False);
+            Assert.That(identity.isOwned, Is.False);
             // same as before
             Assert.That(compStart.called, Is.EqualTo(1));
             // same as before
@@ -973,7 +973,7 @@ namespace Mirror.Tests
             Assert.That(identity.netId, Is.EqualTo(0));
             Assert.That(identity.connectionToClient, Is.Null);
             Assert.That(identity.connectionToServer, Is.Null);
-            Assert.That(identity.hasAuthority, Is.False);
+            Assert.That(identity.isOwned, Is.False);
             Assert.That(identity.observers, Is.Empty);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServerTest.cs
@@ -335,7 +335,7 @@ namespace Mirror.Tests
                 NetworkServer.localConnection);
 
             // need to have authority for this test
-            Assert.That(player.hasAuthority, Is.True);
+            Assert.That(player.isOwned, Is.True);
 
             // destroy and ignore 'Destroy called in Edit mode' error
             LogAssert.ignoreFailingMessages = true;
@@ -1103,11 +1103,11 @@ namespace Mirror.Tests
             go.SetActive(true);
 
             // set authority from false to true, which should call OnStartAuthority
-            identity.hasAuthority = true;
+            identity.isOwned = true;
             identity.NotifyAuthority();
 
             // shouldn't be touched
-            Assert.That(identity.hasAuthority, Is.True);
+            Assert.That(identity.isOwned, Is.True);
             // start should be called
             Assert.That(compStart.called, Is.EqualTo(1));
             // stop shouldn't
@@ -1118,7 +1118,7 @@ namespace Mirror.Tests
             Assert.That(identity.netId, Is.Zero);
 
             // should be changed
-            Assert.That(identity.hasAuthority, Is.False);
+            Assert.That(identity.isOwned, Is.False);
             // same as before
             Assert.That(compStart.called, Is.EqualTo(1));
             // stop should be called


### PR DESCRIPTION
two reasons:
**1. hasAuthority isn't obvious. for example, many components have checks like:**

<img width="462" alt="2022-10-12 - 11-46-00@2x" src="https://user-images.githubusercontent.com/16416509/195310020-86a75567-8500-4664-8bdd-6c4ea909a23d.png">

"clientAuthority && hasAuthority" is just weird logic.
"clientAuthority && owned" is much easier to understand.

**2. prepares for SyncDirection.**
there's going to be a difference between "owned" and "authority":
- owned: if a NetworkIdentity is one of the connection's .owned entities
- authority: if we are allowed to modify this component's state. depends on SyncDirection and owned.
