### PR TITLE
feature: SyncDirection (V2) to easily support client auth components without extra Rpcs/Cmds. previously OnSerialize was only server-to-client direction.

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -26,7 +26,7 @@ namespace Mirror
 {
     public abstract class NetworkTransformBase : NetworkBehaviour
     {
-        // TODO SyncDirection { CLIENT_TO_SERVER, SERVER_TO_CLIENT } is easier?
+        // TODO SyncDirection { ClientToServer, ServerToClient } is easier?
         [Header("Authority")]
         [Tooltip("Set to true if moves come from owner client, set to false if moves always come from server")]
         public bool clientAuthority;

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -926,7 +926,7 @@ namespace Mirror
                     {
                         // set the n-th bit if dirty.
                         // shifting from small to large numbers is varint-efficient.
-                        if (component.syncDirection == SyncDirection.ServerToClient) ownerMask |= (1u << i); // observer components are sent to owner as well
+                        if (initialState || component.syncDirection == SyncDirection.ServerToClient) ownerMask |= (1u << i); // observer components are sent to owner as well
                         observerMask |= (1u << i); // for observers
                     }
                     // else Debug.Log($"{name}.{component.GetType()} Observers is NOT Dirty with initial={initialState}");

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -983,13 +983,6 @@ namespace Mirror
             // the ulong is also varint compressed for minimum bandwidth.
             (ulong ownerMask, ulong observerMask) = ServerDirtyMasks(initialState);
 
-            // varint compresses the mask to 1 byte in most cases.
-            // instead of writing an 8 byte ulong.
-            //   7 components fit into 1 byte.  (previously  7 bytes)
-            //  11 components fit into 2 bytes. (previously 11 bytes)
-            //  16 components fit into 3 bytes. (previously 16 bytes)
-            // TODO imer: client knows amount of comps, write N bytes instead
-
             // if nothing dirty, then don't even write the mask.
             // otherwise, every unchanged object would send a 1 byte dirty mask!
             if (ownerMask    != 0) Compression.CompressVarUInt(ownerWriter,     ownerMask);

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -894,19 +894,6 @@ namespace Mirror
             NetworkBehaviour[] components = NetworkBehaviours;
             for (int i = 0; i < components.Length; ++i)
             {
-                // on the server, we need to consider different sync scenarios:
-                //
-                //   for owner:
-                //      if initalState: always serialize
-                //         (even ClientToServer comps are synced initially)
-                //      if delta: only ServerToClient components and if dirty.
-                //         (ClientToServer deltas come from owner client)
-                //
-                //   for observers:
-                //      if initial: always serialize if for Observers
-                //      if delta: always if for Observers and if dirty.
-                //         (ClientToServer comps need to be broadcast to others)
-                //
                 NetworkBehaviour component = components[i];
 
                 bool dirty = component.IsDirty();

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -884,9 +884,9 @@ namespace Mirror
             }
         }
 
-        // build dirty mask for owner & observer (= all dirty components).
+        // build dirty mask for server owner & observers (= all dirty components).
         // faster to do it in one iteration instead of iterating separately.
-        (ulong, ulong) DirtyMasks(bool initialState)
+        (ulong, ulong) ServerDirtyMasks(bool initialState)
         {
             ulong ownerMask    = 0;
             ulong observerMask = 0;
@@ -894,21 +894,69 @@ namespace Mirror
             NetworkBehaviour[] components = NetworkBehaviours;
             for (int i = 0; i < components.Length; ++i)
             {
+                // on the server, we need to consider different sync scenarios:
+                //
+                //   for owner:
+                //      if initalState: always serialize
+                //         (even ClientToServer comps are synced initially)
+                //      if delta: only ServerToClient components and if dirty.
+                //         (ClientToServer deltas come from owner client)
+                //
+                //   for observers:
+                //      if initial: always serialize if for Observers
+                //      if delta: always if for Observers and if dirty.
+                //         (ClientToServer comps need to be broadcast to others)
+                //
                 NetworkBehaviour component = components[i];
 
-                // check if dirty.
-                // for owner, it's always included if dirty.
-                // for observers, it's only included if dirty AND syncmode to observers.
-                bool ownerDirty    = initialState || component.IsDirty();
-                bool observerDirty = ownerDirty && component.syncMode == SyncMode.Observers;
-
-                // set the n-th bit.
-                // shifting from small to large numbers is varint-efficient.
-                ownerMask    |= (ulong)(ownerDirty    ? 1 : 0) << i;
-                observerMask |= (ulong)(observerDirty ? 1 : 0) << i;
+                // TODO simplify this
+                if (component.syncMode == SyncMode.Owner)
+                {
+                    if (initialState || (component.syncDirection == SyncDirection.ServerToClient && component.IsDirty()))
+                    {
+                        // set the n-th bit if dirty.
+                        // shifting from small to large numbers is varint-efficient.
+                        ownerMask |= (1u << i);
+                    }
+                    // else Debug.Log($"{name}.{component.GetType()} Owner is NOT Dirty with initial={initialState}");
+                }
+                else if (component.syncMode == SyncMode.Observers)
+                {
+                    if (initialState || component.IsDirty())
+                    {
+                        // set the n-th bit if dirty.
+                        // shifting from small to large numbers is varint-efficient.
+                        if (component.syncDirection == SyncDirection.ServerToClient) ownerMask |= (1u << i); // observer components are sent to owner as well
+                        observerMask |= (1u << i); // for observers
+                    }
+                    // else Debug.Log($"{name}.{component.GetType()} Observers is NOT Dirty with initial={initialState}");
+                }
             }
 
             return (ownerMask, observerMask);
+        }
+
+        // build dirty mask for client.
+        // server always knows initialState, so we don't need it here.
+        ulong ClientDirtyMask()
+        {
+            ulong mask = 0;
+
+            NetworkBehaviour[] components = NetworkBehaviours;
+            for (int i = 0; i < components.Length; ++i)
+            {
+                NetworkBehaviour component = components[i];
+
+                // on client, only consider owned components with SyncDirection to server
+                if (isOwned && component.syncDirection == SyncDirection.ClientToServer)
+                {
+                    // set the n-th bit if dirty
+                    // shifting from small to large numbers is varint-efficient.
+                    if (component.IsDirty()) mask |= (1u << i);
+                }
+            }
+
+            return mask;
         }
 
         // check if n-th component is dirty.
@@ -920,11 +968,11 @@ namespace Mirror
             return (mask & nthBit) != 0;
         }
 
