### PR TITLE
feature: perf: NetworkConnectionToClient snapshot interpolated .remoteTimeline to simplify NetworkTransform

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -44,9 +44,6 @@ namespace Mirror
         internal SortedList<double, TransformSnapshot> clientSnapshots = new SortedList<double, TransformSnapshot>();
         internal SortedList<double, TransformSnapshot> serverSnapshots = new SortedList<double, TransformSnapshot>();
 
-        // <servertime, snaps>
-        public static SortedList<double, TimeSnapshot> serverTimeSnapshots = new SortedList<double, TimeSnapshot>();
-
         // only sync when changed hack /////////////////////////////////////////
 #if onlySyncOnChange_BANDWIDTH_SAVING
         [Header("Sync Only If Changed")]
@@ -229,7 +226,7 @@ namespace Mirror
 
             // insert into the server buffer & initialize / adjust / catchup
             SnapshotInterpolation.InsertAndAdjust(
-                serverTimeSnapshots,
+                connectionToClient.serverTimeSnapshots,
                 snapshot,
                 ref connectionToClient.serverTimeline,
                 ref connectionToClient.serverTimescale,
@@ -409,7 +406,7 @@ namespace Mirror
                 if (serverSnapshots.Count > 0)
                 {
                     // timeline starts when the first snapshot arrives.
-                    if (serverTimeSnapshots.Count > 0)
+                    if (connectionToClient.serverTimeSnapshots.Count > 0)
                     {
                         // progress local timeline.
                         SnapshotInterpolation.StepTime(Time.unscaledDeltaTime, ref connectionToClient.serverTimeline, connectionToClient.serverTimescale);
@@ -417,7 +414,7 @@ namespace Mirror
                         // progress local interpolation.
                         // TimeSnapshot doesn't interpolate anything.
                         // this is merely to keep removing older snapshots.
-                        SnapshotInterpolation.StepInterpolation(serverTimeSnapshots, connectionToClient.serverTimeline, out _, out _, out _);
+                        SnapshotInterpolation.StepInterpolation(connectionToClient.serverTimeSnapshots, connectionToClient.serverTimeline, out _, out _, out _);
                         // Debug.Log($"NetworkClient SnapshotInterpolation @ {localTimeline:F2} t={t:F2}");
                     }
 

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -44,7 +44,6 @@ namespace Mirror
         internal SortedList<double, TransformSnapshot> clientSnapshots = new SortedList<double, TransformSnapshot>();
         internal SortedList<double, TransformSnapshot> serverSnapshots = new SortedList<double, TransformSnapshot>();
 
-
         // only sync when changed hack /////////////////////////////////////////
 #if onlySyncOnChange_BANDWIDTH_SAVING
         [Header("Sync Only If Changed")]

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -200,12 +200,6 @@ namespace Mirror
 
             // construct snapshot with batch timestamp to save bandwidth
             // insert time snapshot ////////////////////////////////////////////
-            // TransformSnapshot snapshot = new TransformSnapshot(
-            //     timestamp,
-            //     NetworkTime.localTime,
-            //     position.Value, rotation.Value, scale.Value
-            // );
-
             TimeSnapshot snapshot = new TimeSnapshot(
                 timestamp,
                 NetworkTime.localTime // 2019 doesn't have double time yet

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -210,36 +210,7 @@ namespace Mirror
                 timestamp,
                 NetworkTime.localTime // 2019 doesn't have double time yet
             );
-
-            // (optional) dynamic adjustment
-            if (NetworkClient.dynamicAdjustment)
-            {
-                // set bufferTime on the fly.
-                // shows in inspector for easier debugging :)
-                connectionToClient.serverBufferTimeMultiplier = SnapshotInterpolation.DynamicAdjustment(
-                    NetworkServer.sendInterval,
-                    connectionToClient.serverDeliveryTimeEma.StandardDeviation,
-                    NetworkClient.dynamicAdjustmentTolerance
-                );
-                // Debug.Log($"[Server]: {name} delivery std={serverDeliveryTimeEma.StandardDeviation} bufferTimeMult := {bufferTimeMultiplier} ");
-            }
-
-            // insert into the server buffer & initialize / adjust / catchup
-            SnapshotInterpolation.InsertAndAdjust(
-                connectionToClient.serverTimeSnapshots,
-                snapshot,
-                ref connectionToClient.serverTimeline,
-                ref connectionToClient.serverTimescale,
-                NetworkServer.sendInterval,
-                connectionToClient.serverBufferTime,
-                NetworkClient.catchupSpeed,
-                NetworkClient.slowdownSpeed,
-                ref connectionToClient.serverDriftEma,
-                NetworkClient.catchupNegativeThreshold,
-                NetworkClient.catchupPositiveThreshold,
-                ref connectionToClient.serverDeliveryTimeEma
-            );
-
+            connectionToClient.OnTimeSnapshot(snapshot);
 
             // insert transform snapshot ///////////////////////////////////////
             SnapshotInterpolation.InsertIfNotExists(serverSnapshots, new TransformSnapshot(

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -362,34 +362,6 @@ namespace Mirror
             {
                 if (serverSnapshots.Count > 0)
                 {
-                    // timeline starts when the first snapshot arrives.
-                    if (connectionToClient.serverTimeSnapshots.Count > 0)
-                    {
-                        // progress local timeline.
-                        SnapshotInterpolation.StepTime(Time.unscaledDeltaTime, ref connectionToClient.serverTimeline, connectionToClient.serverTimescale);
-
-                        // progress local interpolation.
-                        // TimeSnapshot doesn't interpolate anything.
-                        // this is merely to keep removing older snapshots.
-                        SnapshotInterpolation.StepInterpolation(connectionToClient.serverTimeSnapshots, connectionToClient.serverTimeline, out _, out _, out _);
-                        // Debug.Log($"NetworkClient SnapshotInterpolation @ {localTimeline:F2} t={t:F2}");
-                    }
-
-                    // step transform
-                    // SnapshotInterpolation.Step(
-                    //     serverSnapshots,
-                    //     Time.unscaledDeltaTime,
-                    //     ref connectionToClient.serverTimeline,
-                    //     connectionToClient.serverTimescale,
-                    //     out TransformSnapshot fromSnapshot,
-                    //     out TransformSnapshot toSnapshot,
-                    //     out double t);
-                    //
-                    // // interpolate & apply
-                    // TransformSnapshot computed = TransformSnapshot.Interpolate(fromSnapshot, toSnapshot, t);
-                    // ApplySnapshot(computed);
-
-
                     // step the transform interpolation without touching time.
                     // NetworkClient is responsible for time globally.
                     SnapshotInterpolation.StepInterpolation(

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -38,9 +38,6 @@ namespace Mirror
         // target transform to sync. can be on a child.
         protected abstract Transform targetComponent { get; }
 
-        [Tooltip("Buffer size limit to avoid ever growing list memory consumption attacks.")]
-        public int bufferSizeLimit = 64;
-
         internal SortedList<double, TransformSnapshot> clientSnapshots = new SortedList<double, TransformSnapshot>();
         internal SortedList<double, TransformSnapshot> serverSnapshots = new SortedList<double, TransformSnapshot>();
 
@@ -169,7 +166,7 @@ namespace Mirror
             if (!clientAuthority) return;
 
             // protect against ever growing buffer size attacks
-            if (serverSnapshots.Count >= bufferSizeLimit) return;
+            if (serverSnapshots.Count >= connectionToClient.snapshotBufferSizeLimit) return;
 
             // only player owned objects (with a connection) can send to
             // server. we can get the timestamp from the connection.
@@ -233,7 +230,7 @@ namespace Mirror
             if (IsClientWithAuthority) return;
 
             // protect against ever growing buffer size attacks
-            if (clientSnapshots.Count >= bufferSizeLimit) return;
+            if (clientSnapshots.Count >= connectionToClient.snapshotBufferSizeLimit) return;
 
             // on the client, we receive rpcs for all entities.
             // not all of them have a connectionToServer.
@@ -597,12 +594,6 @@ namespace Mirror
 
         protected virtual void OnDisable() => Reset();
         protected virtual void OnEnable() => Reset();
-
-        protected virtual void OnValidate()
-        {
-            // buffer limit should be at least multiplier to have enough in there
-            bufferSizeLimit = Mathf.Max((int)NetworkClient.bufferTimeMultiplier, bufferSizeLimit);
-        }
 
         public override void OnSerialize(NetworkWriter writer, bool initialState)
         {

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -198,15 +198,7 @@ namespace Mirror
             if (!rotation.HasValue) rotation = serverSnapshots.Count > 0 ? serverSnapshots.Values[serverSnapshots.Count - 1].rotation : targetComponent.localRotation;
             if (!scale.HasValue)    scale    = serverSnapshots.Count > 0 ? serverSnapshots.Values[serverSnapshots.Count - 1].scale    : targetComponent.localScale;
 
-            // construct snapshot with batch timestamp to save bandwidth
-            // insert time snapshot ////////////////////////////////////////////
-            TimeSnapshot snapshot = new TimeSnapshot(
-                timestamp,
-                NetworkTime.localTime // 2019 doesn't have double time yet
-            );
-            connectionToClient.OnTimeSnapshot(snapshot);
-
-            // insert transform snapshot ///////////////////////////////////////
+            // insert transform snapshot
             SnapshotInterpolation.InsertIfNotExists(serverSnapshots, new TransformSnapshot(
                 timestamp,         // arrival remote timestamp. NOT remote time.
 #if !UNITY_2020_3_OR_NEWER

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -363,7 +363,7 @@ namespace Mirror
                     // NetworkClient is responsible for time globally.
                     SnapshotInterpolation.StepInterpolation(
                         serverSnapshots,
-                        connectionToClient.serverTimeline,
+                        connectionToClient.remoteTimeline,
                         out TransformSnapshot from,
                         out TransformSnapshot to,
                         out double t);

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -31,7 +31,7 @@ namespace Mirror
         double bufferTime => NetworkServer.sendInterval * bufferTimeMultiplier;
 
         // <clienttime, snaps>
-        SortedList<double, TimeSnapshot> snapshots = new SortedList<double, TimeSnapshot>();
+        readonly SortedList<double, TimeSnapshot> snapshots = new SortedList<double, TimeSnapshot>();
 
         // Snapshot Buffer size limit to avoid ever growing list memory consumption attacks from clients.
         public int snapshotBufferSizeLimit = 64;

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using UnityEngine;
 
 namespace Mirror
 {
@@ -72,6 +73,22 @@ namespace Mirror
                 NetworkClient.catchupPositiveThreshold,
                 ref serverDeliveryTimeEma
             );
+        }
+
+        public void UpdateTimeInterpolation()
+        {
+            // timeline starts when the first snapshot arrives.
+            if (serverTimeSnapshots.Count > 0)
+            {
+                // progress local timeline.
+                SnapshotInterpolation.StepTime(Time.unscaledDeltaTime, ref serverTimeline, serverTimescale);
+
+                // progress local interpolation.
+                // TimeSnapshot doesn't interpolate anything.
+                // this is merely to keep removing older snapshots.
+                SnapshotInterpolation.StepInterpolation(serverTimeSnapshots, serverTimeline, out _, out _, out _);
+                // Debug.Log($"NetworkClient SnapshotInterpolation @ {localTimeline:F2} t={t:F2}");
+            }
         }
 
         // Send stage three: hand off to transport

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -20,9 +20,12 @@ namespace Mirror
         // unbatcher
         public Unbatcher unbatcher = new Unbatcher();
 
-        // in host mode, we apply snapshot interpolation to for each connection.
-        // this way other players are still smooth on hosted games.
-        // in other words, we still need ema etc. on server here.
+        // server runs a time snapshot interpolation for each client's local time.
+        // this is necessary for client auth movement to still be smooth on the
+        // server for host mode.
+        // TODO move them along server's timeline in the future.
+        //      perhaps with an offset.
+        //      for now, keep compatibility by manually constructing a timeline.
         ExponentialMovingAverage driftEma;
         ExponentialMovingAverage deliveryTimeEma; // average delivery time (standard deviation gives average jitter)
         public double remoteTimeline;

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -23,15 +23,15 @@ namespace Mirror
         // in host mode, we apply snapshot interpolation to for each connection.
         // this way other players are still smooth on hosted games.
         // in other words, we still need ema etc. on server here.
-        public ExponentialMovingAverage driftEma;
-        public ExponentialMovingAverage deliveryTimeEma; // average delivery time (standard deviation gives average jitter)
+        ExponentialMovingAverage driftEma;
+        ExponentialMovingAverage deliveryTimeEma; // average delivery time (standard deviation gives average jitter)
         public double remoteTimeline;
         public double remoteTimescale;
-        public double bufferTimeMultiplier = 2;
-        public double bufferTime => NetworkServer.sendInterval * bufferTimeMultiplier;
+        double bufferTimeMultiplier = 2;
+        double bufferTime => NetworkServer.sendInterval * bufferTimeMultiplier;
 
         // <clienttime, snaps>
-        public SortedList<double, TimeSnapshot> snapshots = new SortedList<double, TimeSnapshot>();
+        SortedList<double, TimeSnapshot> snapshots = new SortedList<double, TimeSnapshot>();
 
         // Snapshot Buffer size limit to avoid ever growing list memory consumption attacks from clients.
         public int snapshotBufferSizeLimit = 64;

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -29,6 +29,8 @@ namespace Mirror
         public double serverBufferTimeMultiplier = 2;
         public double serverBufferTime => NetworkServer.sendInterval * serverBufferTimeMultiplier;
 
+        // <clienttime, snaps>
+        public SortedList<double, TimeSnapshot> serverTimeSnapshots = new SortedList<double, TimeSnapshot>();
 
         public NetworkConnectionToClient(int networkConnectionId)
             : base(networkConnectionId)

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -49,6 +49,10 @@ namespace Mirror
         [Obsolete("NetworkManager.serverTickInterval was moved to NetworkServer.tickInterval for consistency.")]
         public float serverTickInterval => NetworkServer.tickInterval;
 
+        /// <summary>Server Update frequency, per second. Use around 60Hz for fast paced games like Counter-Strike to minimize latency. Use around 30Hz for games like WoW to minimize computations. Use around 1-10Hz for slow paced games like EVE.</summary>
+        [Tooltip("Client broadcasts 'sendRate' times per second. Use around 60Hz for fast paced games like Counter-Strike to minimize latency. Use around 30Hz for games like WoW to minimize computations. Use around 1-10Hz for slow paced games like EVE.")]
+        public int clientSendRate = 30; // 33 ms
+
         /// <summary>Automatically switch to this scene upon going offline (on start / on disconnect / on shutdown).</summary>
         [Header("Scene Management")]
         [Scene]
@@ -323,6 +327,8 @@ namespace Mirror
                 authenticator.OnStartClient();
                 authenticator.OnClientAuthenticated.AddListener(OnClientAuthenticated);
             }
+
+            NetworkClient.sendRate = clientSendRate;
         }
 
         /// <summary>Starts the client, connects it to the server with networkAddress.</summary>

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1788,6 +1788,10 @@ namespace Mirror
             // process all incoming messages first before updating the world
             if (Transport.active != null)
                 Transport.active.ServerEarlyUpdate();
+
+            // step each connection's local time interpolation in early update.
+            foreach (NetworkConnectionToClient connection in connections.Values)
+                connection.UpdateTimeInterpolation();
         }
 
         internal static void NetworkLateUpdate()

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -135,6 +135,7 @@ namespace Mirror
             RegisterHandler<CommandMessage>(OnCommandMessage);
             RegisterHandler<NetworkPingMessage>(NetworkTime.OnServerPing, false);
             RegisterHandler<EntityStateMessage>(OnEntityStateMessage, true);
+            RegisterHandler<TimeSnapshotMessage>(OnTimeSnapshotMessage, true);
         }
 
         /// <summary>Starts server and listens to incoming connections with max connections limit.</summary>
@@ -1019,6 +1020,28 @@ namespace Mirror
             }
             // no warning. don't spam server logs.
             // else Debug.LogWarning($"Did not find target for sync message for {message.netId} . Note: this can be completely normal because UDP messages may arrive out of order, so this message might have arrived after a Destroy message.");
+        }
+
+        // client sends TimeSnapshotMessage every sendInterval.
+        // batching already includes the remoteTimestamp.
+        // we simply insert it on-message here.
+        // => only for reliable channel. unreliable would always arrive earlier.
+        static void OnTimeSnapshotMessage(NetworkConnectionToClient connection, TimeSnapshotMessage _)
+        {
+            // insert another snapshot for snapshot interpolation.
+            // before calling OnDeserialize so components can use
+            // NetworkTime.time and NetworkTime.timeStamp.
+
+            // TODO validation?
+            // maybe we shouldn't allow timeline to deviate more than a certain %.
+            // for now, this is only used for client authority movement.
+
+#if !UNITY_2020_3_OR_NEWER
+            // Unity 2019 doesn't have Time.timeAsDouble yet
+            connection.OnTimeSnapshot(new TimeSnapshot(connection.remoteTimeStamp, NetworkTime.localTime));
+#else
+            connection.OnTimeSnapshot(new TimeSnapshot(connection.remoteTimeStamp, Time.timeAsDouble));
+#endif
         }
 
         // spawning ////////////////////////////////////////////////////////////

--- a/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
@@ -215,7 +215,7 @@ namespace Mirror.Tests.NetworkTransform2k
         [Test]
         public void OnClientToServerSync_WithClientAuthority_BufferSizeLimit()
         {
-            component.bufferSizeLimit = 1;
+            component.connectionToClient.snapshotBufferSizeLimit = 1;
 
             // authority is required
             component.clientAuthority = true;
@@ -267,7 +267,7 @@ namespace Mirror.Tests.NetworkTransform2k
         [Test]
         public void OnServerToClientSync_WithoutClientAuthority_bufferSizeLimit()
         {
-            component.bufferSizeLimit = 1;
+            component.connectionToClient.snapshotBufferSizeLimit = 1;
 
             // pretend to be the client object
             component.netIdentity.isServer = false;


### PR DESCRIPTION
server always interpolates client auth movement for smooth visuals in host mode.
this was previously in NetworkTransform.

NT now only interps the transform value. NetworkClient only the time.
this also reduces redundant snapshot time interpolation for connections with multiple owned objects.

prepares for NetworkTransform V3, so we don't need to do time interpolation in there.