### PR TITLE
NetworkPingDisplay: make connection quality readable (Q: STATUS [■■··]) and auto-size bar by enum

### DIFF
--- a/Assets/Mirror/Components/NetworkPingDisplay.cs
+++ b/Assets/Mirror/Components/NetworkPingDisplay.cs
@@ -11,16 +11,14 @@ namespace Mirror
     [HelpURL("https://mirror-networking.gitbook.io/docs/components/network-ping-display")]
     public class NetworkPingDisplay : MonoBehaviour
     {
-        [Header("UI")]
         public Color color = Color.white;
         public int padding = 2;
-        public int width = 250;
+        public int width = 150;
         public int height = 25;
         
-        [Header("Bar Characters")]
+        [Header("Bar Character")]
         [Tooltip("Character to represent filled segments of the connection quality bar")]
-        public char filledChar = '■';
-        public char emptyChar  = '·';
+        public char barChar = '■';
 
 #if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
@@ -34,18 +32,25 @@ namespace Mirror
             GUILayout.BeginArea(rect);
             GUIStyle style = GUI.skin.GetStyle("Label");
             style.alignment = TextAnchor.MiddleRight;
+            style.richText = true; // enable colored substrings
+            
+            GUILayout.BeginHorizontal(style);
             
             double rttMs = Math.Round(NetworkTime.rtt * 1000);
             var quality = NetworkClient.connectionQuality;
             int totalSegments = Enum.GetValues(typeof(ConnectionQuality)).Length - 1;
             int filled = Mathf.Clamp((int)quality, 0, totalSegments);
-            string bar = new string(filledChar, filled) + new string(emptyChar, totalSegments - filled);
 
-            GUILayout.BeginHorizontal(style);
+            string lit   = new string(barChar, filled);
+            string unlit = new string(barChar, totalSegments - filled);
+            string litColor  = ColorUtility.ToHtmlStringRGB(quality.ColorCode());
+            string unlitColor = "666666";
+            
+            // Q: [■■■■] (lit part colored, unlit part grey)
+            string bar = $"[<color=#{litColor}>{lit}</color><color=#{unlitColor}>{unlit}</color>]";
             GUILayout.Label($"RTT: {rttMs} ms");
-            GUI.color = quality.ColorCode();
-            GUILayout.Label($"Q: {quality} [{bar}]");
-                
+            GUILayout.Label($"Q: {bar}");
+            
             GUILayout.EndHorizontal();
             GUILayout.EndArea();
             GUI.color = Color.white;


### PR DESCRIPTION
This PR improves the default NetworkPingDisplay overlay so that connection quality is immediately readable and consistent across enum changes.

**Replaces the hard-to-parse “dash count” with:**
-  `Q: EXCELLENT [■■■■] / Q: ESTIMATING [····]`
- Auto-sizes the bar based on the ConnectionQuality enum (no magic numbers).
- Keeps the change minimal: only tweaks inside OnGUI(), no public API changes.

**Motivation**
The previous UI showed quality as a growing number of dashes:`Q: ----`
This is ambiguous for players and non-obvious for developers (how many “-” is GOOD?). Explicit text + a fixed-length bar is a common visual language and improves usability without adding complexity. Especially when we work in Editor
<img width="2555" height="1324" alt="Screenshot 2025-09-15 203006" src="https://github.com/user-attachments/assets/4edc8392-08ed-4034-9574-68eb6e0e41b5" />


**What changed (high level)**

- Compute totalSegments from the enum:` int totalSegments = Enum.GetValues(typeof(ConnectionQuality)).Length - 1;`
- Build a compact bar using filled/empty glyphs (■ / ·)(made also customizable) based on (int)quality.
- Print `Q: {STATUS} [{bar}]` and keep RTT as before.

**Before / After** 

**Before:** 
<img width="849" height="554" alt="Screenshot 2025-09-15 201324" src="https://github.com/user-attachments/assets/1b305542-8680-4d91-878a-c8bd3df2c173" />
<img width="238" height="125" alt="Screenshot 2025-09-15 202500" src="https://github.com/user-attachments/assets/b359684a-e8d6-4895-a6e2-ca1998d43e12" />


**After:** 
<img width="851" height="556" alt="Screenshot 2025-09-15 200718" src="https://github.com/user-attachments/assets/58792755-f369-479b-bad7-7c4f09b8c05f" />
<img width="308" height="130" alt="Screenshot 2025-09-15 202311" src="https://github.com/user-attachments/assets/184a449f-7dd2-409a-9b94-0e2ad8852980" />