-        // serialize all components using dirtyComponentsMask
+        // serialize components into writer on the server.
         // check ownerWritten/observersWritten to know if anything was written
         // We pass dirtyComponentsMask into this function so that we can check
         // if any Components are dirty before creating writers
-        internal void Serialize(bool initialState, NetworkWriter ownerWriter, NetworkWriter observersWriter)
+        internal void SerializeServer(bool initialState, NetworkWriter ownerWriter, NetworkWriter observersWriter)
         {
             // ensure NetworkBehaviours are valid before usage
             ValidateComponents();
@@ -933,7 +981,7 @@ namespace Mirror
             // instead of writing a 1 byte index per component,
             // we limit components to 64 bits and write one ulong instead.
             // the ulong is also varint compressed for minimum bandwidth.
-            (ulong ownerMask, ulong observerMask) = DirtyMasks(initialState);
+            (ulong ownerMask, ulong observerMask) = ServerDirtyMasks(initialState);
 
             // varint compresses the mask to 1 byte in most cases.
             // instead of writing an 8 byte ulong.
@@ -953,44 +1001,128 @@ namespace Mirror
             {
                 for (int i = 0; i < components.Length; ++i)
                 {
+                    // on the server, we need to consider different sync scenarios:
+                    //
+                    //   for owner:
+                    //      if initalState: always serialize
+                    //         (even ClientToServer comps are synced initially)
+                    //      if delta: only ServerToClient components and if dirty.
+                    //         (ClientToServer deltas come from owner client)
+                    //
+                    //   for observers:
+                    //      if initial: always serialize if for Observers
+                    //      if delta: always if for Observers and if dirty.
+                    //         (ClientToServer comps need to be broadcast to others)
+                    //
                     NetworkBehaviour comp = components[i];
 
                     // is this component dirty?
                     // reuse the mask instead of calling comp.IsDirty() again here.
+                    // Debug.Log($"[Server] considering {name}.{comp.GetType()}: IsDirty={IsDirty(ownerMask, i)}");
                     if (IsDirty(ownerMask, i))
                     {
                         //Debug.Log($"SerializeAll: {name} -> {comp.GetType()} initial:{ initialState}");
-
-                        // remember start position in case we need to copy it into
-                        // observers writer too
-                        int startPosition = ownerWriter.Position;
-
-                        // serialize into ownerWriter first
-                        // (owner always gets everything!)
                         comp.Serialize(ownerWriter, initialState);
+                    }
 
-                        // copy into observersWriter too if SyncMode.Observers
-                        // -> we copy instead of calling OnSerialize again because
-                        //    we don't know what magic the user does in OnSerialize.
-                        // -> it's not guaranteed that calling it twice gets the
-                        //    same result
-                        // -> it's not guaranteed that calling it twice doesn't mess
-                        //    with the user's OnSerialize timing code etc.
-                        // => so we just copy the result without touching
-                        //    OnSerialize again
-                        if (IsDirty(observerMask, i))
-                        // if (comp.syncMode == SyncMode.Observers)
-                        {
-                            ArraySegment<byte> segment = ownerWriter.ToArraySegment();
-                            int length = ownerWriter.Position - startPosition;
-                            observersWriter.WriteBytes(segment.Array, startPosition, length);
-                        }
+                    // todo if either is dirty, only call serialize once?
+                    if (IsDirty(observerMask, i))
+                    {
+                        comp.Serialize(observersWriter, initialState);
                     }
                 }
             }
         }
 
