### PR TITLE
[Part 2] breaking: NetworkTransform.clientAuthority flag obsoleted. use SyncDirection instead. automatically sets syncDirection if still used.

### DIFF
--- a/Assets/Mirror/Examples/AdditiveLevels/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/AdditiveLevels/Scripts/PlayerController.cs
@@ -31,7 +31,7 @@ namespace Mirror.Examples.AdditiveLevels
 
             characterController.enabled = false;
             GetComponent<Rigidbody>().isKinematic = true;
-            GetComponent<NetworkTransform>().clientAuthority = true;
+            GetComponent<NetworkTransform>().syncDirection = SyncDirection.ClientToServer;
         }
 
         public override void OnStartLocalPlayer()

--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/PlayerController.cs
@@ -17,7 +17,7 @@ namespace Mirror.Examples.AdditiveScenes
 
             characterController.enabled = false;
             GetComponent<Rigidbody>().isKinematic = true;
-            GetComponent<NetworkTransform>().clientAuthority = true;
+            GetComponent<NetworkTransform>().syncDirection = SyncDirection.ClientToServer;
         }
 
         public override void OnStartLocalPlayer()

--- a/Assets/Mirror/Examples/Benchmark/Prefabs/Player.prefab
+++ b/Assets/Mirror/Examples/Benchmark/Prefabs/Player.prefab
@@ -99,9 +99,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sceneId: 0
+  _assetId: 242745736
   serverOnly: 0
   visible: 0
-  m_AssetId: e1299008405d14b17b1ca459a6cd44a2
   hasSpawned: 0
 --- !u!114 &3679374677650722848
 MonoBehaviour:
@@ -115,20 +115,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 1
   syncMode: 0
-  syncInterval: 0.1
-  clientAuthority: 1
-  sendRate: 30
-  bufferTimeMultiplier: 1
-  bufferSizeLimit: 64
-  catchupNegativeThreshold: -1
-  catchupPositiveThreshold: 1
-  catchupSpeed: 0.009999999776482582
-  slowdownSpeed: 0.009999999776482582
-  driftEmaDuration: 1
-  dynamicAdjustment: 1
-  dynamicAdjustmentTolerance: 1
-  deliveryTimeEmaDuration: 2
+  syncInterval: 0.033333335
+  target: {fileID: 2697352357490696306}
+  clientAuthority: 0
   onlySyncOnChange: 0
   bufferResetMultiplier: 5
   positionSensitivity: 0.01
@@ -152,6 +143,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c482338c8cc6d4a3cba81934c0151972, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncDirection: 0
   syncMode: 0
   syncInterval: 0.1
   speed: 20

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/PlayerController.cs
@@ -17,7 +17,7 @@ namespace Mirror.Examples.MultipleAdditiveScenes
 
             characterController.enabled = false;
             GetComponent<Rigidbody>().isKinematic = true;
-            GetComponent<NetworkTransform>().clientAuthority = true;
+            GetComponent<NetworkTransform>().syncDirection = SyncDirection.ClientToServer;
         }
 
         public override void OnStartLocalPlayer()

--- a/Assets/Mirror/Examples/Room/Scripts/PlayerController.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/PlayerController.cs
@@ -17,7 +17,7 @@ namespace Mirror.Examples.NetworkRoom
 
             characterController.enabled = false;
             GetComponent<Rigidbody>().isKinematic = true;
-            GetComponent<NetworkTransform>().clientAuthority = true;
+            GetComponent<NetworkTransform>().syncDirection = SyncDirection.ClientToServer;
         }
 
         public override void OnStartLocalPlayer()

--- a/Assets/Mirror/Examples/Tanks/Prefabs/Tank.prefab
+++ b/Assets/Mirror/Examples/Tanks/Prefabs/Tank.prefab
@@ -73,7 +73,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.033333335
   target: {fileID: 4492442352427800}
-  clientAuthority: 1
+  clientAuthority: 0
   onlySyncOnChange: 1
   bufferResetMultiplier: 5
   positionSensitivity: 0.01
@@ -101,7 +101,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.033333335
   target: {fileID: 7831918942946891958}
-  clientAuthority: 1
+  clientAuthority: 0
   onlySyncOnChange: 1
   bufferResetMultiplier: 5
   positionSensitivity: 0.01

--- a/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
@@ -198,7 +198,7 @@ namespace Mirror.Tests.NetworkTransform2k
         public void OnClientToServerSync_WithoutClientAuthority()
         {
             // call OnClientToServerSync without authority
-            component.clientAuthority = false;
+            component.syncDirection = SyncDirection.ServerToClient;
             component.OnClientToServerSync(Vector3.zero, Quaternion.identity, Vector3.zero);
             Assert.That(component.serverSnapshots.Count, Is.EqualTo(0));
         }
@@ -207,7 +207,7 @@ namespace Mirror.Tests.NetworkTransform2k
         public void OnClientToServerSync_WithClientAuthority()
         {
             // call OnClientToServerSync with authority
-            component.clientAuthority = true;
+            component.syncDirection = SyncDirection.ClientToServer;
             component.OnClientToServerSync(Vector3.zero, Quaternion.identity, Vector3.zero);
             Assert.That(component.serverSnapshots.Count, Is.EqualTo(1));
         }
@@ -218,7 +218,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.connectionToClient.snapshotBufferSizeLimit = 1;
 
             // authority is required
-            component.clientAuthority = true;
+            component.syncDirection = SyncDirection.ClientToServer;
 
             // add first should work
             component.OnClientToServerSync(Vector3.zero, Quaternion.identity, Vector3.zero);
@@ -239,7 +239,7 @@ namespace Mirror.Tests.NetworkTransform2k
 
             // call OnClientToServerSync with authority and nullable types
             // to make sure it uses the last valid position then.
-            component.clientAuthority = true;
+            component.syncDirection = SyncDirection.ClientToServer;
             component.OnClientToServerSync(new Vector3?(), new Quaternion?(), new Vector3?());
             Assert.That(component.serverSnapshots.Count, Is.EqualTo(1));
             TransformSnapshot first = component.serverSnapshots.Values[0];
@@ -258,7 +258,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.netIdentity.isLocalPlayer = true;
 
             // call OnServerToClientSync without authority
-            component.clientAuthority = false;
+            component.syncDirection = SyncDirection.ServerToClient;
             component.OnServerToClientSync(Vector3.zero, Quaternion.identity, Vector3.zero);
             Assert.That(component.clientSnapshots.Count, Is.EqualTo(1));
         }
@@ -275,7 +275,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.netIdentity.isLocalPlayer = true;
 
             // client authority has to be disabled
-            component.clientAuthority = false;
+            component.syncDirection = SyncDirection.ServerToClient;
 
             // add first should work
             component.OnServerToClientSync(Vector3.zero, Quaternion.identity, Vector3.zero);
@@ -296,7 +296,7 @@ namespace Mirror.Tests.NetworkTransform2k
             component.netIdentity.isLocalPlayer = true;
 
             // call OnServerToClientSync with authority
-            component.clientAuthority = true;
+            component.syncDirection = SyncDirection.ClientToServer;
             component.OnServerToClientSync(Vector3.zero, Quaternion.identity, Vector3.zero);
             Assert.That(component.clientSnapshots.Count, Is.EqualTo(0));
         }


### PR DESCRIPTION
merge #3249 first.
baby steps to migrate to V3 easily without breakage.

<img width="423" alt="2022-10-24 - 18-35-19@2x" src="https://user-images.githubusercontent.com/16416509/197578645-19326243-45b1-42ed-a67b-1fa6f4a5ef26.png">
