### PR TITLE
cleanup NetworkIdentity fields initialization on server

### DIFF
--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -635,19 +635,6 @@ namespace Mirror
 
         internal void OnStartServer()
         {
-            // If the instance/net ID is invalid here then this is an object instantiated from a prefab and the server should assign a valid ID
-            // NOTE: this might not be necessary because the above m_IsServer
-            //       check already checks netId. BUT this case here checks only
-            //       netId, so it would still check cases where isServer=false
-            //       but netId!=0.
-            if (netId != 0)
-            {
-                // This object has already been spawned, this method might be called again
-                // if we try to respawn all objects.  This can happen when we add a scene
-                // in that case there is nothing else to do.
-                return;
-            }
-
             netId = GetNextNetworkId();
             observers = new Dictionary<int, NetworkConnectionToClient>();
 

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -637,15 +637,6 @@ namespace Mirror
         {
             observers = new Dictionary<int, NetworkConnectionToClient>();
 
-            //Debug.Log($"OnStartServer {this} NetId:{netId} SceneId:{sceneId:X}");
-
-            // in host mode we set isClient true before calling OnStartServer,
-            // otherwise isClient is false in OnStartServer.
-            if (NetworkClient.active)
-            {
-                isClient = true;
-            }
-
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {
                 // an exception in OnStartServer should be caught, so that one

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -635,15 +635,6 @@ namespace Mirror
 
         internal void OnStartServer()
         {
-            // set isLocalPlayer earlier, in case OnStartLocalplayer is called
-            // AFTER OnStartClient, in which case it would still be falsse here.
-            // many projects will check isLocalPlayer in OnStartClient though.
-            // TODO ideally set isLocalPlayer when NetworkClient.localPlayer is set?
-            if (NetworkClient.localPlayer == this)
-            {
-                isLocalPlayer = true;
-            }
-
             // If the instance/net ID is invalid here then this is an object instantiated from a prefab and the server should assign a valid ID
             // NOTE: this might not be necessary because the above m_IsServer
             //       check already checks netId. BUT this case here checks only

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -635,7 +635,6 @@ namespace Mirror
 
         internal void OnStartServer()
         {
-            netId = GetNextNetworkId();
             observers = new Dictionary<int, NetworkConnectionToClient>();
 
             //Debug.Log($"OnStartServer {this} NetId:{netId} SceneId:{sceneId:X}");

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -639,10 +639,6 @@ namespace Mirror
 
             //Debug.Log($"OnStartServer {this} NetId:{netId} SceneId:{sceneId:X}");
 
-            // add to spawned (note: the original EnableIsServer isn't needed
-            // because we already set m_isServer=true above)
-            NetworkServer.spawned[netId] = this;
-
             // in host mode we set isClient true before calling OnStartServer,
             // otherwise isClient is false in OnStartServer.
             if (NetworkClient.active)

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -635,13 +635,6 @@ namespace Mirror
 
         internal void OnStartServer()
         {
-            // do nothing if already spawned
-            if (isServer)
-                return;
-
-            // set isServer flag
-            isServer = true;
-
             // set isLocalPlayer earlier, in case OnStartLocalplayer is called
             // AFTER OnStartClient, in which case it would still be falsse here.
             // many projects will check isLocalPlayer in OnStartClient though.

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1191,6 +1191,9 @@ namespace Mirror
                 identity.isLocalPlayer = NetworkClient.localPlayer == identity;
                 identity.netId = NetworkIdentity.GetNextNetworkId();
 
+                // add to spawned (after assigning netId)
+                spawned[identity.netId] = identity;
+
                 // callback after all fields were set
                 identity.OnStartServer();
             }

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1189,6 +1189,7 @@ namespace Mirror
                 // configure NetworkIdentity
                 identity.isServer = true;
                 identity.isLocalPlayer = NetworkClient.localPlayer == identity;
+                identity.netId = NetworkIdentity.GetNextNetworkId();
 
                 // callback after all fields were set
                 identity.OnStartServer();

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1188,6 +1188,7 @@ namespace Mirror
             {
                 // configure NetworkIdentity
                 identity.isLocalPlayer = NetworkClient.localPlayer == identity;
+                identity.isClient = NetworkClient.active;
                 identity.isServer = true;
                 identity.netId = NetworkIdentity.GetNextNetworkId();
 

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1187,8 +1187,8 @@ namespace Mirror
             if (!identity.isServer && identity.netId == 0)
             {
                 // configure NetworkIdentity
-                identity.isServer = true;
                 identity.isLocalPlayer = NetworkClient.localPlayer == identity;
+                identity.isServer = true;
                 identity.netId = NetworkIdentity.GetNextNetworkId();
 
                 // add to spawned (after assigning netId)

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1184,7 +1184,7 @@ namespace Mirror
 
             // only call OnStartServer if not spawned yet.
             // check used to be in NetworkIdentity. may not be necessary anymore.
-            if (!identity.isServer)
+            if (!identity.isServer && identity.netId == 0)
             {
                 // configure NetworkIdentity
                 identity.isServer = true;

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1188,6 +1188,7 @@ namespace Mirror
             {
                 // configure NetworkIdentity
                 identity.isServer = true;
+                identity.isLocalPlayer = NetworkClient.localPlayer == identity;
 
                 // callback after all fields were set
                 identity.OnStartServer();

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1182,7 +1182,16 @@ namespace Mirror
             if (ownerConnection is LocalConnectionToClient)
                 identity.isOwned = true;
 
-            identity.OnStartServer();
+            // only call OnStartServer if not spawned yet.
+            // check used to be in NetworkIdentity. may not be necessary anymore.
+            if (!identity.isServer)
+            {
+                // configure NetworkIdentity
+                identity.isServer = true;
+
+                // callback after all fields were set
+                identity.OnStartServer();
+            }
 
             // Debug.Log($"SpawnObject instance ID {identity.netId} asset ID {identity.assetId}");
 

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -108,9 +108,8 @@ namespace Mirror.Tests
         {
             CreateNetworked(out _, out NetworkIdentity identity, out EmptyBehaviour emptyBehaviour);
 
-            // call OnStartServer so isServer is true
-            identity.OnStartServer();
-            Assert.That(identity.isServer, Is.True);
+            // set isServer
+            identity.isServer = true;
 
             // isServerOnly should be true when isServer = true && isClient = false
             Assert.That(emptyBehaviour.isServer, Is.True);
@@ -558,9 +557,8 @@ namespace Mirror.Tests
         {
             CreateNetworked(out GameObject gameObject, out NetworkIdentity identity, out NetworkBehaviourGetSyncVarGameObjectComponent comp);
 
-            // call OnStartServer so isServer is true
-            identity.OnStartServer();
-            Assert.That(identity.isServer, Is.True);
+            // set isServer
+            identity.isServer = true;
 
             // create a syncable GameObject
             CreateNetworked(out GameObject go, out NetworkIdentity ni);
@@ -584,9 +582,8 @@ namespace Mirror.Tests
         {
             CreateNetworked(out GameObject gameObject, out NetworkIdentity identity, out NetworkBehaviourGetSyncVarGameObjectComponent comp);
 
-            // call OnStartServer and assign netId so isServer is true
-            identity.OnStartServer();
-            Assert.That(identity.isServer, Is.True);
+            // set isServer
+            identity.isServer = true;
 
             // get it on the server. null should work fine.
             GameObject result = comp.GetSyncVarGameObjectExposed();
@@ -719,9 +716,8 @@ namespace Mirror.Tests
         {
             CreateNetworked(out GameObject _, out NetworkIdentity identity, out NetworkBehaviourGetSyncVarNetworkIdentityComponent comp);
 
-            // call OnStartServer so isServer is true
-            identity.OnStartServer();
-            Assert.That(identity.isServer, Is.True);
+            // set isServer
+            identity.isServer = true;
 
             // create a syncable GameObject
             CreateNetworked(out _, out NetworkIdentity ni);
@@ -742,9 +738,8 @@ namespace Mirror.Tests
         {
             CreateNetworked(out GameObject _, out NetworkIdentity identity, out NetworkBehaviourGetSyncVarNetworkIdentityComponent comp);
 
-            // call OnStartServer so isServer is true
-            identity.OnStartServer();
-            Assert.That(identity.isServer, Is.True);
+            // set isServer
+            identity.isServer = true;
 
             // get it on the server. null should work fine.
             NetworkIdentity result = comp.GetSyncVarNetworkIdentityExposed();

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -662,29 +662,12 @@ namespace Mirror.Tests
             Assert.That(compStop.called, Is.EqualTo(1));
         }
 
-        // OnStartServer in host mode should set isClient=true
         [Test]
-        public void OnStartServerInHostModeSetsIsClientTrue()
+        public void Spawn_HostMode_SetsIsClient()
         {
-            CreateNetworked(out GameObject _, out NetworkIdentity identity);
-
-            // call client connect so that internals are set up
-            // (it won't actually successfully connect)
-            NetworkClient.Connect("localhost");
-
-            // manually invoke transport.OnConnected so that NetworkClient.active is set to true
-            Transport.active.OnClientConnected.Invoke();
-            Assert.That(NetworkClient.active, Is.True);
-
-            // isClient needs to be true in OnStartServer if in host mode.
-            // this is a test for a bug that we fixed, where isClient was false
-            // in OnStartServer if in host mode because in host mode, we only
-            // connect the client after starting the server, hence isClient would
-            // be false in OnStartServer until way later.
-            // -> we have the workaround in OnStartServer, so let's also test to
-            //    make sure that nobody ever breaks it again
-            Assert.That(identity.isClient, Is.False);
-            identity.OnStartServer();
+            NetworkServer.Listen(1);
+            ConnectHostClientBlockingAuthenticatedAndReady();
+            CreateNetworkedAndSpawn(out GameObject _, out NetworkIdentity identity);
             Assert.That(identity.isClient, Is.True);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -551,9 +551,8 @@ namespace Mirror.Tests
             // server is needed
             NetworkServer.Listen(1);
 
-            // call OnStartServer so that isServer is true
-            identity.OnStartServer();
-            Assert.That(identity.isServer, Is.True);
+            // set isServer to true
+            identity.isServer = true;
 
             // assign authority
             result = identity.AssignClientAuthority(owner);


### PR DESCRIPTION
inspired by Mirror II.
this is much cleaner and much more obvious.

**MERGE, dont squash**