-        internal void Deserialize(NetworkReader reader, bool initialState)
+        // serialize components into writer on the client.
+        internal void SerializeClient(NetworkWriter writer)
+        {
+            // ensure NetworkBehaviours are valid before usage
+            ValidateComponents();
+            NetworkBehaviour[] components = NetworkBehaviours;
+
+            // instead of writing a 1 byte index per component,
+            // we limit components to 64 bits and write one ulong instead.
+            // the ulong is also varint compressed for minimum bandwidth.
+            ulong dirtyMask = ClientDirtyMask();
+
+            // varint compresses the mask to 1 byte in most cases.
+            // instead of writing an 8 byte ulong.
+            //   7 components fit into 1 byte.  (previously  7 bytes)
+            //  11 components fit into 2 bytes. (previously 11 bytes)
+            //  16 components fit into 3 bytes. (previously 16 bytes)
+            // TODO imer: server knows amount of comps, write N bytes instead
+
+            // if nothing dirty, then don't even write the mask.
+            // otherwise, every unchanged object would send a 1 byte dirty mask!
+            if (dirtyMask != 0) Compression.CompressVarUInt(writer, dirtyMask);
+
+            // serialize all components
+            // perf: only iterate if dirty mask has dirty bits.
+            if (dirtyMask != 0)
+            {
+                // serialize all components
+                for (int i = 0; i < components.Length; ++i)
+                {
+                    // on the client, we need to consider different sync scenarios:
+                    //
+                    //   ServerToClient SyncDirection:
+                    //     do nothing.
+                    //   ClientToServer SyncDirection:
+                    //     serialize only if owned.
+
+                    NetworkBehaviour comp = components[i];
+
+                    // is this component dirty?
+                    // reuse the mask instead of calling comp.IsDirty() again here.
+                    if (IsDirty(dirtyMask, i))
+                    // if (isOwned && component.syncDirection == SyncDirection.ClientToServer)
+                    {
+                        // serialize into writer.
+                        // server always knows initialState, we never need to send it
+                        comp.Serialize(writer, false);
+                    }
+                }
+            }
+        }
+
+        // deserialize components from the client on the server.
+        // there's no 'initialState'. server always knows the initial state.
+        internal bool DeserializeServer(NetworkReader reader)
+        {
+            // ensure NetworkBehaviours are valid before usage
+            ValidateComponents();
+            NetworkBehaviour[] components = NetworkBehaviours;
+
+            // first we deserialize the varinted dirty mask
+            ulong mask = Compression.DecompressVarUInt(reader);
+
+            // now deserialize every dirty component
+            for (int i = 0; i < components.Length; ++i)
+            {
+                // was this one dirty?
+                if (IsDirty(mask, i))
+                {
+                    NetworkBehaviour comp = components[i];
+
+                    // safety check to ensure clients can only modify their own
+                    // ClientToServer components, nothing else.
+                    if (comp.syncDirection == SyncDirection.ClientToServer)
+                    {
+                        // deserialize this component
+                        // server always knows the initial state (initial=false)
+                        // disconnect if failed, to prevent exploits etc.
+                        if (!comp.Deserialize(reader, false)) return false;
+                    }
+                }
+            }
+
+            // successfully deserialized everything
+            return true;
+        }
+
+        // deserialize components from server on the client.
+        internal void DeserializeClient(NetworkReader reader, bool initialState)
         {
             // ensure NetworkBehaviours are valid before usage
             ValidateComponents();
@@ -1006,14 +1138,16 @@ namespace Mirror
                 if (IsDirty(mask, i))
                 {
                     // deserialize this component
-                    components[i].Deserialize(reader, initialState);
+                    NetworkBehaviour comp = components[i];
+                    comp.Deserialize(reader, initialState);
                 }
             }
         }
 
