### PR TITLE
test(NetworkManagerHUD): add unit test

### DIFF
--- a/Assets/Mirror/Core/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Core/NetworkManagerHUD.cs
@@ -9,12 +9,14 @@ namespace Mirror
     [HelpURL("https://mirror-networking.gitbook.io/docs/components/network-manager-hud")]
     public class NetworkManagerHUD : MonoBehaviour
     {
-        NetworkManager manager;
+        // internal so we can access it during unit tests
+        internal NetworkManager manager;
 
         public int offsetX;
         public int offsetY;
 
-        void Awake()
+        // internal so we can access it during unit tests
+        internal void Awake()
         {
             manager = GetComponent<NetworkManager>();
         }

--- a/Assets/Mirror/Tests/Editor/NetworkManagerHUD.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerHUD.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8de871a6df7b61d439459e87909cb1f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Editor/NetworkManagerHUD/NetworkManagerHUDTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerHUD/NetworkManagerHUDTest.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mirror.Tests
+{
+    public class NetworkManagerHUDTest : MirrorEditModeTest
+    {
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+        }
+
+        [Test]
+        public void NetworkManagerHUDAttributesTest()
+        {
+            CreateGameObject(out GameObject manager, out NetworkManagerHUD managerHUD);
+
+            NetworkManagerHUD[] allHUDs = manager.GetComponents<NetworkManagerHUD>();
+
+            // Check if [RequireComponent(typeof(NetworkManager))] works
+            Assert.That(manager.GetComponent<NetworkManager>(), Is.Not.Null);
+            Assert.That(allHUDs.Length, Is.EqualTo(1));
+
+            manager.AddComponent<NetworkManagerHUD>();
+            allHUDs = manager.GetComponents<NetworkManagerHUD>();
+
+            // Check if [DisallowMultipleComponent] works
+            Assert.That(allHUDs.Length, Is.EqualTo(1));
+            Assert.That(allHUDs[0], Is.SameAs(managerHUD));
+        }
+
+        [Test]
+        public void NetworkManagerHUDLifecycleTest()
+        {
+            CreateGameObject(out GameObject managerGO, out NetworkManager networkManager);
+
+            NetworkManagerHUD managerHUD = managerGO.AddComponent<NetworkManagerHUD>();
+
+            Assert.That(managerHUD.manager, Is.Null, "manager should be null before Awake()");
+
+            // Must call Unity lifecycle methods manually in edit mode tests
+            managerHUD.Awake();
+
+            Assert.That(managerHUD.manager, Is.Not.Null, "manager should be set after Awake()");
+            //Assert.That(managerHUD.manager, Is.Not.Null, "manager should be set after Awake()");
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkManagerHUD/NetworkManagerHUDTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerHUD/NetworkManagerHUDTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef1828fc2602ce340b164912fe75647d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added unit tests for the NetworkManagersHUDs lifecycle and attributes.

Not sure about the OnGUI Methods. Found some workaround by using delegates but could be overengineered and not suitable.

```cs
// NetworkManagerHUD
internal Func<string, GUILayoutOption[], bool> button = GUILayout.Button;

internal void OnGUI()
{
  if (button("Host", null))
  {
    //Methods...
  }
}

// NetworkManagerHUDTest
hud.button = (label, options) => true;
hud.OnGUI();

hud.button = (label, options) => false;
hud.OnGUI();
```

Guess can't really do OnGUI within EditModeTests.

Making this one Draft until clear instructions on how to handle OnGUI.