### PR TITLE
fix(NetworkScenePostProcess): Only process the last loaded scene

### DIFF
--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -12,6 +12,9 @@ namespace Mirror
         [PostProcessScene]
         public static void OnPostProcessScene()
         {
+            Scene lastLoadedScene = SceneManager.GetSceneAt(SceneManager.sceneCount - 1);
+            //Debug.Log($"[Mirror] OnPostProcessScene for scene '{lastLoadedScene.name}'");
+
             // find all NetworkIdentities in all scenes
             // => can't limit it to GetActiveScene() because that wouldn't work
             //    for additive scene loads (the additively loaded scene is never
@@ -30,7 +33,7 @@ namespace Mirror
                 .Where(identity => identity.gameObject.hideFlags != HideFlags.NotEditable &&
                                    identity.gameObject.hideFlags != HideFlags.HideAndDontSave &&
                                    identity.gameObject.scene.name != "DontDestroyOnLoad" &&
-                                   identity.gameObject.scene == SceneManager.GetSceneAt(SceneManager.sceneCount - 1) &&
+                                   identity.gameObject.scene == lastLoadedScene &&
                                    !Utils.IsPrefab(identity.gameObject));
 
             foreach (NetworkIdentity identity in identities)


### PR DESCRIPTION
- Faster when there are a lot of additive scenes
- Avoids erroneous halts for unspawned objects in other scenes
- Fixes #4066

Before:
<img width="1155" height="215" alt="image" src="https://github.com/user-attachments/assets/d6cfdf18-c8db-40af-a08c-1c111094884d" />

After:
<img width="565" height="132" alt="image" src="https://github.com/user-attachments/assets/ea6a782c-438e-4700-8b75-e4f37bc1ffc7" />

Unspawned Cube:
<img width="462" height="517" alt="image" src="https://github.com/user-attachments/assets/646063a0-9a63-4ed9-8b4a-0bb8bd142b3c" />

Tested with AdditiveScenes and AdditiveLevels examples:
```cs
IEnumerator ServerLoadSubScenes()
{
    Debug.Log("Spawning Cube");
    Instantiate(spawnPrefabs[0]);
    yield return new WaitForSeconds(0.5f);

    Debug.Log("Loading Subscenes");
    foreach (string additiveScene in additiveScenes)
        yield return SceneManager.LoadSceneAsync(additiveScene, new LoadSceneParameters . . .
}
```

### Performance Gain
Without this PR, logging object counts as each subscene loads shows the increases
- there's only 6 objects per subscene, nothing in the Online scene
<img width="524" height="173" alt="image" src="https://github.com/user-attachments/assets/b67538f6-92ce-4da5-ba7a-afa9c0f81f5c" />

After applying the scene filter we get the expected count for each subscene (6):
<img width="527" height="179" alt="image" src="https://github.com/user-attachments/assets/271f2c99-6ae6-47c9-bf32-78e110d3d2e1" />