-        // get cached serialization for this tick (or serialize if none yet)
-        // IMPORTANT: int tick avoids floating point inaccuracy over days/weeks
-        internal NetworkIdentitySerialization GetSerializationAtTick(int tick)
+        // get cached serialization for this tick (or serialize if none yet).
+        // IMPORTANT: int tick avoids floating point inaccuracy over days/weeks.
+        // calls SerializeServer, so this function is to be called on server.
+        internal NetworkIdentitySerialization GetServerSerializationAtTick(int tick)
         {
             // only rebuild serialization once per tick. reuse otherwise.
             // except for tests, where Time.frameCount never increases.
@@ -1032,9 +1166,9 @@ namespace Mirror
                 lastSerialization.observersWriter.Position = 0;
 
                 // serialize
-                Serialize(false,
-                             lastSerialization.ownerWriter,
-                             lastSerialization.observersWriter);
+                SerializeServer(false,
+                                lastSerialization.ownerWriter,
+                                lastSerialization.observersWriter);
 
                 // clear dirty bits for the components that we serialized.
                 // previously we did this in NetworkServer.BroadcastToConnection

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -921,16 +921,14 @@ namespace Mirror
                 if (initialState || (component.syncDirection == SyncDirection.ServerToClient && dirty))
                     ownerMask |= nthBit;
 
-                // observers need to be considered only for Observers mode
-                if (component.syncMode == SyncMode.Observers)
-                {
-                    // for initial, it should always sync to observers.
-                    // for delta, only if dirty.
-                    // SyncDirection is irrelevant, as both are broadcast to
-                    // observers which aren't the owner.
-                    if (initialState || dirty)
-                        observerMask |= nthBit;
-                }
+                // observers need to be considered only in Observers mode
+                //
+                // for initial, it should always sync to observers.
+                // for delta, only if dirty.
+                // SyncDirection is irrelevant, as both are broadcast to
+                // observers which aren't the owner.
+                if (component.syncMode == SyncMode.Observers && (initialState || dirty))
+                    observerMask |= nthBit;
             }
 
             return (ownerMask, observerMask);

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -85,7 +85,15 @@ namespace Mirror
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Sync Settings", EditorStyles.boldLabel);
 
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("syncMode"));
+            // sync direction
+            SerializedProperty syncDirection = serializedObject.FindProperty("syncDirection");
+            EditorGUILayout.PropertyField(syncDirection);
+
+            // sync mdoe: only show for ServerToClient components
+            if (syncDirection.enumValueIndex == (int)SyncDirection.ServerToClient)
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("syncMode"));
+
+            // sync interval
             EditorGUILayout.PropertyField(serializedObject.FindProperty("syncInterval"));
 
             // apply

--- a/Assets/Mirror/Examples/SyncDirection.meta
+++ b/Assets/Mirror/Examples/SyncDirection.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f11945ec2c0384dd8880a19d3daf98cd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Examples/SyncDirection/Player.cs
+++ b/Assets/Mirror/Examples/SyncDirection/Player.cs
@@ -1,0 +1,46 @@
+﻿using UnityEngine;
+
+namespace Mirror.Examples.SyncDir // ".SyncDirection" would overshadow the enum
+{
+    public class Player : NetworkBehaviour
+    {
+        public TextMesh textMesh;
+        [SyncVar] public int health;
+
+        void Update()
+        {
+            // show health for everyone
+            textMesh.text = health.ToString();
+
+            // space bar increases health for local player.
+            // note that trusting the client is a bad idea, especially with health.
+            // SyncDirection is usually used for movement.
+            //
+            // when using custom OnSerialize, the custom OnDeserialize can still
+            // safely validate client data (check position, velocity etc.).
+            // this is why it's named SyncDirection, and not ClientAuthority.
+            // because the server can still validate the client's data first.
+            //
+            // try to change SyncDirection to ServerToClient in the editor.
+            // then restart the game, clients won't be allowed to change their
+            // own health anymore.
+            if (isLocalPlayer)
+            {
+                if (Input.GetKeyDown(KeyCode.Space))
+                    ++health;
+            }
+        }
+
+        // show instructions
+        void OnGUI()
+        {
+            if (!isLocalPlayer) return;
+
+            int width = 250;
+            int height = 20;
+            GUI.Label(
+                new Rect(Screen.width / 2 - width / 2, Screen.height / 2 - height / 2, width, height),
+                "Press Space to increase your own health!");
+        }
+    }
+}

