### PR TITLE
perf: bundle Rpcs together for each connection. saves 2 bytes of Rpc message headers per Rpc

### DIFF
--- a/Assets/Mirror/Core/Messages.cs
+++ b/Assets/Mirror/Core/Messages.cs
@@ -52,6 +52,15 @@ namespace Mirror
         public ArraySegment<byte> payload;
     }
 
+    // holds multiple buffered rpcs for the given connection.
+    // more efficient than sending one message per rpc.
+    public struct RpcBufferMessage : NetworkMessage
+    {
+        // payload contains multiple serialized RpcMessages.
+        // but without the message header.
+        public ArraySegment<byte> payload;
+    }
+
     public struct SpawnMessage : NetworkMessage
     {
         // netId of new or existing object

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -340,7 +340,7 @@ namespace Mirror
             }
 
             // TODO change conn type to NetworkConnectionToClient to begin with.
-            if (!(conn is NetworkConnectionToClient))
+            if (conn is not NetworkConnectionToClient connToClient)
             {
                 Debug.LogError($"TargetRPC {functionFullName} called on {name} requires a NetworkConnectionToClient but was given {conn.GetType().Name}", gameObject);
                 return;
@@ -357,7 +357,10 @@ namespace Mirror
                 payload = writer.ToArraySegment()
             };
 
-            conn.Send(message, channelId);
+            // serialize it to the connection's rpc buffer.
+            // send them all at once, instead of sending one message per rpc.
+            // conn.Send(message, channelId);
+            connToClient.BufferRpc(message, channelId);
         }
 
         // move the [SyncVar] generated property's .set into C# to avoid much IL

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -166,7 +166,7 @@ namespace Mirror
             // These handlers are the same for host and remote clients
             RegisterHandler<TimeSnapshotMessage>(OnTimeSnapshotMessage);
             RegisterHandler<ChangeOwnerMessage>(OnChangeOwner);
-            RegisterHandler<RpcMessage>(OnRPCMessage);
+            RegisterHandler<RpcBufferMessage>(OnRPCBufferMessage);
         }
 
         // connect /////////////////////////////////////////////////////////////
@@ -1311,6 +1311,20 @@ namespace Mirror
                     identity.HandleRemoteCall(message.componentIndex, message.functionHash, RemoteCallType.ClientRpc, reader);
             }
             // Rpcs often can't be applied if interest management unspawned them
