### PR TITLE
feat: SyncVar hooks can have 2, 1 or no params

### DIFF
--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests.cs
@@ -6,7 +6,7 @@ namespace Mirror.Weaver.Tests
     {
         static string OldNewMethodFormat(string hookName, string ValueType)
         {
-            return string.Format("void {0}({1} oldValue, {1} newValue)", hookName, ValueType);
+            return string.Format("void {0}({1} oldValue, {1} newValue), void {0}({1} oldValue) or void {0}()", hookName, ValueType);
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithNoParams.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithNoParams.cs
@@ -1,0 +1,16 @@
+using Mirror;
+using UnityEngine;
+
+namespace WeaverSyncVarHookTests.FindsHookWithOtherOverloadsInOrder
+{
+    class FindsHookWithNoParams : NetworkBehaviour
+    {
+        [SyncVar(hook = nameof(onChangeHealth))]
+        int health;
+
+        void onChangeHealth()
+        {
+
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithNoParams.cs.meta
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithNoParams.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fcdd7591784c4a5e83ea275b155e924a
+timeCreated: 1767697570

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithOneParam.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithOneParam.cs
@@ -1,0 +1,16 @@
+using Mirror;
+using UnityEngine;
+
+namespace WeaverSyncVarHookTests.FindsHookWithOtherOverloadsInOrder
+{
+    class FindsHookWithOneParam : NetworkBehaviour
+    {
+        [SyncVar(hook = nameof(onChangeHealth))]
+        int health;
+
+        void onChangeHealth(int oldValue)
+        {
+
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithOneParam.cs.meta
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithOneParam.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8789eff36ef34233989182f291e8727c
+timeCreated: 1767697556

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithTwoParams.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithTwoParams.cs
@@ -1,0 +1,16 @@
+using Mirror;
+using UnityEngine;
+
+namespace WeaverSyncVarHookTests.FindsHookWithOtherOverloadsInOrder
+{
+    class FindsHookWithTwoParams : NetworkBehaviour
+    {
+        [SyncVar(hook = nameof(onChangeHealth))]
+        int health;
+
+        void onChangeHealth(int oldValue, int newValue)
+        {
+
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithTwoParams.cs.meta
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests_IsSuccess/FindsHookWithTwoParams.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4ee680a10b3b406da65a9c63144bce5b
+timeCreated: 1767697539

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests~/ErrorWhenNoHookWithCorrectParametersFound.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeHookTests~/ErrorWhenNoHookWithCorrectParametersFound.cs
@@ -7,12 +7,12 @@ namespace WeaverSyncVarHookTests.ErrorWhenNoHookWithCorrectParametersFound
         [SyncVar(hook = nameof(onChangeHealth))]
         int health;
 
-        void onChangeHealth(int someOtherValue)
+        void onChangeHealth(int someOtherValue, int moreValue, bool anotherValue)
         {
 
         }
 
-        void onChangeHealth(int someOtherValue, int moreValue, bool anotherValue)
+        void onChangeHealth(int someOtherValue, int moreValue, int anotherValue, int moreValues)
         {
 
         }


### PR DESCRIPTION
The weaver does this by generating a shim method with 2 params that calls the actual hook method

Not 100% sure if we actually want this for an extra 200 lines of weaver code

Tested with both mono&il2cpp builds (not tested virtual/static hook calls yet, will do if we plan on merging this)