--- a/Assets/Mirror/Examples/SyncDirection/Player.cs.meta
+++ b/Assets/Mirror/Examples/SyncDirection/Player.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 956e0a6952a1c4c0dabd59805ab743a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Examples/SyncDirection/Player.prefab
+++ b/Assets/Mirror/Examples/SyncDirection/Player.prefab
@@ -1,0 +1,219 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &449802645721213856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2697352357490696306}
+  - component: {fileID: 8695142844114820487}
+  - component: {fileID: 6692327599609520039}
+  - component: {fileID: 1078519278818213949}
+  - component: {fileID: -3280429733832156930}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2697352357490696306
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449802645721213856}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6238039487279352128}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8695142844114820487
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449802645721213856}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6692327599609520039
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449802645721213856}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 2dd029e0943dc488ea1435fa13429182, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &1078519278818213949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449802645721213856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  _assetId: 645619783
+  serverOnly: 0
+  visible: 0
+  hasSpawned: 0
+--- !u!114 &-3280429733832156930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449802645721213856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 956e0a6952a1c4c0dabd59805ab743a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 1
+  syncMode: 0
+  syncInterval: 0.1
+  textMesh: {fileID: 5045126741796351903}
+  health: 0
+--- !u!1 &3382624280860738034
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6238039487279352128}
+  - component: {fileID: 5006305470578639025}
+  - component: {fileID: 5045126741796351903}
+  m_Layer: 0
+  m_Name: TextMesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6238039487279352128
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3382624280860738034}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 4, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2697352357490696306}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &5006305470578639025
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3382624280860738034}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10100, guid: 0000000000000000e000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!102 &5045126741796351903
+TextMesh:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3382624280860738034}
+  m_Text: 0
+  m_OffsetZ: 0
+  m_CharacterSize: 0.24
+  m_LineSpacing: 1
+  m_Anchor: 1
+  m_Alignment: 0
+  m_TabSize: 4
+  m_FontSize: 86
+  m_FontStyle: 0
+  m_RichText: 1
+  m_Font: {fileID: 0}
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278190080