+        }
+
+        static void OnRPCBufferMessage(RpcBufferMessage message)
+        {
+            // parse all rpc messages from the buffer
+            using (NetworkReaderPooled reader = NetworkReaderPool.Get(message.payload))
+            {
+                while (reader.Position > 0)
+                {
+                    // read message without header
+                    RpcMessage rpcMessage = reader.Read<RpcMessage>();
+                    OnRPCMessage(rpcMessage);
+                }
+            }
         }
 
         static void OnObjectHide(ObjectHideMessage message) => DestroyObject(message.netId);

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1315,10 +1315,11 @@ namespace Mirror
 
         static void OnRPCBufferMessage(RpcBufferMessage message)
         {
+            // Debug.Log($"NetworkClient.OnRPCBufferMessage of {message.payload.Count} bytes");
             // parse all rpc messages from the buffer
             using (NetworkReaderPooled reader = NetworkReaderPool.Get(message.payload))
             {
-                while (reader.Position > 0)
+                while (reader.Remaining > 0)
                 {
                     // read message without header
                     RpcMessage rpcMessage = reader.Read<RpcMessage>();

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -127,6 +127,10 @@ namespace Mirror
         // helper for both channels
         void BufferRpc(RpcMessage message, NetworkWriter buffer, int channelId, int maxMessageSize)
         {
+            // calculate buffer limit. we can only fit so much into a message.
+            // max - message header - WriteArraySegment size header
+            int bufferLimit = maxMessageSize - NetworkMessages.IdSize - sizeof(int);
+
             // remember previous valid position
             int before = buffer.Position;
 
@@ -141,7 +145,7 @@ namespace Mirror
             // too much to fit into max message size?
             // then flush first, then write it again.
             // (message + message header + 4 bytes WriteArraySegment header)
-            if (buffer.Position + NetworkMessages.IdSize + sizeof(int) >= maxMessageSize)
+            if (buffer.Position > bufferLimit)
             {
                 buffer.Position = before;
                 FlushRpcs(buffer, channelId); // this resets position

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -134,7 +134,7 @@ namespace Mirror
             // remember previous valid position
             int before = buffer.Position;
 
-            // serialize the message
+            // serialize the message without header
             buffer.Write(message);
 
             // before we potentially flush out old messages,

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -137,10 +137,15 @@ namespace Mirror
             // serialize the message
             buffer.Write(message);
 
-            // TODO ensure message fits into max at all.
-            // otherwise flushing would be pointless.
-            // need to check buffer.Position + IdSize + 4 bytes for message payload?
-            // int written = buffer.Position - before;
+            // before we potentially flush out old messages,
+            // let's ensure this single message can even fit the limit.
+            // otherwise no point in flushing.
+            int messageSize = buffer.Position - before;
+            if (messageSize > bufferLimit)
+            {
+                Debug.LogWarning($"NetworkConnectionToClient: discarded RpcMesage for netId={message.netId} componentIndex={message.componentIndex} functionHash={message.functionHash} because it's larger than the rpc buffer limit of {bufferLimit} bytes for the channel: {channelId}");
+                return;
+            }
 
             // too much to fit into max message size?
             // then flush first, then write it again.

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -128,8 +128,8 @@ namespace Mirror
         void BufferRpc(RpcMessage message, NetworkWriter buffer, int channelId, int maxMessageSize)
         {
             // calculate buffer limit. we can only fit so much into a message.
-            // max - message header - WriteArraySegment size header
-            int bufferLimit = maxMessageSize - NetworkMessages.IdSize - sizeof(int);
+            // max - message header - WriteArraySegment size header - batch header
+            int bufferLimit = maxMessageSize - NetworkMessages.IdSize - sizeof(int) - Batcher.HeaderSize;
 
             // remember previous valid position
             int before = buffer.Position;

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -11,8 +11,8 @@ namespace Mirror
         // this way we don't need one NetworkMessage per rpc.
         // => prepares for LocalWorldState as well.
         // ensure max size when adding!
-        internal NetworkWriter reliableRpcs = new NetworkWriter();
-        internal NetworkWriter unreliableRpcs = new NetworkWriter();
+        NetworkWriter reliableRpcs = new NetworkWriter();
+        NetworkWriter unreliableRpcs = new NetworkWriter();
 
         public override string address =>
             Transport.active.ServerGetClientAddress(connectionId);

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -11,8 +11,8 @@ namespace Mirror
         // this way we don't need one NetworkMessage per rpc.
         // => prepares for LocalWorldState as well.
         // ensure max size when adding!
-        NetworkWriter reliableRpcs = new NetworkWriter();
-        NetworkWriter unreliableRpcs = new NetworkWriter();
+        readonly NetworkWriter reliableRpcs = new NetworkWriter();
+        readonly NetworkWriter unreliableRpcs = new NetworkWriter();
 
         public override string address =>
             Transport.active.ServerGetClientAddress(connectionId);

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -399,7 +399,7 @@ namespace Mirror
         }
 
         /// <summary>Send a message to only clients which are ready with option to include the owner of the object identity</summary>
-        // TODO put rpcs into NetworkServer.Update WorldState packet, then finally remove SendToReady!
+        // TODO obsolete this later. it's not used anymore
         public static void SendToReadyObservers<T>(NetworkIdentity identity, T message, bool includeOwner = true, int channelId = Channels.Reliable)
             where T : struct, NetworkMessage
         {
@@ -429,7 +429,7 @@ namespace Mirror
         }
 
         /// <summary>Send a message to only clients which are ready including the owner of the NetworkIdentity</summary>
-        // TODO put rpcs into NetworkServer.Update WorldState packet, then finally remove SendToReady!
+        // TODO obsolete this later. it's not used anymore
         public static void SendToReadyObservers<T>(NetworkIdentity identity, T message, int channelId)
             where T : struct, NetworkMessage
         {

--- a/Assets/Mirror/Tests/Editor/ClientRpcTest.cs
+++ b/Assets/Mirror/Tests/Editor/ClientRpcTest.cs
@@ -188,7 +188,8 @@ namespace Mirror.Tests.RemoteAttrributeTest
                 Assert.That(incomingInt, Is.EqualTo(someInt));
             };
             hostBehaviour.SendInt(someInt);
-            ProcessMessages();
+            ProcessMessages(); // first update flushes the rpc on the server
+            ProcessMessages(); // second update processes it on the client
             Assert.That(called, Is.EqualTo(1));
         }
     }


### PR DESCRIPTION
- also prepares for LocalWorldState
- and possibly allows for further optimizations, i.e. <<functionHash, N rpcs...>> 
