### PR TITLE
NetworkBehaviour.lastCommandSender

### DIFF
--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -163,6 +163,13 @@ namespace Mirror
         // hook guard prevents that.
         ulong syncVarHookGuard;
 
+        // [Command(requiresAuthority=false)] on global objects allow any sender.
+        // senders can be verified with optional (NetworkConnectionToClient) parameter.
+        // if a studio forgot to add that parameter, then validating senders would requires a full server + client rebuild.
+        // sometimes that's not possible in time (i.e. urgent exploits), in that case - this field can be used.
+        protected NetworkConnectionToClient lastCommandSender = null;
+        internal void SetLastCommandSender(NetworkConnectionToClient conn) => lastCommandSender = conn;
+
         protected virtual void OnValidate()
         {
             // Skip if Editor is in Play mode

--- a/Assets/Mirror/Core/RemoteCalls.cs
+++ b/Assets/Mirror/Core/RemoteCalls.cs
@@ -129,6 +129,9 @@ namespace Mirror.RemoteCalls
             if (GetInvokerForHash(functionHash, remoteCallType, out Invoker invoker) &&
                 invoker.componentType.IsInstanceOfType(component))
             {
+                // set sender in case it's needed
+                component.SetLastCommandSender(senderConnection);
+
                 // invoke function on this component
                 invoker.function(component, reader, senderConnection);
                 return true;


### PR DESCRIPTION
preview PR open for discussion.
adds life safer in case of exploits in production games.

basically:
- studio forgot validating sender in a [Command(requiresAuthority=false)]
- adding NetworkConnectionToClient parameter is the solution, however:
- this would require a full server + client release, which is very costly and takes validation time
- adding this flag in some form can be a life safer: server sided change without needing a client rebuild