--- a/Assets/Mirror/Examples/SyncDirection/Player.prefab.meta
+++ b/Assets/Mirror/Examples/SyncDirection/Player.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c1affccc0b0c040a486023a5cff7fd46
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Examples/SyncDirection/Scene.unity
+++ b/Assets/Mirror/Examples/SyncDirection/Scene.unity
@@ -1,0 +1,607 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 23800000, guid: 0bc607fa2e315482ebe98797e844e11f, type: 2}
+--- !u!1 &88936773
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 88936777}
+  - component: {fileID: 88936776}
+  - component: {fileID: 88936774}
+  - component: {fileID: 88936778}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &88936774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 88936773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9021b6cc314944290986ab6feb48db79, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  height: 150
+  maxLogCount: 50
+  hotKey: 293
+--- !u!20 &88936776
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 88936773}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.39215687, g: 0.58431375, b: 0.92941177, a: 1}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 35
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &88936777
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 88936773}
+  m_LocalRotation: {x: 0.38268343, y: 0, z: 0, w: 0.92387956}
+  m_LocalPosition: {x: 0, y: 50, z: -80}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
+--- !u!114 &88936778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 88936773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6635375fbc6be456ea640b75add6378e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  showGUI: 1
+  showLog: 0
+--- !u!1 &148314705
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 148314710}
+  - component: {fileID: 148314709}
+  - component: {fileID: 148314708}
+  - component: {fileID: 148314707}
+  m_Layer: 0
+  m_Name: NetworkManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &148314707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 148314705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b0fecffa3f624585964b0d0eb21b18e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Port: 7777
+  DualMode: 1
+  NoDelay: 1
+  Interval: 10
+  Timeout: 10000
+  FastResend: 2
+  CongestionWindow: 0
+  SendWindowSize: 4096
+  ReceiveWindowSize: 4096
+  MaxRetransmit: 40
+  NonAlloc: 1
+  MaximizeSendReceiveBuffersToOSLimit: 1
+  ReliableMaxMessageSize: 298449
+  UnreliableMaxMessageSize: 1199
+  debugLog: 0
+  statisticsGUI: 0
+  statisticsLog: 0
+--- !u!114 &148314708
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 148314705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6442dc8070ceb41f094e44de0bf87274, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  offsetX: 0
+  offsetY: 0
+--- !u!114 &148314709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 148314705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8aab4c8111b7c411b9b92cf3dbc5bd4e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dontDestroyOnLoad: 1
+  runInBackground: 1
+  autoStartServerBuild: 1
+  autoConnectClientBuild: 0
+  serverTickRate: 30
+  offlineScene: 
+  onlineScene: 
+  transport: {fileID: 148314707}
+  networkAddress: localhost
+  maxConnections: 1000
+  authenticator: {fileID: 0}
+  playerPrefab: {fileID: 449802645721213856, guid: c1affccc0b0c040a486023a5cff7fd46,
+    type: 3}
+  autoCreatePlayer: 1
+  playerSpawnMethod: 1
+  spawnPrefabs: []
+  timeInterpolationGui: 1
+--- !u!4 &148314710
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 148314705}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &985780316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 985780318}
+  - component: {fileID: 985780317}
+  m_Layer: 0
+  m_Name: SpawnPosition (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &985780317
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 985780316}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41f84591ce72545258ea98cb7518d8b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &985780318
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 985780316}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &996584419
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 996584421}
+  - component: {fileID: 996584420}
+  m_Layer: 0
+  m_Name: SpawnPosition (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &996584420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996584419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41f84591ce72545258ea98cb7518d8b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &996584421
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996584419}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1001938617
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001938619}
+  - component: {fileID: 1001938618}
+  m_Layer: 0
+  m_Name: SpawnPosition (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1001938618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001938617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41f84591ce72545258ea98cb7518d8b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1001938619
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001938617}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1592625468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1592625470}
+  - component: {fileID: 1592625469}
+  m_Layer: 0
+  m_Name: SpawnPosition (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1592625469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1592625468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41f84591ce72545258ea98cb7518d8b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1592625470
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1592625468}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2054208274
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2054208276}
+  - component: {fileID: 2054208275}
+  m_Layer: 0
+  m_Name: Directional light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2054208275
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2054208274}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 0.8
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &2054208276
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2054208274}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}

--- a/Assets/Mirror/Examples/SyncDirection/Scene.unity.meta
+++ b/Assets/Mirror/Examples/SyncDirection/Scene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 13d58f0d13296447ea167348d60d6c22
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Examples/SyncDirection/White.mat
+++ b/Assets/Mirror/Examples/SyncDirection/White.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: White
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _EMISSION
+  m_LightmapFlags: 0
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0.3254902, g: 0.3254902, b: 0.3254902, a: 1}

--- a/Assets/Mirror/Examples/SyncDirection/White.mat.meta
+++ b/Assets/Mirror/Examples/SyncDirection/White.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2dd029e0943dc488ea1435fa13429182
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentitySerializationTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentitySerializationTests.cs
@@ -265,5 +265,41 @@ namespace Mirror.Tests
             // we don't own this one so we shouldn't serialize & sync it.
             Assert.That(ownerWriter.Position, Is.EqualTo(0));
         }
