### PR TITLE
feat: Add Mirror.Transports AsmDef

### DIFF
--- a/Assets/Mirror/Transports/Mirror.Transports.asmdef
+++ b/Assets/Mirror/Transports/Mirror.Transports.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Mirror.Transports",
+    "rootNamespace": "",
+    "references": [
+        "GUID:30817c1a0e6d646d99c048fc403f5979",
+        "GUID:6806a62c384838046a3c66c44f06d75f",
+        "GUID:725ee7191c021de4dbf9269590ded755"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Mirror/Transports/Mirror.Transports.asmdef.meta
+++ b/Assets/Mirror/Transports/Mirror.Transports.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 627104647b9c04b4ebb8978a92ecac63
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Keeps transports in their own assembly to users' own AsmDef's can reference them.

See conversation in Discord - Light-Reflective-Mirror channel.

![image](https://user-images.githubusercontent.com/9826063/204176135-ae766c99-a7fd-46d5-a38f-53b659f6aa58.png)