+
+        // server should still broadcast ClientToServer components to everyone
+        // except the owner.
+        [Test]
+        public void SerializeServer_ObserversMode_ClientToServer()
+        {
+            CreateNetworked(out GameObject _, out NetworkIdentity identity,
+                out SyncVarTest1NetworkBehaviour comp);
+
+            // pretend to be owned
+            identity.isOwned = true;
+            comp.syncMode = SyncMode.Observers;
+            comp.syncInterval = 0;
+
+            // set to CLIENT with some unique values
+            // and set connection to server to pretend we are the owner.
+            comp.syncDirection = SyncDirection.ClientToServer;
+            comp.value = 12345;
+
+            // initial: should write something for owner and observers
+            identity.SerializeServer(true, ownerWriter, observersWriter);
+            Debug.Log("initial ownerWriter: " + ownerWriter);
+            Debug.Log("initial observerWriter: " + observersWriter);
+            Assert.That(ownerWriter.Position, Is.GreaterThan(0));
+            Assert.That(observersWriter.Position, Is.GreaterThan(0));
+
+            // delta: should only write for observers
+            ++comp.value; // change something
+            ownerWriter.Position = 0;
+            observersWriter.Position = 0;
+            identity.SerializeServer(false, ownerWriter, observersWriter);
+            Debug.Log("delta ownerWriter: " + ownerWriter);
+            Debug.Log("delta observersWriter: " + observersWriter);
+            Assert.That(ownerWriter.Position, Is.EqualTo(0));
+            Assert.That(observersWriter.Position, Is.GreaterThan(0));
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkIdentitySerializationTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentitySerializationTests.cs
@@ -49,11 +49,11 @@ namespace Mirror.Tests
             serverObserversComp.value = 42;
 
             // serialize server object
-            serverIdentity.Serialize(true, ownerWriter, observersWriter);
+            serverIdentity.SerializeServer(true, ownerWriter, observersWriter);
 
             // deserialize client object with OWNER payload
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            clientIdentity.Deserialize(reader, true);
+            clientIdentity.DeserializeClient(reader, true);
             Assert.That(clientOwnerComp.value, Is.EqualTo("42"));
             Assert.That(clientObserversComp.value, Is.EqualTo(42));
 
@@ -63,7 +63,7 @@ namespace Mirror.Tests
 
             // deserialize client object with OBSERVERS payload
             reader = new NetworkReader(observersWriter.ToArray());
-            clientIdentity.Deserialize(reader, true);
+            clientIdentity.DeserializeClient(reader, true);
             Assert.That(clientOwnerComp.value, Is.EqualTo(null)); // owner mode shouldn't be in data
             Assert.That(clientObserversComp.value, Is.EqualTo(42)); // observers mode should be in data
         }
@@ -95,13 +95,13 @@ namespace Mirror.Tests
             // serialize server object
             // should work even if compExc throws an exception.
             // error log because of the exception is expected.
-            serverIdentity.Serialize(true, ownerWriter, observersWriter);
+            serverIdentity.SerializeServer(true, ownerWriter, observersWriter);
 
             // deserialize client object with OWNER payload
             // should work even if compExc throws an exception
             // error log because of the exception is expected
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            clientIdentity.Deserialize(reader, true);
+            clientIdentity.DeserializeClient(reader, true);
             Assert.That(clientComp2.value, Is.EqualTo("42"));
 
             // reset component values
@@ -111,7 +111,7 @@ namespace Mirror.Tests
             // should work even if compExc throws an exception
             // error log because of the exception is expected
             reader = new NetworkReader(observersWriter.ToArray());
-            clientIdentity.Deserialize(reader, true);
+            clientIdentity.DeserializeClient(reader, true);
             Assert.That(clientComp2.value, Is.EqualTo(null)); // owner mode should be in data
 
             // restore error checks
@@ -186,13 +186,13 @@ namespace Mirror.Tests
             serverComp.value = "42";
 
             // serialize server object
-            serverIdentity.Serialize(true, ownerWriter, observersWriter);
+            serverIdentity.SerializeServer(true, ownerWriter, observersWriter);
 
             // deserialize on client
             // ignore warning log because of serialization mismatch
             LogAssert.ignoreFailingMessages = true;
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            clientIdentity.Deserialize(reader, true);
+            clientIdentity.DeserializeClient(reader, true);
             LogAssert.ignoreFailingMessages = false;
 
             // the mismatch component will fail, but the one before and after
@@ -205,7 +205,7 @@ namespace Mirror.Tests
         // 0-dirty-mask. instead, we need to ensure it writes nothing.
         // too easy to miss, with too significant bandwidth implications.
         [Test]
-        public void Serialize_NotInitial_NotDirty_WritesNothing()
+        public void SerializeServer_NotInitial_NotDirty_WritesNothing()
         {
             // create spawned so that isServer/isClient is set properly
             CreateNetworkedAndSpawn(
@@ -218,9 +218,52 @@ namespace Mirror.Tests
             // serialize server object.
             // 'initial' would write everything.
             // instead, try 'not initial' with 0 dirty bits
-            serverIdentity.Serialize(false, ownerWriter, observersWriter);
+            serverIdentity.SerializeServer(false, ownerWriter, observersWriter);
             Assert.That(ownerWriter.Position, Is.EqualTo(0));
             Assert.That(observersWriter.Position, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void SerializeClient_NotInitial_NotDirty_WritesNothing()
+        {
+            // create spawned so that isServer/isClient is set properly
+            CreateNetworkedAndSpawn(
+                out _, out NetworkIdentity serverIdentity, out SerializeTest1NetworkBehaviour serverComp1, out SerializeTest2NetworkBehaviour serverComp2,
+                out _, out NetworkIdentity clientIdentity, out SerializeTest1NetworkBehaviour clientComp1, out SerializeTest2NetworkBehaviour clientComp2);
+
+            // change nothing
+            // clientComp.value = "42";
+
+            // serialize client object
+            serverIdentity.SerializeClient(ownerWriter);
+            Assert.That(ownerWriter.Position, Is.EqualTo(0));
+        }
+
+        // serialize -> deserialize. multiple components to be sure.
+        // one for Owner, one for Observer
+        // one ServerToClient, one ClientToServer
+        [Test]
+        public void SerializeAndDeserialize_ClientToServer_NOT_OWNED()
+        {
+            CreateNetworked(out GameObject _, out NetworkIdentity identity,
+                out SerializeTest1NetworkBehaviour comp1,
+                out SerializeTest2NetworkBehaviour comp2);
+
+            // set to CLIENT with some unique values
+            // and set connection to server to pretend we are the owner.
+            identity.isOwned = false;
+            identity.connectionToServer = null; // NOT OWNED
+            comp1.syncDirection = SyncDirection.ServerToClient;
+            comp1.value = 12345;
+            comp2.syncDirection = SyncDirection.ClientToServer;
+            comp2.value = "67890";
+
+            // serialize all
+            identity.SerializeClient(ownerWriter);
+
+            // shouldn't sync anything. because even though it's ClientToServer,
+            // we don't own this one so we shouldn't serialize & sync it.
+            Assert.That(ownerWriter.Position, Is.EqualTo(0));
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -153,6 +153,16 @@ namespace Mirror.Tests
         }
     }
 
+    class SyncVarTest1NetworkBehaviour : NetworkBehaviour
+    {
+        [SyncVar] public int value;
+    }
+
+    class SyncVarTest2NetworkBehaviour : NetworkBehaviour
+    {
+        [SyncVar] public string value;
+    }
+
     class SerializeExceptionNetworkBehaviour : NetworkBehaviour
     {
         public override void OnSerialize(NetworkWriter writer, bool initialState)

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
@@ -407,14 +407,14 @@ namespace Mirror.Tests.SyncVarAttributeTests
             NetworkWriter ownerWriter = new NetworkWriter();
             // not really used in this Test
             NetworkWriter observersWriter = new NetworkWriter();
-            serverIdentity.Serialize(true, ownerWriter, observersWriter);
+            serverIdentity.SerializeServer(true, ownerWriter, observersWriter);
 
             // set up a "client" object
             CreateNetworked(out _, out NetworkIdentity clientIdentity, out SyncVarAbstractNetworkBehaviour clientBehaviour);
 
             // apply all the data from the server object
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            clientIdentity.Deserialize(reader, true);
+            clientIdentity.DeserializeClient(reader, true);
 
             // check that the syncvars got updated
             Assert.That(clientBehaviour.monster1, Is.EqualTo(serverBehaviour.monster1), "Data should be synchronized");

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -66,10 +66,10 @@ namespace Mirror.Tests.Runtime
             // 14 * 24 hours per day * 60 minutes per hour * 60 seconds per minute = 14 days
             // NOTE: change this to 'float' to see the tests fail
             int tick = 14 * 24 * 60 * 60;
-            NetworkIdentitySerialization serialization = identity.GetSerializationAtTick(tick);
+            NetworkIdentitySerialization serialization = identity.GetServerSerializationAtTick(tick);
             // advance tick
             ++tick;
-            NetworkIdentitySerialization serializationNew = identity.GetSerializationAtTick(tick);
+            NetworkIdentitySerialization serializationNew = identity.GetServerSerializationAtTick(tick);
 
             // if the serialization has been changed the tickTimeStamp should have moved
             Assert.That(serialization.tick == serializationNew.tick, Is.False);


### PR DESCRIPTION
previous attempt didn't broadcast ClientToServer components to other clients.

now includes a small demo too.
<img width="613" alt="2022-10-19 - 23-53-27@2x" src="https://user-images.githubusercontent.com/16416509/196812024-60188955-7c6c-4a43-a4ef-1472afe76f10.png">
